### PR TITLE
Fix typography init in Theme.kt

### DIFF
--- a/app/src/main/java/com/ioannapergamali/mysmartroute/view/ui/Theme.kt
+++ b/app/src/main/java/com/ioannapergamali/mysmartroute/view/ui/Theme.kt
@@ -56,7 +56,7 @@ enum class AppTheme(val label: String, val seed: Color, val fontFamily: FontFami
         )
 
     val typography: Typography
-        get() = Typography(defaultFontFamily = fontFamily)
+        get() = Typography()
 }
 
 @Composable


### PR DESCRIPTION
## Summary
- remove obsolete defaultFontFamily parameter

## Testing
- `./gradlew assembleDebug -x lint` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_684a09deb51c83288a8d7ee2df1d5a5b