### PR TITLE
Προσθήκη οθόνης επιλογής θέματος

### DIFF
--- a/app/src/main/java/com/ioannapergamali/mysmartroute/data/local/MySmartRouteDatabase.kt
+++ b/app/src/main/java/com/ioannapergamali/mysmartroute/data/local/MySmartRouteDatabase.kt
@@ -11,13 +11,14 @@ import com.ioannapergamali.mysmartroute.data.local.VehicleEntity
 import com.ioannapergamali.mysmartroute.data.local.PoIEntity
 
 @Database(
-    entities = [UserEntity::class, VehicleEntity::class, PoIEntity::class],
-    version = 3
+    entities = [UserEntity::class, VehicleEntity::class, PoIEntity::class, SettingsEntity::class],
+    version = 4
 )
 abstract class MySmartRouteDatabase : RoomDatabase() {
     abstract fun userDao(): UserDao
     abstract fun vehicleDao(): VehicleDao
     abstract fun poIDao(): PoIDao
+    abstract fun settingsDao(): SettingsDao
 
     companion object {
         @Volatile
@@ -39,13 +40,26 @@ abstract class MySmartRouteDatabase : RoomDatabase() {
             }
         }
 
+        private val MIGRATION_3_4 = object : Migration(3, 4) {
+            override fun migrate(database: SupportSQLiteDatabase) {
+                database.execSQL(
+                    "CREATE TABLE IF NOT EXISTS `settings` (" +
+                        "`userId` TEXT NOT NULL, " +
+                        "`theme` TEXT NOT NULL, " +
+                        "`darkTheme` INTEGER NOT NULL, " +
+                        "PRIMARY KEY(`userId`)" +
+                        ")"
+                )
+            }
+        }
+
         fun getInstance(context: Context): MySmartRouteDatabase {
             return INSTANCE ?: synchronized(this) {
                 INSTANCE ?: Room.databaseBuilder(
                     context.applicationContext,
                     MySmartRouteDatabase::class.java,
                     "mysmartroute.db"
-                ).addMigrations(MIGRATION_2_3)
+                ).addMigrations(MIGRATION_2_3, MIGRATION_3_4)
                     .build().also { INSTANCE = it }
             }
         }

--- a/app/src/main/java/com/ioannapergamali/mysmartroute/data/local/SettingsDao.kt
+++ b/app/src/main/java/com/ioannapergamali/mysmartroute/data/local/SettingsDao.kt
@@ -1,0 +1,15 @@
+package com.ioannapergamali.mysmartroute.data.local
+
+import androidx.room.Dao
+import androidx.room.Insert
+import androidx.room.OnConflictStrategy
+import androidx.room.Query
+
+@Dao
+interface SettingsDao {
+    @Insert(onConflict = OnConflictStrategy.REPLACE)
+    suspend fun insert(settings: SettingsEntity)
+
+    @Query("SELECT * FROM settings WHERE userId = :userId LIMIT 1")
+    suspend fun getSettings(userId: String): SettingsEntity?
+}

--- a/app/src/main/java/com/ioannapergamali/mysmartroute/data/local/SettingsEntity.kt
+++ b/app/src/main/java/com/ioannapergamali/mysmartroute/data/local/SettingsEntity.kt
@@ -1,0 +1,11 @@
+package com.ioannapergamali.mysmartroute.data.local
+
+import androidx.room.Entity
+import androidx.room.PrimaryKey
+
+@Entity(tableName = "settings")
+data class SettingsEntity(
+    @PrimaryKey val userId: String,
+    val theme: String,
+    val darkTheme: Boolean
+)

--- a/app/src/main/java/com/ioannapergamali/mysmartroute/model/navigation/NavigationHost.kt
+++ b/app/src/main/java/com/ioannapergamali/mysmartroute/model/navigation/NavigationHost.kt
@@ -16,6 +16,7 @@ import com.ioannapergamali.mysmartroute.view.ui.screens.PoIListScreen
 import com.ioannapergamali.mysmartroute.view.ui.screens.SettingsScreen
 import com.ioannapergamali.mysmartroute.view.ui.screens.AboutScreen
 import com.ioannapergamali.mysmartroute.view.ui.screens.SupportScreen
