### PR TITLE
Προσθήκη οθόνης Databases

### DIFF
--- a/app/src/main/java/com/ioannapergamali/mysmartroute/data/local/SettingsDao.kt
+++ b/app/src/main/java/com/ioannapergamali/mysmartroute/data/local/SettingsDao.kt
@@ -12,4 +12,7 @@ interface SettingsDao {
 
     @Query("SELECT * FROM settings WHERE userId = :userId LIMIT 1")
     suspend fun getSettings(userId: String): SettingsEntity?
+
+    @Query("SELECT * FROM settings")
+    suspend fun getAllSettings(): List<SettingsEntity>
 }

--- a/app/src/main/java/com/ioannapergamali/mysmartroute/data/local/UserDao.kt
+++ b/app/src/main/java/com/ioannapergamali/mysmartroute/data/local/UserDao.kt
@@ -12,4 +12,7 @@ interface UserDao {
 
     @Query("SELECT * FROM users WHERE id = :id")
     suspend fun getUser(id: String): UserEntity?
+
+    @Query("SELECT * FROM users")
+    suspend fun getAllUsers(): List<UserEntity>
 }

--- a/app/src/main/java/com/ioannapergamali/mysmartroute/data/local/VehicleDao.kt
+++ b/app/src/main/java/com/ioannapergamali/mysmartroute/data/local/VehicleDao.kt
@@ -12,4 +12,7 @@ interface VehicleDao {
 
     @Query("SELECT * FROM vehicles WHERE userId = :userId")
     suspend fun getVehiclesForUser(userId: String): List<VehicleEntity>
+
+    @Query("SELECT * FROM vehicles")
+    suspend fun getAllVehicles(): List<VehicleEntity>
 }

--- a/app/src/main/java/com/ioannapergamali/mysmartroute/model/navigation/NavigationHost.kt
+++ b/app/src/main/java/com/ioannapergamali/mysmartroute/model/navigation/NavigationHost.kt
@@ -19,6 +19,9 @@ import com.ioannapergamali.mysmartroute.view.ui.screens.SupportScreen
 import com.ioannapergamali.mysmartroute.view.ui.screens.ThemePickerScreen
 import com.ioannapergamali.mysmartroute.view.ui.screens.FontPickerScreen
 import com.ioannapergamali.mysmartroute.view.ui.screens.SoundPickerScreen
+import com.ioannapergamali.mysmartroute.view.ui.screens.DatabaseMenuScreen
+import com.ioannapergamali.mysmartroute.view.ui.screens.LocalDatabaseScreen
+import com.ioannapergamali.mysmartroute.view.ui.screens.FirebaseDatabaseScreen
 
 
 
