### PR TITLE
Fix sendVerificationEmail return type

### DIFF
--- a/app/src/main/java/com/ioannapergamali/mysmartroute/viewmodel/AuthenticationViewModel.kt
+++ b/app/src/main/java/com/ioannapergamali/mysmartroute/viewmodel/AuthenticationViewModel.kt
@@ -205,13 +205,13 @@ class AuthenticationViewModel : ViewModel() {
         _currentUserRole.value = null
     }
 
-    private fun FirebaseUser.sendVerificationEmail() {
+    private fun FirebaseUser.sendVerificationEmail(): Task<Void> {
         val actionCodeSettings = ActionCodeSettings.newBuilder()
             .setUrl("https://${BuildConfig.FIREBASE_AUTH_DOMAIN}")
             .setHandleCodeInApp(true)
             .setAndroidPackageName(BuildConfig.APPLICATION_ID, true, null)
             .setDynamicLinkDomain(BuildConfig.DYNAMIC_LINK_DOMAIN)
             .build()
-        sendEmailVerification(actionCodeSettings)
+        return sendEmailVerification(actionCodeSettings)
     }
 }


### PR DESCRIPTION
## Summary
- return Task from `sendVerificationEmail` so we can attach completion callbacks

## Testing
- `./gradlew testReleaseUnitTest` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_68506d76196c83289e4c782f172a881b