### PR TITLE
Προσθήκη navigation drawer

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -13,8 +13,8 @@ android {
         applicationId = "com.ioannapergamali.mysmartroute"
         minSdk = 33
         targetSdk = 35
-        versionCode = 1
-        versionName = "1.0"
+        versionCode = 2
+        versionName = "1.1"
         testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"
     }
 

--- a/app/src/main/java/com/ioannapergamali/mysmartroute/model/navigation/NavigationHost.kt
+++ b/app/src/main/java/com/ioannapergamali/mysmartroute/model/navigation/NavigationHost.kt
@@ -13,11 +13,14 @@ import com.ioannapergamali.mysmartroute.view.ui.screens.RegisterVehicleScreen
 import com.ioannapergamali.mysmartroute.view.ui.screens.AnnounceTransportScreen
 import com.ioannapergamali.mysmartroute.view.ui.screens.DirectionsMapScreen
 import com.ioannapergamali.mysmartroute.view.ui.screens.PoIListScreen
+import com.ioannapergamali.mysmartroute.view.ui.screens.SettingsScreen
+import com.ioannapergamali.mysmartroute.view.ui.screens.AboutScreen
+import com.ioannapergamali.mysmartroute.view.ui.screens.SupportScreen
 
 
 
 @Composable
-fun NavigationHost(navController : NavHostController) {
+fun NavigationHost(navController : NavHostController, openDrawer: () -> Unit) {
 
     NavHost(navController = navController , startDestination = "home") {
 
@@ -29,7 +32,8 @@ fun NavigationHost(navController : NavHostController) {
                 },
                 onNavigateToLogin = {
                     navController.navigate("login")
-                }
+                },
+                openDrawer = openDrawer
             )
         }
 
@@ -40,7 +44,8 @@ fun NavigationHost(navController : NavHostController) {
                     navController.navigate("menu") {
                         popUpTo("login") { inclusive = true }
                     }
-                }
+                },
+                openDrawer = openDrawer
             )
         }
 
