### PR TITLE
Προσθήκη επιλογής θεμάτων

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -63,6 +63,9 @@ dependencies {
     implementation("androidx.navigation:navigation-compose:2.7.1")
     implementation("androidx.compose.material:material-icons-extended:1.6.4")
 
+    // DataStore για αποθήκευση ρυθμίσεων
+    implementation("androidx.datastore:datastore-preferences:1.1.7")
+
     // Firebase
     implementation("com.google.firebase:firebase-auth-ktx:22.3.1")
     implementation("com.google.firebase:firebase-firestore-ktx:24.11.1")

--- a/app/src/main/java/com/ioannapergamali/mysmartroute/utils/ThemePreferenceManager.kt
+++ b/app/src/main/java/com/ioannapergamali/mysmartroute/utils/ThemePreferenceManager.kt
@@ -1,0 +1,27 @@
+package com.ioannapergamali.mysmartroute.utils
+
+import android.content.Context
+import androidx.datastore.preferences.core.intPreferencesKey
+import androidx.datastore.preferences.core.edit
+import androidx.datastore.preferences.preferencesDataStore
+import com.ioannapergamali.mysmartroute.view.ui.AppTheme
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.map
+
+private val Context.dataStore by preferencesDataStore(name = "settings")
+
+object ThemePreferenceManager {
+    private val THEME_KEY = intPreferencesKey("theme")
+
+    fun themeFlow(context: Context): Flow<AppTheme> =
+        context.dataStore.data.map { prefs ->
+            val index = prefs[THEME_KEY] ?: 0
+            AppTheme.values().getOrElse(index) { AppTheme.Ocean }
+        }
+
+    suspend fun setTheme(context: Context, theme: AppTheme) {
+        context.dataStore.edit { prefs ->
+            prefs[THEME_KEY] = theme.ordinal
+        }
+    }
+}

--- a/app/src/main/java/com/ioannapergamali/mysmartroute/view/ui/Theme.kt
+++ b/app/src/main/java/com/ioannapergamali/mysmartroute/view/ui/Theme.kt
@@ -1,0 +1,44 @@
+package com.ioannapergamali.mysmartroute.view.ui
+
+import androidx.compose.material3.ColorScheme
+import androidx.compose.material3.darkColorScheme
+import androidx.compose.material3.lightColorScheme
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.graphics.Color
+
+enum class AppTheme(val label: String, val seed: Color) {
+    Ocean("Ocean", Color(0xFF2196F3)),
+    Sunset("Sunset", Color(0xFFEF5350)),
+    Forest("Forest", Color(0xFF2E7D32)),
+    Lemon("Lemon", Color(0xFFF9A825)),
+    Rose("Rose", Color(0xFFD81B60)),
+    Orange("Orange", Color(0xFFFB8C00)),
+    Purple("Purple", Color(0xFF8E24AA)),
+    Coffee("Coffee", Color(0xFF795548)),
+    Cyan("Cyan", Color(0xFF00838F)),
+    Teal("Teal", Color(0xFF00796B));
+
+    val lightColors: ColorScheme
+        get() = lightColorScheme(
+            primary = seed,
+            secondary = seed,
+            tertiary = seed
+        )
+
+    val darkColors: ColorScheme
+        get() = darkColorScheme(
+            primary = seed,
+            secondary = seed,
+            tertiary = seed
+        )
+}
+
+@Composable
+fun MysmartrouteTheme(theme: AppTheme, darkTheme: Boolean, content: @Composable () -> Unit) {
+    val colorScheme = if (darkTheme) theme.darkColors else theme.lightColors
+    androidx.compose.material3.MaterialTheme(
+        colorScheme = colorScheme,
+        typography = androidx.compose.material3.MaterialTheme.typography,
+        content = content
+    )
+}

--- a/app/src/main/java/com/ioannapergamali/mysmartroute/view/ui/screens/SettingsScreen.kt
+++ b/app/src/main/java/com/ioannapergamali/mysmartroute/view/ui/screens/SettingsScreen.kt
@@ -3,16 +3,37 @@ package com.ioannapergamali.mysmartroute.view.ui.screens
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.width
+import androidx.compose.ui.Alignment
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.lazy.items
 import androidx.compose.material3.Scaffold
 import androidx.compose.material3.Text
+import androidx.compose.material3.RadioButton
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.collectAsState
+import androidx.compose.runtime.getValue
+import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.unit.dp
 import androidx.navigation.NavController
 import com.ioannapergamali.mysmartroute.view.ui.components.TopBar
+import com.ioannapergamali.mysmartroute.view.ui.AppTheme
+import com.ioannapergamali.mysmartroute.utils.ThemePreferenceManager
+import kotlinx.coroutines.launch
+import androidx.compose.runtime.rememberCoroutineScope
 
 @Composable
 fun SettingsScreen(navController: NavController, openDrawer: () -> Unit) {
+    val context = LocalContext.current
+    val scope = rememberCoroutineScope()
+    val currentTheme by ThemePreferenceManager.themeFlow(context).collectAsState(initial = AppTheme.Ocean)
+    val themes = AppTheme.values()
+
     Scaffold(
         topBar = {
             TopBar(
@@ -24,7 +45,29 @@ fun SettingsScreen(navController: NavController, openDrawer: () -> Unit) {
         }
     ) { padding ->
         Column(modifier = Modifier.fillMaxSize().padding(padding).padding(16.dp)) {
-            Text("Settings screen")
+            Text("Επιλογή θέματος")
+            LazyColumn {
+                items(themes) { theme ->
+                    Row(
+                        verticalAlignment = Alignment.CenterVertically,
+                        modifier = Modifier
+                            .fillMaxWidth()
+                            .clickable {
+                                scope.launch { ThemePreferenceManager.setTheme(context, theme) }
+                            }
+                            .padding(vertical = 8.dp)
+                    ) {
+                        RadioButton(
+                            selected = theme == currentTheme,
+                            onClick = {
+                                scope.launch { ThemePreferenceManager.setTheme(context, theme) }
+                            }
+                        )
+                        Spacer(Modifier.width(8.dp))
+                        Text(theme.label)
+                    }
+                }
+            }
         }
     }
 }

--- a/app/src/main/java/com/ioannapergamali/mysmartroute/viewmodel/MainActivity.kt
+++ b/app/src/main/java/com/ioannapergamali/mysmartroute/viewmodel/MainActivity.kt
@@ -3,10 +3,17 @@ package com.ioannapergamali.mysmartroute.viewmodel
 import android.os.Bundle
 import androidx.activity.ComponentActivity
 import androidx.activity.compose.setContent
+import androidx.compose.runtime.collectAsState
+import androidx.compose.runtime.getValue
+import androidx.compose.ui.platform.LocalContext
+import androidx.compose.material3.isSystemInDarkTheme
 import androidx.navigation.compose.rememberNavController
 import com.ioannapergamali.mysmartroute.model.navigation.NavigationHost
+import com.ioannapergamali.mysmartroute.view.ui.MysmartrouteTheme
+import com.ioannapergamali.mysmartroute.view.ui.AppTheme
 import com.ioannapergamali.mysmartroute.view.ui.components.DrawerWrapper
 import com.ioannapergamali.mysmartroute.utils.MiuiUtils
+import com.ioannapergamali.mysmartroute.utils.ThemePreferenceManager
 
 
 
@@ -18,9 +25,13 @@ class MainActivity : ComponentActivity()
         // Προαιρετικός έλεγχος ύπαρξης του MIUI Service Delivery provider
         MiuiUtils.callServiceDelivery(this, "ping")
         setContent {
-            val navController = rememberNavController()
-            DrawerWrapper(navController = navController) { openDrawer ->
-                NavigationHost(navController = navController, openDrawer = openDrawer)
+            val context = LocalContext.current
+            val theme by ThemePreferenceManager.themeFlow(context).collectAsState(initial = AppTheme.Ocean)
+            MysmartrouteTheme(theme = theme, darkTheme = isSystemInDarkTheme()) {
+                val navController = rememberNavController()
+                DrawerWrapper(navController = navController) { openDrawer ->
+                    NavigationHost(navController = navController, openDrawer = openDrawer)
+                }
             }
         }
     }


### PR DESCRIPTION
## Συνοπτικά
- δημιουργήθηκε νέο `Theme.kt` με 10 Material3 θέματα
- προστέθηκε `ThemePreferenceManager` για αποθήκευση με DataStore
- ενημερώθηκε η `MainActivity` για φόρτωση του θέματος
- προσθήκη επιλογής θέματος στην οθόνη ρυθμίσεων
- δήλωση εξάρτησης `datastore-preferences`

## Έλεγχοι
- `./gradlew build` *(αποτυγχάνει λόγω έλλειψης Android SDK)*

------
https://chatgpt.com/codex/tasks/task_e_6849c4da08b4832882f4cd941da8a1bc