### PR TITLE
Handle invalid coordinates from Directions API

### DIFF
--- a/app/src/main/java/com/ioannapergamali/mysmartroute/utils/CoordinateUtils.kt
+++ b/app/src/main/java/com/ioannapergamali/mysmartroute/utils/CoordinateUtils.kt
@@ -1,0 +1,19 @@
+package com.ioannapergamali.mysmartroute.utils
+
+import com.google.android.gms.maps.model.LatLng
+
+/** Utility helpers for coordinate validation */
+object CoordinateUtils {
+    /**
+     * Returns true if [latLng] is not null and represents a valid geographic coordinate.
+     */
+    fun isValid(latLng: LatLng?): Boolean {
+        return latLng != null &&
+            latLng.latitude in -90.0..90.0 &&
+            latLng.longitude in -180.0..180.0
+    }
+}
+
+/** Extension to quickly validate a [LatLng] */
+fun LatLng.isValid(): Boolean =
+    latitude in -90.0..90.0 && longitude in -180.0..180.0

--- a/app/src/main/java/com/ioannapergamali/mysmartroute/view/ui/screens/AnnounceTransportScreen.kt
+++ b/app/src/main/java/com/ioannapergamali/mysmartroute/view/ui/screens/AnnounceTransportScreen.kt
@@ -43,6 +43,7 @@ import com.ioannapergamali.mysmartroute.model.enumerations.VehicleType
 import com.ioannapergamali.mysmartroute.R
 import com.ioannapergamali.mysmartroute.utils.MapsUtils
 import com.ioannapergamali.mysmartroute.utils.NetworkUtils
+import com.ioannapergamali.mysmartroute.utils.CoordinateUtils
 import com.ioannapergamali.mysmartroute.view.ui.components.TopBar
 import com.ioannapergamali.mysmartroute.viewmodel.TransportAnnouncementViewModel
 import com.ioannapergamali.mysmartroute.viewmodel.VehicleViewModel
