### PR TITLE
Fix HomeScreen alignment type mismatch

### DIFF
--- a/app/src/main/java/com/ioannapergamali/mysmartroute/view/ui/screens/HomeScreen.kt
+++ b/app/src/main/java/com/ioannapergamali/mysmartroute/view/ui/screens/HomeScreen.kt
@@ -58,8 +58,8 @@ fun HomeScreen(
         ScreenContainer(modifier = Modifier.padding(paddingValues)) {
             val isLarge = windowInfo.width > 600.dp && windowInfo.orientation == WindowOrientation.Landscape
             val containerModifier = if (isLarge) Modifier.fillMaxWidth() else Modifier.fillMaxSize()
-            val arrangement = if (isLarge) Arrangement.Center else Arrangement.Top
-            val alignment = if (isLarge) Alignment.CenterVertically else Alignment.CenterHorizontally
+            val arrangement: Arrangement.Vertical = if (isLarge) Arrangement.Center else Arrangement.Top
+            val alignment: Alignment.Horizontal = Alignment.CenterHorizontally
             if (isLarge) {
                 Row(
                     modifier = containerModifier,


### PR DESCRIPTION
## Summary
- fix alignment variable type to avoid `Any` inference error

## Testing
- `./gradlew assembleDebug` *(fails: maven.pkg.jetbrains.space blocked)*

------
https://chatgpt.com/codex/tasks/task_e_684fd6cb8c7883288f68ce28500bd81e