### PR TITLE
Fix dependency version

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -42,7 +42,7 @@ android {
 dependencies {
     implementation("androidx.core:core-ktx:1.12.0")
     implementation("androidx.appcompat:appcompat:1.6.1")
-    implementation("com.google.android.material:material:1.11.1")
+    implementation("com.google.android.material:material:1.11.0")
     implementation("androidx.activity:activity-ktx:1.8.0")
     implementation("androidx.constraintlayout:constraintlayout:2.1.4")
 


### PR DESCRIPTION
## Summary
- fix Google Material dependency version so Gradle can resolve it

## Testing
- `./gradlew --version` *(fails: Unable to tunnel through proxy)*

------
https://chatgpt.com/codex/tasks/task_e_6844660f0d648328b6638d100cd4d083