### PR TITLE
Ρύθμιση δυναμικού μεγέθους λογότυπου

### DIFF
--- a/app/src/main/java/com/ioannapergamali/mysmartroute/view/ui/components/LogoImage.kt
+++ b/app/src/main/java/com/ioannapergamali/mysmartroute/view/ui/components/LogoImage.kt
@@ -10,8 +10,7 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.asImageBitmap
 import androidx.compose.ui.graphics.painter.BitmapPainter
 import androidx.compose.ui.layout.ContentScale
-import androidx.compose.ui.res.dimensionResource
-import com.ioannapergamali.mysmartroute.R
+import com.ioannapergamali.mysmartroute.view.ui.util.rememberAdaptiveLogoSize
 
 @Composable
 fun LogoImage(
@@ -19,7 +18,7 @@ fun LogoImage(
     contentDescription: String?,
     modifier: Modifier = Modifier
 ) {
-    val targetSize = dimensionResource(id = R.dimen.logo_size)
+    val targetSize = rememberAdaptiveLogoSize()
 
     val painter = remember(base64Data) {
         val bytes = Base64.decode(base64Data, Base64.DEFAULT)

--- a/app/src/main/java/com/ioannapergamali/mysmartroute/view/ui/util/LogoSizeUtils.kt
+++ b/app/src/main/java/com/ioannapergamali/mysmartroute/view/ui/util/LogoSizeUtils.kt
@@ -1,0 +1,39 @@
+package com.ioannapergamali.mysmartroute.view.ui.util
+
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.remember
+import androidx.compose.ui.platform.LocalConfiguration
+import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.platform.LocalDensity
+import androidx.compose.ui.unit.Dp
+import kotlin.math.pow
+import kotlin.math.sqrt
+
+/**
+ * Υπολογίζει δυναμικά το μέγεθος του λογότυπου ώστε να προσαρμόζεται
+ * σε διαφορετικές φυσικές διαστάσεις οθονών.
+ *
+ * @param referenceDiagonalInches Το μέγεθος οθόνης (σε ίντσες) στο οποίο
+ * προορίζεται να είναι [sizeAtReferencePx]. Προεπιλογή 7 ίντσες.
+ * @param sizeAtReferencePx Το μέγεθος του λογότυπου σε pixels όταν η διαγώνιος
+ * είναι [referenceDiagonalInches]. Προεπιλογή 40 px.
+ */
+@Composable
+fun rememberAdaptiveLogoSize(
+    referenceDiagonalInches: Float = 7f,
+    sizeAtReferencePx: Float = 40f
+): Dp {
+    val context = LocalContext.current
+    val density = LocalDensity.current
+    val configuration = LocalConfiguration.current
+
+    return remember(configuration) {
+        val metrics = context.resources.displayMetrics
+        val widthPx = metrics.widthPixels.toFloat()
+        val heightPx = metrics.heightPixels.toFloat()
+        val diagonalPx = sqrt(widthPx.pow(2) + heightPx.pow(2))
+        val diagonalInches = diagonalPx / metrics.densityDpi.toFloat()
+        val targetPx = sizeAtReferencePx * (diagonalInches / referenceDiagonalInches)
+        with(density) { targetPx.toDp() }
+    }
+}


### PR DESCRIPTION
## Summary
- προσθήκη συνάρτησης `rememberAdaptiveLogoSize` για προσαρμοσμένο μέγεθος λογότυπου
- χρήση της νέας συνάρτησης στο `LogoImage`

## Testing
- `./gradlew testDebug` *(απέτυχε λόγω περιορισμένης πρόσβασης δικτύου για λήψη εξαρτήσεων)*

------
https://chatgpt.com/codex/tasks/task_e_684fedb021f48328880ef7b681667356