### PR TITLE
Προσθήκη βοηθητικού AuthLinkUtils

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -19,6 +19,8 @@ android {
         vectorDrawables {
             useSupportLibrary = true
         }
+        buildConfigField("String", "FIREBASE_AUTH_DOMAIN", "\"mysmartroute-26a64.firebaseapp.com\"")
+        buildConfigField("String", "DYNAMIC_LINK_DOMAIN", "\"mysmartroute.page.link\"")
     }
 
     androidResources {

--- a/app/src/main/java/com/ioannapergamali/mysmartroute/utils/AuthLinkUtils.kt
+++ b/app/src/main/java/com/ioannapergamali/mysmartroute/utils/AuthLinkUtils.kt
@@ -1,0 +1,19 @@
+package com.ioannapergamali.mysmartroute.utils
+
+import com.google.firebase.auth.ActionCodeSettings
+import com.ioannapergamali.mysmartroute.BuildConfig
+
+object AuthLinkUtils {
+    fun buildActionCodeSettings(): ActionCodeSettings {
+        return ActionCodeSettings.newBuilder()
+            .setUrl("https://${BuildConfig.FIREBASE_AUTH_DOMAIN}/completeSignIn")
+            .setHandleCodeInApp(true)
+            .setAndroidPackageName(
+                BuildConfig.APPLICATION_ID,
+                true,
+                null
+            )
+            .setDynamicLinkDomain(BuildConfig.DYNAMIC_LINK_DOMAIN)
+            .build()
+    }
+}

--- a/app/src/main/java/com/ioannapergamali/mysmartroute/viewmodel/AuthenticationViewModel.kt
+++ b/app/src/main/java/com/ioannapergamali/mysmartroute/viewmodel/AuthenticationViewModel.kt
@@ -4,7 +4,7 @@ import android.content.Context
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import com.google.firebase.auth.FirebaseAuth
-import com.google.firebase.auth.ktx.actionCodeSettings
+import com.ioannapergamali.mysmartroute.utils.AuthLinkUtils
 import com.google.firebase.firestore.FirebaseFirestore
 import com.ioannapergamali.mysmartroute.data.local.MySmartRouteDatabase
 import com.ioannapergamali.mysmartroute.data.local.UserEntity
@@ -111,15 +111,7 @@ class AuthenticationViewModel : ViewModel() {
                             .document(uid)
                             .set(userData)
                             .addOnSuccessListener {
-                                val actionSettings = actionCodeSettings {
-                                    url = "https://mysmartroute.page.link/verify"
-                                    handleCodeInApp = true
-                                    setAndroidPackageName(
-                                        "com.ioannapergamali.mysmartroute",
-                                        true,
-                                        null
-                                    )
-                                }
+                                val actionSettings = AuthLinkUtils.buildActionCodeSettings()
                                 result.user?.sendEmailVerification(actionSettings)
                                 viewModelScope.launch {
                                     authDao.insert(AuthenticationEntity(id = uid))
@@ -176,15 +168,7 @@ class AuthenticationViewModel : ViewModel() {
 
     fun resendVerificationEmail() {
         val user = auth.currentUser
-        val actionSettings = actionCodeSettings {
-            url = "https://mysmartroute.page.link/verify"
-            handleCodeInApp = true
-            setAndroidPackageName(
-                "com.ioannapergamali.mysmartroute",
-                true,
-                null
-            )
-        }
+        val actionSettings = AuthLinkUtils.buildActionCodeSettings()
         user?.sendEmailVerification(actionSettings)
             ?.addOnCompleteListener { task ->
                 if (task.isSuccessful) {


### PR DESCRIPTION
## Summary
- add new BuildConfig fields with Firebase auth & dynamic link domains
- centralize ActionCodeSettings creation in `AuthLinkUtils`
- use the helper in `AuthenticationViewModel`

## Testing
- `./gradlew test --no-daemon` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_68503d49c6648328b7010576954e0199