### PR TITLE
Fix import for LogoImage.kt

### DIFF
--- a/app/src/main/java/com/ioannapergamali/mysmartroute/view/ui/components/LogoImage.kt
+++ b/app/src/main/java/com/ioannapergamali/mysmartroute/view/ui/components/LogoImage.kt
@@ -3,6 +3,7 @@ package com.ioannapergamali.mysmartroute.view.ui.components
 import android.graphics.BitmapFactory
 import android.util.Base64
 import androidx.compose.foundation.Image
+import androidx.compose.foundation.layout.size
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.remember
 import androidx.compose.ui.Modifier


### PR DESCRIPTION
## Περιγραφή
Προστέθηκε η εισαγωγή `size` από το `androidx.compose.foundation.layout` στο αρχείο `LogoImage.kt`. Η αλλαγή λύνει το σφάλμα "Unresolved reference: size" κατά τη μεταγλώττιση.

## Τεστ
Εκτελέστηκε η εντολή `./gradlew test`, όμως η διαδικασία δεν ολοκληρώθηκε λόγω περιορισμών στο δίκτυο.

------
https://chatgpt.com/codex/tasks/task_e_684fcbd2f20083288a0fb2be33b27b5a