### PR TITLE
Add material icons extended dependency

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -57,6 +57,7 @@ dependencies {
     implementation("androidx.compose.ui:ui-tooling-preview:1.6.4")
     implementation("androidx.compose.runtime:runtime-livedata:1.6.4")
     implementation("androidx.navigation:navigation-compose:2.7.1")
+    implementation("androidx.compose.material:material-icons-extended:1.6.4")
 
     // Firebase
     implementation(platform("com.google.firebase:firebase-bom:33.14.0"))


### PR DESCRIPTION
## Summary
- include `material-icons-extended` for Compose icons

## Testing
- `./gradlew test` *(fails: Unable to tunnel through proxy)*

------
https://chatgpt.com/codex/tasks/task_e_6843299a3948832891fcb5db7c880da3