### PR TITLE
Implement transport announcement

### DIFF
--- a/app/src/main/java/com/ioannapergamali/mysmartroute/model/classes/transports/TransportAnnouncement.kt
+++ b/app/src/main/java/com/ioannapergamali/mysmartroute/model/classes/transports/TransportAnnouncement.kt
@@ -1,0 +1,17 @@
+package com.ioannapergamali.mysmartroute.model.classes.transports
+
+import com.ioannapergamali.mysmartroute.model.classes.routes.Route
+import com.ioannapergamali.mysmartroute.model.enumerations.VehicleType
+
+/**
+ * Represents a driver's availability for a specific transport.
+ */
+data class TransportAnnouncement(
+    val id: String,
+    val driverId: String,
+    val vehicleType: VehicleType,
+    val route: Route,
+    val date: Int,
+    val cost: Double,
+    val durationMinutes: Int
+)

--- a/app/src/main/java/com/ioannapergamali/mysmartroute/model/navigation/NavigationHost.kt
+++ b/app/src/main/java/com/ioannapergamali/mysmartroute/model/navigation/NavigationHost.kt
@@ -9,6 +9,7 @@ import com.ioannapergamali.mysmartroute.view.ui.screens.SignUpScreen
 import com.ioannapergamali.mysmartroute.view.ui.screens.LoginScreen
 import com.ioannapergamali.mysmartroute.view.ui.screens.MenuScreen
 import com.ioannapergamali.mysmartroute.view.ui.screens.RegisterVehicleScreen
+import com.ioannapergamali.mysmartroute.view.ui.screens.AnnounceTransportScreen
 
 
 
