### PR TITLE
Implement sign-out after sign‑up

### DIFF
--- a/app/src/main/java/com/ioannapergamali/mysmartroute/view/ui/screens/SignUpScreen.kt
+++ b/app/src/main/java/com/ioannapergamali/mysmartroute/view/ui/screens/SignUpScreen.kt
@@ -198,6 +198,7 @@ fun SignUpScreen(
                         "Παρακαλώ ενεργοποιήστε τον λογαριασμό σας μέσω e-mail",
                         Toast.LENGTH_LONG
                     ).show()
+                    viewModel.signOut()
                     onSignUpSuccess()
                 }
 


### PR DESCRIPTION
## Summary
- after a successful sign-up, sign out automatically before returning to the login screen

## Testing
- `./gradlew test` *(fails: could not download dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_684f93ecbee483289d79b54dedd05eb1