@@ -111,11 +112,14 @@ fun AnnounceTransportScreen(navController: NavController) {
     }
 
     LaunchedEffect(startLatLng, endLatLng, selectedVehicleType) {
-        if (!isKeyMissing && startLatLng != null && endLatLng != null) {
+        if (!isKeyMissing &&
+            CoordinateUtils.isValid(startLatLng) &&
+            CoordinateUtils.isValid(endLatLng)
+        ) {
             if (NetworkUtils.isInternetAvailable(context)) {
                 showRoute = false
                 val type = selectedVehicleType ?: VehicleType.CAR
-                val (duration, points) = MapsUtils.fetchDurationAndPath(startLatLng!!, endLatLng!!, apiKey, type)
+                val result = MapsUtils.fetchDurationAndPath(startLatLng!!, endLatLng!!, apiKey, type)
                 val factor = when (selectedVehicleType) {
                     VehicleType.BICYCLE -> 1.5
                     VehicleType.MOTORBIKE -> 0.8
@@ -123,11 +127,16 @@ fun AnnounceTransportScreen(navController: NavController) {
                     VehicleType.SMALLBUS -> 1.1
                     else -> 1.0
                 }
-                durationMinutes = (duration * factor).toInt()
-                routePoints = points
+                durationMinutes = (result.duration * factor).toInt()
+                routePoints = result.points
+                if (result.status == "NOT_FOUND" || result.status == "INVALID_REQUEST") {
+                    Toast.makeText(context, context.getString(R.string.invalid_coordinates), Toast.LENGTH_SHORT).show()
+                }
             } else {
                 Toast.makeText(context, context.getString(R.string.no_internet), Toast.LENGTH_SHORT).show()
             }
+        } else if (startLatLng != null || endLatLng != null) {
+            Toast.makeText(context, context.getString(R.string.invalid_coordinates), Toast.LENGTH_SHORT).show()
         }
     }
 
@@ -210,10 +219,13 @@ fun AnnounceTransportScreen(navController: NavController) {
                 coroutineScope.launch {
                     Log.d(TAG, "Fetching directions from $startLatLng to $endLatLng")
                     Toast.makeText(context, "Αναζήτηση διαδρομής...", Toast.LENGTH_SHORT).show()
-                    if (!isKeyMissing && startLatLng != null && endLatLng != null) {
+                    if (!isKeyMissing &&
+                        CoordinateUtils.isValid(startLatLng) &&
+                        CoordinateUtils.isValid(endLatLng)
+                    ) {
                         if (NetworkUtils.isInternetAvailable(context)) {
                             val type = selectedVehicleType ?: VehicleType.CAR
-                            val (duration, points) = MapsUtils.fetchDurationAndPath(startLatLng!!, endLatLng!!, apiKey, type)
+                            val result = MapsUtils.fetchDurationAndPath(startLatLng!!, endLatLng!!, apiKey, type)
                             val factor = when (selectedVehicleType) {
                                 VehicleType.BICYCLE -> 1.5
                                 VehicleType.MOTORBIKE -> 0.8
@@ -221,18 +233,27 @@ fun AnnounceTransportScreen(navController: NavController) {
                                 VehicleType.SMALLBUS -> 1.1
                                 else -> 1.0
                             }
-                            durationMinutes = (duration * factor).toInt()
-                            routePoints = points
-                            if (routePoints.isNotEmpty()) {
-                                Log.d(TAG, "Route received with ${routePoints.size} points, duration $durationMinutes")
-                                Toast.makeText(context, "Διαδρομή βρέθηκε", Toast.LENGTH_SHORT).show()
-                            } else {
-                                Log.w(TAG, "Route not found or API error")
-                                Toast.makeText(context, "Δεν βρέθηκε διαδρομή", Toast.LENGTH_SHORT).show()
+                            durationMinutes = (result.duration * factor).toInt()
+                            routePoints = result.points
+                            when {
+                                result.status == "OK" && routePoints.isNotEmpty() -> {
+                                    Log.d(TAG, "Route received with ${routePoints.size} points, duration $durationMinutes")
+                                    Toast.makeText(context, "Διαδρομή βρέθηκε", Toast.LENGTH_SHORT).show()
+                                }
+                                result.status == "NOT_FOUND" || result.status == "INVALID_REQUEST" -> {
+                                    Log.w(TAG, "Invalid coordinates provided")
+                                    Toast.makeText(context, context.getString(R.string.invalid_coordinates), Toast.LENGTH_SHORT).show()
+                                }
+                                else -> {
+                                    Log.w(TAG, "Route not found or API error: ${result.status}")
+                                    Toast.makeText(context, "Δεν βρέθηκε διαδρομή", Toast.LENGTH_SHORT).show()
+                                }
                             }
                         } else {
                             Toast.makeText(context, context.getString(R.string.no_internet), Toast.LENGTH_SHORT).show()
                         }
+                    } else {
+                        Toast.makeText(context, context.getString(R.string.invalid_coordinates), Toast.LENGTH_SHORT).show()
                     }
                     showRoute = true
                     Log.d(TAG, "Displaying route on map")
@@ -254,13 +275,15 @@ fun AnnounceTransportScreen(navController: NavController) {
                         IconButton(onClick = {
                             coroutineScope.launch {
                                 val addr = withContext(Dispatchers.IO) {
-                                    Geocoder(context).getFromLocationName(fromQuery, 1)?.firstOrNull()
+                                    try { Geocoder(context).getFromLocationName(fromQuery, 1)?.firstOrNull() } catch (e: Exception) { null }
                                 }
-                                addr?.let {
-                                    startLatLng = LatLng(it.latitude, it.longitude)
+                                if (addr != null) {
+                                    startLatLng = LatLng(addr.latitude, addr.longitude)
                                     showRoute = false
-                                    fromQuery = it.getAddressLine(0) ?: fromQuery
+                                    fromQuery = addr.getAddressLine(0) ?: fromQuery
                                     cameraPositionState.position = CameraPosition.fromLatLngZoom(startLatLng!!, 10f)
+                                } else {
+                                    Toast.makeText(context, context.getString(R.string.invalid_coordinates), Toast.LENGTH_SHORT).show()
                                 }
                             }
                         }) {
@@ -302,13 +325,15 @@ fun AnnounceTransportScreen(navController: NavController) {
                         IconButton(onClick = {
                             coroutineScope.launch {
                                 val addr = withContext(Dispatchers.IO) {
-                                    Geocoder(context).getFromLocationName(toQuery, 1)?.firstOrNull()
+                                    try { Geocoder(context).getFromLocationName(toQuery, 1)?.firstOrNull() } catch (e: Exception) { null }
                                 }
-                                addr?.let {
-                                    endLatLng = LatLng(it.latitude, it.longitude)
+                                if (addr != null) {
+                                    endLatLng = LatLng(addr.latitude, addr.longitude)
                                     showRoute = false
-                                    toQuery = it.getAddressLine(0) ?: toQuery
+                                    toQuery = addr.getAddressLine(0) ?: toQuery
                                     cameraPositionState.position = CameraPosition.fromLatLngZoom(endLatLng!!, 10f)
+                                } else {
+                                    Toast.makeText(context, context.getString(R.string.invalid_coordinates), Toast.LENGTH_SHORT).show()
                                 }
                             }
                         }) {

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -10,4 +10,5 @@
     <string name="open_in_maps">Άνοιγμα στο Google Maps</string>
     <string name="directions">Οδηγίες</string>
     <string name="no_internet">Δεν υπάρχει σύνδεση στο διαδίκτυο</string>
+    <string name="invalid_coordinates">Μη έγκυρες συντεταγμένες</string>
 </resources>


### PR DESCRIPTION
## Summary
- return status from MapsUtils.fetchDurationAndPath
- warn about invalid coordinates if Directions API responds NOT_FOUND
- show invalid toast when Geocoder lookup fails

## Testing
- `./gradlew assembleDebug --no-daemon` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_6847577c00bc832894002d67d31ae57b