### PR TITLE
Fix unmatched brace in HomeScreen.kt

### DIFF
--- a/app/src/main/java/com/ioannapergamali/mysmartroute/view/ui/screens/HomeScreen.kt
+++ b/app/src/main/java/com/ioannapergamali/mysmartroute/view/ui/screens/HomeScreen.kt
@@ -122,7 +122,6 @@ fun HomeScreen(
             else -> {}
         }
     }
-}
 
 @Composable
 private fun HomeContent(


### PR DESCRIPTION
## Summary
- remove extra closing brace in `HomeScreen.kt`

## Testing
- `./gradlew test` *(fails: Could not download dependencies because maven.pkg.jetbrains.space is blocked)*

------
https://chatgpt.com/codex/tasks/task_e_684fc9eef6bc83288e0a41f7a3473451