### PR TITLE
Προσθήκη ελέγχου MIUI provider

### DIFF
--- a/app/src/main/java/com/ioannapergamali/mysmartroute/utils/MiuiUtils.kt
+++ b/app/src/main/java/com/ioannapergamali/mysmartroute/utils/MiuiUtils.kt
@@ -1,0 +1,35 @@
+package com.ioannapergamali.mysmartroute.utils
+
+import android.content.Context
+import android.net.Uri
+import android.os.Bundle
+import android.util.Log
+
+/** Helper for MIUI specific providers */
+object MiuiUtils {
+    private const val TAG = "MiuiUtils"
+    private const val SERVICE_DELIVERY_AUTHORITY =
+        "com.miui.personalassistant.servicedeliver.system.provider"
+
+    /**
+     * Safely calls a method on the MIUI Service Delivery provider.
+     *
+     * @param context A valid [Context].
+     * @param methodName The method to invoke on the provider.
+     * @param extras Optional extras for the call.
+     * @return The result [Bundle] from the provider, or null if it doesn't exist.
+     */
+    fun callServiceDelivery(
+        context: Context,
+        methodName: String,
+        extras: Bundle? = null,
+    ): Bundle? {
+        val uri = Uri.parse("content://$SERVICE_DELIVERY_AUTHORITY")
+        return try {
+            context.contentResolver.call(uri, methodName, null, extras)
+        } catch (e: IllegalArgumentException) {
+            Log.w(TAG, "Service Delivery provider not found on device")
+            null
+        }
+    }
+}

--- a/app/src/main/java/com/ioannapergamali/mysmartroute/viewmodel/MainActivity.kt
+++ b/app/src/main/java/com/ioannapergamali/mysmartroute/viewmodel/MainActivity.kt
@@ -5,6 +5,7 @@ import androidx.activity.ComponentActivity
 import androidx.activity.compose.setContent
 import androidx.navigation.compose.rememberNavController
 import com.ioannapergamali.mysmartroute.model.navigation.NavigationHost
+import com.ioannapergamali.mysmartroute.utils.MiuiUtils
 
 
 
@@ -13,6 +14,8 @@ class MainActivity : ComponentActivity()
     override fun onCreate(savedInstanceState : Bundle?)
     {
         super.onCreate(savedInstanceState)
+        // Προαιρετικός έλεγχος ύπαρξης του MIUI Service Delivery provider
+        MiuiUtils.callServiceDelivery(this, "ping")
         setContent {
                 val navController = rememberNavController()
                 NavigationHost(navController = navController)


### PR DESCRIPTION
## Summary
- create `MiuiUtils` to safely access MIUI Service Delivery provider
- use `MiuiUtils` in `MainActivity` during startup

## Testing
- `./gradlew test --no-daemon` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_6847937fdb8c8328bf0dfafff3fbb4e4