### PR TITLE
Σύνδεση πεδίου id με αναφορά authentication

### DIFF
--- a/app/src/main/java/com/ioannapergamali/mysmartroute/utils/FirestoreMappers.kt
+++ b/app/src/main/java/com/ioannapergamali/mysmartroute/utils/FirestoreMappers.kt
@@ -1,5 +1,5 @@
 package com.ioannapergamali.mysmartroute.utils
-
+import com.google.firebase.firestore.DocumentSnapshot
 import com.google.firebase.firestore.DocumentReference
 import com.google.firebase.firestore.FirebaseFirestore
 import com.ioannapergamali.mysmartroute.data.local.SettingsEntity
@@ -52,3 +52,22 @@ fun SettingsEntity.toFirestoreMap(db: FirebaseFirestore): Map<String, Any> = map
 fun AuthenticationEntity.toFirestoreMap(): Map<String, Any> = mapOf(
     "id" to id
 )
+
+/** Μετατροπή εγγράφου Firestore σε [UserEntity] διαβάζοντας το id ως DocumentReference. */
+fun com.google.firebase.firestore.DocumentSnapshot.toUserEntity(): UserEntity? {
+    val ref = getDocumentReference("id") ?: return null
+    return UserEntity(
+        id = ref.id,
+        name = getString("name") ?: "",
+        surname = getString("surname") ?: "",
+        username = getString("username") ?: "",
+        email = getString("email") ?: "",
+        phoneNum = getString("phoneNum") ?: "",
+        password = getString("password") ?: "",
+        role = getString("role") ?: "",
+        city = getString("city") ?: "",
+        streetName = getString("streetName") ?: "",
+        streetNum = (getLong("streetNum") ?: 0L).toInt(),
+        postalCode = (getLong("postalCode") ?: 0L).toInt()
+    )
+}

--- a/app/src/main/java/com/ioannapergamali/mysmartroute/viewmodel/DatabaseViewModel.kt
+++ b/app/src/main/java/com/ioannapergamali/mysmartroute/viewmodel/DatabaseViewModel.kt
@@ -46,23 +46,7 @@ class DatabaseViewModel : ViewModel() {
     fun loadFirebaseData() {
         viewModelScope.launch {
             val users = firestore.collection("users").get().await()
-                .documents.mapNotNull { doc ->
-                    val ref = doc.getDocumentReference("id") ?: return@mapNotNull null
-                    UserEntity(
-                        id = ref.id,
-                        name = doc.getString("name") ?: "",
-                        surname = doc.getString("surname") ?: "",
-                        username = doc.getString("username") ?: "",
-                        email = doc.getString("email") ?: "",
-                        phoneNum = doc.getString("phoneNum") ?: "",
-                        password = doc.getString("password") ?: "",
-                        role = doc.getString("role") ?: "",
-                        city = doc.getString("city") ?: "",
-                        streetName = doc.getString("streetName") ?: "",
-                        streetNum = (doc.getLong("streetNum") ?: 0L).toInt(),
-                        postalCode = (doc.getLong("postalCode") ?: 0L).toInt()
-                    )
-                }
+                .documents.mapNotNull { it.toUserEntity() }
             val vehicles = firestore.collection("vehicles").get().await()
                 .documents.mapNotNull { doc ->
                     val userRef = doc.getDocumentReference("userId") ?: return@mapNotNull null
@@ -111,23 +95,7 @@ class DatabaseViewModel : ViewModel() {
             try {
                 if (remoteTs > localTs) {
                     val users = firestore.collection("users").get().await()
-                        .documents.mapNotNull { doc ->
-                            val ref = doc.getDocumentReference("id") ?: return@mapNotNull null
-                            UserEntity(
-                                id = ref.id,
-                                name = doc.getString("name") ?: "",
-                                surname = doc.getString("surname") ?: "",
-                                username = doc.getString("username") ?: "",
-                                email = doc.getString("email") ?: "",
-                                phoneNum = doc.getString("phoneNum") ?: "",
-                                password = doc.getString("password") ?: "",
-                                role = doc.getString("role") ?: "",
-                                city = doc.getString("city") ?: "",
-                                streetName = doc.getString("streetName") ?: "",
-                                streetNum = (doc.getLong("streetNum") ?: 0L).toInt(),
-                                postalCode = (doc.getLong("postalCode") ?: 0L).toInt()
-                            )
-                        }
+                        .documents.mapNotNull { it.toUserEntity() }
                     val vehicles = firestore.collection("vehicles").get().await()
                         .documents.mapNotNull { doc ->
                             val userRef = doc.getDocumentReference("userId") ?: return@mapNotNull null


### PR DESCRIPTION
## Summary
- προσθήκη επέκτασης `toUserEntity` για ευκολότερη μετατροπή εγγράφων σε `UserEntity`
- απλοποίηση φόρτωσης χρηστών από Firestore με χρήση της νέας επέκτασης

## Testing
- `./gradlew test --no-daemon -q` *(απέτυχε λόγω περιορισμών δικτύου)*

------
https://chatgpt.com/codex/tasks/task_e_684ed82260b083289cb47cac572979e1