### PR TITLE
Fix Compose annotation in MysmartrouteTheme

### DIFF
--- a/app/src/main/java/com/ioannapergamali/mysmartroute/view/ui/Theme.kt
+++ b/app/src/main/java/com/ioannapergamali/mysmartroute/view/ui/Theme.kt
@@ -83,6 +83,7 @@ private fun typographyWithFont(font: FontFamily): Typography {
     )
 }
 
+@Composable
 @OptIn(ExperimentalMaterial3Api::class)
 fun MysmartrouteTheme(
     theme: AppTheme,


### PR DESCRIPTION
## Summary
- mark `MysmartrouteTheme` as a `@Composable` function

## Testing
- `./gradlew test --no-daemon` *(fails: Downloading gradle and build takes too long)*

------
https://chatgpt.com/codex/tasks/task_e_684a493073c88328aa26e9736db0ad3b