### PR TITLE
Embed interactive directions

### DIFF
--- a/app/src/main/java/com/ioannapergamali/mysmartroute/model/navigation/NavigationHost.kt
+++ b/app/src/main/java/com/ioannapergamali/mysmartroute/model/navigation/NavigationHost.kt
@@ -4,12 +4,14 @@ import androidx.compose.runtime.Composable
 import androidx.navigation.NavHostController
 import androidx.navigation.compose.NavHost
 import androidx.navigation.compose.composable
+import androidx.navigation.navArgument
 import com.ioannapergamali.mysmartroute.view.ui.screens.HomeScreen
 import com.ioannapergamali.mysmartroute.view.ui.screens.SignUpScreen
 import com.ioannapergamali.mysmartroute.view.ui.screens.LoginScreen
 import com.ioannapergamali.mysmartroute.view.ui.screens.MenuScreen
 import com.ioannapergamali.mysmartroute.view.ui.screens.RegisterVehicleScreen
 import com.ioannapergamali.mysmartroute.view.ui.screens.AnnounceTransportScreen
+import com.ioannapergamali.mysmartroute.view.ui.screens.DirectionsMapScreen
 
 
 
@@ -63,6 +65,18 @@ fun NavigationHost(navController : NavHostController) {
 
         composable("announceTransport") {
             AnnounceTransportScreen(navController = navController)
+        }
+
+        composable(
+            route = "directionsMap/{start}/{end}",
+            arguments = listOf(
+                navArgument("start") { defaultValue = "" },
+                navArgument("end") { defaultValue = "" }
+            )
+        ) { backStackEntry ->
+            val start = backStackEntry.arguments?.getString("start") ?: ""
+            val end = backStackEntry.arguments?.getString("end") ?: ""
+            DirectionsMapScreen(navController = navController, start = start, end = end)
         }
 
 

--- a/app/src/main/java/com/ioannapergamali/mysmartroute/view/ui/screens/AnnounceTransportScreen.kt
+++ b/app/src/main/java/com/ioannapergamali/mysmartroute/view/ui/screens/AnnounceTransportScreen.kt
@@ -169,6 +169,17 @@ fun AnnounceTransportScreen(navController: NavController) {
                     Polyline(points = routePoints)
                 }
             }
+
+            if (startLatLng != null && endLatLng != null) {
+                val start = "${'$'}{startLatLng!!.latitude},${'$'}{startLatLng!!.longitude}"
+                val end = "${'$'}{endLatLng!!.latitude},${'$'}{endLatLng!!.longitude}"
+                Spacer(modifier = Modifier.height(8.dp))
+                Button(onClick = {
+                    navController.navigate("directionsMap/${'$'}start/${'$'}end")
+                }) {
+                    Text("View Directions Map")
+                }
+            }
         }
 
         Spacer(modifier = Modifier.height(8.dp))

--- a/app/src/main/java/com/ioannapergamali/mysmartroute/view/ui/screens/DirectionsMapScreen.kt
+++ b/app/src/main/java/com/ioannapergamali/mysmartroute/view/ui/screens/DirectionsMapScreen.kt
@@ -1,0 +1,40 @@
+package com.ioannapergamali.mysmartroute.view.ui.screens
+
+import android.webkit.WebView
+import android.webkit.WebViewClient
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.padding
+import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.Scaffold
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.viewinterop.AndroidView
+import androidx.navigation.NavController
+import com.ioannapergamali.mysmartroute.view.ui.components.TopBar
+
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+fun DirectionsMapScreen(
+    navController: NavController,
+    start: String,
+    end: String
+) {
+    Scaffold(
+        topBar = {
+            TopBar(title = "Directions", navController = navController)
+        }
+    ) { paddingValues ->
+        AndroidView(
+            factory = { context ->
+                WebView(context).apply {
+                    webViewClient = WebViewClient()
+                    settings.javaScriptEnabled = true
+                    loadUrl("https://www.google.com/maps/dir/$start/$end")
+                }
+            },
+            modifier = Modifier
+                .fillMaxSize()
+                .padding(paddingValues)
+        )
+    }
+}


### PR DESCRIPTION
## Summary
- add `DirectionsMapScreen` that shows google.com/maps directions in a WebView
- allow navigating to this screen from `AnnounceTransportScreen`
- register the new screen in `NavigationHost`

## Testing
- `./gradlew test` *(fails: Unable to tunnel through proxy)*

------
https://chatgpt.com/codex/tasks/task_e_6845fe9818308328a707ba8a86b30cac