### PR TITLE
Add Material Icons dependency

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -57,6 +57,7 @@ dependencies {
     implementation("androidx.compose.ui:ui-tooling-preview:1.6.4")
     implementation("androidx.compose.runtime:runtime-livedata:1.6.4")
     implementation("androidx.navigation:navigation-compose:2.7.1")
+    // Provides additional Material icons such as `Logout`
     implementation("androidx.compose.material:material-icons-extended:1.6.4")
 
     // Firebase

--- a/app/src/main/java/com/ioannapergamali/mysmartroute/view/ui/components/TopBar.kt
+++ b/app/src/main/java/com/ioannapergamali/mysmartroute/view/ui/components/TopBar.kt
@@ -32,7 +32,7 @@ fun TopBar(
         actions = {
             if (showLogout) {
                 IconButton(onClick = onLogout) {
-                    Icon(Icons.Default.Logout, contentDescription = "logout")
+                    Icon(Icons.Filled.Logout, contentDescription = "logout")
                 }
             }
         }


### PR DESCRIPTION
## Summary
- ensure icons such as `Logout` are available by adding material icons extended dependency comment in `app/build.gradle.kts`
- use `Icons.Filled.Logout` explicitly in `TopBar`

## Testing
- `./gradlew test --no-daemon` *(fails: Unable to tunnel through proxy)*

------
https://chatgpt.com/codex/tasks/task_e_684347446d1483289fe7485fa3088db7