@@ -115,6 +118,18 @@ fun NavigationHost(navController : NavHostController, openDrawer: () -> Unit) {
 
         composable("support") {
             SupportScreen(navController = navController, openDrawer = openDrawer)
+        }
+
+        composable("databaseMenu") {
+            DatabaseMenuScreen(navController = navController, openDrawer = openDrawer)
+        }
+
+        composable("localDb") {
+            LocalDatabaseScreen(navController = navController, openDrawer = openDrawer)
+        }
+
+        composable("firebaseDb") {
+            FirebaseDatabaseScreen(navController = navController, openDrawer = openDrawer)
         }
 
 

--- a/app/src/main/java/com/ioannapergamali/mysmartroute/view/ui/components/NavigationDrawer.kt
+++ b/app/src/main/java/com/ioannapergamali/mysmartroute/view/ui/components/NavigationDrawer.kt
@@ -5,6 +5,7 @@ import androidx.compose.material.icons.filled.Info
 import androidx.compose.material.icons.filled.Settings
 import androidx.compose.material.icons.filled.Email
 import androidx.compose.material.icons.filled.ExitToApp
+import androidx.compose.material.icons.filled.Storage
 import androidx.compose.material3.*
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.foundation.layout.padding
@@ -48,6 +49,15 @@ fun DrawerMenu(navController: NavController, closeDrawer: () -> Unit) {
                 closeDrawer()
             },
             icon = { Icon(Icons.Filled.Email, contentDescription = null, tint = MaterialTheme.colorScheme.primary) }
+        )
+        NavigationDrawerItem(
+            label = { Text("Databases") },
+            selected = false,
+            onClick = {
+                navController.navigate("databaseMenu")
+                closeDrawer()
+            },
+            icon = { Icon(Icons.Filled.Storage, contentDescription = null, tint = MaterialTheme.colorScheme.primary) }
         )
         val activity = (LocalContext.current as? Activity)
         NavigationDrawerItem(

--- a/app/src/main/java/com/ioannapergamali/mysmartroute/view/ui/screens/DatabaseMenuScreen.kt
+++ b/app/src/main/java/com/ioannapergamali/mysmartroute/view/ui/screens/DatabaseMenuScreen.kt
@@ -1,0 +1,41 @@
+package com.ioannapergamali.mysmartroute.view.ui.screens
+
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.padding
+import androidx.compose.material3.Button
+import androidx.compose.material3.Scaffold
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.unit.dp
+import androidx.navigation.NavController
+import com.ioannapergamali.mysmartroute.view.ui.components.TopBar
+
+@Composable
+fun DatabaseMenuScreen(navController: NavController, openDrawer: () -> Unit) {
+    Scaffold(
+        topBar = {
+            TopBar(
+                title = "Databases",
+                navController = navController,
+                showMenu = true,
+                onMenuClick = openDrawer
+            )
+        }
+    ) { padding ->
+        Column(
+            modifier = Modifier
+                .fillMaxSize()
+                .padding(padding)
+                .padding(16.dp)
+        ) {
+            Button(onClick = { navController.navigate("localDb") }) {
+                Text("Local DB")
+            }
+            Button(onClick = { navController.navigate("firebaseDb") }, modifier = Modifier.padding(top = 8.dp)) {
+                Text("Firebase")
+            }
+        }
+    }
+}

--- a/app/src/main/java/com/ioannapergamali/mysmartroute/view/ui/screens/FirebaseDatabaseScreen.kt
+++ b/app/src/main/java/com/ioannapergamali/mysmartroute/view/ui/screens/FirebaseDatabaseScreen.kt
@@ -1,0 +1,76 @@
+package com.ioannapergamali.mysmartroute.view.ui.screens
+
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.lazy.items
+import androidx.compose.material3.CircularProgressIndicator
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Scaffold
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.collectAsState
+import androidx.compose.runtime.getValue
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.unit.dp
+import androidx.lifecycle.viewmodel.compose.viewModel
+import androidx.navigation.NavController
+import com.ioannapergamali.mysmartroute.view.ui.components.TopBar
+import com.ioannapergamali.mysmartroute.viewmodel.DatabaseViewModel
+
+@Composable
+fun FirebaseDatabaseScreen(navController: NavController, openDrawer: () -> Unit) {
+    val viewModel: DatabaseViewModel = viewModel()
+    val data by viewModel.firebaseData.collectAsState()
+
+    LaunchedEffect(Unit) { viewModel.loadFirebaseData() }
+
+    Scaffold(
+        topBar = {
+            TopBar(
+                title = "Firebase DB",
+                navController = navController,
+                showMenu = true,
+                onMenuClick = openDrawer
+            )
+        }
+    ) { padding ->
+        if (data == null) {
+            Column(modifier = Modifier.fillMaxSize().padding(padding)) {
+                CircularProgressIndicator(modifier = Modifier.padding(16.dp))
+            }
+        } else {
+            LazyColumn(
+                modifier = Modifier
+                    .fillMaxSize()
+                    .padding(padding)
+                    .padding(16.dp)
+            ) {
+                item { Text("Users", style = MaterialTheme.typography.titleMedium) }
+                items(data!!.users) { user ->
+                    Text("${'$'}{user.id} - ${'$'}{user.username}")
+                }
+                item { Spacer(modifier = Modifier.padding(8.dp)) }
+                item { Text("Vehicles", style = MaterialTheme.typography.titleMedium) }
+                items(data!!.vehicles) { vehicle ->
+                    Text("${'$'}{vehicle.id} - ${'$'}{vehicle.description}")
+                }
+                item { Spacer(modifier = Modifier.padding(8.dp)) }
+                item { Text("PoIs", style = MaterialTheme.typography.titleMedium) }
+                items(data!!.pois) { poi ->
+                    Text("${'$'}{poi.id} - ${'$'}{poi.name}")
+                }
+                item { Spacer(modifier = Modifier.padding(8.dp)) }
+                item { Text("Settings", style = MaterialTheme.typography.titleMedium) }
+                items(data!!.settings) { setting ->
+                    Text("${'$'}{setting.userId} - ${'$'}{setting.theme}")
+                }
+                item { Spacer(modifier = Modifier.padding(8.dp)) }
+                item { Text("Authentication table δεν είναι διαθέσιμη από το client", color = MaterialTheme.colorScheme.error) }
+            }
+        }
+    }
+}

--- a/app/src/main/java/com/ioannapergamali/mysmartroute/view/ui/screens/LocalDatabaseScreen.kt
+++ b/app/src/main/java/com/ioannapergamali/mysmartroute/view/ui/screens/LocalDatabaseScreen.kt
@@ -1,0 +1,77 @@
+package com.ioannapergamali.mysmartroute.view.ui.screens
+
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.lazy.items
+import androidx.compose.material3.CircularProgressIndicator
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Scaffold
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.collectAsState
+import androidx.compose.runtime.getValue
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.unit.dp
+import androidx.lifecycle.viewmodel.compose.viewModel
+import androidx.navigation.NavController
+import com.ioannapergamali.mysmartroute.view.ui.components.TopBar
+import com.ioannapergamali.mysmartroute.viewmodel.DatabaseViewModel
+
+@Composable
+fun LocalDatabaseScreen(navController: NavController, openDrawer: () -> Unit) {
+    val viewModel: DatabaseViewModel = viewModel()
+    val context = LocalContext.current
+    val data by viewModel.localData.collectAsState()
+
+    LaunchedEffect(Unit) { viewModel.loadLocalData(context) }
+
+    Scaffold(
+        topBar = {
+            TopBar(
+                title = "Local DB",
+                navController = navController,
+                showMenu = true,
+                onMenuClick = openDrawer
+            )
+        }
+    ) { padding ->
+        if (data == null) {
+            Column(modifier = Modifier.fillMaxSize().padding(padding),
+                ) {
+                CircularProgressIndicator(modifier = Modifier.padding(16.dp))
+            }
+        } else {
+            LazyColumn(
+                modifier = Modifier
+                    .fillMaxSize()
+                    .padding(padding)
+                    .padding(16.dp)
+            ) {
+                item { Text("Users", style = MaterialTheme.typography.titleMedium) }
+                items(data!!.users) { user ->
+                    Text("${'$'}{user.id} - ${'$'}{user.username}")
+                }
+                item { Spacer(modifier = Modifier.padding(8.dp)) }
+                item { Text("Vehicles", style = MaterialTheme.typography.titleMedium) }
+                items(data!!.vehicles) { vehicle ->
+                    Text("${'$'}{vehicle.id} - ${'$'}{vehicle.description}")
+                }
+                item { Spacer(modifier = Modifier.padding(8.dp)) }
+                item { Text("PoIs", style = MaterialTheme.typography.titleMedium) }
+                items(data!!.pois) { poi ->
+                    Text("${'$'}{poi.id} - ${'$'}{poi.name}")
+                }
+                item { Spacer(modifier = Modifier.padding(8.dp)) }
+                item { Text("Settings", style = MaterialTheme.typography.titleMedium) }
+                items(data!!.settings) { setting ->
+                    Text("${'$'}{setting.userId} - ${'$'}{setting.theme}")
+                }
+            }
+        }
+    }
+}

--- a/app/src/main/java/com/ioannapergamali/mysmartroute/viewmodel/DatabaseViewModel.kt
+++ b/app/src/main/java/com/ioannapergamali/mysmartroute/viewmodel/DatabaseViewModel.kt
@@ -1,0 +1,59 @@
+package com.ioannapergamali.mysmartroute.viewmodel
+
+import android.content.Context
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.viewModelScope
+import com.google.firebase.firestore.FirebaseFirestore
+import com.ioannapergamali.mysmartroute.data.local.MySmartRouteDatabase
+import com.ioannapergamali.mysmartroute.data.local.PoIEntity
+import com.ioannapergamali.mysmartroute.data.local.SettingsEntity
+import com.ioannapergamali.mysmartroute.data.local.UserEntity
+import com.ioannapergamali.mysmartroute.data.local.VehicleEntity
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.tasks.await
+
+/** ViewModel για προβολή δεδομένων βάσεων. */
+class DatabaseViewModel : ViewModel() {
+    private val firestore = FirebaseFirestore.getInstance()
+
+    private val _localData = MutableStateFlow<DatabaseData?>(null)
+    val localData: StateFlow<DatabaseData?> = _localData
+
+    private val _firebaseData = MutableStateFlow<DatabaseData?>(null)
+    val firebaseData: StateFlow<DatabaseData?> = _firebaseData
+
+    fun loadLocalData(context: Context) {
+        viewModelScope.launch {
+            val db = MySmartRouteDatabase.getInstance(context)
+            val users = db.userDao().getAllUsers()
+            val vehicles = db.vehicleDao().getAllVehicles()
+            val pois = db.poIDao().getAll()
+            val settings = db.settingsDao().getAllSettings()
+            _localData.value = DatabaseData(users, vehicles, pois, settings)
+        }
+    }
+
+    fun loadFirebaseData() {
+        viewModelScope.launch {
+            val users = firestore.collection("users").get().await()
+                .documents.mapNotNull { it.toObject(UserEntity::class.java) }
+            val vehicles = firestore.collection("vehicles").get().await()
+                .documents.mapNotNull { it.toObject(VehicleEntity::class.java) }
+            val pois = firestore.collection("pois").get().await()
+                .documents.mapNotNull { it.toObject(PoIEntity::class.java) }
+            val settings = firestore.collection("user_settings").get().await()
+                .documents.mapNotNull { it.toObject(SettingsEntity::class.java) }
+            _firebaseData.value = DatabaseData(users, vehicles, pois, settings)
+        }
+    }
+}
+
+/** Δομή για τα δεδομένα κάθε βάσης. */
+data class DatabaseData(
+    val users: List<UserEntity>,
+    val vehicles: List<VehicleEntity>,
+    val pois: List<PoIEntity>,
+    val settings: List<SettingsEntity>
+)


### PR DESCRIPTION
## Notes
- Προστέθηκαν νέες μέθοδοι στα DAO για ανάκτηση όλων των εγγραφών.
- Δημιουργήθηκε `DatabaseViewModel` για φόρτωση τοπικών και Firebase δεδομένων.
- Νέες οθόνες `DatabaseMenuScreen`, `LocalDatabaseScreen` και `FirebaseDatabaseScreen`.
- Προστέθηκε επιλογή **Databases** στο πλάινο μενού και νέες διαδρομές στο `NavigationHost`.

## Testing
- `./gradlew assembleDebug` (αποτυχία: λείπει Android SDK)


------
https://chatgpt.com/codex/tasks/task_e_684ac491011483288dbb55dc56e07caf