### PR TITLE
Refresh route when selecting new map point

### DIFF
--- a/app/src/main/java/com/ioannapergamali/mysmartroute/view/ui/screens/AnnounceTransportScreen.kt
+++ b/app/src/main/java/com/ioannapergamali/mysmartroute/view/ui/screens/AnnounceTransportScreen.kt
@@ -168,6 +168,7 @@ fun AnnounceTransportScreen(navController: NavController) {
                 }
                 durationMinutes = (result.duration * factor).toInt()
                 routePoints = result.points
+                showRoute = result.status == "OK" && routePoints.isNotEmpty()
                 if (result.status == "NOT_FOUND" || result.status == "INVALID_REQUEST") {
                     Toast.makeText(context, context.getString(R.string.invalid_coordinates), Toast.LENGTH_SHORT).show()
                 }


### PR DESCRIPTION
## Summary
- automatically display new route after selecting a new point in **AnnounceTransportScreen**

## Testing
- `./gradlew test --no-daemon` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_684985dfc1e8832889dd5630b87bfbf4