### PR TITLE
Update sign-up flow

### DIFF
--- a/app/src/main/java/com/ioannapergamali/mysmartroute/model/navigation/NavigationHost.kt
+++ b/app/src/main/java/com/ioannapergamali/mysmartroute/model/navigation/NavigationHost.kt
@@ -45,7 +45,7 @@ fun NavigationHost(navController : NavHostController, openDrawer: () -> Unit) {
             SignUpScreen(
                 navController = navController ,
                 onSignUpSuccess = {
-                    navController.navigate("menu") {
+                    navController.navigate("home") {
                         popUpTo("signup") { inclusive = true }
                     }
                 },

--- a/app/src/main/java/com/ioannapergamali/mysmartroute/view/ui/screens/SignUpScreen.kt
+++ b/app/src/main/java/com/ioannapergamali/mysmartroute/view/ui/screens/SignUpScreen.kt
@@ -190,8 +190,13 @@ fun SignUpScreen(
                 is AuthenticationViewModel.SignUpState.Success -> {
                     Toast.makeText(
                         context,
-                        "User created and stored successfully",
+                        "Η εγγραφή ολοκληρώθηκε με επιτυχία",
                         Toast.LENGTH_SHORT
+                    ).show()
+                    Toast.makeText(
+                        context,
+                        "Παρακαλώ ενεργοποιήστε τον λογαριασμό σας μέσω e-mail",
+                        Toast.LENGTH_LONG
                     ).show()
                     onSignUpSuccess()
                 }


### PR DESCRIPTION
## Summary
- show additional toast in SignUpScreen prompting email verification
- navigate back to the home screen after a successful sign-up

## Testing
- `./gradlew test` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_684f1c31698483288e5e31314620440f