### PR TITLE
Implement user login screen

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -61,6 +61,7 @@ dependencies {
     implementation(platform("com.google.firebase:firebase-bom:33.14.0"))
     implementation("com.google.firebase:firebase-analytics")
     implementation(libs.firebase.firestore.ktx)
+    implementation("com.google.firebase:firebase-auth-ktx")
 
     // Testing
     testImplementation("junit:junit:4.13.2")

--- a/app/src/main/java/com/ioannapergamali/mysmartroute/model/navigation/NavigationHost.kt
+++ b/app/src/main/java/com/ioannapergamali/mysmartroute/model/navigation/NavigationHost.kt
@@ -8,6 +8,7 @@ import androidx.navigation.compose.NavHost
 import androidx.navigation.compose.composable
 import com.ioannapergamali.mysmartroute.view.ui.screens.HomeScreen
 import com.ioannapergamali.mysmartroute.view.ui.screens.SignUpScreen
+import com.ioannapergamali.mysmartroute.view.ui.screens.LoginScreen
 
 
 
@@ -24,26 +25,26 @@ fun NavigationHost(navController : NavHostController) {
                 navController = navController ,
                 onNavigateToSignUp = {
                     navController.navigate("Signup")
+                },
+                onNavigateToLogin = {
+                    navController.navigate("login")
                 }
             )
         }
-//        // Login Screen
-//        composable("login") {
-//            LoginScreen(
-//                navController = navController ,
-//                onLoginSuccess = {
-//                    navController.navigate("menu") {
-//                        popUpTo("login") { inclusive = true }
-//                    }
-//                } ,
-//                onLoginFailure = { errorMessage ->
-//                    Toast.makeText(context , errorMessage , Toast.LENGTH_SHORT).show()
-//                } ,
-//                onNavigateToSettings = {
-//                    navController.navigate("settings")
-//                }
-//            )
-//        }
+
+        composable("login") {
+            LoginScreen(
+                navController = navController ,
+                onLoginSuccess = {
+                    navController.navigate("menu") {
+                        popUpTo("login") { inclusive = true }
+                    }
+                } ,
+                onLoginFailure = { errorMessage ->
+                    Toast.makeText(context , errorMessage , Toast.LENGTH_SHORT).show()
+                }
+            )
+        }
 
 
 

