### PR TITLE
Ενεργοποίηση fallbackToDestructiveMigration

### DIFF
--- a/app/src/main/java/com/ioannapergamali/mysmartroute/data/local/MySmartRouteDatabase.kt
+++ b/app/src/main/java/com/ioannapergamali/mysmartroute/data/local/MySmartRouteDatabase.kt
@@ -180,6 +180,7 @@ abstract class MySmartRouteDatabase : RoomDatabase() {
                     MIGRATION_6_7,
                     MIGRATION_7_8
                 )
+                    .fallbackToDestructiveMigration()
                     .build().also { INSTANCE = it }
             }
         }


### PR DESCRIPTION
## Περιγραφή
Προστέθηκε η κλήση `fallbackToDestructiveMigration()` στο `MySmartRouteDatabase` ώστε η βάση να αναδημιουργείται αυτόματα όταν αποτύχει κάποιο migration και να αποφεύγεται το crash που εμφανίστηκε στο logcat.

## Testing
- `./gradlew test --no-daemon` *(απέτυχε λόγω περιορισμών δικτύου)*

------
https://chatgpt.com/codex/tasks/task_e_684b48c7b0a483288fab021d7710926c