### PR TITLE
Προσθήκη κουμπιού ελέγχου σύνδεσης

### DIFF
--- a/app/src/main/java/com/ioannapergamali/mysmartroute/view/ui/screens/AnnounceTransportScreen.kt
+++ b/app/src/main/java/com/ioannapergamali/mysmartroute/view/ui/screens/AnnounceTransportScreen.kt
@@ -275,6 +275,17 @@ fun AnnounceTransportScreen(navController: NavController) {
         }
 
         Spacer(modifier = Modifier.height(8.dp))
+        Button(onClick = {
+            if (NetworkUtils.isInternetAvailable(context)) {
+                Toast.makeText(context, context.getString(R.string.internet_available), Toast.LENGTH_SHORT).show()
+            } else {
+                Toast.makeText(context, context.getString(R.string.no_internet), Toast.LENGTH_SHORT).show()
+            }
+        }) {
+            Text(stringResource(R.string.check_internet))
+        }
+
+        Spacer(modifier = Modifier.height(8.dp))
 
         ExposedDropdownMenuBox(expanded = fromExpanded, onExpandedChange = { fromExpanded = !fromExpanded }) {
             TextField(

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -10,8 +10,10 @@
     <string name="open_in_maps">Άνοιγμα στο Google Maps</string>
     <string name="directions">Οδηγίες</string>
     <string name="no_internet">Δεν υπάρχει σύνδεση στο διαδίκτυο</string>
+    <string name="internet_available">Η σύνδεση στο διαδίκτυο είναι ενεργή</string>
     <string name="invalid_coordinates">Μη έγκυρες συντεταγμένες</string>
     <string name="check_coordinates">Έλεγχος συντεταγμένων</string>
+    <string name="check_internet">Έλεγχος Internet</string>
     <string name="coordinates_valid">Οι συντεταγμένες είναι έγκυρες</string>
     <string name="coordinates_missing">Πρέπει να οριστούν και οι δύο συντεταγμένες</string>
 </resources>


### PR DESCRIPTION
## Summary
- add button to check internet connection on AnnounceTransportScreen
- add strings for internet check message

## Testing
- `./gradlew test` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_68476bf4b5288328b284eccb989c31e1