### PR TITLE
Fix BuildConfig not generated

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -24,6 +24,7 @@ android {
 
     buildFeatures {
         compose = true
+        buildConfig = true
     }
 
     composeOptions {


### PR DESCRIPTION
## Summary
- ensure BuildConfig is generated by the app module

## Testing
- `./gradlew :app:generateDebugBuildConfig --console=plain` *(fails: no output due to environment restrictions)*

------
https://chatgpt.com/codex/tasks/task_e_684b2a1538988328817ec82f8c37653c