### PR TITLE
Remove const from drawable assets

### DIFF
--- a/app/src/main/java/com/ioannapergamali/mysmartroute/view/ui/components/LogoAssets.kt
+++ b/app/src/main/java/com/ioannapergamali/mysmartroute/view/ui/components/LogoAssets.kt
@@ -5,8 +5,8 @@ import com.ioannapergamali.mysmartroute.R
 
 object LogoAssets {
     @DrawableRes
-    const val LOGO = R.drawable.logo
+    val LOGO: Int = R.drawable.logo
 
     @DrawableRes
-    const val COMPANY = R.drawable.company
+    val COMPANY: Int = R.drawable.company
 }


### PR DESCRIPTION
## Summary
- fix `LogoAssets` by replacing `const val` with `val` for drawable resources

## Testing
- `./gradlew test --no-daemon` *(fails: could not download dependencies due to network access restrictions)*

------
https://chatgpt.com/codex/tasks/task_e_684fffbb6c0c83288b8b8f35ea271d90