### PR TITLE
Improve home screen animation and layout

### DIFF
--- a/app/src/main/java/com/ioannapergamali/mysmartroute/view/ui/animation/SlideFadeInAnimation.kt
+++ b/app/src/main/java/com/ioannapergamali/mysmartroute/view/ui/animation/SlideFadeInAnimation.kt
@@ -1,0 +1,31 @@
+package com.ioannapergamali.mysmartroute.view.ui.animation
+
+import androidx.compose.animation.core.Animatable
+import androidx.compose.animation.core.FastOutSlowInEasing
+import androidx.compose.animation.core.tween
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.remember
+import androidx.compose.ui.unit.Dp
+import androidx.compose.ui.unit.dp
+
+@Composable
+fun rememberSlideFadeInAnimation(durationMillis: Int = 1000): Pair<Dp, Float> {
+    val offset = remember { Animatable(-40f) }
+    val alpha = remember { Animatable(0f) }
+
+    LaunchedEffect(Unit) {
+        offset.animateTo(
+            targetValue = 0f,
+            animationSpec = tween(durationMillis = durationMillis, easing = FastOutSlowInEasing)
+        )
+    }
+    LaunchedEffect(Unit) {
+        alpha.animateTo(
+            targetValue = 1f,
+            animationSpec = tween(durationMillis = durationMillis, easing = FastOutSlowInEasing)
+        )
+    }
+
+    return Pair(offset.value.dp, alpha.value)
+}

--- a/app/src/main/java/com/ioannapergamali/mysmartroute/view/ui/screens/HomeScreen.kt
+++ b/app/src/main/java/com/ioannapergamali/mysmartroute/view/ui/screens/HomeScreen.kt
@@ -1,14 +1,8 @@
 package com.ioannapergamali.mysmartroute.view.ui.screens
 
-import androidx.compose.animation.core.FastOutSlowInEasing
-import androidx.compose.animation.core.LinearEasing
-import androidx.compose.animation.core.RepeatMode
-import androidx.compose.animation.core.animateFloat
-import androidx.compose.animation.core.infiniteRepeatable
-import androidx.compose.animation.core.rememberInfiniteTransition
-import androidx.compose.animation.core.tween
 import androidx.compose.foundation.Image
 import androidx.compose.foundation.layout.*
+import androidx.compose.foundation.clickable
 import androidx.compose.material3.*
 import androidx.compose.runtime.*
 import androidx.compose.ui.Alignment
@@ -20,6 +14,7 @@ import androidx.navigation.NavController
 import com.ioannapergamali.movewise.ui.components.TopBar
 import com.ioannapergamali.mysmartroute.R
 import com.ioannapergamali.mysmartroute.view.ui.animation.rememberBreathingAnimation
+import com.ioannapergamali.mysmartroute.view.ui.animation.rememberSlideFadeInAnimation
 
 @Composable
 fun HomeScreen(
@@ -41,18 +36,25 @@ fun HomeScreen(
             .padding(paddingValues)
             .padding(16.dp)
 
-        val (scale, alpha) = rememberBreathingAnimation()
+        val (logoScale, logoAlpha) = rememberBreathingAnimation()
+        val (textOffset, textAlpha) = rememberSlideFadeInAnimation()
 
         Column(
             modifier = contentModifier,
-            verticalArrangement = Arrangement.SpaceBetween,
+            verticalArrangement = Arrangement.Top,
             horizontalAlignment = Alignment.CenterHorizontally
         ) {
             Text(
-                text = "Welcome to",
+                text = "Welcome",
                 style = MaterialTheme.typography.headlineLarge,
-                modifier = Modifier.padding(vertical = 8.dp)
+                modifier = Modifier
+                    .offset(y = textOffset)
+                    .graphicsLayer {
+                        this.alpha = textAlpha
+                    }
             )
+
+            Spacer(modifier = Modifier.height(12.dp))
 
             Image(
                 painter = painterResource(id = R.drawable.sr),
@@ -60,21 +62,27 @@ fun HomeScreen(
                 modifier = Modifier
                     .size(180.dp)
                     .graphicsLayer {
-                        scaleX = scale
-                        scaleY = scale
-                        this.alpha = alpha
+                        scaleX = logoScale
+                        scaleY = logoScale
+                        this.alpha = logoAlpha
                     }
-                    .padding(vertical = 8.dp)
             )
 
-            Column(horizontalAlignment = Alignment.CenterHorizontally) {
-                Button(onClick = { onNavigateToSignUp() }) {
-                    Text("Sign Up")
-                }
-                Spacer(modifier = Modifier.height(8.dp))
-                Button(onClick = { onNavigateToLogin() }) {
-                    Text("Login")
-                }
+            Spacer(modifier = Modifier.height(16.dp))
+
+            Button(onClick = { onNavigateToLogin() }) {
+                Text("Login")
+            }
+
+            Spacer(modifier = Modifier.height(8.dp))
+
+            Row {
+                Text("If you don't have account ")
+                Text(
+                    text = "Sign Up",
+                    color = MaterialTheme.colorScheme.primary,
+                    modifier = Modifier.clickable { onNavigateToSignUp() }
+                )
             }
         }
     }


### PR DESCRIPTION
## Summary
- remove old text pulse animation
- add slide and fade-in animation for welcome text
- align home screen content at the top
- add spacing between welcome text, logo, and actions

## Testing
- `./gradlew test --no-daemon` *(fails: Unable to tunnel through proxy)*
- `./gradlew tasks --no-daemon` *(fails: Unable to tunnel through proxy)*

------
https://chatgpt.com/codex/tasks/task_e_6842f574e03483288540d6964fa9e473