### PR TITLE
Εμφάνιση μηνύματος αν λείπει το API key

### DIFF
--- a/app/src/main/java/com/ioannapergamali/mysmartroute/view/ui/screens/AnnounceTransportScreen.kt
+++ b/app/src/main/java/com/ioannapergamali/mysmartroute/view/ui/screens/AnnounceTransportScreen.kt
@@ -173,6 +173,8 @@ fun AnnounceTransportScreen(navController: NavController) {
             }
 
             // Removed external maps button; map is shown directly on screen
+        } else {
+            Text(stringResource(R.string.map_api_key_missing))
         }
 
         Spacer(modifier = Modifier.height(8.dp))


### PR DESCRIPTION
## Summary
- προσθήκη μηνύματος στην οθόνη AnnounceTransport όταν απουσιάζει το Google Maps API key

## Testing
- `./gradlew testDebug` *(απέτυχε λόγω περιορισμών περιβάλλοντος)*

------
https://chatgpt.com/codex/tasks/task_e_684700f4dce48328947bbf2bbc19f0a6