### PR TITLE
Improve theme picker styling

### DIFF
--- a/app/src/main/java/com/ioannapergamali/mysmartroute/view/ui/screens/ThemePickerScreen.kt
+++ b/app/src/main/java/com/ioannapergamali/mysmartroute/view/ui/screens/ThemePickerScreen.kt
@@ -11,6 +11,8 @@ import androidx.compose.material3.Text
 import androidx.compose.material3.TextField
 import androidx.compose.material3.DropdownMenuItem
 import androidx.compose.material3.Switch
+import androidx.compose.material3.Scaffold
+import androidx.compose.material3.MaterialTheme
 import com.ioannapergamali.mysmartroute.view.ui.MysmartrouteTheme
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.collectAsState
@@ -25,6 +27,7 @@ import androidx.navigation.NavController
 import com.ioannapergamali.mysmartroute.view.ui.AppTheme
 import com.ioannapergamali.mysmartroute.viewmodel.SettingsViewModel
 import com.ioannapergamali.mysmartroute.utils.ThemePreferenceManager
+import com.ioannapergamali.mysmartroute.view.ui.components.TopBar
 
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable
@@ -39,36 +42,51 @@ fun ThemePickerScreen(navController: NavController) {
     var dark = remember { mutableStateOf(currentDark) }
 
     MysmartrouteTheme(theme = selectedTheme.value, darkTheme = dark.value) {
-        Column(Modifier.fillMaxSize().padding(16.dp)) {
-            Text("Themes")
-            ExposedDropdownMenuBox(expanded = expanded.value, onExpandedChange = { expanded.value = !expanded.value }) {
-                TextField(
-                    readOnly = true,
-                    value = selectedTheme.value.label,
-                    onValueChange = {},
-                    label = { Text("Theme") },
-                    trailingIcon = { ExposedDropdownMenuDefaults.TrailingIcon(expanded = expanded.value) },
-                    modifier = Modifier.menuAnchor()
-                )
-                ExposedDropdownMenu(expanded = expanded.value, onDismissRequest = { expanded.value = false }) {
-                    AppTheme.values().forEach { theme ->
-                        DropdownMenuItem(text = { Text(theme.label) }, onClick = {
-                            selectedTheme.value = theme
-                            expanded.value = false
-                        })
+        Scaffold(
+            topBar = {
+                TopBar(title = "Themes", navController = navController)
+            },
+            containerColor = MaterialTheme.colorScheme.background
+        ) { padding ->
+            Column(
+                modifier = Modifier
+                    .fillMaxSize()
+                    .padding(padding)
+                    .padding(16.dp)
+            ) {
+                Text("Themes")
+                ExposedDropdownMenuBox(expanded = expanded.value, onExpandedChange = { expanded.value = !expanded.value }) {
+                    TextField(
+                        readOnly = true,
+                        value = selectedTheme.value.label,
+                        onValueChange = {},
+                        label = { Text("Theme") },
+                        trailingIcon = { ExposedDropdownMenuDefaults.TrailingIcon(expanded = expanded.value) },
+                        modifier = Modifier.menuAnchor()
+                    )
+                    ExposedDropdownMenu(expanded = expanded.value, onDismissRequest = { expanded.value = false }) {
+                        AppTheme.values().forEach { theme ->
+                            DropdownMenuItem(text = { Text(theme.label) }, onClick = {
+                                selectedTheme.value = theme
+                                expanded.value = false
+                            })
+                        }
                     }
                 }
-            }
-            Text("Dark Theme")
-            Switch(checked = dark.value, onCheckedChange = {
-                dark.value = it
-            })
+                Text("Dark Theme")
+                Switch(checked = dark.value, onCheckedChange = {
+                    dark.value = it
+                })
 
-            Button(onClick = {
-                viewModel.applyTheme(context, selectedTheme.value, dark.value)
-                navController.popBackStack()
-            }, modifier = Modifier.padding(top = 16.dp)) {
-                Text("Apply")
+                Button(
+                    onClick = {
+                        viewModel.applyTheme(context, selectedTheme.value, dark.value)
+                        navController.popBackStack()
+                    },
+                    modifier = Modifier.padding(top = 16.dp)
+                ) {
+                    Text("Apply")
+                }
             }
         }
     }


### PR DESCRIPTION
## Summary
- update `ThemePickerScreen` to use `Scaffold`
- add top bar and use Material theme background

## Testing
- `./gradlew assembleDebug` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_6849f79c2c408328ad735b923af4c73e