### PR TITLE
Fix HomeScreen UI state scope

### DIFF
--- a/app/src/main/java/com/ioannapergamali/mysmartroute/view/ui/screens/HomeScreen.kt
+++ b/app/src/main/java/com/ioannapergamali/mysmartroute/view/ui/screens/HomeScreen.kt
@@ -103,23 +103,23 @@ fun HomeScreen(
                 }
             }
         }
-    }
 
-    LaunchedEffect(uiState) {
-        when (uiState) {
-            is AuthenticationViewModel.LoginState.Success -> {
-                Toast.makeText(context, "Login successful", Toast.LENGTH_SHORT).show()
-                navController.navigate("menu") {
-                    popUpTo("home") { inclusive = true }
+        LaunchedEffect(uiState) {
+            when (uiState) {
+                is AuthenticationViewModel.LoginState.Success -> {
+                    Toast.makeText(context, "Login successful", Toast.LENGTH_SHORT).show()
+                    navController.navigate("menu") {
+                        popUpTo("home") { inclusive = true }
+                    }
+                    // Άνοιγμα του πλαϊνού μενού ώστε να εμφανιστεί η επιλογή "Settings"
+                    openDrawer()
                 }
-                // Άνοιγμα του πλαϊνού μενού ώστε να εμφανιστεί η επιλογή "Settings"
-                openDrawer()
+                is AuthenticationViewModel.LoginState.Error -> {
+                    val message = (uiState as AuthenticationViewModel.LoginState.Error).message
+                    Toast.makeText(context, message, Toast.LENGTH_SHORT).show()
+                }
+                else -> {}
             }
-            is AuthenticationViewModel.LoginState.Error -> {
-                val message = (uiState as AuthenticationViewModel.LoginState.Error).message
-                Toast.makeText(context, message, Toast.LENGTH_SHORT).show()
-            }
-            else -> {}
         }
     }
 }


### PR DESCRIPTION
## Summary
- move LaunchedEffect block inside the Scaffold callback

## Testing
- `./gradlew --version`
- `./gradlew :app:assembleDebug --dry-run` *(fails: blocked domains)*

------
https://chatgpt.com/codex/tasks/task_e_684fd8ac4bdc83288f49e3b5f07a293b