### PR TITLE
Add Directions API status logging

### DIFF
--- a/app/src/main/java/com/ioannapergamali/mysmartroute/view/ui/screens/AnnounceTransportScreen.kt
+++ b/app/src/main/java/com/ioannapergamali/mysmartroute/view/ui/screens/AnnounceTransportScreen.kt
@@ -120,6 +120,7 @@ fun AnnounceTransportScreen(navController: NavController) {
                 showRoute = false
                 val type = selectedVehicleType ?: VehicleType.CAR
                 val result = MapsUtils.fetchDurationAndPath(startLatLng!!, endLatLng!!, apiKey, type)
+                Log.d(TAG, "Directions API status: ${'$'}{result.status}")
                 val factor = when (selectedVehicleType) {
                     VehicleType.BICYCLE -> 1.5
                     VehicleType.MOTORBIKE -> 0.8
@@ -226,6 +227,7 @@ fun AnnounceTransportScreen(navController: NavController) {
                         if (NetworkUtils.isInternetAvailable(context)) {
                             val type = selectedVehicleType ?: VehicleType.CAR
                             val result = MapsUtils.fetchDurationAndPath(startLatLng!!, endLatLng!!, apiKey, type)
+                            Log.d(TAG, "Directions API status: ${'$'}{result.status}")
                             val factor = when (selectedVehicleType) {
                                 VehicleType.BICYCLE -> 1.5
                                 VehicleType.MOTORBIKE -> 0.8


### PR DESCRIPTION
## Summary
- log Directions API status when fetching directions

## Testing
- `./gradlew test` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_68476e7345a883288bd71ed3b807e034