### PR TITLE
Fix build issues and update Room

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -1,16 +1,12 @@
 plugins {
     id("kotlin-kapt")
     id("com.android.application")
-    id("com.google.gms.google-services")
     id("org.jetbrains.kotlin.android")
+    id("com.google.gms.google-services")
 }
-
-
 
 android {
     namespace = "com.ioannapergamali.mysmartroute"
-    // Χρησιμοποιούμε την πιο πρόσφατη σταθερή έκδοση του Android SDK
-    // Το core-ktx 1.16 απαιτεί compileSdk >= 35
     compileSdk = 35
 
     defaultConfig {
@@ -19,21 +15,22 @@ android {
         targetSdk = 35
         versionCode = 1
         versionName = "1.0"
-
         testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"
-        // Χρησιμοποιούμε μόνο τους πόρους της Αγγλικής γλώσσας για να
-        // αποφύγουμε προβλήματα με εσφαλμένες μεταφράσεις τρίτων βιβλιοθηκών
         //resourceConfigurations.add("en")
     }
-    // ✅ Νέο API για επιλογή locale
+
     androidResources {
         localeFilters.add("en")
     }
+
     buildFeatures {
         compose = true
     }
 
     composeOptions {
+        kotlinCompilerExtensionVersion = "1.5.14"
+    }
+
     kotlinOptions {
         jvmTarget = "11"
     }
@@ -50,11 +47,9 @@ dependencies {
     implementation("androidx.compose.material3:material3:1.2.1")
     implementation("androidx.compose.ui:ui:1.6.4")
     implementation("androidx.compose.ui:ui-text:1.6.4")
-
     implementation("androidx.compose.ui:ui-tooling-preview:1.6.4")
     implementation("androidx.compose.runtime:runtime-livedata:1.6.4")
     implementation("androidx.navigation:navigation-compose:2.7.1")
-    // Provides additional Material icons such as `Logout`
     implementation("androidx.compose.material:material-icons-extended:1.6.4")
 
     // Firebase
@@ -78,4 +73,5 @@ dependencies {
     androidTestImplementation("androidx.test.ext:junit:1.1.5")
     androidTestImplementation("androidx.test.espresso:espresso-core:3.5.1")
 }
-apply(plugin = "com.google.gms.google-services")}
+
+apply(plugin = "com.google.gms.google-services")

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,7 +1,7 @@
 [versions]
-agp = "8.9.2"
+agp = "8.9.3"
 kotlin = "1.9.23"
-coreKtx = "1.10.1"
+coreKtx = "1.12.0"
 junit = "4.13.2"
 junitVersion = "1.1.5"
 espressoCore = "3.5.1"
@@ -12,7 +12,7 @@ constraintlayout = "2.1.4"
 material3Android = "1.3.2"
 firebaseFirestoreKtx = "25.1.4"
 firebaseAuthKtx = "22.3.1"
-room = "2.6.1"
+room = "2.7.1"
 
 [libraries]
 androidx-core-ktx = { group = "androidx.core", name = "core-ktx", version.ref = "coreKtx" }


### PR DESCRIPTION
## Summary
- fix `app/build.gradle.kts` syntax
- upgrade Room to 2.7.1
- update AGP and `core-ktx` versions in the version catalog

## Testing
- `./gradlew assembleDebug` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_6846f4a2ba748328bd5729bf8ab3ba1d