### PR TITLE
Fix soundtrack load

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -38,13 +38,6 @@ android {
     kotlinOptions {
         jvmTarget = "17"
     }
-    sourceSets {
-        getByName("main") {
-            assets {
-                srcDirs("src/main/assets")
-            }
-        }
-    }
 }
 
 kotlin {

--- a/app/src/main/java/com/ioannapergamali/mysmartroute/utils/SoundManager.kt
+++ b/app/src/main/java/com/ioannapergamali/mysmartroute/utils/SoundManager.kt
@@ -2,17 +2,15 @@ package com.ioannapergamali.mysmartroute.utils
 
 import android.content.Context
 import android.media.MediaPlayer
+import com.ioannapergamali.mysmartroute.R
 
 object SoundManager {
     private var mediaPlayer: MediaPlayer? = null
 
     fun initialize(context: Context) {
         if (mediaPlayer == null) {
-            mediaPlayer = MediaPlayer().apply {
-                val fd = context.assets.openFd("soundtrack.mp3")
-                setDataSource(fd.fileDescriptor, fd.startOffset, fd.length)
+            mediaPlayer = MediaPlayer.create(context, R.raw.soundtrack).apply {
                 isLooping = true
-                prepare()
             }
         }
     }


### PR DESCRIPTION
## Summary
- move soundtrack.mp3 from assets to res/raw
- simplify `SoundManager` initialization using `MediaPlayer.create`
- remove unused asset source set

## Testing
- `./gradlew test --no-daemon` *(fails: SDK location not found)*
- `./gradlew assembleDebug --no-daemon` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_684a7ee023848328be57016859b73bfa