### PR TITLE
Fix vector logos usage

### DIFF
--- a/app/src/main/java/com/ioannapergamali/mysmartroute/view/ui/components/LogoImage.kt
+++ b/app/src/main/java/com/ioannapergamali/mysmartroute/view/ui/components/LogoImage.kt
@@ -1,0 +1,20 @@
+package com.ioannapergamali.mysmartroute.view.ui.components
+
+import androidx.annotation.DrawableRes
+import androidx.compose.foundation.Image
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.res.painterResource
+
+@Composable
+fun LogoImage(
+    @DrawableRes resId: Int,
+    contentDescription: String?,
+    modifier: Modifier = Modifier
+) {
+    Image(
+        painter = painterResource(id = resId),
+        contentDescription = contentDescription,
+        modifier = modifier
+    )
+}

--- a/app/src/main/java/com/ioannapergamali/mysmartroute/view/ui/screens/AboutScreen.kt
+++ b/app/src/main/java/com/ioannapergamali/mysmartroute/view/ui/screens/AboutScreen.kt
@@ -1,20 +1,19 @@
 package com.ioannapergamali.mysmartroute.view.ui.screens
 
 import androidx.compose.foundation.layout.*
-import androidx.compose.foundation.Image
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Scaffold
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.unit.dp
 import com.ioannapergamali.mysmartroute.BuildConfig
 import com.ioannapergamali.mysmartroute.R
 import com.ioannapergamali.mysmartroute.view.ui.components.ScreenContainer
 import androidx.navigation.NavController
 import com.ioannapergamali.mysmartroute.view.ui.components.TopBar
+import com.ioannapergamali.mysmartroute.view.ui.components.LogoImage
 
 @Composable
 fun AboutScreen(navController: NavController, openDrawer: () -> Unit) {
@@ -33,8 +32,8 @@ fun AboutScreen(navController: NavController, openDrawer: () -> Unit) {
                 horizontalAlignment = Alignment.CenterHorizontally,
                 modifier = Modifier.fillMaxWidth()
             ) {
-                Image(
-                    painter = painterResource(id = R.drawable.company),
+                LogoImage(
+                    resId = R.drawable.company,
                     contentDescription = "Company logo",
                     modifier = Modifier.size(160.dp)
                 )

--- a/app/src/main/java/com/ioannapergamali/mysmartroute/view/ui/screens/HomeScreen.kt
+++ b/app/src/main/java/com/ioannapergamali/mysmartroute/view/ui/screens/HomeScreen.kt
@@ -1,6 +1,5 @@
 package com.ioannapergamali.mysmartroute.view.ui.screens
 
-import androidx.compose.foundation.Image
 import androidx.compose.foundation.layout.*
 import androidx.compose.foundation.clickable
 import androidx.compose.material3.*
@@ -8,7 +7,6 @@ import androidx.compose.runtime.*
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.graphicsLayer
-import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.res.dimensionResource
 import com.ioannapergamali.mysmartroute.view.ui.util.rememberWindowInfo
@@ -16,6 +14,7 @@ import com.ioannapergamali.mysmartroute.view.ui.util.WindowOrientation
 import androidx.compose.ui.unit.Dp
 import androidx.navigation.NavController
 import com.ioannapergamali.mysmartroute.view.ui.components.TopBar
+import com.ioannapergamali.mysmartroute.view.ui.components.LogoImage
 import com.ioannapergamali.mysmartroute.R
 import com.ioannapergamali.mysmartroute.view.ui.animation.rememberBreathingAnimation
 import com.ioannapergamali.mysmartroute.view.ui.animation.rememberSlideFadeInAnimation
@@ -153,8 +152,8 @@ private fun HomeContent(
 
         Spacer(modifier = Modifier.height(12.dp))
 
-        Image(
-            painter = painterResource(id = R.drawable.logo),
+        LogoImage(
+            resId = R.drawable.logo,
             contentDescription = "Animated Logo",
             modifier = Modifier
                 .size(dimensionResource(id = R.dimen.logo_size))


### PR DESCRIPTION
## Summary
- add a composable `LogoImage` for displaying vector logos
- use `LogoImage` in `HomeScreen` and `AboutScreen` for the new assets

## Testing
- `./gradlew test` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_684d83e1ec6c8328bd653fbf937af39a