### PR TITLE
Fix PoI type conflict

### DIFF
--- a/app/src/main/java/com/ioannapergamali/mysmartroute/model/classes/poi/BasicPoI.kt
+++ b/app/src/main/java/com/ioannapergamali/mysmartroute/model/classes/poi/BasicPoI.kt
@@ -10,7 +10,5 @@ data class BasicPoI(
     override val id: String,
     override val description: String,
     override val type: PoIType
-) : PoI {
-    override fun getType(): PoIType = type
-}
+) : PoI
 

--- a/app/src/main/java/com/ioannapergamali/mysmartroute/model/interfaces/PoI.kt
+++ b/app/src/main/java/com/ioannapergamali/mysmartroute/model/interfaces/PoI.kt
@@ -6,6 +6,4 @@ interface PoI {
     val id: String
     val description: String
     val type: PoIType
-
-    fun getType(): PoIType
 }


### PR DESCRIPTION
## Summary
- remove `getType()` from `PoI` interface to avoid JVM signature clash
- simplify `BasicPoI` implementation

## Testing
- `./gradlew test --no-daemon` *(fails: Unable to tunnel through proxy)*

------
https://chatgpt.com/codex/tasks/task_e_6842ed71f7ac8328b18220c23b0b5245