### PR TITLE
Διαδρομή στο ίδιο χάρτη

### DIFF
--- a/app/src/main/java/com/ioannapergamali/mysmartroute/view/ui/screens/AnnounceTransportScreen.kt
+++ b/app/src/main/java/com/ioannapergamali/mysmartroute/view/ui/screens/AnnounceTransportScreen.kt
@@ -23,8 +23,6 @@ import androidx.compose.foundation.layout.Row
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.Check
 import androidx.compose.material.icons.filled.Place
-import android.content.Intent
-import android.net.Uri
 import com.google.maps.android.compose.GoogleMap
 import com.google.maps.android.compose.Marker
 import com.google.maps.android.compose.rememberCameraPositionState
@@ -63,6 +61,7 @@ fun AnnounceTransportScreen(navController: NavController) {
 
     var mapSelectionMode by remember { mutableStateOf<MapSelectionMode?>(null) }
     var routePoints by remember { mutableStateOf<List<LatLng>>(emptyList()) }
+    var showRoute by remember { mutableStateOf(false) }
 
     var fromQuery by remember { mutableStateOf("") }
     var fromExpanded by remember { mutableStateOf(false) }
@@ -139,6 +138,7 @@ fun AnnounceTransportScreen(navController: NavController) {
                     when (mapSelectionMode) {
                         MapSelectionMode.FROM -> {
                             startLatLng = latLng
+                            showRoute = false
                             coroutineScope.launch {
                                 val addr = withContext(Dispatchers.IO) {
                                     Geocoder(context).getFromLocation(latLng.latitude, latLng.longitude, 1)?.firstOrNull()
@@ -149,6 +149,7 @@ fun AnnounceTransportScreen(navController: NavController) {
                         }
                         MapSelectionMode.TO -> {
                             endLatLng = latLng
+                            showRoute = false
                             coroutineScope.launch {
                                 val addr = withContext(Dispatchers.IO) {
                                     Geocoder(context).getFromLocation(latLng.latitude, latLng.longitude, 1)?.firstOrNull()
@@ -167,7 +168,7 @@ fun AnnounceTransportScreen(navController: NavController) {
                 endLatLng?.let {
                     Marker(state = rememberMarkerState(position = it), title = "To")
                 }
-                if (routePoints.isNotEmpty()) {
+                if (showRoute && routePoints.isNotEmpty()) {
                     Polyline(points = routePoints)
                 }
             }
@@ -180,9 +181,7 @@ fun AnnounceTransportScreen(navController: NavController) {
         if (startLatLng != null && endLatLng != null) {
             Spacer(modifier = Modifier.height(8.dp))
             Button(onClick = {
-                val start = "${startLatLng!!.latitude},${startLatLng!!.longitude}"
-                val end = "${endLatLng!!.latitude},${endLatLng!!.longitude}"
-                navController.navigate("directionsMap/$start/$end")
+                showRoute = true
             }) {
                 Text(stringResource(R.string.directions))
             }
@@ -204,6 +203,7 @@ fun AnnounceTransportScreen(navController: NavController) {
                                 }
                                 addr?.let {
                                     startLatLng = LatLng(it.latitude, it.longitude)
+                                    showRoute = false
                                     fromQuery = it.getAddressLine(0) ?: fromQuery
                                     cameraPositionState.position = CameraPosition.fromLatLngZoom(startLatLng!!, 10f)
                                 }
@@ -226,6 +226,7 @@ fun AnnounceTransportScreen(navController: NavController) {
                         onClick = {
                             fromQuery = address.getAddressLine(0) ?: ""
                             startLatLng = LatLng(address.latitude, address.longitude)
+                            showRoute = false
                             cameraPositionState.position = CameraPosition.fromLatLngZoom(startLatLng!!, 10f)
                             fromExpanded = false
                         }
@@ -250,6 +251,7 @@ fun AnnounceTransportScreen(navController: NavController) {
                                 }
                                 addr?.let {
                                     endLatLng = LatLng(it.latitude, it.longitude)
+                                    showRoute = false
                                     toQuery = it.getAddressLine(0) ?: toQuery
                                     cameraPositionState.position = CameraPosition.fromLatLngZoom(endLatLng!!, 10f)
                                 }
@@ -272,6 +274,7 @@ fun AnnounceTransportScreen(navController: NavController) {
                         onClick = {
                             toQuery = address.getAddressLine(0) ?: ""
                             endLatLng = LatLng(address.latitude, address.longitude)
+                            showRoute = false
                             cameraPositionState.position = CameraPosition.fromLatLngZoom(endLatLng!!, 10f)
                             toExpanded = false
                         }
@@ -301,6 +304,7 @@ fun AnnounceTransportScreen(navController: NavController) {
                             text = { Text(it.name) },
                             onClick = {
                                 selectedVehicleType = it
+                                showRoute = false
                                 vehicleMenuExpanded = false
                             }
                         )


### PR DESCRIPTION
## Περίληψη
- αποτροπή επαναφοράς της κατάστασης `showRoute` όταν υπολογίζεται νέα διαδρομή
- απόκρυψη της διαδρομής κάθε φορά που αλλάζει το σημείο εκκίνησης, προορισμού ή το όχημα

## Testing
- `./gradlew test --console=plain` *(απέτυχε: δεν υπάρχει Android SDK)*


------
https://chatgpt.com/codex/tasks/task_e_68471465849c83289520303da1c23457