### PR TITLE
Εμφάνιση toast και καταγραφών σφαλμάτων

### DIFF
--- a/app/src/main/java/com/ioannapergamali/mysmartroute/viewmodel/SettingsViewModel.kt
+++ b/app/src/main/java/com/ioannapergamali/mysmartroute/viewmodel/SettingsViewModel.kt
@@ -1,6 +1,7 @@
 package com.ioannapergamali.mysmartroute.viewmodel
 
 import android.content.Context
+import android.util.Log
 import android.widget.Toast
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
@@ -38,7 +39,18 @@ class SettingsViewModel : ViewModel() {
             soundVolume = 1f
         )
         val updated = transform(current)
-        dao.insert(updated)
+        try {
+            dao.insert(updated)
+            withContext(Dispatchers.Main) {
+                Toast.makeText(context, "Οι ρυθμίσεις αποθηκεύτηκαν", Toast.LENGTH_SHORT).show()
+            }
+        } catch (e: Exception) {
+            Log.e("SettingsViewModel", "Local save error", e)
+            withContext(Dispatchers.Main) {
+                Toast.makeText(context, "Σφάλμα αποθήκευσης", Toast.LENGTH_SHORT).show()
+            }
+            return
+        }
 
         if (NetworkUtils.isInternetAvailable(context)) {
             val data = mapOf(
@@ -53,10 +65,8 @@ class SettingsViewModel : ViewModel() {
                     .document(userId)
                     .set(data)
                     .await()
-                withContext(Dispatchers.Main) {
-                    Toast.makeText(context, "Οι ρυθμίσεις αποθηκεύτηκαν", Toast.LENGTH_SHORT).show()
-                }
-            } catch (_: Exception) {
+            } catch (e: Exception) {
+                Log.e("SettingsViewModel", "Cloud sync error", e)
                 withContext(Dispatchers.Main) {
                     Toast.makeText(context, "Αποτυχία αποθήκευσης στο cloud", Toast.LENGTH_SHORT).show()
                 }


### PR DESCRIPTION
## Σύντομη περιγραφή
Προστέθηκαν μηνύματα Toast για επιτυχή ή αποτυχημένη αποθήκευση ρυθμίσεων και
καταγραφή των σφαλμάτων με `Log.e` στο `SettingsViewModel`.

## Αλλαγές
- Προστέθηκε η κλάση `Log` στα imports.
- Στην `updateSettings` έγινε χειρισμός εξαίρεσης κατά την τοπική αποθήκευση.
  - Σε επιτυχία εμφανίζεται Toast επιβεβαίωσης.
  - Σε αποτυχία εμφανίζεται Toast σφάλματος και γίνεται καταγραφή.
- Στον συγχρονισμό με Firebase προστέθηκε καταγραφή σφαλμάτων.

## Έλεγχοι
- `./gradlew test` (απέτυχε λόγω έλλειψης Android SDK).

------
https://chatgpt.com/codex/tasks/task_e_684ab661fc488328b4387b5dbfeeee8e