### PR TITLE
Add soundtrack toggle option

### DIFF
--- a/app/src/main/java/com/ioannapergamali/mysmartroute/model/navigation/NavigationHost.kt
+++ b/app/src/main/java/com/ioannapergamali/mysmartroute/model/navigation/NavigationHost.kt
@@ -18,6 +18,7 @@ import com.ioannapergamali.mysmartroute.view.ui.screens.AboutScreen
 import com.ioannapergamali.mysmartroute.view.ui.screens.SupportScreen
 import com.ioannapergamali.mysmartroute.view.ui.screens.ThemePickerScreen
 import com.ioannapergamali.mysmartroute.view.ui.screens.FontPickerScreen
+import com.ioannapergamali.mysmartroute.view.ui.screens.SoundPickerScreen
 
 
 
@@ -102,6 +103,10 @@ fun NavigationHost(navController : NavHostController, openDrawer: () -> Unit) {
 
         composable("fontPicker") {
             FontPickerScreen(navController = navController)
+        }
+
+        composable("soundPicker") {
+            SoundPickerScreen(navController = navController)
         }
 
         composable("about") {

--- a/app/src/main/java/com/ioannapergamali/mysmartroute/utils/SoundPreferenceManager.kt
+++ b/app/src/main/java/com/ioannapergamali/mysmartroute/utils/SoundPreferenceManager.kt
@@ -1,0 +1,25 @@
+package com.ioannapergamali.mysmartroute.utils
+
+import android.content.Context
+import androidx.datastore.preferences.core.booleanPreferencesKey
+import androidx.datastore.preferences.core.edit
+import androidx.datastore.preferences.preferencesDataStore
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.map
+
+private val Context.soundDataStore by preferencesDataStore(name = "sound_settings")
+
+object SoundPreferenceManager {
+    private val SOUND_KEY = booleanPreferencesKey("sound_enabled")
+
+    fun soundEnabledFlow(context: Context): Flow<Boolean> =
+        context.soundDataStore.data.map { prefs ->
+            prefs[SOUND_KEY] ?: true
+        }
+
+    suspend fun setSoundEnabled(context: Context, enabled: Boolean) {
+        context.soundDataStore.edit { prefs ->
+            prefs[SOUND_KEY] = enabled
+        }
+    }
+}

--- a/app/src/main/java/com/ioannapergamali/mysmartroute/view/ui/screens/HomeScreen.kt
+++ b/app/src/main/java/com/ioannapergamali/mysmartroute/view/ui/screens/HomeScreen.kt
@@ -15,6 +15,9 @@ import com.ioannapergamali.mysmartroute.view.ui.components.TopBar
 import com.ioannapergamali.mysmartroute.R
 import com.ioannapergamali.mysmartroute.view.ui.animation.rememberBreathingAnimation
 import com.ioannapergamali.mysmartroute.view.ui.animation.rememberSlideFadeInAnimation
+import com.ioannapergamali.mysmartroute.utils.SoundPreferenceManager
+import androidx.compose.ui.platform.LocalContext
+import android.media.MediaPlayer
 
 @Composable
 fun HomeScreen(
@@ -41,6 +44,30 @@ fun HomeScreen(
 
         val (logoScale, logoAlpha) = rememberBreathingAnimation()
         val (textOffset, textAlpha) = rememberSlideFadeInAnimation()
+
+        val context = LocalContext.current
+        val soundEnabled by SoundPreferenceManager.soundEnabledFlow(context).collectAsState(initial = true)
+
+        val mediaPlayer = remember {
+            MediaPlayer().apply {
+                val fd = context.assets.openFd("soundtrack.mp3")
+                setDataSource(fd.fileDescriptor, fd.startOffset, fd.length)
+                prepare()
+                isLooping = true
+            }
+        }
+
+        LaunchedEffect(soundEnabled) {
+            if (soundEnabled) {
+                if (!mediaPlayer.isPlaying) mediaPlayer.start()
+            } else {
+                if (mediaPlayer.isPlaying) mediaPlayer.pause()
+            }
+        }
+
+        DisposableEffect(Unit) {
+            onDispose { mediaPlayer.release() }
+        }
 
         Column(
             modifier = contentModifier,

--- a/app/src/main/java/com/ioannapergamali/mysmartroute/view/ui/screens/SettingsScreen.kt
+++ b/app/src/main/java/com/ioannapergamali/mysmartroute/view/ui/screens/SettingsScreen.kt
@@ -31,6 +31,9 @@ fun SettingsScreen(navController: NavController, openDrawer: () -> Unit) {
             Button(onClick = { navController.navigate("fontPicker") }, modifier = Modifier.padding(top = 8.dp)) {
                 Text("Επιλογή γραμματοσειράς")
             }
+            Button(onClick = { navController.navigate("soundPicker") }, modifier = Modifier.padding(top = 8.dp)) {
+                Text("Επιλογή ήχου")
+            }
         }
     }
 }

--- a/app/src/main/java/com/ioannapergamali/mysmartroute/view/ui/screens/SoundPickerScreen.kt
+++ b/app/src/main/java/com/ioannapergamali/mysmartroute/view/ui/screens/SoundPickerScreen.kt
@@ -1,0 +1,74 @@
+package com.ioannapergamali.mysmartroute.view.ui.screens
+
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.padding
+import androidx.compose.material3.Button
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Scaffold
+import androidx.compose.material3.Switch
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.collectAsState
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.unit.dp
+import androidx.lifecycle.viewmodel.compose.viewModel
+import androidx.navigation.NavController
+import com.ioannapergamali.mysmartroute.utils.SoundPreferenceManager
+import com.ioannapergamali.mysmartroute.utils.ThemePreferenceManager
+import com.ioannapergamali.mysmartroute.utils.FontPreferenceManager
+import com.ioannapergamali.mysmartroute.view.ui.MysmartrouteTheme
+import com.ioannapergamali.mysmartroute.view.ui.AppTheme
+import com.ioannapergamali.mysmartroute.view.ui.AppFont
+import com.ioannapergamali.mysmartroute.view.ui.components.TopBar
+import com.ioannapergamali.mysmartroute.viewmodel.SettingsViewModel
+
+@Composable
+fun SoundPickerScreen(navController: NavController) {
+    val context = LocalContext.current
+    val viewModel: SettingsViewModel = viewModel()
+
+    val currentTheme by ThemePreferenceManager.themeFlow(context).collectAsState(initial = AppTheme.Ocean)
+    val currentDark by ThemePreferenceManager.darkThemeFlow(context).collectAsState(initial = false)
+    val currentFont by FontPreferenceManager.fontFlow(context).collectAsState(initial = AppFont.SansSerif)
+    val soundEnabled by SoundPreferenceManager.soundEnabledFlow(context).collectAsState(initial = true)
+
+    val soundState = remember { mutableStateOf(soundEnabled) }
+
+    LaunchedEffect(soundEnabled) { soundState.value = soundEnabled }
+
+    MysmartrouteTheme(theme = currentTheme, darkTheme = currentDark, font = currentFont.fontFamily) {
+        Scaffold(
+            topBar = { TopBar(title = "Sound", navController = navController) },
+            containerColor = MaterialTheme.colorScheme.background
+        ) { padding ->
+            Column(
+                modifier = Modifier
+                    .fillMaxSize()
+                    .padding(padding)
+                    .padding(16.dp)
+            ) {
+                Text("Ήχος")
+                Switch(
+                    checked = soundState.value,
+                    onCheckedChange = { soundState.value = it }
+                )
+
+                Button(
+                    onClick = {
+                        viewModel.applySoundEnabled(context, soundState.value)
+                        navController.popBackStack()
+                    },
+                    modifier = Modifier.padding(top = 16.dp)
+                ) {
+                    Text("Apply")
+                }
+            }
+        }
+    }
+}

--- a/app/src/main/java/com/ioannapergamali/mysmartroute/viewmodel/SettingsViewModel.kt
+++ b/app/src/main/java/com/ioannapergamali/mysmartroute/viewmodel/SettingsViewModel.kt
@@ -12,6 +12,7 @@ import com.ioannapergamali.mysmartroute.utils.NetworkUtils
 import com.ioannapergamali.mysmartroute.utils.ThemePreferenceManager
 import com.ioannapergamali.mysmartroute.utils.FontPreferenceManager
 import com.ioannapergamali.mysmartroute.view.ui.AppFont
+import com.ioannapergamali.mysmartroute.utils.SoundPreferenceManager
 import kotlinx.coroutines.launch
 
 class SettingsViewModel : ViewModel() {
@@ -41,6 +42,12 @@ class SettingsViewModel : ViewModel() {
     fun applyFont(context: Context, font: AppFont) {
         viewModelScope.launch {
             FontPreferenceManager.setFont(context, font)
+        }
+    }
+
+    fun applySoundEnabled(context: Context, enabled: Boolean) {
+        viewModelScope.launch {
+            SoundPreferenceManager.setSoundEnabled(context, enabled)
         }
     }
 }


### PR DESCRIPTION
## Summary
- manage sound preferences via `SoundPreferenceManager`
- play soundtrack on home screen
- add sound option screen and button in settings
- route to sound screen in navigation

## Testing
- `./gradlew test` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_684a6c76e598832880d5897609fd917e