### PR TITLE
Fix Directions API status logging

### DIFF
--- a/app/src/main/java/com/ioannapergamali/mysmartroute/view/ui/screens/AnnounceTransportScreen.kt
+++ b/app/src/main/java/com/ioannapergamali/mysmartroute/view/ui/screens/AnnounceTransportScreen.kt
@@ -120,7 +120,7 @@ fun AnnounceTransportScreen(navController: NavController) {
                 showRoute = false
                 val type = selectedVehicleType ?: VehicleType.CAR
                 val result = MapsUtils.fetchDurationAndPath(startLatLng!!, endLatLng!!, apiKey, type)
-                Log.d(TAG, "Directions API status: ${'$'}{result.status}")
+                Log.d(TAG, "Directions API status: ${result.status}")
                 val factor = when (selectedVehicleType) {
                     VehicleType.BICYCLE -> 1.5
                     VehicleType.MOTORBIKE -> 0.8
@@ -227,7 +227,7 @@ fun AnnounceTransportScreen(navController: NavController) {
                         if (NetworkUtils.isInternetAvailable(context)) {
                             val type = selectedVehicleType ?: VehicleType.CAR
                             val result = MapsUtils.fetchDurationAndPath(startLatLng!!, endLatLng!!, apiKey, type)
-                            Log.d(TAG, "Directions API status: ${'$'}{result.status}")
+                            Log.d(TAG, "Directions API status: ${result.status}")
                             val factor = when (selectedVehicleType) {
                                 VehicleType.BICYCLE -> 1.5
                                 VehicleType.MOTORBIKE -> 0.8


### PR DESCRIPTION
## Summary
- show actual result from Directions API in logs by removing literal `$` escape

## Testing
- `./gradlew test --continue` *(fails: Starting a Gradle Daemon)*

------
https://chatgpt.com/codex/tasks/task_e_684774a881ec8328a1f20ad096844af3