### PR TITLE
Fix soundtrack initialization

### DIFF
--- a/app/src/main/java/com/ioannapergamali/mysmartroute/utils/SoundPreferenceManager.kt
+++ b/app/src/main/java/com/ioannapergamali/mysmartroute/utils/SoundPreferenceManager.kt
@@ -6,6 +6,7 @@ import androidx.datastore.preferences.core.floatPreferencesKey
 import androidx.datastore.preferences.core.edit
 import androidx.datastore.preferences.preferencesDataStore
 import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.flow.map
 
 private val Context.soundDataStore by preferencesDataStore(name = "sound_settings")
@@ -23,6 +24,12 @@ object SoundPreferenceManager {
         context.soundDataStore.data.map { prefs ->
             prefs[VOLUME_KEY] ?: 1f
         }
+
+    suspend fun getSoundEnabled(context: Context): Boolean =
+        soundEnabledFlow(context).first()
+
+    suspend fun getSoundVolume(context: Context): Float =
+        soundVolumeFlow(context).first()
 
     suspend fun setSoundEnabled(context: Context, enabled: Boolean) {
         context.soundDataStore.edit { prefs ->

--- a/app/src/main/java/com/ioannapergamali/mysmartroute/viewmodel/MainActivity.kt
+++ b/app/src/main/java/com/ioannapergamali/mysmartroute/viewmodel/MainActivity.kt
@@ -6,6 +6,7 @@ import androidx.activity.compose.setContent
 import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.LaunchedEffect
+import androidx.lifecycle.lifecycleScope
 import androidx.compose.ui.platform.LocalContext
 import androidx.navigation.compose.rememberNavController
 import com.ioannapergamali.mysmartroute.model.navigation.NavigationHost
@@ -18,6 +19,7 @@ import com.ioannapergamali.mysmartroute.utils.MiuiUtils
 import com.ioannapergamali.mysmartroute.utils.ThemePreferenceManager
 import com.ioannapergamali.mysmartroute.utils.SoundPreferenceManager
 import com.ioannapergamali.mysmartroute.utils.SoundManager
+import kotlinx.coroutines.launch
 
 
 
@@ -28,9 +30,14 @@ class MainActivity : ComponentActivity()
         super.onCreate(savedInstanceState)
         // Προαιρετικός έλεγχος ύπαρξης του MIUI Service Delivery provider
         MiuiUtils.callServiceDelivery(this, "ping")
-        // Initialize the soundtrack before setting the Compose content so that
-        // playback can start immediately when the UI is composed.
+        // Initialize the soundtrack and start playback based on saved preferences.
         SoundManager.initialize(applicationContext)
+        lifecycleScope.launch {
+            val enabled = SoundPreferenceManager.getSoundEnabled(applicationContext)
+            val volume = SoundPreferenceManager.getSoundVolume(applicationContext)
+            SoundManager.setVolume(volume)
+            if (enabled) SoundManager.play()
+        }
         setContent {
             val context = LocalContext.current
             val theme by ThemePreferenceManager.themeFlow(context).collectAsState(initial = AppTheme.Ocean)


### PR DESCRIPTION
## Summary
- load sound preferences when activity starts and apply volume
- expose helpers to get sound preference values

## Testing
- `./gradlew tasks --all`

------
https://chatgpt.com/codex/tasks/task_e_684aa7dbe6548328bcc4df2b02f24525