### PR TITLE
Add address dropdowns and vehicle selection

### DIFF
--- a/app/src/main/java/com/ioannapergamali/mysmartroute/viewmodel/VehicleViewModel.kt
+++ b/app/src/main/java/com/ioannapergamali/mysmartroute/viewmodel/VehicleViewModel.kt
@@ -18,6 +18,9 @@ class VehicleViewModel : ViewModel() {
     private val db = FirebaseFirestore.getInstance()
     private val auth = FirebaseAuth.getInstance()
 
+    private val _vehicles = MutableStateFlow<List<VehicleEntity>>(emptyList())
+    val vehicles: StateFlow<List<VehicleEntity>> = _vehicles
+
     private val _registerState = MutableStateFlow<RegisterState>(RegisterState.Idle)
     val registerState: StateFlow<RegisterState> = _registerState
 
@@ -68,6 +71,14 @@ class VehicleViewModel : ViewModel() {
                 dao.insert(entity)
                 _registerState.value = RegisterState.Success
             }
+        }
+    }
+
+    fun loadRegisteredVehicles(context: Context) {
+        viewModelScope.launch {
+            val userId = auth.currentUser?.uid ?: return@launch
+            val dao = MySmartRouteDatabase.getInstance(context).vehicleDao()
+            _vehicles.value = dao.getVehiclesForUser(userId)
         }
     }
 


### PR DESCRIPTION
## Summary
- load vehicles from DB in `VehicleViewModel`
- allow address autocomplete using Geocoder
- add dropdown menus for picking start, end and vehicle
- use selected vehicle type when announcing transport

## Testing
- `./gradlew test` *(fails: Unable to tunnel through proxy)*

------
https://chatgpt.com/codex/tasks/task_e_6845eb6eb1c08328896ae98ba65dc40d