### PR TITLE
Μεγαλύτερο λογότυπο και νέο εικονίδιο εφαρμογής

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -9,9 +9,9 @@
         android:allowBackup="true"
         android:dataExtractionRules="@xml/data_extraction_rules"
         android:fullBackupContent="@xml/backup_rules"
-        android:icon="@drawable/logo"
+        android:icon="@drawable/icon"
         android:label="@string/app_name"
-        android:roundIcon="@drawable/logo"
+        android:roundIcon="@drawable/icon"
         android:supportsRtl="true"
         android:theme="@style/Theme.Mysmartroute"
         tools:targetApi="31">

--- a/app/src/main/java/com/ioannapergamali/mysmartroute/view/ui/util/LogoSizeUtils.kt
+++ b/app/src/main/java/com/ioannapergamali/mysmartroute/view/ui/util/LogoSizeUtils.kt
@@ -59,7 +59,7 @@ fun rememberLogoSize(): Dp {
         val diagonalPx = sqrt(widthPx.pow(2) + heightPx.pow(2))
         val density = metrics.density
         val diagonalInches = diagonalPx / metrics.densityDpi.toFloat()
-        val baseDp = 40f / density
+        val baseDp = 96f / density
 
         val targetDp = when {
             diagonalInches in 7f..9f -> baseDp


### PR DESCRIPTION
## Summary
- αυξήθηκε το προεπιλεγμένο μέγεθος λογοτύπου ώστε να εμφανίζεται μεγαλύτερο
- ορίστηκε ως εικονίδιο εφαρμογής η εικόνα `icon.png` αντί για το `logo.png`

## Testing
- `./gradlew test` *(απέτυχε: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_6850163e92608328813d7b74d047df20