### PR TITLE
Προσθήκη adaptive μεγέθους λογότυπου

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -9,9 +9,9 @@
         android:allowBackup="true"
         android:dataExtractionRules="@xml/data_extraction_rules"
         android:fullBackupContent="@xml/backup_rules"
-        android:icon="@mipmap/ic_launcher"
+        android:icon="@drawable/logo"
         android:label="@string/app_name"
-        android:roundIcon="@mipmap/ic_launcher_round"
+        android:roundIcon="@drawable/logo"
         android:supportsRtl="true"
         android:theme="@style/Theme.Mysmartroute"
         tools:targetApi="31">

--- a/app/src/main/java/com/ioannapergamali/mysmartroute/view/ui/components/LogoImage.kt
+++ b/app/src/main/java/com/ioannapergamali/mysmartroute/view/ui/components/LogoImage.kt
@@ -7,7 +7,7 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.layout.ContentScale
 import androidx.compose.ui.res.painterResource
 import androidx.annotation.DrawableRes
-import com.ioannapergamali.mysmartroute.view.ui.util.rememberAdaptiveLogoSize
+import com.ioannapergamali.mysmartroute.view.ui.util.rememberLogoSize
 
 @Composable
 fun LogoImage(
@@ -15,7 +15,7 @@ fun LogoImage(
     contentDescription: String?,
     modifier: Modifier = Modifier
 ) {
-    val targetSize = rememberAdaptiveLogoSize()
+    val targetSize = rememberLogoSize()
 
     Image(
         painter = painterResource(drawableRes),

--- a/app/src/main/java/com/ioannapergamali/mysmartroute/view/ui/util/LogoSizeUtils.kt
+++ b/app/src/main/java/com/ioannapergamali/mysmartroute/view/ui/util/LogoSizeUtils.kt
@@ -41,3 +41,30 @@ fun rememberAdaptiveLogoSize(
         with(density) { targetPx.toDp() }
     }
 }
+
+/**
+ * Απλούστερη παραλλαγή που επιστρέφει 40 px για οθόνες 7-9 ιντσών
+ * και προσαρμόζει γραμμικά για μικρότερες ή μεγαλύτερες συσκευές.
+ */
+@Composable
+fun rememberLogoSize(): Dp {
+    val context = LocalContext.current
+    val density = LocalDensity.current
+    val configuration = LocalConfiguration.current
+
+    return remember(configuration) {
+        val metrics = context.resources.displayMetrics
+        val widthPx = metrics.widthPixels.toFloat()
+        val heightPx = metrics.heightPixels.toFloat()
+        val diagonalPx = sqrt(widthPx.pow(2) + heightPx.pow(2))
+        val diagonalInches = diagonalPx / metrics.densityDpi.toFloat()
+
+        val targetPx = when {
+            diagonalInches in 7f..9f -> 40f
+            diagonalInches < 7f -> 40f * (diagonalInches / 7f)
+            else -> 40f * (diagonalInches / 9f)
+        }
+
+        with(density) { targetPx.toDp() }
+    }
+}


### PR DESCRIPTION
## Συνοπτικά
- το λογότυπο χρησιμοποιείται πλέον ως εικονίδιο εφαρμογής
- προστέθηκε νέα συνάρτηση `rememberLogoSize` για εύκολη προσαρμογή μεγέθους
- το `LogoImage` αξιοποιεί την νέα συνάρτηση

## Έλεγχοι
- `./gradlew test` *(αποτυχημένο λόγω έλλειψης Android SDK)*

------
https://chatgpt.com/codex/tasks/task_e_6850048775e48328ad77479711eda3e2