### PR TITLE
Fix build by updating Material library

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -46,7 +46,7 @@ android {
 dependencies {
     implementation("androidx.core:core-ktx:1.12.0")
     implementation("androidx.appcompat:appcompat:1.6.1")
-    implementation("com.google.android.material:material:1.11.0")
+    implementation("com.google.android.material:material:1.12.0")
     implementation("androidx.activity:activity-ktx:1.8.0")
     implementation("androidx.constraintlayout:constraintlayout:2.1.4")
 


### PR DESCRIPTION
## Summary
- update `com.google.android.material:material` to 1.12.0

## Testing
- `./gradlew :app:assembleDebug` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_6846d5f8d4c08328ab18995e21c3fc19