### PR TITLE
Fix invalid map API key message

### DIFF
--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -1,5 +1,6 @@
 <resources>
     <string name="app_name">mysmartroute</string>
     <string name="google_maps_key">YOUR_API_KEY</string>
-    <string name="map_api_key_missing">Google Maps API key is missing. Please set 'google_maps_key' in res/values/strings.xml</string>
+    <!-- Escape single quotes to avoid aapt compile errors on some versions -->
+    <string name="map_api_key_missing">Google Maps API key is missing. Please set &#39;google_maps_key&#39; in res/values/strings.xml</string>
 </resources>


### PR DESCRIPTION
## Summary
- escape apostrophe inside `map_api_key_missing` to avoid aapt errors

## Testing
- `./gradlew help` *(fails: Unable to tunnel through proxy)*

------
https://chatgpt.com/codex/tasks/task_e_68437df351c48328833983fb0cfbbf67