### PR TITLE
Fix LocalContext in passenger menu

### DIFF
--- a/app/src/main/java/com/ioannapergamali/mysmartroute/view/ui/components/TopBar.kt
+++ b/app/src/main/java/com/ioannapergamali/mysmartroute/view/ui/components/TopBar.kt
@@ -1,4 +1,4 @@
-package com.ioannapergamali.movewise.ui.components
+package com.ioannapergamali.mysmartroute.view.ui.components
 
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.automirrored.filled.List

--- a/app/src/main/java/com/ioannapergamali/mysmartroute/view/ui/screens/HomeScreen.kt
+++ b/app/src/main/java/com/ioannapergamali/mysmartroute/view/ui/screens/HomeScreen.kt
@@ -11,7 +11,7 @@ import androidx.compose.ui.graphics.graphicsLayer
 import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.unit.dp
 import androidx.navigation.NavController
-import com.ioannapergamali.movewise.ui.components.TopBar
+import com.ioannapergamali.mysmartroute.view.ui.components.TopBar
 import com.ioannapergamali.mysmartroute.R
 import com.ioannapergamali.mysmartroute.view.ui.animation.rememberBreathingAnimation
 import com.ioannapergamali.mysmartroute.view.ui.animation.rememberSlideFadeInAnimation

--- a/app/src/main/java/com/ioannapergamali/mysmartroute/view/ui/screens/LoginScreen.kt
+++ b/app/src/main/java/com/ioannapergamali/mysmartroute/view/ui/screens/LoginScreen.kt
@@ -9,7 +9,7 @@ import androidx.compose.ui.text.input.PasswordVisualTransformation
 import androidx.compose.ui.unit.dp
 import androidx.lifecycle.viewmodel.compose.viewModel
 import androidx.navigation.NavController
-import com.ioannapergamali.movewise.ui.components.TopBar
+import com.ioannapergamali.mysmartroute.view.ui.components.TopBar
 import com.ioannapergamali.mysmartroute.viewmodel.AuthenticationViewModel
 import android.widget.Toast
 import androidx.compose.ui.platform.LocalContext

--- a/app/src/main/java/com/ioannapergamali/mysmartroute/view/ui/screens/MenuScreen.kt
+++ b/app/src/main/java/com/ioannapergamali/mysmartroute/view/ui/screens/MenuScreen.kt
@@ -13,7 +13,7 @@ import androidx.lifecycle.viewmodel.compose.viewModel
 import androidx.compose.ui.platform.LocalContext
 import android.widget.Toast
 import androidx.navigation.NavController
-import com.ioannapergamali.movewise.ui.components.TopBar
+import com.ioannapergamali.mysmartroute.view.ui.components.TopBar
 import com.ioannapergamali.mysmartroute.model.enumerations.UserRole
 import com.ioannapergamali.mysmartroute.viewmodel.AuthenticationViewModel
 
@@ -64,6 +64,8 @@ fun MenuScreen(navController: NavController) {
 
 @Composable
 private fun PassengerMenu(viewModel: AuthenticationViewModel, navController: NavController) {
+    val context = LocalContext.current
+
     val actions = listOf(
         "Sign out",
         "Manage Favorite Means of Transport",
@@ -82,7 +84,7 @@ private fun PassengerMenu(viewModel: AuthenticationViewModel, navController: Nav
         when (index) {
             0 -> {
                 viewModel.signOut()
-                Toast.makeText(LocalContext.current, "Logged out", Toast.LENGTH_SHORT).show()
+                Toast.makeText(context, "Logged out", Toast.LENGTH_SHORT).show()
                 navController.navigate("home") {
                     popUpTo("menu") { inclusive = true }
                 }

--- a/app/src/main/java/com/ioannapergamali/mysmartroute/view/ui/screens/SignUpScreen.kt
+++ b/app/src/main/java/com/ioannapergamali/mysmartroute/view/ui/screens/SignUpScreen.kt
@@ -15,7 +15,7 @@ import androidx.lifecycle.viewmodel.compose.viewModel
 import androidx.navigation.NavController
 import androidx.compose.ui.platform.LocalContext
 import android.widget.Toast
-import com.ioannapergamali.movewise.ui.components.TopBar
+import com.ioannapergamali.mysmartroute.view.ui.components.TopBar
 import com.ioannapergamali.mysmartroute.model.enumerations.UserRole
 import com.ioannapergamali.mysmartroute.viewmodel.AuthenticationViewModel
 


### PR DESCRIPTION
## Summary
- access `LocalContext.current` inside `PassengerMenu` composable and reuse it in the click handler

## Testing
- `./gradlew test` *(fails: Unable to tunnel through proxy)*

------
https://chatgpt.com/codex/tasks/task_e_68433baa6bcc8328a373567fe6721a32