### PR TITLE
Fix map API key string escape issue

### DIFF
--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -2,5 +2,5 @@
     <string name="app_name">mysmartroute</string>
     <string name="google_maps_key">YOUR_API_KEY</string>
     <!-- Displayed when no Google Maps API key is provided -->
-    <string name="map_api_key_missing">Google Maps API key is missing. Please set 'google_maps_key' in res/values/strings.xml</string>
+    <string name="map_api_key_missing">Google Maps API key is missing. Please set &#39;google_maps_key&#39; in res/values/strings.xml</string>
 </resources>


### PR DESCRIPTION
## Summary
- escape apostrophes in `map_api_key_missing` string resource

## Testing
- `gradlew -v` *(fails: Unable to tunnel through proxy)*

------
https://chatgpt.com/codex/tasks/task_e_684468767c308328a041c74f4eb7c8ef