@@ -53,23 +58,24 @@ fun NavigationHost(navController : NavHostController) {
                     navController.navigate("menu") {
                         popUpTo("signup") { inclusive = true }
                     }
-                }
+                },
+                openDrawer = openDrawer
             )
         }
         composable("menu") {
-            MenuScreen(navController = navController)
+            MenuScreen(navController = navController, openDrawer = openDrawer)
         }
 
         composable("registerVehicle") {
-            RegisterVehicleScreen(navController = navController)
+            RegisterVehicleScreen(navController = navController, openDrawer = openDrawer)
         }
 
         composable("announceTransport") {
-            AnnounceTransportScreen(navController = navController)
+            AnnounceTransportScreen(navController = navController, openDrawer = openDrawer)
         }
 
         composable("poiList") {
-            PoIListScreen(navController = navController)
+            PoIListScreen(navController = navController, openDrawer = openDrawer)
         }
 
         composable(
@@ -81,7 +87,19 @@ fun NavigationHost(navController : NavHostController) {
         ) { backStackEntry ->
             val start = backStackEntry.arguments?.getString("start") ?: ""
             val end = backStackEntry.arguments?.getString("end") ?: ""
-            DirectionsMapScreen(navController = navController, start = start, end = end)
+            DirectionsMapScreen(navController = navController, start = start, end = end, openDrawer = openDrawer)
+        }
+
+        composable("settings") {
+            SettingsScreen(navController = navController, openDrawer = openDrawer)
+        }
+
+        composable("about") {
+            AboutScreen(navController = navController, openDrawer = openDrawer)
+        }
+
+        composable("support") {
+            SupportScreen(navController = navController, openDrawer = openDrawer)
         }
 
 

--- a/app/src/main/java/com/ioannapergamali/mysmartroute/view/ui/components/NavigationDrawer.kt
+++ b/app/src/main/java/com/ioannapergamali/mysmartroute/view/ui/components/NavigationDrawer.kt
@@ -1,0 +1,67 @@
+package com.ioannapergamali.mysmartroute.view.ui.components
+
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.Info
+import androidx.compose.material.icons.filled.Settings
+import androidx.compose.material.icons.filled.Email
+import androidx.compose.material3.*
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.rememberCoroutineScope
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.unit.dp
+import androidx.navigation.NavController
+import kotlinx.coroutines.launch
+
+@Composable
+fun DrawerMenu(navController: NavController, closeDrawer: () -> Unit) {
+    ModalDrawerSheet {
+        Text("Menu", modifier = Modifier.padding(16.dp))
+        Divider()
+        NavigationDrawerItem(
+            label = { Text("Settings") },
+            selected = false,
+            onClick = {
+                navController.navigate("settings")
+                closeDrawer()
+            },
+            icon = { Icon(Icons.Filled.Settings, contentDescription = null) }
+        )
+        NavigationDrawerItem(
+            label = { Text("About") },
+            selected = false,
+            onClick = {
+                navController.navigate("about")
+                closeDrawer()
+            },
+            icon = { Icon(Icons.Filled.Info, contentDescription = null) }
+        )
+        NavigationDrawerItem(
+            label = { Text("Support") },
+            selected = false,
+            onClick = {
+                navController.navigate("support")
+                closeDrawer()
+            },
+            icon = { Icon(Icons.Filled.Email, contentDescription = null) }
+        )
+    }
+}
+
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+fun DrawerWrapper(
+    navController: NavController,
+    content: @Composable (openDrawer: () -> Unit) -> Unit
+) {
+    val drawerState = rememberDrawerState(initialValue = DrawerValue.Closed)
+    val scope = rememberCoroutineScope()
+
+    ModalNavigationDrawer(
+        drawerState = drawerState,
+        drawerContent = {
+            DrawerMenu(navController) { scope.launch { drawerState.close() } }
+        }
+    ) {
+        content { scope.launch { drawerState.open() } }
+    }
+}

--- a/app/src/main/java/com/ioannapergamali/mysmartroute/view/ui/components/TopBar.kt
+++ b/app/src/main/java/com/ioannapergamali/mysmartroute/view/ui/components/TopBar.kt
@@ -2,6 +2,7 @@ package com.ioannapergamali.mysmartroute.view.ui.components
 
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.automirrored.filled.List
+import androidx.compose.material.icons.filled.Menu
 import androidx.compose.material.icons.filled.Logout
 import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.Icon
@@ -16,16 +17,20 @@ import androidx.navigation.NavController
 fun TopBar(
     title: String,
     navController: NavController,
+    showMenu: Boolean = false,
     showLogout: Boolean = false,
+    onMenuClick: () -> Unit = {},
     onLogout: () -> Unit = {}
 ) {
     TopAppBar(
         title = { Text(title) },
         navigationIcon = {
-            IconButton(onClick = { navController.popBackStack() }) {
+            IconButton(onClick = {
+                if (showMenu) onMenuClick() else navController.popBackStack()
+            }) {
                 Icon(
-                    Icons.AutoMirrored.Filled.List,
-                    contentDescription = "list"
+                    if (showMenu) Icons.Filled.Menu else Icons.AutoMirrored.Filled.List,
+                    contentDescription = if (showMenu) "menu" else "list"
                 )
             }
         },

--- a/app/src/main/java/com/ioannapergamali/mysmartroute/view/ui/screens/AboutScreen.kt
+++ b/app/src/main/java/com/ioannapergamali/mysmartroute/view/ui/screens/AboutScreen.kt
@@ -1,0 +1,33 @@
+package com.ioannapergamali.mysmartroute.view.ui.screens
+
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.padding
+import androidx.compose.material3.Scaffold
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.unit.dp
+import androidx.navigation.NavController
+import com.ioannapergamali.mysmartroute.view.ui.components.TopBar
+
+@Composable
+fun AboutScreen(navController: NavController, openDrawer: () -> Unit) {
+    Scaffold(
+        topBar = {
+            TopBar(
+                title = "About",
+                navController = navController,
+                showMenu = true,
+                onMenuClick = openDrawer
+            )
+        }
+    ) { padding ->
+        Column(modifier = Modifier.fillMaxSize().padding(padding).padding(16.dp)) {
+            Text("Developer: Ιωάννα Περγάμαλη")
+            Text("Company: JOPE")
+            Text("Address: Πάροδος Κρήτης 8, Γάζι, ΤΚ 71414")
+            Text("Repository: https://github.com/ipergamali/mysmartroute.git")
+        }
+    }
+}

--- a/app/src/main/java/com/ioannapergamali/mysmartroute/view/ui/screens/AnnounceTransportScreen.kt
+++ b/app/src/main/java/com/ioannapergamali/mysmartroute/view/ui/screens/AnnounceTransportScreen.kt
@@ -77,7 +77,7 @@ private suspend fun geocode(context: Context, query: String): Pair<LatLng, Strin
 
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable
-fun AnnounceTransportScreen(navController: NavController) {
+fun AnnounceTransportScreen(navController: NavController, openDrawer: () -> Unit) {
     val viewModel: TransportAnnouncementViewModel = viewModel()
     val vehicleViewModel: VehicleViewModel = viewModel()
     val poiViewModel: PoIViewModel = viewModel()
@@ -178,7 +178,12 @@ fun AnnounceTransportScreen(navController: NavController) {
     }
 
     Column(modifier = Modifier.fillMaxSize().padding(16.dp)) {
-        TopBar(title = "Announce Transport", navController = navController)
+        TopBar(
+            title = "Announce Transport",
+            navController = navController,
+            showMenu = true,
+            onMenuClick = openDrawer
+        )
         Spacer(modifier = Modifier.height(16.dp))
 
         if (!isKeyMissing) {

--- a/app/src/main/java/com/ioannapergamali/mysmartroute/view/ui/screens/DirectionsMapScreen.kt
+++ b/app/src/main/java/com/ioannapergamali/mysmartroute/view/ui/screens/DirectionsMapScreen.kt
@@ -17,11 +17,17 @@ import com.ioannapergamali.mysmartroute.view.ui.components.TopBar
 fun DirectionsMapScreen(
     navController: NavController,
     start: String,
-    end: String
+    end: String,
+    openDrawer: () -> Unit
 ) {
     Scaffold(
         topBar = {
-            TopBar(title = "Directions", navController = navController)
+            TopBar(
+                title = "Directions",
+                navController = navController,
+                showMenu = true,
+                onMenuClick = openDrawer
+            )
         }
     ) { paddingValues ->
         AndroidView(

--- a/app/src/main/java/com/ioannapergamali/mysmartroute/view/ui/screens/HomeScreen.kt
+++ b/app/src/main/java/com/ioannapergamali/mysmartroute/view/ui/screens/HomeScreen.kt
@@ -20,13 +20,16 @@ import com.ioannapergamali.mysmartroute.view.ui.animation.rememberSlideFadeInAni
 fun HomeScreen(
     navController: NavController,
     onNavigateToSignUp: () -> Unit,
-    onNavigateToLogin: () -> Unit
+    onNavigateToLogin: () -> Unit,
+    openDrawer: () -> Unit
 ) {
     Scaffold(
         topBar = {
             TopBar(
                 title = "Home",
-                navController = navController
+                navController = navController,
+                showMenu = true,
+                onMenuClick = openDrawer
             )
         }
     ) { paddingValues ->

--- a/app/src/main/java/com/ioannapergamali/mysmartroute/view/ui/screens/LoginScreen.kt
+++ b/app/src/main/java/com/ioannapergamali/mysmartroute/view/ui/screens/LoginScreen.kt
@@ -18,7 +18,8 @@ import androidx.compose.ui.platform.LocalContext
 fun LoginScreen(
     navController: NavController,
     onLoginSuccess: () -> Unit,
-    onLoginFailure: (String) -> Unit = {}
+    onLoginFailure: (String) -> Unit = {},
+    openDrawer: () -> Unit
 ) {
     val viewModel: AuthenticationViewModel = viewModel()
     val uiState by viewModel.loginState.collectAsState()
@@ -31,7 +32,9 @@ fun LoginScreen(
         topBar = {
             TopBar(
                 title = "Login",
-                navController = navController
+                navController = navController,
+                showMenu = true,
+                onMenuClick = openDrawer
             )
         }
     ) { paddingValues ->

--- a/app/src/main/java/com/ioannapergamali/mysmartroute/view/ui/screens/MenuScreen.kt
+++ b/app/src/main/java/com/ioannapergamali/mysmartroute/view/ui/screens/MenuScreen.kt
@@ -18,7 +18,7 @@ import com.ioannapergamali.mysmartroute.model.enumerations.UserRole
 import com.ioannapergamali.mysmartroute.viewmodel.AuthenticationViewModel
 
 @Composable
-fun MenuScreen(navController: NavController) {
+fun MenuScreen(navController: NavController, openDrawer: () -> Unit) {
     val viewModel: AuthenticationViewModel = viewModel()
     val role by viewModel.currentUserRole.collectAsState()
 
@@ -33,7 +33,9 @@ fun MenuScreen(navController: NavController) {
             TopBar(
                 title = "Menu",
                 navController = navController,
+                showMenu = true,
                 showLogout = true,
+                onMenuClick = openDrawer,
                 onLogout = {
                     viewModel.signOut()
                     Toast.makeText(context, "Logged out", Toast.LENGTH_SHORT).show()

--- a/app/src/main/java/com/ioannapergamali/mysmartroute/view/ui/screens/PoIListScreen.kt
+++ b/app/src/main/java/com/ioannapergamali/mysmartroute/view/ui/screens/PoIListScreen.kt
@@ -20,14 +20,14 @@ import com.ioannapergamali.mysmartroute.viewmodel.PoIViewModel
 
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable
-fun PoIListScreen(navController: NavController) {
+fun PoIListScreen(navController: NavController, openDrawer: () -> Unit) {
     val viewModel: PoIViewModel = viewModel()
     val pois by viewModel.pois.collectAsState()
     val context = LocalContext.current
 
     LaunchedEffect(Unit) { viewModel.loadPois(context) }
 
-    Scaffold(topBar = { TopBar(title = "PoIs", navController = navController) }) { padding ->
+    Scaffold(topBar = { TopBar(title = "PoIs", navController = navController, showMenu = true, onMenuClick = openDrawer) }) { padding ->
         Column(Modifier.fillMaxSize()) {
             LazyColumn(modifier = Modifier.fillMaxSize()) {
                 items(pois) { poi ->

--- a/app/src/main/java/com/ioannapergamali/mysmartroute/view/ui/screens/RegisterVehicleScreen.kt
+++ b/app/src/main/java/com/ioannapergamali/mysmartroute/view/ui/screens/RegisterVehicleScreen.kt
@@ -17,7 +17,7 @@ import com.ioannapergamali.mysmartroute.viewmodel.VehicleViewModel
 
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable
-fun RegisterVehicleScreen(navController: NavController) {
+fun RegisterVehicleScreen(navController: NavController, openDrawer: () -> Unit) {
     val viewModel: VehicleViewModel = viewModel()
     val state by viewModel.registerState.collectAsState()
     val context = LocalContext.current
@@ -29,7 +29,12 @@ fun RegisterVehicleScreen(navController: NavController) {
 
     Scaffold(
         topBar = {
-            TopBar(title = "Register Vehicle", navController = navController)
+            TopBar(
+                title = "Register Vehicle",
+                navController = navController,
+                showMenu = true,
+                onMenuClick = openDrawer
+            )
         }
     ) { paddingValues ->
         Column(

--- a/app/src/main/java/com/ioannapergamali/mysmartroute/view/ui/screens/SettingsScreen.kt
+++ b/app/src/main/java/com/ioannapergamali/mysmartroute/view/ui/screens/SettingsScreen.kt
@@ -1,0 +1,30 @@
+package com.ioannapergamali.mysmartroute.view.ui.screens
+
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.padding
+import androidx.compose.material3.Scaffold
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.unit.dp
+import androidx.navigation.NavController
+import com.ioannapergamali.mysmartroute.view.ui.components.TopBar
+
+@Composable
+fun SettingsScreen(navController: NavController, openDrawer: () -> Unit) {
+    Scaffold(
+        topBar = {
+            TopBar(
+                title = "Settings",
+                navController = navController,
+                showMenu = true,
+                onMenuClick = openDrawer
+            )
+        }
+    ) { padding ->
+        Column(modifier = Modifier.fillMaxSize().padding(padding).padding(16.dp)) {
+            Text("Settings screen")
+        }
+    }
+}

--- a/app/src/main/java/com/ioannapergamali/mysmartroute/view/ui/screens/SignUpScreen.kt
+++ b/app/src/main/java/com/ioannapergamali/mysmartroute/view/ui/screens/SignUpScreen.kt
@@ -23,7 +23,8 @@ import com.ioannapergamali.mysmartroute.viewmodel.AuthenticationViewModel
 fun SignUpScreen(
     navController: NavController,
     onSignUpSuccess: () -> Unit,
-    onSignUpFailure: (String) -> Unit = {}
+    onSignUpFailure: (String) -> Unit = {},
+    openDrawer: () -> Unit
 ) {
     val viewModel: AuthenticationViewModel = viewModel()
     val uiState by viewModel.signUpState.collectAsState()
@@ -47,7 +48,9 @@ fun SignUpScreen(
         topBar = {
             TopBar(
                 title = "Sign Up",
-                navController = navController
+                navController = navController,
+                showMenu = true,
+                onMenuClick = openDrawer
             )
         }
     ) { paddingValues ->

--- a/app/src/main/java/com/ioannapergamali/mysmartroute/view/ui/screens/SupportScreen.kt
+++ b/app/src/main/java/com/ioannapergamali/mysmartroute/view/ui/screens/SupportScreen.kt
@@ -1,0 +1,31 @@
+package com.ioannapergamali.mysmartroute.view.ui.screens
+
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.padding
+import androidx.compose.material3.Scaffold
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.unit.dp
+import androidx.navigation.NavController
+import com.ioannapergamali.mysmartroute.view.ui.components.TopBar
+
+@Composable
+fun SupportScreen(navController: NavController, openDrawer: () -> Unit) {
+    Scaffold(
+        topBar = {
+            TopBar(
+                title = "Support",
+                navController = navController,
+                showMenu = true,
+                onMenuClick = openDrawer
+            )
+        }
+    ) { padding ->
+        Column(modifier = Modifier.fillMaxSize().padding(padding).padding(16.dp)) {
+            Text("Email: smartroute@info.gr")
+            Text("Address: Πάροδος Κρήτης 8, Γάζι, ΤΚ 71414")
+        }
+    }
+}

--- a/app/src/main/java/com/ioannapergamali/mysmartroute/viewmodel/MainActivity.kt
+++ b/app/src/main/java/com/ioannapergamali/mysmartroute/viewmodel/MainActivity.kt
@@ -5,6 +5,7 @@ import androidx.activity.ComponentActivity
 import androidx.activity.compose.setContent
 import androidx.navigation.compose.rememberNavController
 import com.ioannapergamali.mysmartroute.model.navigation.NavigationHost
+import com.ioannapergamali.mysmartroute.view.ui.components.DrawerWrapper
 import com.ioannapergamali.mysmartroute.utils.MiuiUtils
 
 
@@ -17,8 +18,10 @@ class MainActivity : ComponentActivity()
         // Προαιρετικός έλεγχος ύπαρξης του MIUI Service Delivery provider
         MiuiUtils.callServiceDelivery(this, "ping")
         setContent {
-                val navController = rememberNavController()
-                NavigationHost(navController = navController)
+            val navController = rememberNavController()
+            DrawerWrapper(navController = navController) { openDrawer ->
+                NavigationHost(navController = navController, openDrawer = openDrawer)
+            }
         }
     }
 


### PR DESCRIPTION
## Summary
- προστέθηκε navigation drawer με επιλογές Settings, About και Support
- δημιουργήθηκαν οι οθόνες Settings, About και Support
- ενημερώθηκε το TopBar ώστε να υποστηρίζει menu button
- όλες οι οθόνες χρησιμοποιούν πλέον το συρτάρι πλοήγησης
- αυξήθηκε το versionName σε 1.1

## Testing
- `./gradlew assembleDebug` *(αποτυγχάνει: SDK location not found)*
- `./gradlew test` *(αποτυγχάνει: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_6849b48974a48328b050e352be52a9db