### PR TITLE
Fix settings sync with Firestore

### DIFF
--- a/app/src/main/java/com/ioannapergamali/mysmartroute/viewmodel/SettingsViewModel.kt
+++ b/app/src/main/java/com/ioannapergamali/mysmartroute/viewmodel/SettingsViewModel.kt
@@ -45,7 +45,14 @@ class SettingsViewModel : ViewModel() {
                 "soundEnabled" to updated.soundEnabled,
                 "soundVolume" to updated.soundVolume
             )
-            db.collection("user_settings").document(userId).set(data)
+            try {
+                db.collection("user_settings")
+                    .document(userId)
+                    .set(data)
+                    .await()
+            } catch (_: Exception) {
+                // ignore to keep local changes even if cloud sync fails
+            }
         }
     }
 


### PR DESCRIPTION
## Summary
- wait for Firestore write to finish when saving settings

## Testing
- `./gradlew test --quiet` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_684ab07b64d48328a6786d77bede9a3c