### PR TITLE
Fix extra closing brace in SignUpScreen

### DIFF
--- a/app/src/main/java/com/ioannapergamali/mysmartroute/view/ui/screens/SignUpScreen.kt
+++ b/app/src/main/java/com/ioannapergamali/mysmartroute/view/ui/screens/SignUpScreen.kt
@@ -207,4 +207,3 @@ fun SignUpScreen(
         }
     }
 }
-}


### PR DESCRIPTION
## Summary
- fix unbalanced brace in `SignUpScreen.kt`

## Testing
- `./gradlew test` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_684b0f06381483289b3e6a3c81b7e34a