### PR TITLE
Integrate Google Maps in transport announcement

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -70,6 +70,14 @@ dependencies {
     implementation(libs.androidx.room.ktx)
     kapt(libs.androidx.room.compiler)
 
+    // Google Maps
+    implementation("com.google.android.gms:play-services-maps:18.2.0")
+    implementation("com.google.maps.android:maps-compose:2.11.4")
+    implementation("com.google.android.gms:play-services-location:21.0.1")
+
+    // Networking for Directions API
+    implementation("com.squareup.okhttp3:okhttp:4.10.0")
+
     // Testing
     testImplementation("junit:junit:4.13.2")
     androidTestImplementation("androidx.test.ext:junit:1.1.5")

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -2,6 +2,9 @@
 <manifest xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:tools="http://schemas.android.com/tools">
 
+    <uses-permission android:name="android.permission.INTERNET" />
+    <uses-permission android:name="android.permission.ACCESS_FINE_LOCATION" />
+
     <application
         android:allowBackup="true"
         android:dataExtractionRules="@xml/data_extraction_rules"
@@ -12,6 +15,9 @@
         android:supportsRtl="true"
         android:theme="@style/Theme.Mysmartroute"
         tools:targetApi="31">
+        <meta-data
+            android:name="com.google.android.geo.API_KEY"
+            android:value="@string/google_maps_key" />
         <activity
             android:name=".viewmodel.MainActivity"
             android:exported="true">

--- a/app/src/main/java/com/ioannapergamali/mysmartroute/utils/MapsUtils.kt
+++ b/app/src/main/java/com/ioannapergamali/mysmartroute/utils/MapsUtils.kt
@@ -1,0 +1,37 @@
+package com.ioannapergamali.mysmartroute.utils
+
+import com.google.android.gms.maps.model.LatLng
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.withContext
+import okhttp3.OkHttpClient
+import okhttp3.Request
+import org.json.JSONObject
+
+object MapsUtils {
+    private val client = OkHttpClient()
+
+    private fun buildDirectionsUrl(origin: LatLng, destination: LatLng, apiKey: String): String {
+        val originParam = "${origin.latitude},${origin.longitude}"
+        val destParam = "${destination.latitude},${destination.longitude}"
+        return "https://maps.googleapis.com/maps/api/directions/json?origin=$originParam&destination=$destParam&key=$apiKey"
+    }
+
+    private fun parseDuration(json: String): Int {
+        val jsonObj = JSONObject(json)
+        val routes = jsonObj.getJSONArray("routes")
+        if (routes.length() == 0) return 0
+        val legs = routes.getJSONObject(0).getJSONArray("legs")
+        if (legs.length() == 0) return 0
+        val durationSec = legs.getJSONObject(0).getJSONObject("duration").getInt("value")
+        return durationSec / 60
+    }
+
+    suspend fun fetchDuration(origin: LatLng, destination: LatLng, apiKey: String): Int = withContext(Dispatchers.IO) {
+        val request = Request.Builder().url(buildDirectionsUrl(origin, destination, apiKey)).build()
+        client.newCall(request).execute().use { response ->
+            if (!response.isSuccessful) return@withContext 0
+            val body = response.body?.string() ?: return@withContext 0
+            return@withContext parseDuration(body)
+        }
+    }
+}

--- a/app/src/main/java/com/ioannapergamali/mysmartroute/view/ui/screens/AnnounceTransportScreen.kt
+++ b/app/src/main/java/com/ioannapergamali/mysmartroute/view/ui/screens/AnnounceTransportScreen.kt
@@ -17,7 +17,13 @@ import androidx.compose.runtime.setValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.unit.dp
+import com.google.maps.android.compose.GoogleMap
+import com.google.maps.android.compose.Marker
+import com.google.maps.android.compose.rememberCameraPositionState
+import com.google.android.gms.maps.model.CameraPosition
+import com.google.android.gms.maps.model.LatLng
 import androidx.lifecycle.viewmodel.compose.viewModel
 import androidx.navigation.NavController
 import com.ioannapergamali.mysmartroute.model.classes.routes.Route
@@ -31,31 +37,63 @@ fun AnnounceTransportScreen(navController: NavController) {
     val viewModel: TransportAnnouncementViewModel = viewModel()
     val state by viewModel.state.collectAsState()
 
-    var start by remember { mutableStateOf("") }
-    var end by remember { mutableStateOf("") }
+    val context = LocalContext.current
+
+    var startLatLng by remember { mutableStateOf<LatLng?>(null) }
+    var endLatLng by remember { mutableStateOf<LatLng?>(null) }
     var costInput by remember { mutableStateOf("") }
-    var durationInput by remember { mutableStateOf("") }
+    var durationMinutes by remember { mutableStateOf(0) }
     var dateInput by remember { mutableStateOf("") }
+
+    val cameraPositionState = rememberCameraPositionState {
+        position = CameraPosition.fromLatLngZoom(LatLng(37.9838, 23.7275), 9f)
+    }
+
+    LaunchedEffect(startLatLng, endLatLng) {
+        if (startLatLng != null && endLatLng != null) {
+            // Replace with your real API key
+            val apiKey = context.getString(R.string.google_maps_key)
+            durationMinutes = MapsUtils.fetchDuration(startLatLng!!, endLatLng!!, apiKey)
+        }
+    }
 
     Column(modifier = Modifier.fillMaxSize().padding(16.dp)) {
         TopBar(title = "Announce Transport", navController = navController)
         Spacer(modifier = Modifier.height(16.dp))
-        TextField(value = start, onValueChange = { start = it }, label = { Text("From") })
-        Spacer(modifier = Modifier.height(8.dp))
-        TextField(value = end, onValueChange = { end = it }, label = { Text("To") })
+
+        GoogleMap(
+            modifier = Modifier.weight(1f),
+            cameraPositionState = cameraPositionState,
+            onMapClick = { latLng ->
+                if (startLatLng == null) {
+                    startLatLng = latLng
+                    cameraPositionState.position = CameraPosition.fromLatLngZoom(latLng, 10f)
+                } else if (endLatLng == null) {
+                    endLatLng = latLng
+                } else {
+                    startLatLng = latLng
+                    endLatLng = null
+                }
+            }
+        ) {
+            startLatLng?.let { Marker(position = it, title = "From") }
+            endLatLng?.let { Marker(position = it, title = "To") }
+        }
+
         Spacer(modifier = Modifier.height(8.dp))
         TextField(value = costInput, onValueChange = { costInput = it }, label = { Text("Cost") })
         Spacer(modifier = Modifier.height(8.dp))
-        TextField(value = durationInput, onValueChange = { durationInput = it }, label = { Text("Duration (min)") })
+        Text(text = "Duration: $durationMinutes min")
         Spacer(modifier = Modifier.height(8.dp))
         TextField(value = dateInput, onValueChange = { dateInput = it }, label = { Text("Date") })
         Spacer(modifier = Modifier.height(16.dp))
         Button(onClick = {
             val cost = costInput.toDoubleOrNull() ?: 0.0
-            val duration = durationInput.toIntOrNull() ?: 0
             val date = dateInput.toIntOrNull() ?: 0
+            val start = startLatLng?.let { "${it.latitude},${it.longitude}" } ?: ""
+            val end = endLatLng?.let { "${it.latitude},${it.longitude}" } ?: ""
             val route = Route(start, end, cost)
-            viewModel.announce(route, VehicleType.CAR, date, cost, duration)
+            viewModel.announce(route, VehicleType.CAR, date, cost, durationMinutes)
         }) {
             Text("Announce")
         }

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -1,3 +1,4 @@
 <resources>
     <string name="app_name">mysmartroute</string>
+    <string name="google_maps_key">YOUR_API_KEY</string>
 </resources>


### PR DESCRIPTION
## Summary
- enable Google Maps dependencies and OkHttp
- store Google API key placeholder
- request Internet and location permissions
- add new `MapsUtils` helper for duration via Directions API
- update `AnnounceTransportScreen` to pick start and end from a map and auto-calc duration

## Testing
- `./gradlew test` *(fails: Unable to tunnel through proxy)*

------
https://chatgpt.com/codex/tasks/task_e_684369e3ea608328b818c261458e059a