### PR TITLE
Add Directions Map screen navigation

### DIFF
--- a/app/src/main/java/com/ioannapergamali/mysmartroute/model/navigation/NavigationHost.kt
+++ b/app/src/main/java/com/ioannapergamali/mysmartroute/model/navigation/NavigationHost.kt
@@ -11,6 +11,7 @@ import com.ioannapergamali.mysmartroute.view.ui.screens.LoginScreen
 import com.ioannapergamali.mysmartroute.view.ui.screens.MenuScreen
 import com.ioannapergamali.mysmartroute.view.ui.screens.RegisterVehicleScreen
 import com.ioannapergamali.mysmartroute.view.ui.screens.AnnounceTransportScreen
+import com.ioannapergamali.mysmartroute.view.ui.screens.DirectionsMapScreen
 
 
 
@@ -64,6 +65,18 @@ fun NavigationHost(navController : NavHostController) {
 
         composable("announceTransport") {
             AnnounceTransportScreen(navController = navController)
+        }
+
+        composable(
+            route = "directionsMap/{start}/{end}",
+            arguments = listOf(
+                navArgument("start") { defaultValue = "" },
+                navArgument("end") { defaultValue = "" }
+            )
+        ) { backStackEntry ->
+            val start = backStackEntry.arguments?.getString("start") ?: ""
+            val end = backStackEntry.arguments?.getString("end") ?: ""
+            DirectionsMapScreen(navController = navController, start = start, end = end)
         }
 
 

--- a/app/src/main/java/com/ioannapergamali/mysmartroute/view/ui/screens/AnnounceTransportScreen.kt
+++ b/app/src/main/java/com/ioannapergamali/mysmartroute/view/ui/screens/AnnounceTransportScreen.kt
@@ -177,6 +177,17 @@ fun AnnounceTransportScreen(navController: NavController) {
             Text(stringResource(R.string.map_api_key_missing))
         }
 
+        if (startLatLng != null && endLatLng != null) {
+            Spacer(modifier = Modifier.height(8.dp))
+            Button(onClick = {
+                val start = "${startLatLng!!.latitude},${startLatLng!!.longitude}"
+                val end = "${endLatLng!!.latitude},${endLatLng!!.longitude}"
+                navController.navigate("directionsMap/$start/$end")
+            }) {
+                Text(stringResource(R.string.directions))
+            }
+        }
+
         Spacer(modifier = Modifier.height(8.dp))
 
         ExposedDropdownMenuBox(expanded = fromExpanded, onExpandedChange = { fromExpanded = !fromExpanded }) {

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -8,4 +8,5 @@
 </string>
 
     <string name="open_in_maps">Άνοιγμα στο Google Maps</string>
+    <string name="directions">Οδηγίες</string>
 </resources>


### PR DESCRIPTION
## Summary
- add DirectionsMap route to NavigationHost
- show Directions button on announce transport screen
- add string for the new button label

## Testing
- `./gradlew tasks --no-daemon --quiet` *(fails: `IDLE`)*

------
https://chatgpt.com/codex/tasks/task_e_6847065764288328af734252ee85cf6e