### PR TITLE
Adjust logo size adaptation

### DIFF
--- a/app/src/main/java/com/ioannapergamali/mysmartroute/view/ui/util/LogoSizeUtils.kt
+++ b/app/src/main/java/com/ioannapergamali/mysmartroute/view/ui/util/LogoSizeUtils.kt
@@ -33,7 +33,11 @@ fun rememberAdaptiveLogoSize(
         val heightPx = metrics.heightPixels.toFloat()
         val diagonalPx = sqrt(widthPx.pow(2) + heightPx.pow(2))
         val diagonalInches = diagonalPx / metrics.densityDpi.toFloat()
-        val targetPx = sizeAtReferencePx * (diagonalInches / referenceDiagonalInches)
+        val targetPx = when {
+            diagonalInches in 7f..9f -> sizeAtReferencePx
+            diagonalInches < 7f -> sizeAtReferencePx * (diagonalInches / 7f)
+            else -> sizeAtReferencePx * (diagonalInches / 9f)
+        }
         with(density) { targetPx.toDp() }
     }
 }


### PR DESCRIPTION
## Summary
- adjust `rememberAdaptiveLogoSize` so screens from 7‑9" keep a 40px logo

## Testing
- `./gradlew test --no-daemon` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_685001567e8883289adfb2bff684e0ae