### PR TITLE
Fix error reset when selecting map point

### DIFF
--- a/app/src/main/java/com/ioannapergamali/mysmartroute/view/ui/screens/AnnounceTransportScreen.kt
+++ b/app/src/main/java/com/ioannapergamali/mysmartroute/view/ui/screens/AnnounceTransportScreen.kt
@@ -224,6 +224,7 @@ fun AnnounceTransportScreen(navController: NavController) {
                                 fromQuery = reverseGeocode(context, latLng) ?: "${latLng.latitude},${latLng.longitude}"
                                 selectedFromDescription = fromQuery
                             }
+                            fromError = false
                             mapSelectionMode = null
                         }
                         MapSelectionMode.TO -> {
@@ -233,6 +234,7 @@ fun AnnounceTransportScreen(navController: NavController) {
                                 toQuery = reverseGeocode(context, latLng) ?: "${latLng.latitude},${latLng.longitude}"
                                 selectedToDescription = toQuery
                             }
+                            toError = false
                             mapSelectionMode = null
                         }
                         null -> {}


### PR DESCRIPTION
## Summary
- clear error flags when selecting a location on the map

## Testing
- `./gradlew test --console=plain` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_68498386bde48328b291898932058789