### PR TITLE
Fix settings sync foreign key issue

### DIFF
--- a/app/src/main/java/com/ioannapergamali/mysmartroute/viewmodel/SettingsViewModel.kt
+++ b/app/src/main/java/com/ioannapergamali/mysmartroute/viewmodel/SettingsViewModel.kt
@@ -151,7 +151,12 @@ class SettingsViewModel : ViewModel() {
     fun syncSettings(context: Context) {
         viewModelScope.launch {
             val userId = auth.currentUser?.uid ?: return@launch
-            val dao = MySmartRouteDatabase.getInstance(context).settingsDao()
+            val dbLocal = MySmartRouteDatabase.getInstance(context)
+            val userDao = dbLocal.userDao()
+            if (userDao.getUser(userId) == null) {
+                userDao.insert(UserEntity(id = userId))
+            }
+            val dao = dbLocal.settingsDao()
 
             val local = dao.getSettings(userId)
             val remote = if (NetworkUtils.isInternetAvailable(context)) {


### PR DESCRIPTION
## Summary
- ensure user exists before inserting settings during sync

## Testing
- `./gradlew test` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_684c177bfa28832892ad4ea6627d400b