### PR TITLE
Fix resource compilation by limiting locales

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -20,6 +20,9 @@ android {
         versionName = "1.0"
 
         testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"
+        // Χρησιμοποιούμε μόνο τους πόρους της Αγγλικής γλώσσας για να
+        // αποφύγουμε προβλήματα με εσφαλμένες μεταφράσεις τρίτων βιβλιοθηκών
+        resourceConfigurations.add("en")
     }
 
     buildFeatures {


### PR DESCRIPTION
## Summary
- limit packaged resources to English to avoid invalid translations

## Testing
- `./gradlew test` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_6846cf95c3a48328926c9a73c69609ec