### PR TITLE
Fix build with latest Android SDK

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -10,12 +10,13 @@ plugins {
 android {
     namespace = "com.ioannapergamali.mysmartroute"
     // Χρησιμοποιούμε την πιο πρόσφατη σταθερή έκδοση του Android SDK
-    compileSdk = 34
+    // Το core-ktx 1.16 απαιτεί compileSdk >= 35
+    compileSdk = 35
 
     defaultConfig {
         applicationId = "com.ioannapergamali.mysmartroute"
         minSdk = 33
-        targetSdk = 34
+        targetSdk = 35
         versionCode = 1
         versionName = "1.0"
 


### PR DESCRIPTION
## Summary
- update compileSdk and targetSdk to 35

## Testing
- `./gradlew :app:assembleDebug --stacktrace` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_6846e4edca1c8328b464bbc63945cb0a