### PR TITLE
Show vehicle-specific route

### DIFF
--- a/app/src/main/java/com/ioannapergamali/mysmartroute/view/ui/screens/AnnounceTransportScreen.kt
+++ b/app/src/main/java/com/ioannapergamali/mysmartroute/view/ui/screens/AnnounceTransportScreen.kt
@@ -91,7 +91,8 @@ fun AnnounceTransportScreen(navController: NavController) {
 
     LaunchedEffect(startLatLng, endLatLng, selectedVehicleType) {
         if (!isKeyMissing && startLatLng != null && endLatLng != null) {
-            val result = MapsUtils.fetchDurationAndPath(startLatLng!!, endLatLng!!, apiKey)
+            val type = selectedVehicleType ?: VehicleType.CAR
+            val result = MapsUtils.fetchDurationAndPath(startLatLng!!, endLatLng!!, apiKey, type)
             val factor = when (selectedVehicleType) {
                 VehicleType.BICYCLE -> 1.5
                 VehicleType.MOTORBIKE -> 0.8


### PR DESCRIPTION
## Summary
- support vehicle-specific travel modes when querying Google Directions
- show path for chosen vehicle in AnnounceTransportScreen

## Testing
- `./gradlew test --quiet` *(fails: Unable to tunnel through proxy)*

------
https://chatgpt.com/codex/tasks/task_e_6845f9661ec0832891d104682637ac1b