### PR TITLE
Fix login drawer behavior

### DIFF
--- a/app/src/main/java/com/ioannapergamali/mysmartroute/view/ui/screens/HomeScreen.kt
+++ b/app/src/main/java/com/ioannapergamali/mysmartroute/view/ui/screens/HomeScreen.kt
@@ -132,6 +132,8 @@ fun HomeScreen(
                 navController.navigate("menu") {
                     popUpTo("home") { inclusive = true }
                 }
+                // Άνοιγμα του πλαϊνού μενού ώστε να εμφανιστεί η επιλογή "Settings"
+                openDrawer()
             }
             is AuthenticationViewModel.LoginState.Error -> {
                 val message = (uiState as AuthenticationViewModel.LoginState.Error).message


### PR DESCRIPTION
## Summary
- open the drawer automatically after successful login
- confirm BuildConfig import for About screen

## Testing
- `./gradlew assembleDebug` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_684b25c03ab08328b9d2c0e3085ae6fd