### PR TITLE
Implement offline signup storage

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -1,4 +1,5 @@
 plugins {
+    id("kotlin-kapt")
     id("com.android.application")
     id("com.google.gms.google-services")
     id("org.jetbrains.kotlin.android")
@@ -62,6 +63,10 @@ dependencies {
     implementation("com.google.firebase:firebase-analytics")
     implementation(libs.firebase.firestore.ktx)
     implementation(libs.firebase.auth.ktx)
+
+    implementation(libs.androidx.room.runtime)
+    implementation(libs.androidx.room.ktx)
+    kapt(libs.androidx.room.compiler)
 
     // Testing
     testImplementation("junit:junit:4.13.2")

--- a/app/src/main/java/com/ioannapergamali/mysmartroute/data/local/MySmartRouteDatabase.kt
+++ b/app/src/main/java/com/ioannapergamali/mysmartroute/data/local/MySmartRouteDatabase.kt
@@ -1,0 +1,26 @@
+package com.ioannapergamali.mysmartroute.data.local
+
+import android.content.Context
+import androidx.room.Database
+import androidx.room.Room
+import androidx.room.RoomDatabase
+
+@Database(entities = [UserEntity::class], version = 1)
+abstract class MySmartRouteDatabase : RoomDatabase() {
+    abstract fun userDao(): UserDao
+
+    companion object {
+        @Volatile
+        private var INSTANCE: MySmartRouteDatabase? = null
+
+        fun getInstance(context: Context): MySmartRouteDatabase {
+            return INSTANCE ?: synchronized(this) {
+                INSTANCE ?: Room.databaseBuilder(
+                    context.applicationContext,
+                    MySmartRouteDatabase::class.java,
+                    "mysmartroute.db"
+                ).build().also { INSTANCE = it }
+            }
+        }
+    }
+}

--- a/app/src/main/java/com/ioannapergamali/mysmartroute/data/local/UserDao.kt
+++ b/app/src/main/java/com/ioannapergamali/mysmartroute/data/local/UserDao.kt
@@ -1,0 +1,15 @@
+package com.ioannapergamali.mysmartroute.data.local
+
+import androidx.room.Dao
+import androidx.room.Insert
+import androidx.room.OnConflictStrategy
+import androidx.room.Query
+
+@Dao
+interface UserDao {
+    @Insert(onConflict = OnConflictStrategy.REPLACE)
+    suspend fun insert(user: UserEntity)
+
+    @Query("SELECT * FROM users WHERE id = :id")
+    suspend fun getUser(id: String): UserEntity?
+}

--- a/app/src/main/java/com/ioannapergamali/mysmartroute/data/local/UserEntity.kt
+++ b/app/src/main/java/com/ioannapergamali/mysmartroute/data/local/UserEntity.kt
@@ -1,0 +1,20 @@
+package com.ioannapergamali.mysmartroute.data.local
+
+import androidx.room.Entity
+import androidx.room.PrimaryKey
+
+@Entity(tableName = "users")
+data class UserEntity(
+    @PrimaryKey val id: String,
+    val name: String,
+    val surname: String,
+    val username: String,
+    val email: String,
+    val phoneNum: String,
+    val password: String,
+    val role: String,
+    val city: String,
+    val streetName: String,
+    val streetNum: Int,
+    val postalCode: Int
+)

--- a/app/src/main/java/com/ioannapergamali/mysmartroute/utils/NetworkUtils.kt
+++ b/app/src/main/java/com/ioannapergamali/mysmartroute/utils/NetworkUtils.kt
@@ -1,0 +1,14 @@
+package com.ioannapergamali.mysmartroute.utils
+
+import android.content.Context
+import android.net.ConnectivityManager
+import android.net.NetworkCapabilities
+
+object NetworkUtils {
+    fun isInternetAvailable(context: Context): Boolean {
+        val connectivityManager = context.getSystemService(Context.CONNECTIVITY_SERVICE) as ConnectivityManager
+        val network = connectivityManager.activeNetwork ?: return false
+        val capabilities = connectivityManager.getNetworkCapabilities(network) ?: return false
+        return capabilities.hasCapability(NetworkCapabilities.NET_CAPABILITY_INTERNET)
+    }
+}

--- a/app/src/main/java/com/ioannapergamali/mysmartroute/view/ui/screens/SignUpScreen.kt
+++ b/app/src/main/java/com/ioannapergamali/mysmartroute/view/ui/screens/SignUpScreen.kt
@@ -13,6 +13,7 @@ import androidx.compose.ui.text.input.PasswordVisualTransformation
 import androidx.compose.ui.unit.dp
 import androidx.lifecycle.viewmodel.compose.viewModel
 import androidx.navigation.NavController
+import androidx.compose.ui.platform.LocalContext
 import com.ioannapergamali.movewise.ui.components.TopBar
 import com.ioannapergamali.mysmartroute.model.enumerations.UserRole
 import com.ioannapergamali.mysmartroute.viewmodel.AuthenticationViewModel
@@ -25,6 +26,7 @@ fun SignUpScreen(
 ) {
     val viewModel: AuthenticationViewModel = viewModel()
     val uiState by viewModel.signUpState.collectAsState()
+    val context = LocalContext.current
 
     var name by remember { mutableStateOf("") }
     var surname by remember { mutableStateOf("") }
@@ -104,6 +106,7 @@ fun SignUpScreen(
 
                 if (streetNum != null && postalCode != null) {
                     viewModel.signUp(
+                        context,
                         name, surname, username, email, phoneNum, password,
                         com.ioannapergamali.mysmartroute.model.classes.users.UserAddress(city, streetName, streetNum, postalCode),
                         selectedRole

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -12,6 +12,7 @@ constraintlayout = "2.1.4"
 material3Android = "1.3.2"
 firebaseFirestoreKtx = "25.1.4"
 firebaseAuthKtx = "22.3.1"
+room = "2.6.1"
 
 [libraries]
 androidx-core-ktx = { group = "androidx.core", name = "core-ktx", version.ref = "coreKtx" }
@@ -25,6 +26,9 @@ androidx-constraintlayout = { group = "androidx.constraintlayout", name = "const
 androidx-material3-android = { group = "androidx.compose.material3", name = "material3-android", version.ref = "material3Android" }
 firebase-firestore-ktx = { group = "com.google.firebase", name = "firebase-firestore-ktx", version.ref = "firebaseFirestoreKtx" }
 firebase-auth-ktx = { group = "com.google.firebase", name = "firebase-auth-ktx", version.ref = "firebaseAuthKtx" }
+androidx-room-runtime = { group = "androidx.room", name = "room-runtime", version.ref = "room" }
+androidx-room-ktx = { group = "androidx.room", name = "room-ktx", version.ref = "room" }
+androidx-room-compiler = { group = "androidx.room", name = "room-compiler", version.ref = "room" }
 
 [plugins]
 android-application = { id = "com.android.application", version.ref = "agp" }


### PR DESCRIPTION
## Summary
- add Room DB for storing users locally
- create context-aware signup that stores a user entity offline and online
- include network availability checks
- hook up context in `SignUpScreen`

## Testing
- `./gradlew test --no-daemon` *(fails: Unable to tunnel through proxy)*

------
https://chatgpt.com/codex/tasks/task_e_684317fff7908328949f92ca3166e893