### PR TITLE
Fixed logo scaling

### DIFF
--- a/app/src/main/java/com/ioannapergamali/mysmartroute/view/ui/components/LogoImage.kt
+++ b/app/src/main/java/com/ioannapergamali/mysmartroute/view/ui/components/LogoImage.kt
@@ -10,22 +10,16 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.asImageBitmap
 import androidx.compose.ui.graphics.painter.BitmapPainter
 import androidx.compose.ui.layout.ContentScale
-import androidx.compose.ui.platform.LocalConfiguration
-import androidx.compose.ui.unit.Dp
-import androidx.compose.ui.unit.dp
+import androidx.compose.ui.res.dimensionResource
+import com.ioannapergamali.mysmartroute.R
 
 @Composable
 fun LogoImage(
     base64Data: String,
     contentDescription: String?,
-    modifier: Modifier = Modifier,
-    baseSize: Dp = 40.dp,
-    referenceWidth: Dp = 600.dp
+    modifier: Modifier = Modifier
 ) {
-    val configuration = LocalConfiguration.current
-    val screenWidth = configuration.screenWidthDp.dp
-    val scale = screenWidth.value / referenceWidth.value
-    val targetSize = baseSize * scale
+    val targetSize = dimensionResource(id = R.dimen.logo_size)
 
     val painter = remember(base64Data) {
         val bytes = Base64.decode(base64Data, Base64.DEFAULT)

--- a/app/src/main/res/values-sw600dp/dimens.xml
+++ b/app/src/main/res/values-sw600dp/dimens.xml
@@ -1,4 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
     <dimen name="padding_screen">32dp</dimen>
+    <dimen name="logo_size">40dp</dimen>
 </resources>

--- a/app/src/main/res/values/dimens.xml
+++ b/app/src/main/res/values/dimens.xml
@@ -1,4 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
     <dimen name="padding_screen">16dp</dimen>
+    <dimen name="logo_size">32dp</dimen>
 </resources>


### PR DESCRIPTION
## Summary
- set `logo_size` dimens for general and sw600dp devices
- use `dimensionResource` in `LogoImage` to read logo size

## Testing
- `./gradlew test --quiet` *(fails: maven.pkg.jetbrains.space blocked)*

------
https://chatgpt.com/codex/tasks/task_e_684fe7b0abdc83288f4990d7e6fa4c1b