### PR TITLE
Adjust home screen layout and bring back text pulse

### DIFF
--- a/app/src/main/java/com/ioannapergamali/mysmartroute/view/ui/animation/TextPulseAnimation.kt
+++ b/app/src/main/java/com/ioannapergamali/mysmartroute/view/ui/animation/TextPulseAnimation.kt
@@ -1,0 +1,37 @@
+package com.ioannapergamali.mysmartroute.view.ui.animation
+
+import androidx.compose.animation.core.FastOutSlowInEasing
+import androidx.compose.animation.core.RepeatMode
+import androidx.compose.animation.core.animateFloat
+import androidx.compose.animation.core.infiniteRepeatable
+import androidx.compose.animation.core.rememberInfiniteTransition
+import androidx.compose.animation.core.tween
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+
+@Composable
+fun rememberTextPulseAnimation(): Pair<Float, Float> {
+    val infiniteTransition = rememberInfiniteTransition(label = "text_pulse")
+
+    val scale by infiniteTransition.animateFloat(
+        initialValue = 0.9f,
+        targetValue = 1.1f,
+        animationSpec = infiniteRepeatable(
+            animation = tween(durationMillis = 1500, easing = FastOutSlowInEasing),
+            repeatMode = RepeatMode.Reverse
+        ),
+        label = "scale"
+    )
+
+    val alpha by infiniteTransition.animateFloat(
+        initialValue = 0.5f,
+        targetValue = 1f,
+        animationSpec = infiniteRepeatable(
+            animation = tween(durationMillis = 1500, easing = FastOutSlowInEasing),
+            repeatMode = RepeatMode.Reverse
+        ),
+        label = "alpha"
+    )
+
+    return Pair(scale, alpha)
+}

--- a/app/src/main/java/com/ioannapergamali/mysmartroute/view/ui/screens/HomeScreen.kt
+++ b/app/src/main/java/com/ioannapergamali/mysmartroute/view/ui/screens/HomeScreen.kt
@@ -1,14 +1,8 @@
 package com.ioannapergamali.mysmartroute.view.ui.screens
 
-import androidx.compose.animation.core.FastOutSlowInEasing
-import androidx.compose.animation.core.LinearEasing
-import androidx.compose.animation.core.RepeatMode
-import androidx.compose.animation.core.animateFloat
-import androidx.compose.animation.core.infiniteRepeatable
-import androidx.compose.animation.core.rememberInfiniteTransition
-import androidx.compose.animation.core.tween
 import androidx.compose.foundation.Image
 import androidx.compose.foundation.layout.*
+import androidx.compose.foundation.clickable
 import androidx.compose.material3.*
 import androidx.compose.runtime.*
 import androidx.compose.ui.Alignment
@@ -20,6 +14,7 @@ import androidx.navigation.NavController
 import com.ioannapergamali.movewise.ui.components.TopBar
 import com.ioannapergamali.mysmartroute.R
 import com.ioannapergamali.mysmartroute.view.ui.animation.rememberBreathingAnimation
+import com.ioannapergamali.mysmartroute.view.ui.animation.rememberTextPulseAnimation
 
 @Composable
 fun HomeScreen(
@@ -41,18 +36,25 @@ fun HomeScreen(
             .padding(paddingValues)
             .padding(16.dp)
 
-        val (scale, alpha) = rememberBreathingAnimation()
+        val (logoScale, logoAlpha) = rememberBreathingAnimation()
+        val (textScale, textAlpha) = rememberTextPulseAnimation()
 
         Column(
             modifier = contentModifier,
-            verticalArrangement = Arrangement.SpaceBetween,
+            verticalArrangement = Arrangement.Top,
             horizontalAlignment = Alignment.CenterHorizontally
         ) {
             Text(
-                text = "Welcome to",
+                text = "WELCOME TO",
                 style = MaterialTheme.typography.headlineLarge,
-                modifier = Modifier.padding(vertical = 8.dp)
+                modifier = Modifier.graphicsLayer {
+                    scaleX = textScale
+                    scaleY = textScale
+                    this.alpha = textAlpha
+                }
             )
+
+            Spacer(modifier = Modifier.height(4.dp))
 
             Image(
                 painter = painterResource(id = R.drawable.sr),
@@ -60,21 +62,27 @@ fun HomeScreen(
                 modifier = Modifier
                     .size(180.dp)
                     .graphicsLayer {
-                        scaleX = scale
-                        scaleY = scale
-                        this.alpha = alpha
+                        scaleX = logoScale
+                        scaleY = logoScale
+                        this.alpha = logoAlpha
                     }
-                    .padding(vertical = 8.dp)
             )
 
-            Column(horizontalAlignment = Alignment.CenterHorizontally) {
-                Button(onClick = { onNavigateToSignUp() }) {
-                    Text("Sign Up")
-                }
-                Spacer(modifier = Modifier.height(8.dp))
-                Button(onClick = { onNavigateToLogin() }) {
-                    Text("Login")
-                }
+            Spacer(modifier = Modifier.height(16.dp))
+
+            Button(onClick = { onNavigateToLogin() }) {
+                Text("Login")
+            }
+
+            Spacer(modifier = Modifier.height(8.dp))
+
+            Row {
+                Text("If you don't have account ")
+                Text(
+                    text = "Sign Up",
+                    color = MaterialTheme.colorScheme.primary,
+                    modifier = Modifier.clickable { onNavigateToSignUp() }
+                )
             }
         }
     }

--- a/app/src/main/java/com/ioannapergamali/mysmartroute/view/ui/screens/HomeScreen.kt
+++ b/app/src/main/java/com/ioannapergamali/mysmartroute/view/ui/screens/HomeScreen.kt
@@ -54,8 +54,6 @@ fun HomeScreen(
                 }
             )
 
-            Spacer(modifier = Modifier.height(4.dp))
-
             Image(
                 painter = painterResource(id = R.drawable.sr),
                 contentDescription = "Animated Logo",
@@ -68,13 +66,13 @@ fun HomeScreen(
                     }
             )
 
-            Spacer(modifier = Modifier.height(16.dp))
+            Spacer(modifier = Modifier.height(8.dp))
 
             Button(onClick = { onNavigateToLogin() }) {
                 Text("Login")
             }
 
-            Spacer(modifier = Modifier.height(8.dp))
+            Spacer(modifier = Modifier.height(4.dp))
 
             Row {
                 Text("If you don't have account ")


### PR DESCRIPTION
## Summary
- restore text pulse animation for welcome message
- update home screen to match requested layout
- remove unused slide-and-fade animation

## Testing
- `./gradlew test --no-daemon` *(fails: Unable to tunnel through proxy)*
- `./gradlew tasks --no-daemon` *(fails: Unable to tunnel through proxy)*

------
https://chatgpt.com/codex/tasks/task_e_6842f574e03483288540d6964fa9e473