### PR TITLE
Βελτίωση οθόνης About με logo και έκδοση

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -13,8 +13,8 @@ android {
         applicationId = "com.ioannapergamali.mysmartroute"
         minSdk = 33
         targetSdk = 35
-        versionCode = 3
-        versionName = "1.2"
+        versionCode = 4
+        versionName = "1.3"
         testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"
     }
 

--- a/app/src/main/java/com/ioannapergamali/mysmartroute/view/ui/screens/AboutScreen.kt
+++ b/app/src/main/java/com/ioannapergamali/mysmartroute/view/ui/screens/AboutScreen.kt
@@ -1,12 +1,17 @@
 package com.ioannapergamali.mysmartroute.view.ui.screens
 
-import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.*
+import androidx.compose.foundation.Image
+import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Scaffold
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.unit.dp
-import com.ioannapergamali.mysmartroute.view.ui.components.ScreenContainer
+import com.ioannapergamali.mysmartroute.BuildConfig
+import com.ioannapergamali.mysmartroute.R
 import com.ioannapergamali.mysmartroute.view.ui.components.ScreenContainer
 import androidx.navigation.NavController
 import com.ioannapergamali.mysmartroute.view.ui.components.TopBar
@@ -24,10 +29,34 @@ fun AboutScreen(navController: NavController, openDrawer: () -> Unit) {
         }
     ) { padding ->
         ScreenContainer(modifier = Modifier.padding(padding)) {
-            Text("Developer: Ιωάννα Περγάμαλη")
-            Text("Company: JOPE")
-            Text("Address: Πάροδος Κρήτης 8, Γάζι, ΤΚ 71414")
-            Text("Repository: https://github.com/ipergamali/mysmartroute.git")
+            Column(
+                horizontalAlignment = Alignment.CenterHorizontally,
+                modifier = Modifier.fillMaxWidth()
+            ) {
+                Image(
+                    painter = painterResource(id = R.drawable.company),
+                    contentDescription = "Company logo",
+                    modifier = Modifier.size(160.dp)
+                )
+
+                Spacer(modifier = Modifier.height(16.dp))
+
+                Text(
+                    text = "Credits",
+                    style = MaterialTheme.typography.titleLarge
+                )
+
+                Spacer(modifier = Modifier.height(8.dp))
+
+                Text("Developer: Ιωάννα Περγάμαλη")
+                Text("Version: ${BuildConfig.VERSION_NAME}")
+
+                Spacer(modifier = Modifier.height(8.dp))
+
+                Text("Company: JOPE")
+                Text("Address: Πάροδος Κρήτης 8, Γάζι, ΤΚ 71414")
+                Text("Repository: https://github.com/ipergamali/mysmartroute.git")
+            }
         }
     }
 }


### PR DESCRIPTION
## Summary
- εμφάνιση λογοτύπου και μορφοποιημένων στοιχείων στο About
- ανάδειξη της έκδοσης εφαρμογής στο About
- αναβάθμιση versionName σε 1.3

## Testing
- `./gradlew test` *(απέτυχε: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_684b238ebe5083288ffa35c571048ead