### PR TITLE
Enable resend verification email on login

### DIFF
--- a/app/src/main/java/com/ioannapergamali/mysmartroute/view/ui/screens/HomeScreen.kt
+++ b/app/src/main/java/com/ioannapergamali/mysmartroute/view/ui/screens/HomeScreen.kt
@@ -78,6 +78,7 @@ fun HomeScreen(
                         uiState = uiState,
                         onLogin = { viewModel.login(email, password) },
                         onNavigateToSignUp = onNavigateToSignUp,
+                        onResendVerification = { viewModel.resendVerificationEmail() },
                         modifier = Modifier.weight(1f)
                     )
                 }
@@ -98,7 +99,8 @@ fun HomeScreen(
                         onPasswordChange = { password = it },
                         uiState = uiState,
                         onLogin = { viewModel.login(email, password) },
-                        onNavigateToSignUp = onNavigateToSignUp
+                        onNavigateToSignUp = onNavigateToSignUp,
+                        onResendVerification = { viewModel.resendVerificationEmail() }
                     )
                 }
             }
@@ -117,6 +119,9 @@ fun HomeScreen(
                 is AuthenticationViewModel.LoginState.Error -> {
                     val message = (uiState as AuthenticationViewModel.LoginState.Error).message
                     Toast.makeText(context, message, Toast.LENGTH_SHORT).show()
+                }
+                is AuthenticationViewModel.LoginState.EmailVerificationSent -> {
+                    Toast.makeText(context, "Το email επιβεβαίωσης στάλθηκε", Toast.LENGTH_SHORT).show()
                 }
                 else -> {}
             }
@@ -137,6 +142,7 @@ private fun HomeContent(
     uiState: AuthenticationViewModel.LoginState,
     onLogin: () -> Unit,
     onNavigateToSignUp: () -> Unit,
+    onResendVerification: () -> Unit,
     modifier: Modifier = Modifier
 ) {
     Column(
@@ -182,13 +188,20 @@ private fun HomeContent(
             modifier = Modifier.fillMaxWidth()
         )
 
-        if (uiState is AuthenticationViewModel.LoginState.Error) {
-            Spacer(modifier = Modifier.height(8.dp))
-            Text(
-                text = uiState.message,
-                color = MaterialTheme.colorScheme.error
-            )
+    if (uiState is AuthenticationViewModel.LoginState.Error) {
+        Spacer(modifier = Modifier.height(8.dp))
+        Text(
+            text = uiState.message,
+            color = MaterialTheme.colorScheme.error
+        )
+    }
+
+    if (uiState is AuthenticationViewModel.LoginState.EmailNotVerified) {
+        Spacer(modifier = Modifier.height(8.dp))
+        Button(onClick = onResendVerification) {
+            Text("Αποστολή ξανά email επιβεβαίωσης")
         }
+    }
 
         Spacer(Modifier.height(16.dp))
 

--- a/app/src/main/java/com/ioannapergamali/mysmartroute/viewmodel/AuthenticationViewModel.kt
+++ b/app/src/main/java/com/ioannapergamali/mysmartroute/viewmodel/AuthenticationViewModel.kt
@@ -151,7 +151,7 @@ class AuthenticationViewModel : ViewModel() {
                                 _loginState.value = LoginState.Success
                                 loadCurrentUserRole()
                             } else {
-                                _loginState.value = LoginState.Error("Email not verified")
+                                _loginState.value = LoginState.EmailNotVerified
                             }
                         }
                     } else {
@@ -162,6 +162,21 @@ class AuthenticationViewModel : ViewModel() {
                     _loginState.value = LoginState.Error(e.localizedMessage ?: "Login failed")
                 }
         }
+    }
+
+    fun resendVerificationEmail() {
+        val user = auth.currentUser
+        user?.sendEmailVerification()
+            ?.addOnCompleteListener { task ->
+                if (task.isSuccessful) {
+                    _loginState.value = LoginState.EmailVerificationSent
+                } else {
+                    _loginState.value = LoginState.Error(
+                        task.exception?.localizedMessage ?: "Failed to send verification email"
+                    )
+                }
+                auth.signOut()
+            }
     }
 
     sealed class SignUpState {
@@ -176,6 +191,8 @@ class AuthenticationViewModel : ViewModel() {
         object Loading : LoginState()
         object Success : LoginState()
         data class Error(val message: String) : LoginState()
+        object EmailNotVerified : LoginState()
+        object EmailVerificationSent : LoginState()
     }
 
     fun loadCurrentUserRole() {


### PR DESCRIPTION
## Summary
- update `AuthenticationViewModel` to support resending a verification email when login fails
- display button in `HomeScreen` to resend verification email

## Testing
- `./gradlew test` *(fails: maven.pkg.jetbrains.space blocked)*

------
https://chatgpt.com/codex/tasks/task_e_6850352e565483288886f909efb04db6