### PR TITLE
Add coordinate check button

### DIFF
--- a/app/src/main/java/com/ioannapergamali/mysmartroute/view/ui/screens/AnnounceTransportScreen.kt
+++ b/app/src/main/java/com/ioannapergamali/mysmartroute/view/ui/screens/AnnounceTransportScreen.kt
@@ -264,6 +264,17 @@ fun AnnounceTransportScreen(navController: NavController) {
         }
 
         Spacer(modifier = Modifier.height(8.dp))
+        Button(onClick = {
+            if (CoordinateUtils.isValid(startLatLng) && CoordinateUtils.isValid(endLatLng)) {
+                Toast.makeText(context, context.getString(R.string.coordinates_valid), Toast.LENGTH_SHORT).show()
+            } else {
+                Toast.makeText(context, context.getString(R.string.coordinates_missing), Toast.LENGTH_SHORT).show()
+            }
+        }) {
+            Text(stringResource(R.string.check_coordinates))
+        }
+
+        Spacer(modifier = Modifier.height(8.dp))
 
         ExposedDropdownMenuBox(expanded = fromExpanded, onExpandedChange = { fromExpanded = !fromExpanded }) {
             TextField(

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -11,4 +11,7 @@
     <string name="directions">Οδηγίες</string>
     <string name="no_internet">Δεν υπάρχει σύνδεση στο διαδίκτυο</string>
     <string name="invalid_coordinates">Μη έγκυρες συντεταγμένες</string>
+    <string name="check_coordinates">Έλεγχος συντεταγμένων</string>
+    <string name="coordinates_valid">Οι συντεταγμένες είναι έγκυρες</string>
+    <string name="coordinates_missing">Πρέπει να οριστούν και οι δύο συντεταγμένες</string>
 </resources>


### PR DESCRIPTION
## Summary
- add new strings for verifying map coordinates
- show a "Check coordinates" button on AnnounceTransportScreen

## Testing
- `./gradlew test` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_68476455c0e883288b4d4768fcfd7e12