### PR TITLE
Add global sound manager with volume

### DIFF
--- a/app/src/main/java/com/ioannapergamali/mysmartroute/utils/SoundManager.kt
+++ b/app/src/main/java/com/ioannapergamali/mysmartroute/utils/SoundManager.kt
@@ -1,0 +1,34 @@
+package com.ioannapergamali.mysmartroute.utils
+
+import android.content.Context
+import android.media.MediaPlayer
+
+object SoundManager {
+    private var mediaPlayer: MediaPlayer? = null
+
+    fun initialize(context: Context) {
+        if (mediaPlayer == null) {
+            mediaPlayer = MediaPlayer().apply {
+                val fd = context.assets.openFd("soundtrack.mp3")
+                setDataSource(fd.fileDescriptor, fd.startOffset, fd.length)
+                isLooping = true
+                prepare()
+            }
+        }
+    }
+
+    fun play() { mediaPlayer?.start() }
+    fun pause() { mediaPlayer?.pause() }
+
+    fun setVolume(volume: Float) {
+        mediaPlayer?.setVolume(volume, volume)
+    }
+
+    val isPlaying: Boolean
+        get() = mediaPlayer?.isPlaying == true
+
+    fun release() {
+        mediaPlayer?.release()
+        mediaPlayer = null
+    }
+}

--- a/app/src/main/java/com/ioannapergamali/mysmartroute/utils/SoundPreferenceManager.kt
+++ b/app/src/main/java/com/ioannapergamali/mysmartroute/utils/SoundPreferenceManager.kt
@@ -2,6 +2,7 @@ package com.ioannapergamali.mysmartroute.utils
 
 import android.content.Context
 import androidx.datastore.preferences.core.booleanPreferencesKey
+import androidx.datastore.preferences.core.floatPreferencesKey
 import androidx.datastore.preferences.core.edit
 import androidx.datastore.preferences.preferencesDataStore
 import kotlinx.coroutines.flow.Flow
