### PR TITLE
Add local material aar support

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -3,8 +3,14 @@ plugins {
     id("com.android.application")
     id("com.google.gms.google-services")
     id("org.jetbrains.kotlin.android")
-
 }
+
+repositories {
+    flatDir {
+        dirs("libs")
+    }
+}
+
 
 android {
     namespace = "com.ioannapergamali.mysmartroute"
@@ -41,7 +47,8 @@ android {
 dependencies {
     implementation("androidx.core:core-ktx:1.12.0")
     implementation("androidx.appcompat:appcompat:1.6.1")
-    implementation("com.google.android.material:material:1.11.0")
+    // Use local AAR since the build environment lacks internet access
+    implementation(files("libs/material-1.11.1.aar"))
     implementation("androidx.activity:activity-ktx:1.8.0")
     implementation("androidx.constraintlayout:constraintlayout:2.1.4")
 


### PR DESCRIPTION
## Summary
- configure `flatDir` repository to load AARs from `app/libs`
- use local `material-1.11.1.aar` instead of remote `material:1.11.0`
- fix Kotlin DSL syntax for including local AAR

## Testing
- `./gradlew tasks --offline` *(fails: Unable to tunnel through proxy)*

------
https://chatgpt.com/codex/tasks/task_e_684392aa4ac8832881a6e0bb4b516b46