### PR TITLE
Fix Firestore deserialization crash

### DIFF
--- a/app/src/main/java/com/ioannapergamali/mysmartroute/data/local/PoIEntity.kt
+++ b/app/src/main/java/com/ioannapergamali/mysmartroute/data/local/PoIEntity.kt
@@ -5,10 +5,10 @@ import androidx.room.PrimaryKey
 
 @Entity(tableName = "pois")
 data class PoIEntity(
-    @PrimaryKey val id: String,
-    val name: String,
-    val description: String,
-    val type: String,
-    val lat: Double,
-    val lng: Double
+    @PrimaryKey val id: String = "",
+    val name: String = "",
+    val description: String = "",
+    val type: String = "",
+    val lat: Double = 0.0,
+    val lng: Double = 0.0
 )


### PR DESCRIPTION
## Summary
- add default values in `PoIEntity` so Firestore can create it without a constructor

## Testing
- `./gradlew testDebug` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_6847add2a7e083288cca51ccee7326ec