### PR TITLE
Fix verification email sending

### DIFF
--- a/app/src/main/java/com/ioannapergamali/mysmartroute/viewmodel/AuthenticationViewModel.kt
+++ b/app/src/main/java/com/ioannapergamali/mysmartroute/viewmodel/AuthenticationViewModel.kt
@@ -4,6 +4,7 @@ import android.content.Context
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import com.google.firebase.auth.FirebaseAuth
+import com.google.firebase.auth.ktx.actionCodeSettings
 import com.google.firebase.firestore.FirebaseFirestore
 import com.ioannapergamali.mysmartroute.data.local.MySmartRouteDatabase
 import com.ioannapergamali.mysmartroute.data.local.UserEntity
@@ -110,7 +111,16 @@ class AuthenticationViewModel : ViewModel() {
                             .document(uid)
                             .set(userData)
                             .addOnSuccessListener {
-                                result.user?.sendEmailVerification()
+                                val actionSettings = actionCodeSettings {
+                                    url = "https://mysmartroute.page.link/verify"
+                                    handleCodeInApp = true
+                                    setAndroidPackageName(
+                                        "com.ioannapergamali.mysmartroute",
+                                        true,
+                                        null
+                                    )
+                                }
+                                result.user?.sendEmailVerification(actionSettings)
                                 viewModelScope.launch {
                                     authDao.insert(AuthenticationEntity(id = uid))
                                     userDao.insert(userEntity.copy(id = uid))
@@ -166,7 +176,16 @@ class AuthenticationViewModel : ViewModel() {
 
     fun resendVerificationEmail() {
         val user = auth.currentUser
-        user?.sendEmailVerification()
+        val actionSettings = actionCodeSettings {
+            url = "https://mysmartroute.page.link/verify"
+            handleCodeInApp = true
+            setAndroidPackageName(
+                "com.ioannapergamali.mysmartroute",
+                true,
+                null
+            )
+        }
+        user?.sendEmailVerification(actionSettings)
             ?.addOnCompleteListener { task ->
                 if (task.isSuccessful) {
                     _loginState.value = LoginState.EmailVerificationSent


### PR DESCRIPTION
## Summary
- use custom ActionCodeSettings when sending verification emails

## Testing
- `./gradlew test --no-daemon` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_685039b06a208328a10ad56e5a7a7b8f