### PR TITLE
Fix ThemePicker initial state

### DIFF
--- a/app/src/main/java/com/ioannapergamali/mysmartroute/view/ui/screens/ThemePickerScreen.kt
+++ b/app/src/main/java/com/ioannapergamali/mysmartroute/view/ui/screens/ThemePickerScreen.kt
@@ -19,6 +19,7 @@ import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
+import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.unit.dp
@@ -37,11 +38,14 @@ fun ThemePickerScreen(navController: NavController) {
     val currentTheme by ThemePreferenceManager.themeFlow(context).collectAsState(initial = AppTheme.Ocean)
     val currentDark by ThemePreferenceManager.darkThemeFlow(context).collectAsState(initial = false)
 
-    var expanded = remember { mutableStateOf(false) }
-    var selectedTheme = remember { mutableStateOf(currentTheme) }
-    var dark = remember { mutableStateOf(currentDark) }
+    var expanded by remember { mutableStateOf(false) }
+    var selectedTheme by remember { mutableStateOf(currentTheme) }
+    var dark by remember { mutableStateOf(currentDark) }
 
-    MysmartrouteTheme(theme = selectedTheme.value, darkTheme = dark.value) {
+    LaunchedEffect(currentTheme) { selectedTheme = currentTheme }
+    LaunchedEffect(currentDark) { dark = currentDark }
+
+    MysmartrouteTheme(theme = selectedTheme, darkTheme = dark) {
         Scaffold(
             topBar = {
                 TopBar(title = "Themes", navController = navController)
@@ -55,32 +59,32 @@ fun ThemePickerScreen(navController: NavController) {
                     .padding(16.dp)
             ) {
                 Text("Themes")
-                ExposedDropdownMenuBox(expanded = expanded.value, onExpandedChange = { expanded.value = !expanded.value }) {
+                ExposedDropdownMenuBox(expanded = expanded, onExpandedChange = { expanded = !expanded }) {
                     TextField(
                         readOnly = true,
-                        value = selectedTheme.value.label,
+                        value = selectedTheme.label,
                         onValueChange = {},
                         label = { Text("Theme") },
-                        trailingIcon = { ExposedDropdownMenuDefaults.TrailingIcon(expanded = expanded.value) },
+                        trailingIcon = { ExposedDropdownMenuDefaults.TrailingIcon(expanded = expanded) },
                         modifier = Modifier.menuAnchor()
                     )
-                    ExposedDropdownMenu(expanded = expanded.value, onDismissRequest = { expanded.value = false }) {
+                    ExposedDropdownMenu(expanded = expanded, onDismissRequest = { expanded = false }) {
                         AppTheme.values().forEach { theme ->
                             DropdownMenuItem(text = { Text(theme.label) }, onClick = {
-                                selectedTheme.value = theme
-                                expanded.value = false
+                                selectedTheme = theme
+                                expanded = false
                             })
                         }
                     }
                 }
                 Text("Dark Theme")
-                Switch(checked = dark.value, onCheckedChange = {
-                    dark.value = it
+                Switch(checked = dark, onCheckedChange = {
+                    dark = it
                 })
 
                 Button(
                     onClick = {
-                        viewModel.applyTheme(context, selectedTheme.value, dark.value)
+                        viewModel.applyTheme(context, selectedTheme, dark)
                         navController.popBackStack()
                     },
                     modifier = Modifier.padding(top = 16.dp)


### PR DESCRIPTION
## Summary
- ensure ThemePickerScreen reads the saved theme and dark mode when opened
- keep the selected theme in sync with current preferences

## Testing
- `./gradlew testDebugUnitTest` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_684a2ac69ad4832881137c31a1b6c151