### PR TITLE
Προσθήκη finishAfterTransition στο onBackPressed

### DIFF
--- a/app/src/main/java/com/ioannapergamali/mysmartroute/viewmodel/MainActivity.kt
+++ b/app/src/main/java/com/ioannapergamali/mysmartroute/viewmodel/MainActivity.kt
@@ -18,4 +18,9 @@ class MainActivity : ComponentActivity()
                 NavigationHost(navController = navController)
         }
     }
+
+    override fun onBackPressed() {
+        finishAfterTransition()
+        super.onBackPressed()
+    }
 }


### PR DESCRIPTION
## Περιγραφή
Προστέθηκε override της `onBackPressed` στο `MainActivity` ώστε να καλείται `finishAfterTransition()` πριν ολοκληρωθεί η ενέργεια επιστροφής. Έτσι διασφαλίζεται ομαλότερο κλείσιμο της activity μετά τα animations.

## Έλεγχοι
- `./gradlew test --stacktrace` *(απέτυχε λόγω απουσίας Android SDK)*

------
https://chatgpt.com/codex/tasks/task_e_6847910b9074832880142b5a70aa0dfb