### PR TITLE
Fix missing bracket in AnnounceTransportScreen

### DIFF
--- a/app/src/main/java/com/ioannapergamali/mysmartroute/view/ui/screens/AnnounceTransportScreen.kt
+++ b/app/src/main/java/com/ioannapergamali/mysmartroute/view/ui/screens/AnnounceTransportScreen.kt
@@ -623,4 +623,5 @@ fun AnnounceTransportScreen(navController: NavController, openDrawer: () -> Unit
             else -> {}
         }
     }
+    }
 }


### PR DESCRIPTION
## Summary
- close `ScreenContainer` before finishing AnnounceTransportScreen

## Testing
- `./gradlew test` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_684afae01ec48328812f798423affda5