### PR TITLE
Fix resource compilation by adding XML headers

### DIFF
--- a/app/src/main/res/values-night/themes.xml
+++ b/app/src/main/res/values-night/themes.xml
@@ -1,3 +1,4 @@
+<?xml version="1.0" encoding="utf-8"?>
 <resources xmlns:tools="http://schemas.android.com/tools">
     <!-- Base application theme. -->
     <style name="Base.Theme.Mysmartroute" parent="Theme.Material3.DayNight.NoActionBar">

--- a/app/src/main/res/values/themes.xml
+++ b/app/src/main/res/values/themes.xml
@@ -1,3 +1,4 @@
+<?xml version="1.0" encoding="utf-8"?>
 <resources xmlns:tools="http://schemas.android.com/tools">
     <!-- Base application theme. -->
     <style name="Base.Theme.Mysmartroute" parent="Theme.Material3.DayNight.NoActionBar">


### PR DESCRIPTION
## Summary
- add explicit XML declarations to both theme resource files

## Testing
- `./gradlew test` *(fails: Unable to tunnel through proxy)*

------
https://chatgpt.com/codex/tasks/task_e_68438e0b59a48328a1f670f11bbc8f82