### PR TITLE
Fix missing closing brace in SignUpScreen

### DIFF
--- a/app/src/main/java/com/ioannapergamali/mysmartroute/view/ui/screens/SignUpScreen.kt
+++ b/app/src/main/java/com/ioannapergamali/mysmartroute/view/ui/screens/SignUpScreen.kt
@@ -141,3 +141,4 @@ fun SignUpScreen(
         }
     }
 }
+}


### PR DESCRIPTION
## Summary
- fix mismatched brace in `SignUpScreen.kt`

## Testing
- `./gradlew test` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_684b0a146fd08328b37f3e722a64e9a4