@@ -11,15 +12,27 @@ private val Context.soundDataStore by preferencesDataStore(name = "sound_setting
 
 object SoundPreferenceManager {
     private val SOUND_KEY = booleanPreferencesKey("sound_enabled")
+    private val VOLUME_KEY = floatPreferencesKey("sound_volume")
 
     fun soundEnabledFlow(context: Context): Flow<Boolean> =
         context.soundDataStore.data.map { prefs ->
             prefs[SOUND_KEY] ?: true
         }
 
+    fun soundVolumeFlow(context: Context): Flow<Float> =
+        context.soundDataStore.data.map { prefs ->
+            prefs[VOLUME_KEY] ?: 1f
+        }
+
     suspend fun setSoundEnabled(context: Context, enabled: Boolean) {
         context.soundDataStore.edit { prefs ->
             prefs[SOUND_KEY] = enabled
+        }
+    }
+
+    suspend fun setSoundVolume(context: Context, volume: Float) {
+        context.soundDataStore.edit { prefs ->
+            prefs[VOLUME_KEY] = volume
         }
     }
 }

--- a/app/src/main/java/com/ioannapergamali/mysmartroute/view/ui/screens/HomeScreen.kt
+++ b/app/src/main/java/com/ioannapergamali/mysmartroute/view/ui/screens/HomeScreen.kt
@@ -46,28 +46,6 @@ fun HomeScreen(
         val (textOffset, textAlpha) = rememberSlideFadeInAnimation()
 
         val context = LocalContext.current
-        val soundEnabled by SoundPreferenceManager.soundEnabledFlow(context).collectAsState(initial = true)
-
-        val mediaPlayer = remember {
-            MediaPlayer().apply {
-                val fd = context.assets.openFd("soundtrack.mp3")
-                setDataSource(fd.fileDescriptor, fd.startOffset, fd.length)
-                prepare()
-                isLooping = true
-            }
-        }
-
-        LaunchedEffect(soundEnabled) {
-            if (soundEnabled) {
-                if (!mediaPlayer.isPlaying) mediaPlayer.start()
-            } else {
-                if (mediaPlayer.isPlaying) mediaPlayer.pause()
-            }
-        }
-
-        DisposableEffect(Unit) {
-            onDispose { mediaPlayer.release() }
-        }
 
         Column(
             modifier = contentModifier,

--- a/app/src/main/java/com/ioannapergamali/mysmartroute/view/ui/screens/SoundPickerScreen.kt
+++ b/app/src/main/java/com/ioannapergamali/mysmartroute/view/ui/screens/SoundPickerScreen.kt
@@ -10,6 +10,7 @@ import androidx.compose.material3.Switch
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.mutableFloatStateOf
 import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
@@ -27,6 +28,7 @@ import com.ioannapergamali.mysmartroute.view.ui.AppTheme
 import com.ioannapergamali.mysmartroute.view.ui.AppFont
 import com.ioannapergamali.mysmartroute.view.ui.components.TopBar
 import com.ioannapergamali.mysmartroute.viewmodel.SettingsViewModel
+import androidx.compose.material3.Slider
 
 @Composable
 fun SoundPickerScreen(navController: NavController) {
@@ -37,10 +39,13 @@ fun SoundPickerScreen(navController: NavController) {
     val currentDark by ThemePreferenceManager.darkThemeFlow(context).collectAsState(initial = false)
     val currentFont by FontPreferenceManager.fontFlow(context).collectAsState(initial = AppFont.SansSerif)
     val soundEnabled by SoundPreferenceManager.soundEnabledFlow(context).collectAsState(initial = true)
+    val currentVolume by SoundPreferenceManager.soundVolumeFlow(context).collectAsState(initial = 1f)
 
     val soundState = remember { mutableStateOf(soundEnabled) }
+    val volumeState = remember { mutableFloatStateOf(currentVolume) }
 
     LaunchedEffect(soundEnabled) { soundState.value = soundEnabled }
+    LaunchedEffect(currentVolume) { volumeState.floatValue = currentVolume }
 
     MysmartrouteTheme(theme = currentTheme, darkTheme = currentDark, font = currentFont.fontFamily) {
         Scaffold(
@@ -59,9 +64,17 @@ fun SoundPickerScreen(navController: NavController) {
                     onCheckedChange = { soundState.value = it }
                 )
 
+                Text("Ένταση", modifier = Modifier.padding(top = 16.dp))
+                Slider(
+                    value = volumeState.floatValue,
+                    onValueChange = { volumeState.floatValue = it },
+                    valueRange = 0f..1f
+                )
+
                 Button(
                     onClick = {
                         viewModel.applySoundEnabled(context, soundState.value)
+                        viewModel.applySoundVolume(context, volumeState.floatValue)
                         navController.popBackStack()
                     },
                     modifier = Modifier.padding(top = 16.dp)

--- a/app/src/main/java/com/ioannapergamali/mysmartroute/viewmodel/MainActivity.kt
+++ b/app/src/main/java/com/ioannapergamali/mysmartroute/viewmodel/MainActivity.kt
@@ -15,6 +15,8 @@ import com.ioannapergamali.mysmartroute.view.ui.AppFont
 import com.ioannapergamali.mysmartroute.utils.FontPreferenceManager
 import com.ioannapergamali.mysmartroute.utils.MiuiUtils
 import com.ioannapergamali.mysmartroute.utils.ThemePreferenceManager
+import com.ioannapergamali.mysmartroute.utils.SoundPreferenceManager
+import com.ioannapergamali.mysmartroute.utils.SoundManager
 
 
 
@@ -30,6 +32,19 @@ class MainActivity : ComponentActivity()
             val theme by ThemePreferenceManager.themeFlow(context).collectAsState(initial = AppTheme.Ocean)
             val dark by ThemePreferenceManager.darkThemeFlow(context).collectAsState(initial = false)
             val font by FontPreferenceManager.fontFlow(context).collectAsState(initial = AppFont.SansSerif)
+            val soundEnabled by SoundPreferenceManager.soundEnabledFlow(context).collectAsState(initial = true)
+            val soundVolume by SoundPreferenceManager.soundVolumeFlow(context).collectAsState(initial = 1f)
+
+            LaunchedEffect(Unit) { SoundManager.initialize(context) }
+            LaunchedEffect(soundEnabled, soundVolume) {
+                SoundManager.setVolume(soundVolume)
+                if (soundEnabled) {
+                    if (!SoundManager.isPlaying) SoundManager.play()
+                } else {
+                    if (SoundManager.isPlaying) SoundManager.pause()
+                }
+            }
+
             MysmartrouteTheme(theme = theme, darkTheme = dark, font = font.fontFamily) {
                 val navController = rememberNavController()
                 DrawerWrapper(navController = navController) { openDrawer ->
@@ -42,5 +57,10 @@ class MainActivity : ComponentActivity()
     override fun onBackPressed() {
         finishAfterTransition()
         super.onBackPressed()
+    }
+
+    override fun onDestroy() {
+        SoundManager.release()
+        super.onDestroy()
     }
 }

--- a/app/src/main/java/com/ioannapergamali/mysmartroute/viewmodel/SettingsViewModel.kt
+++ b/app/src/main/java/com/ioannapergamali/mysmartroute/viewmodel/SettingsViewModel.kt
@@ -50,4 +50,10 @@ class SettingsViewModel : ViewModel() {
             SoundPreferenceManager.setSoundEnabled(context, enabled)
         }
     }
+
+    fun applySoundVolume(context: Context, volume: Float) {
+        viewModelScope.launch {
+            SoundPreferenceManager.setSoundVolume(context, volume)
+        }
+    }
 }


### PR DESCRIPTION
## Summary
- create `SoundManager` singleton for global playback
- store user volume preference in `SoundPreferenceManager`
- add slider in `SoundPickerScreen` for adjusting volume
- update `MainActivity` to control playback based on preferences
- clean up `HomeScreen` local player
- expose new `applySoundVolume` in `SettingsViewModel`

## Testing
- `./gradlew tasks`
- `./gradlew test` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_684a7231a8ac8328aa9157e8164b0b67