### PR TITLE
Show saved POIs on announce screen

### DIFF
--- a/app/src/main/java/com/ioannapergamali/mysmartroute/data/local/PoIDao.kt
+++ b/app/src/main/java/com/ioannapergamali/mysmartroute/data/local/PoIDao.kt
@@ -15,4 +15,10 @@ interface PoIDao {
 
     @Query("SELECT * FROM pois")
     suspend fun getAll(): List<PoIEntity>
+
+    @Query("SELECT * FROM pois WHERE lat = :lat AND lng = :lng LIMIT 1")
+    suspend fun findByLocation(lat: Double, lng: Double): PoIEntity?
+
+    @Query("SELECT * FROM pois WHERE name = :name LIMIT 1")
+    suspend fun findByName(name: String): PoIEntity?
 }

--- a/app/src/main/java/com/ioannapergamali/mysmartroute/view/ui/screens/AnnounceTransportScreen.kt
+++ b/app/src/main/java/com/ioannapergamali/mysmartroute/view/ui/screens/AnnounceTransportScreen.kt
@@ -65,6 +65,7 @@ fun AnnounceTransportScreen(navController: NavController) {
     val poiViewModel: PoIViewModel = viewModel()
     val state by viewModel.state.collectAsState()
     val vehicles by vehicleViewModel.vehicles.collectAsState()
+    val pois by poiViewModel.pois.collectAsState()
 
     val context = LocalContext.current
 
@@ -77,10 +78,16 @@ fun AnnounceTransportScreen(navController: NavController) {
     var fromQuery by remember { mutableStateOf("") }
     var fromExpanded by remember { mutableStateOf(false) }
     var fromSuggestions by remember { mutableStateOf<List<Address>>(emptyList()) }
+    val fromPoiSuggestions = remember(fromQuery, pois) {
+        pois.filter { it.name.contains(fromQuery, ignoreCase = true) }
+    }
 
     var toQuery by remember { mutableStateOf("") }
     var toExpanded by remember { mutableStateOf(false) }
     var toSuggestions by remember { mutableStateOf<List<Address>>(emptyList()) }
+    val toPoiSuggestions = remember(toQuery, pois) {
+        pois.filter { it.name.contains(toQuery, ignoreCase = true) }
+    }
 
     var selectedVehicleType by remember { mutableStateOf<VehicleType?>(null) }
 
@@ -362,6 +369,18 @@ fun AnnounceTransportScreen(navController: NavController) {
                         }
                     )
                 }
+                fromPoiSuggestions.forEach { poi ->
+                    DropdownMenuItem(
+                        text = { Text(poi.name) },
+                        onClick = {
+                            fromQuery = poi.name
+                            startLatLng = LatLng(poi.lat, poi.lng)
+                            showRoute = false
+                            cameraPositionState.position = CameraPosition.fromLatLngZoom(startLatLng!!, 10f)
+                            fromExpanded = false
+                        }
+                    )
+                }
             }
         }
 
@@ -421,6 +440,18 @@ fun AnnounceTransportScreen(navController: NavController) {
                         onClick = {
                             toQuery = address.getAddressLine(0) ?: ""
                             endLatLng = LatLng(address.latitude, address.longitude)
+                            showRoute = false
+                            cameraPositionState.position = CameraPosition.fromLatLngZoom(endLatLng!!, 10f)
+                            toExpanded = false
+                        }
+                    )
+                }
+                toPoiSuggestions.forEach { poi ->
+                    DropdownMenuItem(
+                        text = { Text(poi.name) },
+                        onClick = {
+                            toQuery = poi.name
+                            endLatLng = LatLng(poi.lat, poi.lng)
                             showRoute = false
                             cameraPositionState.position = CameraPosition.fromLatLngZoom(endLatLng!!, 10f)
                             toExpanded = false

--- a/app/src/main/java/com/ioannapergamali/mysmartroute/viewmodel/PoIViewModel.kt
+++ b/app/src/main/java/com/ioannapergamali/mysmartroute/viewmodel/PoIViewModel.kt
@@ -37,9 +37,12 @@ class PoIViewModel : ViewModel() {
 
     fun addPoi(context: Context, name: String, description: String, type: String, lat: Double, lng: Double) {
         viewModelScope.launch {
+            val dao = MySmartRouteDatabase.getInstance(context).poIDao()
+            val exists = dao.findByLocation(lat, lng) != null || dao.findByName(name) != null
+            if (exists) return@launch
+
             val id = UUID.randomUUID().toString()
             val poi = PoIEntity(id, name, description, type, lat, lng)
-            val dao = MySmartRouteDatabase.getInstance(context).poIDao()
             dao.insert(poi)
             val data = hashMapOf(
                 "id" to id,


### PR DESCRIPTION
## Summary
- add DAO methods to query POIs
- avoid inserting duplicate POIs
- display saved POIs in From/To dropdowns of AnnounceTransportScreen

## Testing
- `./gradlew test` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_68496df4c150832883d160518840c7ed