### PR TITLE
Προσθήκη toast για έλεγχο αποθήκευσης ρυθμίσεων

### DIFF
--- a/app/src/main/java/com/ioannapergamali/mysmartroute/view/ui/screens/SettingsScreen.kt
+++ b/app/src/main/java/com/ioannapergamali/mysmartroute/view/ui/screens/SettingsScreen.kt
@@ -26,6 +26,7 @@ import androidx.compose.runtime.remember
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.LocalContext
+import android.widget.Toast
 import androidx.compose.ui.unit.dp
 import androidx.lifecycle.viewmodel.compose.viewModel
 import androidx.navigation.NavController
@@ -158,6 +159,7 @@ fun SettingsScreen(navController: NavController, openDrawer: () -> Unit) {
 
             Button(
                 onClick = {
+                    Toast.makeText(context, "Εφαρμογή ρυθμίσεων...", Toast.LENGTH_SHORT).show()
                     viewModel.applyTheme(context, selectedTheme.value, dark.value)
                     viewModel.applyFont(context, selectedFont.value)
                     viewModel.applySoundEnabled(context, soundState.value)

--- a/app/src/main/java/com/ioannapergamali/mysmartroute/viewmodel/SettingsViewModel.kt
+++ b/app/src/main/java/com/ioannapergamali/mysmartroute/viewmodel/SettingsViewModel.kt
@@ -47,6 +47,9 @@ class SettingsViewModel : ViewModel() {
             soundVolume = 1f
         )
         val updated = transform(current)
+        withContext(Dispatchers.Main) {
+            Toast.makeText(context, "Γίνονται έλεγχοι αποθήκευσης", Toast.LENGTH_SHORT).show()
+        }
         try {
             dao.insert(updated)
             Log.d("SettingsViewModel", "Τοπική αποθήκευση επιτυχής: $updated")
@@ -56,7 +59,7 @@ class SettingsViewModel : ViewModel() {
         } catch (e: Exception) {
             Log.e("SettingsViewModel", "Αποτυχία τοπικής αποθήκευσης", e)
             withContext(Dispatchers.Main) {
-                Toast.makeText(context, "Σφάλμα τοπικής αποθήκευσης", Toast.LENGTH_SHORT).show()
+                Toast.makeText(context, "Σφάλμα τοπικής αποθήκευσης: ${e.localizedMessage}", Toast.LENGTH_LONG).show()
             }
             return
         }
@@ -74,7 +77,7 @@ class SettingsViewModel : ViewModel() {
             } catch (e: Exception) {
                 Log.e("SettingsViewModel", "Αποτυχία αποθήκευσης στο Firestore", e)
                 withContext(Dispatchers.Main) {
-                    Toast.makeText(context, "Σφάλμα cloud αποθήκευσης", Toast.LENGTH_SHORT).show()
+                    Toast.makeText(context, "Σφάλμα cloud αποθήκευσης: ${e.localizedMessage}", Toast.LENGTH_LONG).show()
                 }
             }
         } else {
@@ -148,6 +151,9 @@ class SettingsViewModel : ViewModel() {
     fun saveCurrentSettings(context: Context) {
         viewModelScope.launch {
             Log.d("SettingsViewModel", "Εκκίνηση αποθήκευσης ρυθμίσεων")
+            withContext(Dispatchers.Main) {
+                Toast.makeText(context, "Αποθήκευση ρυθμίσεων...", Toast.LENGTH_SHORT).show()
+            }
             val theme = ThemePreferenceManager.themeFlow(context).first()
             val dark = ThemePreferenceManager.darkThemeFlow(context).first()
             val font = FontPreferenceManager.fontFlow(context).first()


### PR DESCRIPTION
## Σύντομη περίληψη
Προστέθηκαν επιπλέον μηνύματα Toast τόσο στην οθόνη των ρυθμίσεων όσο και στο `SettingsViewModel` ώστε να γίνεται ευκολότερος ο εντοπισμός προβλημάτων κατά την αποθήκευση των αλλαγών. Τα Toast περιλαμβάνουν ενημέρωση έναρξης αποθήκευσης καθώς και τα μηνύματα σφάλματος με τις λεπτομέρειες της εξαίρεσης.

## Δοκιμές
- `./gradlew test` *(απέτυχε λόγω έλλειψης Android SDK)*

------
https://chatgpt.com/codex/tasks/task_e_684b37780a3083289e5449f7dabec7e9