### PR TITLE
Update Material3 dependency

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -55,7 +55,7 @@ dependencies {
     implementation("androidx.constraintlayout:constraintlayout:2.1.4")
 
     // Jetpack Compose
-    implementation("androidx.compose.material3:material3:1.2.1")
+    implementation("androidx.compose.material3:material3-android:1.3.2")
     implementation("androidx.compose.ui:ui:1.6.4")
     implementation("androidx.compose.ui:ui-text:1.6.4")
     implementation("androidx.compose.ui:ui-tooling-preview:1.6.4")


### PR DESCRIPTION
## Summary
- update Material3 dependency to `material3-android:1.3.2`

## Testing
- `./gradlew test` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_6849d4765a6c832898fed0786aca658f