### PR TITLE
Προσαρμογή στο σύστημα dark theme & βελτίωση TopBar

### DIFF
--- a/app/src/main/java/com/ioannapergamali/mysmartroute/utils/ThemePreferenceManager.kt
+++ b/app/src/main/java/com/ioannapergamali/mysmartroute/utils/ThemePreferenceManager.kt
@@ -1,6 +1,7 @@
 package com.ioannapergamali.mysmartroute.utils
 
 import android.content.Context
+import android.content.res.Configuration
 import androidx.datastore.preferences.core.intPreferencesKey
 import androidx.datastore.preferences.core.booleanPreferencesKey
 import androidx.datastore.preferences.core.edit
@@ -15,6 +16,11 @@ object ThemePreferenceManager {
     private val THEME_KEY = intPreferencesKey("theme")
     private val DARK_MODE_KEY = booleanPreferencesKey("dark_mode")
 
+    private fun Context.isSystemDarkTheme(): Boolean {
+        val mode = resources.configuration.uiMode and Configuration.UI_MODE_NIGHT_MASK
+        return mode == Configuration.UI_MODE_NIGHT_YES
+    }
+
     fun themeFlow(context: Context): Flow<AppTheme> =
         context.dataStore.data.map { prefs ->
             val index = prefs[THEME_KEY] ?: 0
@@ -23,7 +29,7 @@ object ThemePreferenceManager {
 
     fun darkThemeFlow(context: Context): Flow<Boolean> =
         context.dataStore.data.map { prefs ->
-            prefs[DARK_MODE_KEY] ?: false
+            prefs[DARK_MODE_KEY] ?: context.isSystemDarkTheme()
         }
 
     suspend fun setTheme(context: Context, theme: AppTheme) {

--- a/app/src/main/java/com/ioannapergamali/mysmartroute/view/ui/components/TopBar.kt
+++ b/app/src/main/java/com/ioannapergamali/mysmartroute/view/ui/components/TopBar.kt
@@ -19,6 +19,9 @@ import androidx.compose.foundation.border
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.unit.dp
 import androidx.compose.material3.MaterialTheme
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.statusBarsPadding
+
 
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable
@@ -30,14 +33,16 @@ fun TopBar(
     onMenuClick: () -> Unit = {},
     onLogout: () -> Unit = {}
 ) {
-    TopAppBar(
-        modifier = Modifier.border(1.dp, MaterialTheme.colorScheme.primary),
-        colors = TopAppBarDefaults.topAppBarColors(
-            containerColor = MaterialTheme.colorScheme.surface,
-            navigationIconContentColor = MaterialTheme.colorScheme.primary,
-            actionIconContentColor = MaterialTheme.colorScheme.primary,
-            titleContentColor = MaterialTheme.colorScheme.primary
-        ),
+    Box(modifier = Modifier.statusBarsPadding()) {
+        TopAppBar(
+            modifier = Modifier.border(1.dp, MaterialTheme.colorScheme.primary),
+            windowInsets = androidx.compose.foundation.layout.WindowInsets(0),
+            colors = TopAppBarDefaults.topAppBarColors(
+                containerColor = MaterialTheme.colorScheme.surface,
+                navigationIconContentColor = MaterialTheme.colorScheme.primary,
+                actionIconContentColor = MaterialTheme.colorScheme.primary,
+                titleContentColor = MaterialTheme.colorScheme.primary
+            ),
         title = { Text(title) },
         navigationIcon = {
             Row {
@@ -72,5 +77,6 @@ fun TopBar(
                 }
             }
         }
-    )
+        )
+    }
 }


### PR DESCRIPTION
## Summary
- το dark theme ενεργοποιείται αυτόματα με βάση τις ρυθμίσεις της συσκευής αν δεν έχει οριστεί επιλογή
- προστέθηκε padding και καταργήθηκαν τα insets από το `TopAppBar` ώστε το περίγραμμα να μην περιλαμβάνει τα εικονίδια του status bar

## Testing
- `./gradlew assembleDebug` *(απέτυχε: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_684a114e38dc8328816499861278e4ab