### PR TITLE
Fix Compose compiler configuration

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -3,7 +3,7 @@ plugins {
     id("com.android.application")
     id("com.google.gms.google-services")
     id("org.jetbrains.kotlin.android")
-    // Compose plugin is not required here
+    id("org.jetbrains.kotlin.plugin.compose")
 
 }
 
@@ -45,9 +45,6 @@ dependencies {
     implementation("com.google.android.material:material:1.10.0")
     implementation("androidx.activity:activity-ktx:1.8.0")
     implementation("androidx.constraintlayout:constraintlayout:2.1.4")
-
-    // Compose Compiler plugin συμβατός με Kotlin 2.1.0
-    implementation("androidx.compose.compiler:compiler:1.5.11")
 
     // Jetpack Compose
     implementation("androidx.compose.material3:material3:1.2.1")

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -1,10 +1,8 @@
 // Top-level build file where you can add configuration options common to all sub-projects/modules.
 
-    plugins {
-        id("com.android.application") version "8.9.2" apply false
-        id("org.jetbrains.kotlin.android") version "2.0.0" apply false
-        //id("org.jetbrains.kotlin.plugin.compose") version "1.5.11" apply false
-    // Compose plugin is not required for this project
-
-        id("com.google.gms.google-services") version "4.4.2" apply false
-    }
+plugins {
+    id("com.android.application") version "8.9.2" apply false
+    id("org.jetbrains.kotlin.android") version "2.0.0" apply false
+    id("org.jetbrains.kotlin.plugin.compose") version "1.5.11" apply false
+    id("com.google.gms.google-services") version "4.4.2" apply false
+}


### PR DESCRIPTION
## Summary
- enable Compose compiler plugin
- configure app module to use the Compose plugin
- remove manual dependency on Compose compiler

## Testing
- `./gradlew assembleDebug` *(fails: Unable to tunnel through proxy)*

------
https://chatgpt.com/codex/tasks/task_e_6843725d56248328984a8790fc3df553