### PR TITLE
Fix map API key missing string

### DIFF
--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -2,5 +2,6 @@
     <string name="app_name">mysmartroute</string>
     <string name="google_maps_key">YOUR_API_KEY</string>
     <!-- Displayed when no Google Maps API key is provided -->
-    <string name="map_api_key_missing">Google Maps API key is missing. Please set &#39;google_maps_key&#39; in res/values/strings.xml</string>
+    <!-- Avoid HTML character references that can trigger resource compilation issues -->
+    <string name="map_api_key_missing">Google Maps API key is missing. Please set 'google_maps_key' in res/values/strings.xml</string>
 </resources>


### PR DESCRIPTION
## Summary
- escape HTML entity in missing key string to avoid Unicode errors

## Testing
- `gradle :app:assembleDebug --console=plain --no-daemon` *(fails: Plugin [id: 'com.android.application', version: '8.9.2'] not found)*

------
https://chatgpt.com/codex/tasks/task_e_684471abe9f08328b276d1e8016b0748