### PR TITLE
Fix Kotlin mismatch by pinning Firebase BOM

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -81,7 +81,8 @@ dependencies {
     implementation("androidx.datastore:datastore-preferences:1.1.7")
 
     // Firebase
-    implementation(platform("com.google.firebase:firebase-bom:33.15.0"))
+    // Χρήση παλαιότερου BOM ώστε να είναι συμβατό με Kotlin 1.9.x
+    implementation(platform("com.google.firebase:firebase-bom:33.8.0"))
     implementation("com.google.firebase:firebase-auth-ktx")
     implementation("com.google.firebase:firebase-firestore-ktx")
 


### PR DESCRIPTION
## Summary
- use a slightly older Firebase BOM compatible with Kotlin 1.9

## Testing
- `./gradlew :app:assembleDebug` *(fails: maven.pkg.jetbrains.space blocked)*

------
https://chatgpt.com/codex/tasks/task_e_68505204fde48328aa35ffdb6766d358