### PR TITLE
Fix compile SDK mismatch

### DIFF
--- a/.github/workflows/android.yml
+++ b/.github/workflows/android.yml
@@ -25,7 +25,7 @@ jobs:
       - name: Set up Android SDK
         uses: android-actions/setup-android@v2
         with:
-          api-level: 33
+          api-level: 36
           ndk: false
 
       # 4) Τρέξε το Gradle build + tests

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -9,13 +9,13 @@ plugins {
 
 android {
     namespace = "com.ioannapergamali.mysmartroute"
-    // Η τρέχουσα σταθερή έκδοση του Android SDK
-    compileSdk = 34
+    // Χρησιμοποιούμε την πιο πρόσφατη έκδοση του Android SDK
+    compileSdk = 36
 
     defaultConfig {
         applicationId = "com.ioannapergamali.mysmartroute"
         minSdk = 33
-        targetSdk = 34
+        targetSdk = 36
         versionCode = 1
         versionName = "1.0"
 


### PR DESCRIPTION
## Summary
- bump compile and target SDK to 36
- update CI to use Android API level 36

## Testing
- `./gradlew clean assembleDebug test --no-daemon` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_6846cc330b7483288532b8ded9f27c1d