### PR TITLE
Update user signup to use Firestore references

### DIFF
--- a/app/src/main/java/com/ioannapergamali/mysmartroute/viewmodel/AuthenticationViewModel.kt
+++ b/app/src/main/java/com/ioannapergamali/mysmartroute/viewmodel/AuthenticationViewModel.kt
@@ -86,22 +86,7 @@ class AuthenticationViewModel : ViewModel() {
                 auth.createUserWithEmailAndPassword(email, password)
                     .addOnSuccessListener { result ->
                         val uid = result.user?.uid ?: userIdLocal
-                        val userData = hashMapOf(
-                            "id" to db.authRef(uid),
-                            "name" to name,
-                            "surname" to surname,
-                            "username" to username,
-                            "email" to email,
-                            "phoneNum" to phoneNum,
-                            "password" to password,
-                            "role" to role.name,
-                            "address" to mapOf(
-                                "city" to address.city,
-                                "streetName" to address.streetName,
-                                "streetNum" to address.streetNum,
-                                "postalCode" to address.postalCode
-                            )
-                        )
+                        val userData = userEntity.copy(id = uid).toFirestoreMap(db)
 
                         db.collection("users")
                             .document(uid)


### PR DESCRIPTION
## Summary
- switch AuthenticationViewModel signup to use `toFirestoreMap` for saving

## Testing
- `./gradlew tasks --all` *(fails: blocked by network)*
- `./gradlew test` *(fails: blocked by network)*

------
https://chatgpt.com/codex/tasks/task_e_684dc36cc2fc83289ee2f8b6816daf79