### PR TITLE
Fix Compose state delegate in ThemePickerScreen

### DIFF
--- a/app/src/main/java/com/ioannapergamali/mysmartroute/view/ui/screens/ThemePickerScreen.kt
+++ b/app/src/main/java/com/ioannapergamali/mysmartroute/view/ui/screens/ThemePickerScreen.kt
@@ -17,6 +17,7 @@ import com.ioannapergamali.mysmartroute.view.ui.MysmartrouteTheme
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
+import androidx.compose.runtime.setValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.LaunchedEffect


### PR DESCRIPTION
## Summary
- fix missing setValue import so mutable state delegates compile

## Testing
- `./gradlew test` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_684a3c5ef4c88328b54c5da557614835