### PR TITLE
Add logout support and user creation toasts

### DIFF
--- a/app/src/main/java/com/ioannapergamali/mysmartroute/model/navigation/NavigationHost.kt
+++ b/app/src/main/java/com/ioannapergamali/mysmartroute/model/navigation/NavigationHost.kt
@@ -1,8 +1,6 @@
 package com.ioannapergamali.mysmartroute.model.navigation
 
-import android.widget.Toast
 import androidx.compose.runtime.Composable
-import androidx.compose.ui.platform.LocalContext
 import androidx.navigation.NavHostController
 import androidx.navigation.compose.NavHost
 import androidx.navigation.compose.composable
@@ -15,9 +13,6 @@ import com.ioannapergamali.mysmartroute.view.ui.screens.MenuScreen
 
 @Composable
 fun NavigationHost(navController : NavHostController) {
-
-    val context = LocalContext.current
-
 
     NavHost(navController = navController , startDestination = "home") {
 
@@ -40,9 +35,6 @@ fun NavigationHost(navController : NavHostController) {
                     navController.navigate("menu") {
                         popUpTo("login") { inclusive = true }
                     }
-                } ,
-                onLoginFailure = { errorMessage ->
-                    Toast.makeText(context , errorMessage , Toast.LENGTH_SHORT).show()
                 }
             )
         }
@@ -56,9 +48,6 @@ fun NavigationHost(navController : NavHostController) {
                     navController.navigate("menu") {
                         popUpTo("signup") { inclusive = true }
                     }
-                } ,
-                onSignUpFailure = { errorMessage ->
-                    Toast.makeText(context , errorMessage , Toast.LENGTH_SHORT).show()
                 }
             )
         }

--- a/app/src/main/java/com/ioannapergamali/mysmartroute/view/ui/components/TopBar.kt
+++ b/app/src/main/java/com/ioannapergamali/mysmartroute/view/ui/components/TopBar.kt
@@ -1,8 +1,8 @@
 package com.ioannapergamali.movewise.ui.components
 
 import androidx.compose.material.icons.Icons
-import androidx.compose.material.icons.automirrored.filled.ArrowBack
 import androidx.compose.material.icons.automirrored.filled.List
+import androidx.compose.material.icons.filled.Logout
 import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.Icon
 import androidx.compose.material3.IconButton
