### PR TITLE
Fix Google Maps missing key string

### DIFF
--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -1,6 +1,6 @@
 <resources>
     <string name="app_name">mysmartroute</string>
     <string name="google_maps_key">YOUR_API_KEY</string>
-    <!-- Escape single quotes to avoid aapt compile errors on some versions -->
-    <string name="map_api_key_missing">Google Maps API key is missing. Please set &#39;google_maps_key&#39; in res/values/strings.xml</string>
+    <!-- Displayed when no Google Maps API key is provided -->
+    <string name="map_api_key_missing">Google Maps API key is missing. Please set 'google_maps_key' in res/values/strings.xml</string>
 </resources>


### PR DESCRIPTION
## Summary
- escape HTML character not needed for missing key string

## Testing
- `./gradlew test` *(fails: Unable to tunnel through proxy)*

------
https://chatgpt.com/codex/tasks/task_e_6844671f9ba48328962c0868254bcc03