### PR TITLE
Add PoI feature with local storage and listing

### DIFF
--- a/app/src/main/java/com/ioannapergamali/mysmartroute/data/local/MySmartRouteDatabase.kt
+++ b/app/src/main/java/com/ioannapergamali/mysmartroute/data/local/MySmartRouteDatabase.kt
@@ -6,11 +6,16 @@ import androidx.room.Room
 import androidx.room.RoomDatabase
 
 import com.ioannapergamali.mysmartroute.data.local.VehicleEntity
+import com.ioannapergamali.mysmartroute.data.local.PoIEntity
 
-@Database(entities = [UserEntity::class, VehicleEntity::class], version = 2)
+@Database(
+    entities = [UserEntity::class, VehicleEntity::class, PoIEntity::class],
+    version = 3
+)
 abstract class MySmartRouteDatabase : RoomDatabase() {
     abstract fun userDao(): UserDao
     abstract fun vehicleDao(): VehicleDao
+    abstract fun poIDao(): PoIDao
 
     companion object {
         @Volatile

--- a/app/src/main/java/com/ioannapergamali/mysmartroute/data/local/PoIDao.kt
+++ b/app/src/main/java/com/ioannapergamali/mysmartroute/data/local/PoIDao.kt
@@ -1,0 +1,18 @@
+package com.ioannapergamali.mysmartroute.data.local
+
+import androidx.room.Dao
+import androidx.room.Insert
+import androidx.room.OnConflictStrategy
+import androidx.room.Query
+
+@Dao
+interface PoIDao {
+    @Insert(onConflict = OnConflictStrategy.REPLACE)
+    suspend fun insertAll(pois: List<PoIEntity>)
+
+    @Insert(onConflict = OnConflictStrategy.REPLACE)
+    suspend fun insert(poi: PoIEntity)
+
+    @Query("SELECT * FROM pois")
+    suspend fun getAll(): List<PoIEntity>
+}

--- a/app/src/main/java/com/ioannapergamali/mysmartroute/data/local/PoIEntity.kt
+++ b/app/src/main/java/com/ioannapergamali/mysmartroute/data/local/PoIEntity.kt
@@ -1,0 +1,14 @@
+package com.ioannapergamali.mysmartroute.data.local
+
+import androidx.room.Entity
+import androidx.room.PrimaryKey
+
+@Entity(tableName = "pois")
+data class PoIEntity(
+    @PrimaryKey val id: String,
+    val name: String,
+    val description: String,
+    val type: String,
+    val lat: Double,
+    val lng: Double
+)

--- a/app/src/main/java/com/ioannapergamali/mysmartroute/model/navigation/NavigationHost.kt
+++ b/app/src/main/java/com/ioannapergamali/mysmartroute/model/navigation/NavigationHost.kt
@@ -12,6 +12,7 @@ import com.ioannapergamali.mysmartroute.view.ui.screens.MenuScreen
 import com.ioannapergamali.mysmartroute.view.ui.screens.RegisterVehicleScreen
 import com.ioannapergamali.mysmartroute.view.ui.screens.AnnounceTransportScreen
 import com.ioannapergamali.mysmartroute.view.ui.screens.DirectionsMapScreen
+import com.ioannapergamali.mysmartroute.view.ui.screens.PoIListScreen
 
 
 
@@ -65,6 +66,10 @@ fun NavigationHost(navController : NavHostController) {
 
         composable("announceTransport") {
             AnnounceTransportScreen(navController = navController)
+        }
+
+        composable("poiList") {
+            PoIListScreen(navController = navController)
         }
 
         composable(

--- a/app/src/main/java/com/ioannapergamali/mysmartroute/view/ui/screens/AnnounceTransportScreen.kt
+++ b/app/src/main/java/com/ioannapergamali/mysmartroute/view/ui/screens/AnnounceTransportScreen.kt
@@ -47,6 +47,7 @@ import com.ioannapergamali.mysmartroute.utils.CoordinateUtils
 import com.ioannapergamali.mysmartroute.view.ui.components.TopBar
 import com.ioannapergamali.mysmartroute.viewmodel.TransportAnnouncementViewModel
 import com.ioannapergamali.mysmartroute.viewmodel.VehicleViewModel
+import com.ioannapergamali.mysmartroute.viewmodel.PoIViewModel
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.withContext
@@ -60,6 +61,7 @@ private const val TAG = "AnnounceTransport"
 fun AnnounceTransportScreen(navController: NavController) {
     val viewModel: TransportAnnouncementViewModel = viewModel()
     val vehicleViewModel: VehicleViewModel = viewModel()
+    val poiViewModel: PoIViewModel = viewModel()
     val state by viewModel.state.collectAsState()
     val vehicles by vehicleViewModel.vehicles.collectAsState()
 
@@ -109,6 +111,7 @@ fun AnnounceTransportScreen(navController: NavController) {
 
     LaunchedEffect(Unit) {
         vehicleViewModel.loadRegisteredVehicles(context)
+        poiViewModel.loadPois(context)
     }
 
     LaunchedEffect(startLatLng, endLatLng, selectedVehicleType) {
@@ -180,6 +183,14 @@ fun AnnounceTransportScreen(navController: NavController) {
                                     Geocoder(context).getFromLocation(latLng.latitude, latLng.longitude, 1)?.firstOrNull()
                                 }
                                 fromQuery = addr?.getAddressLine(0) ?: "${latLng.latitude},${latLng.longitude}"
+                                poiViewModel.addPoi(
+                                    context,
+                                    fromQuery,
+                                    fromQuery,
+                                    "HISTORICAL",
+                                    latLng.latitude,
+                                    latLng.longitude
+                                )
                             }
                             mapSelectionMode = null
                         }
@@ -191,6 +202,14 @@ fun AnnounceTransportScreen(navController: NavController) {
                                     Geocoder(context).getFromLocation(latLng.latitude, latLng.longitude, 1)?.firstOrNull()
                                 }
                                 toQuery = addr?.getAddressLine(0) ?: "${latLng.latitude},${latLng.longitude}"
+                                poiViewModel.addPoi(
+                                    context,
+                                    toQuery,
+                                    toQuery,
+                                    "HISTORICAL",
+                                    latLng.latitude,
+                                    latLng.longitude
+                                )
                             }
                             mapSelectionMode = null
                         }
@@ -306,6 +325,14 @@ fun AnnounceTransportScreen(navController: NavController) {
                                     showRoute = false
                                     fromQuery = addr.getAddressLine(0) ?: fromQuery
                                     cameraPositionState.position = CameraPosition.fromLatLngZoom(startLatLng!!, 10f)
+                                    poiViewModel.addPoi(
+                                        context,
+                                        fromQuery,
+                                        fromQuery,
+                                        "HISTORICAL",
+                                        addr.latitude,
+                                        addr.longitude
+                                    )
                                 } else {
                                     Toast.makeText(context, context.getString(R.string.invalid_coordinates), Toast.LENGTH_SHORT).show()
                                 }
@@ -331,6 +358,14 @@ fun AnnounceTransportScreen(navController: NavController) {
                             showRoute = false
                             cameraPositionState.position = CameraPosition.fromLatLngZoom(startLatLng!!, 10f)
                             fromExpanded = false
+                            poiViewModel.addPoi(
+                                context,
+                                fromQuery,
+                                fromQuery,
+                                "HISTORICAL",
+                                address.latitude,
+                                address.longitude
+                            )
                         }
                     )
                 }
@@ -356,6 +391,14 @@ fun AnnounceTransportScreen(navController: NavController) {
                                     showRoute = false
                                     toQuery = addr.getAddressLine(0) ?: toQuery
                                     cameraPositionState.position = CameraPosition.fromLatLngZoom(endLatLng!!, 10f)
+                                    poiViewModel.addPoi(
+                                        context,
+                                        toQuery,
+                                        toQuery,
+                                        "HISTORICAL",
+                                        addr.latitude,
+                                        addr.longitude
+                                    )
                                 } else {
                                     Toast.makeText(context, context.getString(R.string.invalid_coordinates), Toast.LENGTH_SHORT).show()
                                 }
@@ -381,6 +424,14 @@ fun AnnounceTransportScreen(navController: NavController) {
                             showRoute = false
                             cameraPositionState.position = CameraPosition.fromLatLngZoom(endLatLng!!, 10f)
                             toExpanded = false
+                            poiViewModel.addPoi(
+                                context,
+                                toQuery,
+                                toQuery,
+                                "HISTORICAL",
+                                address.latitude,
+                                address.longitude
+                            )
                         }
                     )
                 }

