### PR TITLE
Enable optional saving of settings

### DIFF
--- a/app/src/main/java/com/ioannapergamali/mysmartroute/view/ui/screens/SettingsScreen.kt
+++ b/app/src/main/java/com/ioannapergamali/mysmartroute/view/ui/screens/SettingsScreen.kt
@@ -1,19 +1,31 @@
 package com.ioannapergamali.mysmartroute.view.ui.screens
 
 import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.padding
 import androidx.compose.material3.Button
+import androidx.compose.material3.Checkbox
 import androidx.compose.material3.Scaffold
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.unit.dp
+import androidx.lifecycle.viewmodel.compose.viewModel
 import androidx.navigation.NavController
 import com.ioannapergamali.mysmartroute.view.ui.components.TopBar
+import com.ioannapergamali.mysmartroute.viewmodel.SettingsViewModel
 
 @Composable
 fun SettingsScreen(navController: NavController, openDrawer: () -> Unit) {
+    val context = LocalContext.current
+    val viewModel: SettingsViewModel = viewModel()
+    val saveChecked = remember { mutableStateOf(false) }
+
     Scaffold(
         topBar = {
             TopBar(
@@ -33,6 +45,21 @@ fun SettingsScreen(navController: NavController, openDrawer: () -> Unit) {
             }
             Button(onClick = { navController.navigate("soundPicker") }, modifier = Modifier.padding(top = 8.dp)) {
                 Text("Επιλογή ήχου")
+            }
+
+            Row(verticalAlignment = Alignment.CenterVertically, modifier = Modifier.padding(top = 16.dp)) {
+                Checkbox(
+                    checked = saveChecked.value,
+                    onCheckedChange = {
+                        saveChecked.value = it
+                        if (it) {
+                            viewModel.saveCurrentSettings(context)
+                        } else {
+                            viewModel.resetSettings(context)
+                        }
+                    }
+                )
+                Text("Οριστική αποθήκευση επιλογών", modifier = Modifier.padding(start = 8.dp))
             }
         }
     }

--- a/app/src/main/java/com/ioannapergamali/mysmartroute/viewmodel/SettingsViewModel.kt
+++ b/app/src/main/java/com/ioannapergamali/mysmartroute/viewmodel/SettingsViewModel.kt
@@ -16,6 +16,7 @@ import com.ioannapergamali.mysmartroute.utils.FontPreferenceManager
 import com.ioannapergamali.mysmartroute.view.ui.AppFont
 import com.ioannapergamali.mysmartroute.utils.SoundPreferenceManager
 import kotlinx.coroutines.launch
+import kotlinx.coroutines.flow.first
 
 class SettingsViewModel : ViewModel() {
     private val db = FirebaseFirestore.getInstance()
@@ -59,28 +60,24 @@ class SettingsViewModel : ViewModel() {
         viewModelScope.launch {
             ThemePreferenceManager.setTheme(context, theme)
             ThemePreferenceManager.setDarkTheme(context, dark)
-            updateSettings(context) { it.copy(theme = theme.name, darkTheme = dark) }
         }
     }
 
     fun applyFont(context: Context, font: AppFont) {
         viewModelScope.launch {
             FontPreferenceManager.setFont(context, font)
-            updateSettings(context) { it.copy(font = font.name) }
         }
     }
 
     fun applySoundEnabled(context: Context, enabled: Boolean) {
         viewModelScope.launch {
             SoundPreferenceManager.setSoundEnabled(context, enabled)
-            updateSettings(context) { it.copy(soundEnabled = enabled) }
         }
     }
 
     fun applySoundVolume(context: Context, volume: Float) {
         viewModelScope.launch {
             SoundPreferenceManager.setSoundVolume(context, volume)
-            updateSettings(context) { it.copy(soundVolume = volume) }
         }
     }
 
@@ -116,6 +113,39 @@ class SettingsViewModel : ViewModel() {
             FontPreferenceManager.setFont(context, AppFont.valueOf(settings.font))
             SoundPreferenceManager.setSoundEnabled(context, settings.soundEnabled)
             SoundPreferenceManager.setSoundVolume(context, settings.soundVolume)
+        }
+    }
+
+    fun saveCurrentSettings(context: Context) {
+        viewModelScope.launch {
+            val theme = ThemePreferenceManager.themeFlow(context).first()
+            val dark = ThemePreferenceManager.darkThemeFlow(context).first()
+            val font = FontPreferenceManager.fontFlow(context).first()
+            val soundEnabled = SoundPreferenceManager.getSoundEnabled(context)
+            val soundVolume = SoundPreferenceManager.getSoundVolume(context)
+            updateSettings(context) {
+                it.copy(
+                    theme = theme.name,
+                    darkTheme = dark,
+                    font = font.name,
+                    soundEnabled = soundEnabled,
+                    soundVolume = soundVolume
+                )
+            }
+        }
+    }
+
+    fun resetSettings(context: Context) {
+        viewModelScope.launch {
+            updateSettings(context) {
+                it.copy(
+                    theme = AppTheme.Ocean.name,
+                    darkTheme = false,
+                    font = AppFont.SansSerif.name,
+                    soundEnabled = true,
+                    soundVolume = 1f
+                )
+            }
         }
     }
 }


### PR DESCRIPTION
## Summary
- update SettingsViewModel to keep DB unchanged during normal edits
- add methods to persist or reset settings
- show checkbox in SettingsScreen for permanent saving

## Testing
- `./gradlew test` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_684ae3d80acc8328832ca3c9221d13f6