@@ -14,16 +14,27 @@ import androidx.navigation.NavController
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable
 fun TopBar(
-        title : String ,
-        navController : NavController
-)
-{
+    title: String,
+    navController: NavController,
+    showLogout: Boolean = false,
+    onLogout: () -> Unit = {}
+) {
     TopAppBar(
-            title = { Text(title) } ,
-            navigationIcon = {
-                IconButton(onClick = { navController.popBackStack() }) {
-                    Icon(Icons.AutoMirrored.Filled.List, contentDescription = "list")
+        title = { Text(title) },
+        navigationIcon = {
+            IconButton(onClick = { navController.popBackStack() }) {
+                Icon(
+                    Icons.AutoMirrored.Filled.List,
+                    contentDescription = "list"
+                )
+            }
+        },
+        actions = {
+            if (showLogout) {
+                IconButton(onClick = onLogout) {
+                    Icon(Icons.Default.Logout, contentDescription = "logout")
                 }
             }
+        }
     )
 }

--- a/app/src/main/java/com/ioannapergamali/mysmartroute/view/ui/screens/LoginScreen.kt
+++ b/app/src/main/java/com/ioannapergamali/mysmartroute/view/ui/screens/LoginScreen.kt
@@ -11,15 +11,18 @@ import androidx.lifecycle.viewmodel.compose.viewModel
 import androidx.navigation.NavController
 import com.ioannapergamali.movewise.ui.components.TopBar
 import com.ioannapergamali.mysmartroute.viewmodel.AuthenticationViewModel
+import android.widget.Toast
+import androidx.compose.ui.platform.LocalContext
 
 @Composable
 fun LoginScreen(
     navController: NavController,
     onLoginSuccess: () -> Unit,
-    onLoginFailure: (String) -> Unit
+    onLoginFailure: (String) -> Unit = {}
 ) {
     val viewModel: AuthenticationViewModel = viewModel()
     val uiState by viewModel.loginState.collectAsState()
+    val context = LocalContext.current
 
     var email by remember { mutableStateOf("") }
     var password by remember { mutableStateOf("") }
@@ -71,8 +74,15 @@ fun LoginScreen(
 
     LaunchedEffect(uiState) {
         when (uiState) {
-            is AuthenticationViewModel.LoginState.Success -> onLoginSuccess()
-            is AuthenticationViewModel.LoginState.Error -> onLoginFailure((uiState as AuthenticationViewModel.LoginState.Error).message)
+            is AuthenticationViewModel.LoginState.Success -> {
+                Toast.makeText(context, "Login successful", Toast.LENGTH_SHORT).show()
+                onLoginSuccess()
+            }
+            is AuthenticationViewModel.LoginState.Error -> {
+                val message = (uiState as AuthenticationViewModel.LoginState.Error).message
+                Toast.makeText(context, message, Toast.LENGTH_SHORT).show()
+                onLoginFailure(message)
+            }
             else -> {}
         }
     }

--- a/app/src/main/java/com/ioannapergamali/mysmartroute/view/ui/screens/MenuScreen.kt
+++ b/app/src/main/java/com/ioannapergamali/mysmartroute/view/ui/screens/MenuScreen.kt
@@ -10,6 +10,8 @@ import androidx.compose.runtime.getValue
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.unit.dp
 import androidx.lifecycle.viewmodel.compose.viewModel
+import androidx.compose.ui.platform.LocalContext
+import android.widget.Toast
 import androidx.navigation.NavController
 import com.ioannapergamali.movewise.ui.components.TopBar
 import com.ioannapergamali.mysmartroute.model.enumerations.UserRole
@@ -24,9 +26,22 @@ fun MenuScreen(navController: NavController) {
         viewModel.loadCurrentUserRole()
     }
 
+    val context = LocalContext.current
+
     Scaffold(
         topBar = {
-            TopBar(title = "Menu", navController = navController)
+            TopBar(
+                title = "Menu",
+                navController = navController,
+                showLogout = true,
+                onLogout = {
+                    viewModel.signOut()
+                    Toast.makeText(context, "Logged out", Toast.LENGTH_SHORT).show()
+                    navController.navigate("home") {
+                        popUpTo("menu") { inclusive = true }
+                    }
+                }
+            )
         }
     ) { paddingValues ->
         Column(
@@ -67,6 +82,7 @@ private fun PassengerMenu(viewModel: AuthenticationViewModel, navController: Nav
         when (index) {
             0 -> {
                 viewModel.signOut()
+                Toast.makeText(LocalContext.current, "Logged out", Toast.LENGTH_SHORT).show()
                 navController.navigate("home") {
                     popUpTo("menu") { inclusive = true }
                 }

--- a/app/src/main/java/com/ioannapergamali/mysmartroute/view/ui/screens/SignUpScreen.kt
+++ b/app/src/main/java/com/ioannapergamali/mysmartroute/view/ui/screens/SignUpScreen.kt
@@ -14,6 +14,7 @@ import androidx.compose.ui.unit.dp
 import androidx.lifecycle.viewmodel.compose.viewModel
 import androidx.navigation.NavController
 import androidx.compose.ui.platform.LocalContext
+import android.widget.Toast
 import com.ioannapergamali.movewise.ui.components.TopBar
 import com.ioannapergamali.mysmartroute.model.enumerations.UserRole
 import com.ioannapergamali.mysmartroute.viewmodel.AuthenticationViewModel
@@ -22,7 +23,7 @@ import com.ioannapergamali.mysmartroute.viewmodel.AuthenticationViewModel
 fun SignUpScreen(
     navController: NavController,
     onSignUpSuccess: () -> Unit,
-    onSignUpFailure: (String) -> Unit
+    onSignUpFailure: (String) -> Unit = {}
 ) {
     val viewModel: AuthenticationViewModel = viewModel()
     val uiState by viewModel.signUpState.collectAsState()
@@ -120,8 +121,19 @@ fun SignUpScreen(
 
     LaunchedEffect(uiState) {
         when (uiState) {
-            is AuthenticationViewModel.SignUpState.Success -> onSignUpSuccess()
-            is AuthenticationViewModel.SignUpState.Error -> onSignUpFailure((uiState as AuthenticationViewModel.SignUpState.Error).message)
+            is AuthenticationViewModel.SignUpState.Success -> {
+                Toast.makeText(
+                    context,
+                    "User created and stored successfully",
+                    Toast.LENGTH_SHORT
+                ).show()
+                onSignUpSuccess()
+            }
+            is AuthenticationViewModel.SignUpState.Error -> {
+                val message = (uiState as AuthenticationViewModel.SignUpState.Error).message
+                Toast.makeText(context, message, Toast.LENGTH_SHORT).show()
+                onSignUpFailure(message)
+            }
             else -> {}
         }
     }


### PR DESCRIPTION
## Summary
- show logout icon in the top bar
- handle logout action in `MenuScreen`
- show toasts on signup/login success or failure
- simplify navigation host

## Testing
- `./gradlew test` *(fails: Unable to tunnel through proxy)*

------
https://chatgpt.com/codex/tasks/task_e_6843222a0ff883289e780dac4d6a5574