### PR TITLE
Fix unresolved `sourceSets` reference

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -37,8 +37,7 @@ android {
 
     kotlinOptions {
         jvmTarget = "17"
-    }sourceSets {
-}
+    }
 
 }
 


### PR DESCRIPTION
## Summary
- remove empty `sourceSets` block from app module

## Testing
- `./gradlew assemble` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_684a86c6a08c83288109b059e20d6c7e