### PR TITLE
Fix gradle repos error

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -5,11 +5,6 @@ plugins {
     id("org.jetbrains.kotlin.android")
 }
 
-repositories {
-    flatDir {
-        dirs("libs")
-    }
-}
 
 
 android {


### PR DESCRIPTION
## Summary
- remove the `flatDir` repository from `app/build.gradle.kts`

This resolves the failure when Gradle is configured to disallow project-level repositories.

## Testing
- `./gradlew test` *(fails: Unable to tunnel through proxy)*

------
https://chatgpt.com/codex/tasks/task_e_6844654ca9d0832886166cf4eb0691ee