### PR TITLE
Add hidden admin setup on first launch

### DIFF
--- a/app/src/main/java/com/ioannapergamali/mysmartroute/utils/FirstLaunchManager.kt
+++ b/app/src/main/java/com/ioannapergamali/mysmartroute/utils/FirstLaunchManager.kt
@@ -1,0 +1,25 @@
+package com.ioannapergamali.mysmartroute.utils
+
+import android.content.Context
+import androidx.datastore.preferences.core.booleanPreferencesKey
+import androidx.datastore.preferences.core.edit
+import androidx.datastore.preferences.preferencesDataStore
+import kotlinx.coroutines.flow.first
+import kotlinx.coroutines.flow.map
+
+private val Context.launchDataStore by preferencesDataStore(name = "launch_settings")
+
+object FirstLaunchManager {
+    private val FIRST_LAUNCH_KEY = booleanPreferencesKey("first_launch")
+
+    suspend fun isFirstLaunch(context: Context): Boolean =
+        context.launchDataStore.data.map { prefs ->
+            prefs[FIRST_LAUNCH_KEY] ?: true
+        }.first()
+
+    suspend fun setFirstLaunch(context: Context, value: Boolean) {
+        context.launchDataStore.edit { prefs ->
+            prefs[FIRST_LAUNCH_KEY] = value
+        }
+    }
+}

--- a/app/src/main/java/com/ioannapergamali/mysmartroute/viewmodel/AuthenticationViewModel.kt
+++ b/app/src/main/java/com/ioannapergamali/mysmartroute/viewmodel/AuthenticationViewModel.kt
@@ -183,6 +183,27 @@ class AuthenticationViewModel : ViewModel() {
             }
     }
 
+    fun seedAdminAccount(context: Context, password: String) {
+        val defaultAdmin = UserAddress(
+            city = "Athens",
+            streetName = "Admin Street",
+            streetNum = 1,
+            postalCode = 11111
+        )
+
+        signUp(
+            context = context,
+            name = "Admin",
+            surname = "User",
+            username = "admin",
+            email = "admin@example.com",
+            phoneNum = "6911111111",
+            password = password,
+            address = defaultAdmin,
+            role = UserRole.ADMIN
+        )
+    }
+
     fun signOut() {
         auth.signOut()
         _currentUserRole.value = null

--- a/app/src/main/java/com/ioannapergamali/mysmartroute/viewmodel/MainActivity.kt
+++ b/app/src/main/java/com/ioannapergamali/mysmartroute/viewmodel/MainActivity.kt
@@ -1,6 +1,8 @@
 package com.ioannapergamali.mysmartroute.viewmodel
 
 import android.os.Bundle
+import android.widget.EditText
+import androidx.appcompat.app.AlertDialog
 import androidx.activity.ComponentActivity
 import androidx.activity.compose.setContent
 import androidx.activity.viewModels
@@ -20,13 +22,18 @@ import com.ioannapergamali.mysmartroute.utils.MiuiUtils
 import com.ioannapergamali.mysmartroute.utils.ThemePreferenceManager
 import com.ioannapergamali.mysmartroute.utils.SoundPreferenceManager
 import com.ioannapergamali.mysmartroute.utils.SoundManager
+import com.ioannapergamali.mysmartroute.utils.FirstLaunchManager
 import com.ioannapergamali.mysmartroute.viewmodel.SettingsViewModel
+import com.ioannapergamali.mysmartroute.viewmodel.AuthenticationViewModel
 import kotlinx.coroutines.launch
 
 
 
 class MainActivity : ComponentActivity() {
     private val settingsViewModel: SettingsViewModel by viewModels()
+    private val authViewModel: AuthenticationViewModel by viewModels()
+
+    private val ADMIN_PASSWORD = "SECRET123" // Βάλτε εδώ τον μυστικό κωδικό
     override fun onCreate(savedInstanceState : Bundle?)
     {
         super.onCreate(savedInstanceState)
@@ -41,6 +48,10 @@ class MainActivity : ComponentActivity() {
             val volume = SoundPreferenceManager.getSoundVolume(applicationContext)
             SoundManager.setVolume(volume)
             if (enabled) SoundManager.play()
+            if (FirstLaunchManager.isFirstLaunch(this@MainActivity)) {
+                showAdminSetupDialog()
+                FirstLaunchManager.setFirstLaunch(this@MainActivity, false)
+            }
         }
         setContent {
             val context = LocalContext.current
@@ -76,5 +87,21 @@ class MainActivity : ComponentActivity() {
     override fun onDestroy() {
         SoundManager.release()
         super.onDestroy()
+    }
+
+    private fun showAdminSetupDialog() {
+        val input = EditText(this)
+        AlertDialog.Builder(this)
+            .setTitle("Admin Setup")
+            .setMessage("Εισάγετε κωδικό διαχειριστή")
+            .setView(input)
+            .setPositiveButton("OK") { _, _ ->
+                val text = input.text.toString()
+                if (text == ADMIN_PASSWORD) {
+                    authViewModel.seedAdminAccount(this, text)
+                }
+            }
+            .setNegativeButton("Cancel", null)
+            .show()
     }
 }


### PR DESCRIPTION
## Summary
- add FirstLaunchManager DataStore helper
- seed admin account when secret password is entered on first launch
- prompt for admin password in MainActivity

## Testing
- `./gradlew test --no-daemon` *(fails: maven.pkg.jetbrains.space blocked)*

------
https://chatgpt.com/codex/tasks/task_e_684f9d8c1c948328bdacec4ef21c6983