### PR TITLE
Fix theme typography parameters

### DIFF
--- a/app/src/main/java/com/ioannapergamali/mysmartroute/view/ui/Theme.kt
+++ b/app/src/main/java/com/ioannapergamali/mysmartroute/view/ui/Theme.kt
@@ -80,21 +80,6 @@ private fun typographyWithFont(font: FontFamily): Typography {
         labelLarge = base.labelLarge.copy(fontFamily = font),
         labelMedium = base.labelMedium.copy(fontFamily = font),
         labelSmall = base.labelSmall.copy(fontFamily = font),
-        displayLargeEmphasized = base.displayLargeEmphasized.copy(fontFamily = font),
-        displayMediumEmphasized = base.displayMediumEmphasized.copy(fontFamily = font),
-        displaySmallEmphasized = base.displaySmallEmphasized.copy(fontFamily = font),
-        headlineLargeEmphasized = base.headlineLargeEmphasized.copy(fontFamily = font),
-        headlineMediumEmphasized = base.headlineMediumEmphasized.copy(fontFamily = font),
-        headlineSmallEmphasized = base.headlineSmallEmphasized.copy(fontFamily = font),
-        titleLargeEmphasized = base.titleLargeEmphasized.copy(fontFamily = font),
-        titleMediumEmphasized = base.titleMediumEmphasized.copy(fontFamily = font),
-        titleSmallEmphasized = base.titleSmallEmphasized.copy(fontFamily = font),
-        bodyLargeEmphasized = base.bodyLargeEmphasized.copy(fontFamily = font),
-        bodyMediumEmphasized = base.bodyMediumEmphasized.copy(fontFamily = font),
-        bodySmallEmphasized = base.bodySmallEmphasized.copy(fontFamily = font),
-        labelLargeEmphasized = base.labelLargeEmphasized.copy(fontFamily = font),
-        labelMediumEmphasized = base.labelMediumEmphasized.copy(fontFamily = font),
-        labelSmallEmphasized = base.labelSmallEmphasized.copy(fontFamily = font),
     )
 }
 


### PR DESCRIPTION
## Summary
- remove obsolete `Emphasized` typography parameters

## Testing
- `./gradlew test --no-daemon` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_684a4780dbe88328ac52d05ccef071a1