--- a/app/src/main/java/com/ioannapergamali/mysmartroute/view/ui/screens/HomeScreen.kt
+++ b/app/src/main/java/com/ioannapergamali/mysmartroute/view/ui/screens/HomeScreen.kt
@@ -24,7 +24,8 @@ import com.ioannapergamali.mysmartroute.view.ui.animation.rememberBreathingAnima
 @Composable
 fun HomeScreen(
     navController: NavController,
-    onNavigateToSignUp: () -> Unit
+    onNavigateToSignUp: () -> Unit,
+    onNavigateToLogin: () -> Unit
 ) {
     Scaffold(
         topBar = {
@@ -69,6 +70,10 @@ fun HomeScreen(
             Column(horizontalAlignment = Alignment.CenterHorizontally) {
                 Button(onClick = { onNavigateToSignUp() }) {
                     Text("Sign Up")
+                }
+                Spacer(modifier = Modifier.height(8.dp))
+                Button(onClick = { onNavigateToLogin() }) {
+                    Text("Login")
                 }
             }
         }

--- a/app/src/main/java/com/ioannapergamali/mysmartroute/view/ui/screens/LoginScreen.kt
+++ b/app/src/main/java/com/ioannapergamali/mysmartroute/view/ui/screens/LoginScreen.kt
@@ -1,0 +1,79 @@
+package com.ioannapergamali.mysmartroute.view.ui.screens
+
+import androidx.compose.foundation.layout.*
+import androidx.compose.material3.*
+import androidx.compose.runtime.*
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.text.input.PasswordVisualTransformation
+import androidx.compose.ui.unit.dp
+import androidx.lifecycle.viewmodel.compose.viewModel
+import androidx.navigation.NavController
+import com.ioannapergamali.movewise.ui.components.TopBar
+import com.ioannapergamali.mysmartroute.viewmodel.AuthenticationViewModel
+
+@Composable
+fun LoginScreen(
+    navController: NavController,
+    onLoginSuccess: () -> Unit,
+    onLoginFailure: (String) -> Unit
+) {
+    val viewModel: AuthenticationViewModel = viewModel()
+    val uiState by viewModel.loginState.collectAsState()
+
+    var username by remember { mutableStateOf("") }
+    var password by remember { mutableStateOf("") }
+
+    Scaffold(
+        topBar = {
+            TopBar(
+                title = "Login",
+                navController = navController
+            )
+        }
+    ) { paddingValues ->
+        Column(
+            modifier = Modifier
+                .fillMaxSize()
+                .padding(paddingValues)
+                .padding(16.dp),
+            horizontalAlignment = Alignment.CenterHorizontally
+        ) {
+            TextField(
+                value = username,
+                onValueChange = { username = it },
+                label = { Text("Username") },
+                modifier = Modifier.fillMaxWidth()
+            )
+            Spacer(Modifier.height(8.dp))
+            TextField(
+                value = password,
+                onValueChange = { password = it },
+                label = { Text("Password") },
+                visualTransformation = PasswordVisualTransformation(),
+                modifier = Modifier.fillMaxWidth()
+            )
+
+            if (uiState is AuthenticationViewModel.LoginState.Error) {
+                Spacer(modifier = Modifier.height(8.dp))
+                Text(
+                    text = (uiState as AuthenticationViewModel.LoginState.Error).message,
+                    color = MaterialTheme.colorScheme.error
+                )
+            }
+
+            Spacer(Modifier.height(16.dp))
+            Button(onClick = { viewModel.login(username, password) }) {
+                Text("Login")
+            }
+        }
+    }
+
+    LaunchedEffect(uiState) {
+        when (uiState) {
+            is AuthenticationViewModel.LoginState.Success -> onLoginSuccess()
+            is AuthenticationViewModel.LoginState.Error -> onLoginFailure((uiState as AuthenticationViewModel.LoginState.Error).message)
+            else -> {}
+        }
+    }
+}

--- a/app/src/main/java/com/ioannapergamali/mysmartroute/view/ui/screens/LoginScreen.kt
+++ b/app/src/main/java/com/ioannapergamali/mysmartroute/view/ui/screens/LoginScreen.kt
@@ -21,7 +21,7 @@ fun LoginScreen(
     val viewModel: AuthenticationViewModel = viewModel()
     val uiState by viewModel.loginState.collectAsState()
 
-    var username by remember { mutableStateOf("") }
+    var email by remember { mutableStateOf("") }
     var password by remember { mutableStateOf("") }
 
     Scaffold(
@@ -40,9 +40,9 @@ fun LoginScreen(
             horizontalAlignment = Alignment.CenterHorizontally
         ) {
             TextField(
-                value = username,
-                onValueChange = { username = it },
-                label = { Text("Username") },
+                value = email,
+                onValueChange = { email = it },
+                label = { Text("Email") },
                 modifier = Modifier.fillMaxWidth()
             )
             Spacer(Modifier.height(8.dp))
@@ -63,7 +63,7 @@ fun LoginScreen(
             }
 
             Spacer(Modifier.height(16.dp))
-            Button(onClick = { viewModel.login(username, password) }) {
+            Button(onClick = { viewModel.login(email, password) }) {
                 Text("Login")
             }
         }


### PR DESCRIPTION
## Summary
- create `LoginScreen` for authentication
- support login state in `AuthenticationViewModel`
- add login route to navigation
- show Login button on home screen

## Testing
- `./gradlew test` *(fails: Unable to tunnel through proxy)*

------
https://chatgpt.com/codex/tasks/task_e_68426972a6ac8328b9d42a2659fbf907