### PR TITLE
Προσθήκη AppOpsUtils για READ_PHONE_STATE

### DIFF
--- a/app/src/main/java/com/ioannapergamali/mysmartroute/utils/AppOpsUtils.kt
+++ b/app/src/main/java/com/ioannapergamali/mysmartroute/utils/AppOpsUtils.kt
@@ -1,0 +1,38 @@
+package com.ioannapergamali.mysmartroute.utils
+
+import android.app.AppOpsManager
+import android.content.Context
+import android.os.Build
+
+/**
+ * Βοηθητικές συναρτήσεις για ελέγχους AppOps.
+ */
+object AppOpsUtils {
+    /**
+     * Ελέγχει αν επιτρέπεται η λειτουργία READ_PHONE_STATE για την εφαρμογή.
+     */
+    fun isReadPhoneStateAllowed(context: Context): Boolean {
+        val appOps = context.getSystemService(Context.APP_OPS_SERVICE) as AppOpsManager
+        val uid = if (Build.VERSION.SDK_INT >= 24) {
+            context.packageManager.getPackageUid(context.packageName, 0)
+        } else {
+            context.applicationInfo.uid
+        }
+        val mode = appOps.checkOpNoThrow(AppOpsManager.OPSTR_READ_PHONE_STATE, uid, context.packageName)
+        return mode == AppOpsManager.MODE_ALLOWED
+    }
+
+    /**
+     * Καταγράφει την ενέργεια READ_PHONE_STATE και επιστρέφει true αν έγινε δεκτή.
+     */
+    fun noteReadPhoneState(context: Context): Boolean {
+        val appOps = context.getSystemService(Context.APP_OPS_SERVICE) as AppOpsManager
+        val uid = if (Build.VERSION.SDK_INT >= 24) {
+            context.packageManager.getPackageUid(context.packageName, 0)
+        } else {
+            context.applicationInfo.uid
+        }
+        val result = appOps.noteOpNoThrow(AppOpsManager.OPSTR_READ_PHONE_STATE, uid, context.packageName)
+        return result == AppOpsManager.MODE_ALLOWED
+    }
+}


### PR DESCRIPTION
## Τι άλλαξε
- Προστέθηκε το αρχείο `AppOpsUtils.kt` με συναρτήσεις ελέγχου και καταγραφής της λειτουργίας `READ_PHONE_STATE` χρησιμοποιώντας το UID και το package της εφαρμογής.

## Οδηγίες
- Χρήση `AppOpsUtils.isReadPhoneStateAllowed(context)` για έλεγχο δικαιωμάτων
- Χρήση `AppOpsUtils.noteReadPhoneState(context)` για καταγραφή της λειτουργίας

## Έλεγχοι
- `./gradlew test --no-daemon` απέτυχε λόγω έλλειψης Android SDK.

------
https://chatgpt.com/codex/tasks/task_e_684aba2c54708328a6e4257ea45fb9a4