### PR TITLE
Improve map screen when API key missing

### DIFF
--- a/app/src/main/java/com/ioannapergamali/mysmartroute/view/ui/screens/AnnounceTransportScreen.kt
+++ b/app/src/main/java/com/ioannapergamali/mysmartroute/view/ui/screens/AnnounceTransportScreen.kt
@@ -19,6 +19,7 @@ import androidx.compose.runtime.remember
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.unit.dp
+import androidx.compose.ui.res.stringResource
 import com.google.maps.android.compose.GoogleMap
 import com.google.maps.android.compose.Marker
 import com.google.maps.android.compose.rememberCameraPositionState
@@ -52,10 +53,11 @@ fun AnnounceTransportScreen(navController: NavController) {
         position = CameraPosition.fromLatLngZoom(LatLng(37.9838, 23.7275), 9f)
     }
 
+    val apiKey = context.getString(R.string.google_maps_key)
+    val isKeyMissing = apiKey.isBlank() || apiKey == "YOUR_API_KEY"
+
     LaunchedEffect(startLatLng, endLatLng) {
-        if (startLatLng != null && endLatLng != null) {
-            // Replace with your real API key
-            val apiKey = context.getString(R.string.google_maps_key)
+        if (!isKeyMissing && startLatLng != null && endLatLng != null) {
             durationMinutes = MapsUtils.fetchDuration(startLatLng!!, endLatLng!!, apiKey)
         }
     }
@@ -64,26 +66,30 @@ fun AnnounceTransportScreen(navController: NavController) {
         TopBar(title = "Announce Transport", navController = navController)
         Spacer(modifier = Modifier.height(16.dp))
 
-        GoogleMap(
-            modifier = Modifier.weight(1f),
-            cameraPositionState = cameraPositionState,
-            onMapClick = { latLng ->
-                if (startLatLng == null) {
-                    startLatLng = latLng
-                    cameraPositionState.position = CameraPosition.fromLatLngZoom(latLng, 10f)
-                } else if (endLatLng == null) {
-                    endLatLng = latLng
-                } else {
-                    startLatLng = latLng
-                    endLatLng = null
+        if (isKeyMissing) {
+            Text(text = stringResource(R.string.map_api_key_missing))
+        } else {
+            GoogleMap(
+                modifier = Modifier.weight(1f),
+                cameraPositionState = cameraPositionState,
+                onMapClick = { latLng ->
+                    if (startLatLng == null) {
+                        startLatLng = latLng
+                        cameraPositionState.position = CameraPosition.fromLatLngZoom(latLng, 10f)
+                    } else if (endLatLng == null) {
+                        endLatLng = latLng
+                    } else {
+                        startLatLng = latLng
+                        endLatLng = null
+                    }
                 }
-            }
-        ) {
-            startLatLng?.let {
-                Marker(state = rememberMarkerState(position = it), title = "From")
-            }
-            endLatLng?.let {
-                Marker(state = rememberMarkerState(position = it), title = "To")
+            ) {
+                startLatLng?.let {
+                    Marker(state = rememberMarkerState(position = it), title = "From")
+                }
+                endLatLng?.let {
+                    Marker(state = rememberMarkerState(position = it), title = "To")
+                }
             }
         }
 

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -1,4 +1,5 @@
 <resources>
     <string name="app_name">mysmartroute</string>
     <string name="google_maps_key">YOUR_API_KEY</string>
+    <string name="map_api_key_missing">Google Maps API key is missing. Please set 'google_maps_key' in res/values/strings.xml</string>
 </resources>


### PR DESCRIPTION
## Summary
- add user-facing message when the Google Maps API key is not set
- guard AnnounceTransportScreen against missing API key

## Testing
- `./gradlew test` *(fails: Unable to tunnel through proxy)*

------
https://chatgpt.com/codex/tasks/task_e_68437ce4485083289ac29b91e7c8385c