### PR TITLE
Fix build by using stable SDK level

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -9,12 +9,13 @@ plugins {
 
 android {
     namespace = "com.ioannapergamali.mysmartroute"
-    compileSdk = 35
+    // Η τρέχουσα σταθερή έκδοση του Android SDK
+    compileSdk = 34
 
     defaultConfig {
         applicationId = "com.ioannapergamali.mysmartroute"
         minSdk = 33
-        targetSdk = 35
+        targetSdk = 34
         versionCode = 1
         versionName = "1.0"
 


### PR DESCRIPTION
## Summary
- update `compileSdk` and `targetSdk` to API 34 in the app module

## Testing
- `gradlew assembleDebug` *(fails: Android SDK not available)*

------
https://chatgpt.com/codex/tasks/task_e_6846b8749ee08328bff7ea0072742360