### PR TITLE
Fix SyncState reference in DatabaseMenuScreen

### DIFF
--- a/app/src/main/java/com/ioannapergamali/mysmartroute/view/ui/screens/DatabaseMenuScreen.kt
+++ b/app/src/main/java/com/ioannapergamali/mysmartroute/view/ui/screens/DatabaseMenuScreen.kt
@@ -18,6 +18,7 @@ import androidx.navigation.NavController
 import androidx.lifecycle.viewmodel.compose.viewModel
 import com.ioannapergamali.mysmartroute.view.ui.components.TopBar
 import com.ioannapergamali.mysmartroute.viewmodel.DatabaseViewModel
+import com.ioannapergamali.mysmartroute.viewmodel.SyncState
 
 @Composable
 fun DatabaseMenuScreen(navController: NavController, openDrawer: () -> Unit) {
@@ -55,10 +56,10 @@ fun DatabaseMenuScreen(navController: NavController, openDrawer: () -> Unit) {
 
     LaunchedEffect(syncState) {
         when (syncState) {
-            is DatabaseViewModel.SyncState.Success -> Toast.makeText(context, "Sync completed", Toast.LENGTH_SHORT).show()
-            is DatabaseViewModel.SyncState.Error -> Toast.makeText(
+            is SyncState.Success -> Toast.makeText(context, "Sync completed", Toast.LENGTH_SHORT).show()
+            is SyncState.Error -> Toast.makeText(
                 context,
-                (syncState as DatabaseViewModel.SyncState.Error).message,
+                (syncState as SyncState.Error).message,
                 Toast.LENGTH_SHORT
             ).show()
             else -> {}


### PR DESCRIPTION
## Summary
- import `SyncState` directly in DatabaseMenuScreen
- update references from `DatabaseViewModel.SyncState` to `SyncState`

## Testing
- `./gradlew test` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_684adfb7e8c08328babb8f4935e81118