### PR TITLE
Fix image scaling

### DIFF
--- a/app/src/main/java/com/ioannapergamali/mysmartroute/view/ui/components/LogoImage.kt
+++ b/app/src/main/java/com/ioannapergamali/mysmartroute/view/ui/components/LogoImage.kt
@@ -5,6 +5,7 @@ import androidx.compose.foundation.Image
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.res.painterResource
+import androidx.compose.ui.layout.ContentScale
 
 @Composable
 fun LogoImage(
@@ -15,6 +16,7 @@ fun LogoImage(
     Image(
         painter = painterResource(id = resId),
         contentDescription = contentDescription,
-        modifier = modifier
+        modifier = modifier,
+        contentScale = ContentScale.Fit
     )
 }


### PR DESCRIPTION
## Summary
- ensure logo vector assets scale correctly by using `ContentScale.Fit`

## Testing
- `./gradlew test` *(fails: maven.pkg.jetbrains.space blocked)*

------
https://chatgpt.com/codex/tasks/task_e_684d98b3728083289ee073461f247f89