+import com.ioannapergamali.mysmartroute.view.ui.screens.ThemePickerScreen
 
 
 
@@ -92,6 +93,10 @@ fun NavigationHost(navController : NavHostController, openDrawer: () -> Unit) {
 
         composable("settings") {
             SettingsScreen(navController = navController, openDrawer = openDrawer)
+        }
+
+        composable("themePicker") {
+            ThemePickerScreen(navController = navController)
         }
 
         composable("about") {

--- a/app/src/main/java/com/ioannapergamali/mysmartroute/utils/ThemePreferenceManager.kt
+++ b/app/src/main/java/com/ioannapergamali/mysmartroute/utils/ThemePreferenceManager.kt
@@ -2,6 +2,7 @@ package com.ioannapergamali.mysmartroute.utils
 
 import android.content.Context
 import androidx.datastore.preferences.core.intPreferencesKey
+import androidx.datastore.preferences.core.booleanPreferencesKey
 import androidx.datastore.preferences.core.edit
 import androidx.datastore.preferences.preferencesDataStore
 import com.ioannapergamali.mysmartroute.view.ui.AppTheme
@@ -12,6 +13,7 @@ private val Context.dataStore by preferencesDataStore(name = "settings")
 
 object ThemePreferenceManager {
     private val THEME_KEY = intPreferencesKey("theme")
+    private val DARK_MODE_KEY = booleanPreferencesKey("dark_mode")
 
     fun themeFlow(context: Context): Flow<AppTheme> =
         context.dataStore.data.map { prefs ->
@@ -19,9 +21,20 @@ object ThemePreferenceManager {
             AppTheme.values().getOrElse(index) { AppTheme.Ocean }
         }
 
+    fun darkThemeFlow(context: Context): Flow<Boolean> =
+        context.dataStore.data.map { prefs ->
+            prefs[DARK_MODE_KEY] ?: false
+        }
+
     suspend fun setTheme(context: Context, theme: AppTheme) {
         context.dataStore.edit { prefs ->
             prefs[THEME_KEY] = theme.ordinal
+        }
+    }
+
+    suspend fun setDarkTheme(context: Context, dark: Boolean) {
+        context.dataStore.edit { prefs ->
+            prefs[DARK_MODE_KEY] = dark
         }
     }
 }

--- a/app/src/main/java/com/ioannapergamali/mysmartroute/view/ui/screens/SettingsScreen.kt
+++ b/app/src/main/java/com/ioannapergamali/mysmartroute/view/ui/screens/SettingsScreen.kt
@@ -3,37 +3,17 @@ package com.ioannapergamali.mysmartroute.view.ui.screens
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.padding
-import androidx.compose.foundation.layout.fillMaxWidth
-import androidx.compose.foundation.layout.Spacer
-import androidx.compose.foundation.layout.width
-import androidx.compose.ui.Alignment
-import androidx.compose.foundation.clickable
-import androidx.compose.foundation.layout.Row
-import androidx.compose.foundation.lazy.LazyColumn
-import androidx.compose.foundation.lazy.items
+import androidx.compose.material3.Button
 import androidx.compose.material3.Scaffold
 import androidx.compose.material3.Text
-import androidx.compose.material3.RadioButton
 import androidx.compose.runtime.Composable
-import androidx.compose.runtime.collectAsState
-import androidx.compose.runtime.getValue
-import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.unit.dp
 import androidx.navigation.NavController
 import com.ioannapergamali.mysmartroute.view.ui.components.TopBar
-import com.ioannapergamali.mysmartroute.view.ui.AppTheme
-import com.ioannapergamali.mysmartroute.utils.ThemePreferenceManager
-import kotlinx.coroutines.launch
-import androidx.compose.runtime.rememberCoroutineScope
 
 @Composable
 fun SettingsScreen(navController: NavController, openDrawer: () -> Unit) {
-    val context = LocalContext.current
-    val scope = rememberCoroutineScope()
-    val currentTheme by ThemePreferenceManager.themeFlow(context).collectAsState(initial = AppTheme.Ocean)
-    val themes = AppTheme.values()
-
     Scaffold(
         topBar = {
             TopBar(
@@ -45,28 +25,8 @@ fun SettingsScreen(navController: NavController, openDrawer: () -> Unit) {
         }
     ) { padding ->
         Column(modifier = Modifier.fillMaxSize().padding(padding).padding(16.dp)) {
-            Text("Επιλογή θέματος")
-            LazyColumn {
-                items(themes) { theme ->
-                    Row(
-                        verticalAlignment = Alignment.CenterVertically,
-                        modifier = Modifier
-                            .fillMaxWidth()
-                            .clickable {
-                                scope.launch { ThemePreferenceManager.setTheme(context, theme) }
-                            }
-                            .padding(vertical = 8.dp)
-                    ) {
-                        RadioButton(
-                            selected = theme == currentTheme,
-                            onClick = {
-                                scope.launch { ThemePreferenceManager.setTheme(context, theme) }
-                            }
-                        )
-                        Spacer(Modifier.width(8.dp))
-                        Text(theme.label)
-                    }
-                }
+            Button(onClick = { navController.navigate("themePicker") }) {
+                Text("Επιλογή θέματος")
             }
         }
     }

--- a/app/src/main/java/com/ioannapergamali/mysmartroute/view/ui/screens/ThemePickerScreen.kt
+++ b/app/src/main/java/com/ioannapergamali/mysmartroute/view/ui/screens/ThemePickerScreen.kt
@@ -1,0 +1,78 @@
+package com.ioannapergamali.mysmartroute.view.ui.screens
+
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.padding
+import androidx.compose.material3.Button
+import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.ExposedDropdownMenuBox
+import androidx.compose.material3.ExposedDropdownMenuDefaults
+import androidx.compose.material3.ExposedDropdownMenu
+import androidx.compose.material3.Text
+import androidx.compose.material3.TextField
+import androidx.compose.material3.DropdownMenuItem
+import androidx.compose.material3.Switch
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.collectAsState
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.rememberCoroutineScope
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.unit.dp
+import androidx.lifecycle.viewmodel.compose.viewModel
+import androidx.navigation.NavController
+import com.ioannapergamali.mysmartroute.view.ui.AppTheme
+import com.ioannapergamali.mysmartroute.viewmodel.SettingsViewModel
+import com.ioannapergamali.mysmartroute.utils.ThemePreferenceManager
+import kotlinx.coroutines.launch
+
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+fun ThemePickerScreen(navController: NavController) {
+    val context = LocalContext.current
+    val scope = rememberCoroutineScope()
+    val viewModel: SettingsViewModel = viewModel()
+    val currentTheme by ThemePreferenceManager.themeFlow(context).collectAsState(initial = AppTheme.Ocean)
+    val currentDark by ThemePreferenceManager.darkThemeFlow(context).collectAsState(initial = false)
+
+    var expanded = remember { mutableStateOf(false) }
+    var selectedTheme = remember { mutableStateOf(currentTheme) }
+    var dark = remember { mutableStateOf(currentDark) }
+
+    Column(Modifier.fillMaxSize().padding(16.dp)) {
+        Text("Themes")
+        ExposedDropdownMenuBox(expanded = expanded.value, onExpandedChange = { expanded.value = !expanded.value }) {
+            TextField(
+                readOnly = true,
+                value = selectedTheme.value.label,
+                onValueChange = {},
+                label = { Text("Theme") },
+                trailingIcon = { ExposedDropdownMenuDefaults.TrailingIcon(expanded = expanded.value) },
+                modifier = Modifier.menuAnchor()
+            )
+            ExposedDropdownMenu(expanded = expanded.value, onDismissRequest = { expanded.value = false }) {
+                AppTheme.values().forEach { theme ->
+                    DropdownMenuItem(text = { Text(theme.label) }, onClick = {
+                        selectedTheme.value = theme
+                        expanded.value = false
+                        scope.launch { ThemePreferenceManager.setTheme(context, theme) }
+                    })
+                }
+            }
+        }
+        Text("Dark Theme")
+        Switch(checked = dark.value, onCheckedChange = {
+            dark.value = it
+            scope.launch { ThemePreferenceManager.setDarkTheme(context, it) }
+        })
+
+        Button(onClick = {
+            viewModel.applyTheme(context, selectedTheme.value, dark.value)
+            navController.popBackStack()
+        }, modifier = Modifier.padding(top = 16.dp)) {
+            Text("Apply")
+        }
+    }
+}

--- a/app/src/main/java/com/ioannapergamali/mysmartroute/viewmodel/MainActivity.kt
+++ b/app/src/main/java/com/ioannapergamali/mysmartroute/viewmodel/MainActivity.kt
@@ -6,7 +6,6 @@ import androidx.activity.compose.setContent
 import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
 import androidx.compose.ui.platform.LocalContext
-import androidx.compose.foundation.isSystemInDarkTheme
 import androidx.navigation.compose.rememberNavController
 import com.ioannapergamali.mysmartroute.model.navigation.NavigationHost
 import com.ioannapergamali.mysmartroute.view.ui.MysmartrouteTheme
@@ -27,7 +26,8 @@ class MainActivity : ComponentActivity()
         setContent {
             val context = LocalContext.current
             val theme by ThemePreferenceManager.themeFlow(context).collectAsState(initial = AppTheme.Ocean)
-            MysmartrouteTheme(theme = theme, darkTheme = isSystemInDarkTheme()) {
+            val dark by ThemePreferenceManager.darkThemeFlow(context).collectAsState(initial = false)
+            MysmartrouteTheme(theme = theme, darkTheme = dark) {
                 val navController = rememberNavController()
                 DrawerWrapper(navController = navController) { openDrawer ->
                     NavigationHost(navController = navController, openDrawer = openDrawer)

--- a/app/src/main/java/com/ioannapergamali/mysmartroute/viewmodel/SettingsViewModel.kt
+++ b/app/src/main/java/com/ioannapergamali/mysmartroute/viewmodel/SettingsViewModel.kt
@@ -1,0 +1,38 @@
+package com.ioannapergamali.mysmartroute.viewmodel
+
+import android.content.Context
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.viewModelScope
+import com.google.firebase.auth.FirebaseAuth
+import com.google.firebase.firestore.FirebaseFirestore
+import com.ioannapergamali.mysmartroute.data.local.MySmartRouteDatabase
+import com.ioannapergamali.mysmartroute.data.local.SettingsEntity
+import com.ioannapergamali.mysmartroute.view.ui.AppTheme
+import com.ioannapergamali.mysmartroute.utils.NetworkUtils
+import com.ioannapergamali.mysmartroute.utils.ThemePreferenceManager
+import kotlinx.coroutines.launch
+
+class SettingsViewModel : ViewModel() {
+    private val db = FirebaseFirestore.getInstance()
+    private val auth = FirebaseAuth.getInstance()
+
+    fun applyTheme(context: Context, theme: AppTheme, dark: Boolean) {
+        viewModelScope.launch {
+            ThemePreferenceManager.setTheme(context, theme)
+            ThemePreferenceManager.setDarkTheme(context, dark)
+
+            val userId = auth.currentUser?.uid ?: return@launch
+            val dao = MySmartRouteDatabase.getInstance(context).settingsDao()
+            val entity = SettingsEntity(userId, theme.name, dark)
+            dao.insert(entity)
+
+            if (NetworkUtils.isInternetAvailable(context)) {
+                val data = mapOf(
+                    "theme" to theme.name,
+                    "darkTheme" to dark
+                )
+                db.collection("user_settings").document(userId).set(data)
+            }
+        }
+    }
+}


### PR DESCRIPTION
## Συνοπτικά
- προστέθηκε `ThemePickerScreen` και νέο `SettingsViewModel`
- επεκτάθηκε η `ThemePreferenceManager` για αποθήκευση dark mode
- δημιουργήθηκε οντότητα `SettingsEntity` με αντίστοιχο `SettingsDao`
- ενημερώθηκε η βάση `MySmartRouteDatabase` και η πλοήγηση
- το κουμπί "Επιλογή θέματος" οδηγεί στη νέα οθόνη

## Έλεγχοι
- `./gradlew assembleDebug` *(αποτυχία: λείπει το Android SDK)*

------
https://chatgpt.com/codex/tasks/task_e_6849cfb9099c832881d21a7ec42406cc