### PR TITLE
Fix missing closing brace causing compile error

### DIFF
--- a/app/src/main/java/com/ioannapergamali/mysmartroute/view/ui/screens/HomeScreen.kt
+++ b/app/src/main/java/com/ioannapergamali/mysmartroute/view/ui/screens/HomeScreen.kt
@@ -122,6 +122,7 @@ fun HomeScreen(
             else -> {}
         }
     }
+}
 
 @Composable
 private fun HomeContent(
@@ -206,5 +207,4 @@ private fun HomeContent(
             )
         }
     }
-}
 }


### PR DESCRIPTION
## Summary
- fix misplaced braces in `HomeScreen.kt`

## Testing
- `./gradlew build -x lint --no-daemon` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_684fcd47e9108328a283ff37d9339069