--- a/app/src/main/java/com/ioannapergamali/mysmartroute/view/ui/screens/MenuScreen.kt
+++ b/app/src/main/java/com/ioannapergamali/mysmartroute/view/ui/screens/MenuScreen.kt
@@ -53,7 +53,7 @@ fun MenuScreen(navController: NavController) {
             when (role) {
                 UserRole.PASSENGER -> PassengerMenu(viewModel, navController)
                 UserRole.DRIVER -> DriverMenu(navController)
-                UserRole.ADMIN -> AdminMenu()
+                UserRole.ADMIN -> AdminMenu(navController)
                 null -> {
                     CircularProgressIndicator()
                 }
@@ -114,7 +114,7 @@ private fun DriverMenu(navController: NavController) {
 }
 
 @Composable
-private fun AdminMenu() {
+private fun AdminMenu(navController: NavController) {
     val actions = listOf(
         "Initialize System",
         "Create User Account",
@@ -130,7 +130,12 @@ private fun AdminMenu() {
         "View Users",
         "Advance Date"
     )
-    MenuTable(actions)
+    MenuTable(actions) { index ->
+        when (index) {
+            10 -> navController.navigate("poiList")
+            else -> {}
+        }
+    }
 }
 
 @Composable

--- a/app/src/main/java/com/ioannapergamali/mysmartroute/view/ui/screens/PoIListScreen.kt
+++ b/app/src/main/java/com/ioannapergamali/mysmartroute/view/ui/screens/PoIListScreen.kt
@@ -1,0 +1,39 @@
+package com.ioannapergamali.mysmartroute.view.ui.screens
+
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.lazy.items
+import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.Scaffold
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.collectAsState
+import androidx.compose.runtime.getValue
+import androidx.compose.ui.Modifier
+import androidx.lifecycle.viewmodel.compose.viewModel
+import androidx.compose.ui.platform.LocalContext
+import androidx.navigation.NavController
+import com.ioannapergamali.mysmartroute.view.ui.components.TopBar
+import com.ioannapergamali.mysmartroute.viewmodel.PoIViewModel
+
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+fun PoIListScreen(navController: NavController) {
+    val viewModel: PoIViewModel = viewModel()
+    val pois by viewModel.pois.collectAsState()
+    val context = LocalContext.current
+
+    LaunchedEffect(Unit) { viewModel.loadPois(context) }
+
+    Scaffold(topBar = { TopBar(title = "PoIs", navController = navController) }) { padding ->
+        Column(Modifier.fillMaxSize()) {
+            LazyColumn(modifier = Modifier.fillMaxSize()) {
+                items(pois) { poi ->
+                    Text(text = "${'$'}{poi.name} (${poi.lat}, ${'$'}{poi.lng})")
+                }
+            }
+        }
+    }
+}

--- a/app/src/main/java/com/ioannapergamali/mysmartroute/viewmodel/PoIViewModel.kt
+++ b/app/src/main/java/com/ioannapergamali/mysmartroute/viewmodel/PoIViewModel.kt
@@ -1,0 +1,55 @@
+package com.ioannapergamali.mysmartroute.viewmodel
+
+import android.content.Context
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.viewModelScope
+import com.google.firebase.firestore.FirebaseFirestore
+import com.ioannapergamali.mysmartroute.data.local.MySmartRouteDatabase
+import com.ioannapergamali.mysmartroute.data.local.PoIEntity
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.launch
+import java.util.UUID
+
+/**
+ * ViewModel to manage Points of Interest (PoIs).
+ */
+class PoIViewModel : ViewModel() {
+    private val db = FirebaseFirestore.getInstance()
+
+    private val _pois = MutableStateFlow<List<PoIEntity>>(emptyList())
+    val pois: StateFlow<List<PoIEntity>> = _pois
+
+    fun loadPois(context: Context) {
+        viewModelScope.launch {
+            val dao = MySmartRouteDatabase.getInstance(context).poIDao()
+            _pois.value = dao.getAll()
+            db.collection("pois").get()
+                .addOnSuccessListener { snapshot ->
+                    val list = snapshot.documents.mapNotNull { doc ->
+                        doc.toObject(PoIEntity::class.java)
+                    }
+                    _pois.value = list
+                    viewModelScope.launch { dao.insertAll(list) }
+                }
+        }
+    }
+
+    fun addPoi(context: Context, name: String, description: String, type: String, lat: Double, lng: Double) {
+        viewModelScope.launch {
+            val id = UUID.randomUUID().toString()
+            val poi = PoIEntity(id, name, description, type, lat, lng)
+            val dao = MySmartRouteDatabase.getInstance(context).poIDao()
+            dao.insert(poi)
+            val data = hashMapOf(
+                "id" to id,
+                "name" to name,
+                "description" to description,
+                "type" to type,
+                "lat" to lat,
+                "lng" to lng
+            )
+            db.collection("pois").document(id).set(data)
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- add PoIEntity and PoIDao for Room storage
- integrate PoI table into MySmartRouteDatabase
- create PoIViewModel for managing POIs in Firestore/Room
- update AnnounceTransportScreen to save selected locations as POIs
- create PoIListScreen and navigation route
- link admin menu to PoI list

## Testing
- `./gradlew test` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_68478c9584808328be6c6766812fab86