### PR TITLE
Fix logo scaling for 7-inch screens

### DIFF
--- a/app/src/main/java/com/ioannapergamali/mysmartroute/view/ui/util/LogoSizeUtils.kt
+++ b/app/src/main/java/com/ioannapergamali/mysmartroute/view/ui/util/LogoSizeUtils.kt
@@ -4,8 +4,8 @@ import androidx.compose.runtime.Composable
 import androidx.compose.runtime.remember
 import androidx.compose.ui.platform.LocalConfiguration
 import androidx.compose.ui.platform.LocalContext
-import androidx.compose.ui.platform.LocalDensity
 import androidx.compose.ui.unit.Dp
+import androidx.compose.ui.unit.dp
 import kotlin.math.pow
 import kotlin.math.sqrt
 
@@ -14,17 +14,16 @@ import kotlin.math.sqrt
  * σε διαφορετικές φυσικές διαστάσεις οθονών.
  *
  * @param referenceDiagonalInches Το μέγεθος οθόνης (σε ίντσες) στο οποίο
- * προορίζεται να είναι [sizeAtReferencePx]. Προεπιλογή 7 ίντσες.
- * @param sizeAtReferencePx Το μέγεθος του λογότυπου σε pixels όταν η διαγώνιος
- * είναι [referenceDiagonalInches]. Προεπιλογή 40 px.
+ * προορίζεται να είναι [sizeAtReferenceDp]. Προεπιλογή 7 ίντσες.
+ * @param sizeAtReferenceDp Το μέγεθος του λογότυπου σε dp όταν η διαγώνιος
+ * είναι [referenceDiagonalInches]. Προεπιλογή 40 dp.
  */
 @Composable
 fun rememberAdaptiveLogoSize(
     referenceDiagonalInches: Float = 7f,
-    sizeAtReferencePx: Float = 40f
+    sizeAtReferenceDp: Float = 40f
 ): Dp {
     val context = LocalContext.current
-    val density = LocalDensity.current
     val configuration = LocalConfiguration.current
 
     return remember(configuration) {
@@ -33,23 +32,22 @@ fun rememberAdaptiveLogoSize(
         val heightPx = metrics.heightPixels.toFloat()
         val diagonalPx = sqrt(widthPx.pow(2) + heightPx.pow(2))
         val diagonalInches = diagonalPx / metrics.densityDpi.toFloat()
-        val targetPx = when {
-            diagonalInches in 7f..9f -> sizeAtReferencePx
-            diagonalInches < 7f -> sizeAtReferencePx * (diagonalInches / 7f)
-            else -> sizeAtReferencePx * (diagonalInches / 9f)
+        val targetDp = when {
+            diagonalInches in 7f..9f -> sizeAtReferenceDp
+            diagonalInches < 7f -> sizeAtReferenceDp * (diagonalInches / 7f)
+            else -> sizeAtReferenceDp * (diagonalInches / 9f)
         }
-        with(density) { targetPx.toDp() }
+        targetDp.dp
     }
 }
 
 /**
- * Απλούστερη παραλλαγή που επιστρέφει 40 px για οθόνες 7-9 ιντσών
+ * Απλούστερη παραλλαγή που επιστρέφει 40 dp για οθόνες 7-9 ιντσών
  * και προσαρμόζει γραμμικά για μικρότερες ή μεγαλύτερες συσκευές.
  */
 @Composable
 fun rememberLogoSize(): Dp {
     val context = LocalContext.current
-    val density = LocalDensity.current
     val configuration = LocalConfiguration.current
 
     return remember(configuration) {
@@ -59,12 +57,12 @@ fun rememberLogoSize(): Dp {
         val diagonalPx = sqrt(widthPx.pow(2) + heightPx.pow(2))
         val diagonalInches = diagonalPx / metrics.densityDpi.toFloat()
 
-        val targetPx = when {
+        val targetDp = when {
             diagonalInches in 7f..9f -> 40f
             diagonalInches < 7f -> 40f * (diagonalInches / 7f)
             else -> 40f * (diagonalInches / 9f)
         }
 
-        with(density) { targetPx.toDp() }
+        targetDp.dp
     }
 }


### PR DESCRIPTION
## Summary
- simplify the adaptive logo calculations
- remove pixel-based scaling and keep result in dp

## Testing
- `./gradlew test` *(fails: SDK location not found)*
- `./gradlew ktlintCheck` *(fails: task not found)*

------
https://chatgpt.com/codex/tasks/task_e_68500d6a8a888328b8b3aa4218486507