### PR TITLE
Προσθήκη Toast για αποθήκευση ρυθμίσεων

### DIFF
--- a/app/src/main/java/com/ioannapergamali/mysmartroute/viewmodel/SettingsViewModel.kt
+++ b/app/src/main/java/com/ioannapergamali/mysmartroute/viewmodel/SettingsViewModel.kt
@@ -1,6 +1,7 @@
 package com.ioannapergamali.mysmartroute.viewmodel
 
 import android.content.Context
+import android.widget.Toast
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import com.google.firebase.auth.FirebaseAuth
@@ -10,6 +11,8 @@ import com.ioannapergamali.mysmartroute.data.local.SettingsEntity
 import com.ioannapergamali.mysmartroute.view.ui.AppTheme
 import com.ioannapergamali.mysmartroute.utils.NetworkUtils
 import kotlinx.coroutines.tasks.await
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.withContext
 import com.ioannapergamali.mysmartroute.utils.ThemePreferenceManager
 import com.ioannapergamali.mysmartroute.utils.FontPreferenceManager
 import com.ioannapergamali.mysmartroute.view.ui.AppFont
@@ -50,8 +53,18 @@ class SettingsViewModel : ViewModel() {
                     .document(userId)
                     .set(data)
                     .await()
+                withContext(Dispatchers.Main) {
+                    Toast.makeText(context, "Οι ρυθμίσεις αποθηκεύτηκαν", Toast.LENGTH_SHORT).show()
+                }
             } catch (_: Exception) {
+                withContext(Dispatchers.Main) {
+                    Toast.makeText(context, "Αποτυχία αποθήκευσης στο cloud", Toast.LENGTH_SHORT).show()
+                }
                 // ignore to keep local changes even if cloud sync fails
+            }
+        } else {
+            withContext(Dispatchers.Main) {
+                Toast.makeText(context, "Εκτός σύνδεσης - τοπική αποθήκευση", Toast.LENGTH_SHORT).show()
             }
         }
     }


### PR DESCRIPTION
## Notes
- Προστέθηκαν Toast μηνύματα για επιβεβαίωση της αποθήκευσης των ρυθμίσεων τόσο επιτυχούς αποστολής όσο και αστοχίας ή offline περίπτωσης
- Δεν ήταν δυνατό να εκτελεστούν τα unit tests λόγω απουσίας Android SDK στο περιβάλλον

## Summary
- Εισαγωγή `Toast`, `Dispatchers` και `withContext`
- Εμφάνιση μηνύματος επιτυχίας/αποτυχίας μετά την αποστολή δεδομένων στο Firestore
- Ενημέρωση χρήστη όταν η συσκευή είναι εκτός σύνδεσης

## Testing
- `./gradlew test` *(απέτυχε: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_684ab29d7f048328b0a48f50bde16faf