### PR TITLE
Fix unmatched brace in HomeScreen.kt

### DIFF
--- a/app/src/main/java/com/ioannapergamali/mysmartroute/view/ui/screens/HomeScreen.kt
+++ b/app/src/main/java/com/ioannapergamali/mysmartroute/view/ui/screens/HomeScreen.kt
@@ -141,3 +141,4 @@ fun HomeScreen(
         }
     }
 }
+}


### PR DESCRIPTION
## Summary
- close `HomeScreen` composable with a final `}`

## Testing
- `./gradlew assembleDebug` *(fails: SDK location not found)*
- `./gradlew test` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_684afd105fc48328a1b6706d294cd899