### PR TITLE
Επέκταση αποθήκευσης ρυθμίσεων

### DIFF
--- a/app/src/main/java/com/ioannapergamali/mysmartroute/data/local/MySmartRouteDatabase.kt
+++ b/app/src/main/java/com/ioannapergamali/mysmartroute/data/local/MySmartRouteDatabase.kt
@@ -12,7 +12,7 @@ import com.ioannapergamali.mysmartroute.data.local.PoIEntity
 
 @Database(
     entities = [UserEntity::class, VehicleEntity::class, PoIEntity::class, SettingsEntity::class],
-    version = 4
+    version = 5
 )
 abstract class MySmartRouteDatabase : RoomDatabase() {
     abstract fun userDao(): UserDao
@@ -53,13 +53,21 @@ abstract class MySmartRouteDatabase : RoomDatabase() {
             }
         }
 
+        private val MIGRATION_4_5 = object : Migration(4, 5) {
+            override fun migrate(database: SupportSQLiteDatabase) {
+                database.execSQL("ALTER TABLE `settings` ADD COLUMN `font` TEXT NOT NULL DEFAULT 'SansSerif'")
+                database.execSQL("ALTER TABLE `settings` ADD COLUMN `soundEnabled` INTEGER NOT NULL DEFAULT 1")
+                database.execSQL("ALTER TABLE `settings` ADD COLUMN `soundVolume` REAL NOT NULL DEFAULT 1.0")
+            }
+        }
+
         fun getInstance(context: Context): MySmartRouteDatabase {
             return INSTANCE ?: synchronized(this) {
                 INSTANCE ?: Room.databaseBuilder(
                     context.applicationContext,
                     MySmartRouteDatabase::class.java,
                     "mysmartroute.db"
-                ).addMigrations(MIGRATION_2_3, MIGRATION_3_4)
+                ).addMigrations(MIGRATION_2_3, MIGRATION_3_4, MIGRATION_4_5)
                     .build().also { INSTANCE = it }
             }
         }

--- a/app/src/main/java/com/ioannapergamali/mysmartroute/data/local/SettingsEntity.kt
+++ b/app/src/main/java/com/ioannapergamali/mysmartroute/data/local/SettingsEntity.kt
@@ -7,5 +7,8 @@ import androidx.room.PrimaryKey
 data class SettingsEntity(
     @PrimaryKey val userId: String,
     val theme: String,
-    val darkTheme: Boolean
+    val darkTheme: Boolean,
+    val font: String,
+    val soundEnabled: Boolean,
+    val soundVolume: Float
 )


### PR DESCRIPTION
## Summary
- προσθήκη των font και ρυθμίσεων ήχου στο `SettingsEntity`
- αναβάθμιση της βάσης σε version 5 με migration για τις νέες στήλες
- επέκταση `SettingsViewModel` ώστε να αποθηκεύει theme, font και ήχο τόσο στη βάση όσο και στο Firebase

## Testing
- `./gradlew testDebug` *(απέτυχε: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_684a79a949248328918fab9a902fe24c