@@ -58,6 +59,10 @@ fun NavigationHost(navController : NavHostController) {
 
         composable("registerVehicle") {
             RegisterVehicleScreen(navController = navController)
+        }
+
+        composable("announceTransport") {
+            AnnounceTransportScreen(navController = navController)
         }
 
 

--- a/app/src/main/java/com/ioannapergamali/mysmartroute/view/ui/screens/AnnounceTransportScreen.kt
+++ b/app/src/main/java/com/ioannapergamali/mysmartroute/view/ui/screens/AnnounceTransportScreen.kt
@@ -1,0 +1,73 @@
+package com.ioannapergamali.mysmartroute.view.ui.screens
+
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.material3.Button
+import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.Text
+import androidx.compose.material3.TextField
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.collectAsState
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.unit.dp
+import androidx.lifecycle.viewmodel.compose.viewModel
+import androidx.navigation.NavController
+import com.ioannapergamali.mysmartroute.model.classes.routes.Route
+import com.ioannapergamali.mysmartroute.model.enumerations.VehicleType
+import com.ioannapergamali.mysmartroute.view.ui.components.TopBar
+import com.ioannapergamali.mysmartroute.viewmodel.TransportAnnouncementViewModel
+
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+fun AnnounceTransportScreen(navController: NavController) {
+    val viewModel: TransportAnnouncementViewModel = viewModel()
+    val state by viewModel.state.collectAsState()
+
+    var start by remember { mutableStateOf("") }
+    var end by remember { mutableStateOf("") }
+    var costInput by remember { mutableStateOf("") }
+    var durationInput by remember { mutableStateOf("") }
+    var dateInput by remember { mutableStateOf("") }
+
+    Column(modifier = Modifier.fillMaxSize().padding(16.dp)) {
+        TopBar(title = "Announce Transport", navController = navController)
+        Spacer(modifier = Modifier.height(16.dp))
+        TextField(value = start, onValueChange = { start = it }, label = { Text("From") })
+        Spacer(modifier = Modifier.height(8.dp))
+        TextField(value = end, onValueChange = { end = it }, label = { Text("To") })
+        Spacer(modifier = Modifier.height(8.dp))
+        TextField(value = costInput, onValueChange = { costInput = it }, label = { Text("Cost") })
+        Spacer(modifier = Modifier.height(8.dp))
+        TextField(value = durationInput, onValueChange = { durationInput = it }, label = { Text("Duration (min)") })
+        Spacer(modifier = Modifier.height(8.dp))
+        TextField(value = dateInput, onValueChange = { dateInput = it }, label = { Text("Date") })
+        Spacer(modifier = Modifier.height(16.dp))
+        Button(onClick = {
+            val cost = costInput.toDoubleOrNull() ?: 0.0
+            val duration = durationInput.toIntOrNull() ?: 0
+            val date = dateInput.toIntOrNull() ?: 0
+            val route = Route(start, end, cost)
+            viewModel.announce(route, VehicleType.CAR, date, cost, duration)
+        }) {
+            Text("Announce")
+        }
+
+        if (state is TransportAnnouncementViewModel.AnnouncementState.Error) {
+            Spacer(modifier = Modifier.height(8.dp))
+            Text(text = (state as TransportAnnouncementViewModel.AnnouncementState.Error).message)
+        }
+    }
+
+    LaunchedEffect(state) {
+        if (state is TransportAnnouncementViewModel.AnnouncementState.Success) {
+            navController.popBackStack()
+        }
+    }
+}

--- a/app/src/main/java/com/ioannapergamali/mysmartroute/view/ui/screens/MenuScreen.kt
+++ b/app/src/main/java/com/ioannapergamali/mysmartroute/view/ui/screens/MenuScreen.kt
@@ -107,6 +107,7 @@ private fun DriverMenu(navController: NavController) {
     MenuTable(actions) { index ->
         when (index) {
             0 -> navController.navigate("registerVehicle")
+            1 -> navController.navigate("announceTransport")
             // TODO: handle other driver actions
         }
     }

--- a/app/src/main/java/com/ioannapergamali/mysmartroute/viewmodel/TransportAnnouncementViewModel.kt
+++ b/app/src/main/java/com/ioannapergamali/mysmartroute/viewmodel/TransportAnnouncementViewModel.kt
@@ -1,0 +1,59 @@
+package com.ioannapergamali.mysmartroute.viewmodel
+
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.viewModelScope
+import com.google.firebase.auth.FirebaseAuth
+import com.ioannapergamali.mysmartroute.model.classes.routes.Route
+import com.ioannapergamali.mysmartroute.model.classes.transports.TransportAnnouncement
+import com.ioannapergamali.mysmartroute.model.enumerations.VehicleType
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.launch
+import java.util.UUID
+
+/**
+ * ViewModel to handle creation of transport availability announcements.
+ */
+class TransportAnnouncementViewModel : ViewModel() {
+    private val auth = FirebaseAuth.getInstance()
+
+    private val _state = MutableStateFlow<AnnouncementState>(AnnouncementState.Idle)
+    val state: StateFlow<AnnouncementState> = _state
+
+    private val _announcements = MutableStateFlow<List<TransportAnnouncement>>(emptyList())
+    val announcements: StateFlow<List<TransportAnnouncement>> = _announcements
+
+    fun announce(route: Route, vehicleType: VehicleType, date: Int, cost: Double, durationMinutes: Int) {
+        viewModelScope.launch {
+            val userId = auth.currentUser?.uid
+            if (userId == null) {
+                _state.value = AnnouncementState.Error("User not logged in")
+                return@launch
+            }
+
+            if (cost <= 0 || durationMinutes <= 0) {
+                _state.value = AnnouncementState.Error("Invalid cost or duration")
+                return@launch
+            }
+
+            val announcement = TransportAnnouncement(
+                id = UUID.randomUUID().toString(),
+                driverId = userId,
+                vehicleType = vehicleType,
+                route = route,
+                date = date,
+                cost = cost,
+                durationMinutes = durationMinutes
+            )
+
+            _announcements.value = _announcements.value + announcement
+            _state.value = AnnouncementState.Success
+        }
+    }
+
+    sealed class AnnouncementState {
+        object Idle : AnnouncementState()
+        object Success : AnnouncementState()
+        data class Error(val message: String) : AnnouncementState()
+    }
+}


### PR DESCRIPTION
## Summary
- add `TransportAnnouncement` data model
- implement `TransportAnnouncementViewModel`
- create `AnnounceTransportScreen` for drivers
- hook announcement screen into navigation and menu

## Testing
- `./gradlew test` *(fails: Unable to tunnel through proxy, 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_68435e390f1c8328bf5aeed22b85cd4f