### PR TITLE
Προσθήκη SMS verification και Google sign up

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -85,6 +85,7 @@ dependencies {
     implementation(platform("com.google.firebase:firebase-bom:33.8.0"))
     implementation("com.google.firebase:firebase-auth-ktx")
     implementation("com.google.firebase:firebase-firestore-ktx")
+    implementation("com.google.android.gms:play-services-auth:21.2.0")
 
     // Room
     implementation("androidx.room:room-runtime:2.6.1")

--- a/app/src/main/java/com/ioannapergamali/mysmartroute/utils/PhoneVerification.kt
+++ b/app/src/main/java/com/ioannapergamali/mysmartroute/utils/PhoneVerification.kt
@@ -1,0 +1,25 @@
+package com.ioannapergamali.mysmartroute.utils
+
+import android.app.Activity
+import com.google.firebase.FirebaseException
+import com.google.firebase.auth.FirebaseAuth
+import com.google.firebase.auth.PhoneAuthCredential
+import com.google.firebase.auth.PhoneAuthOptions
+import com.google.firebase.auth.PhoneAuthProvider
+import java.util.concurrent.TimeUnit
+
+object PhoneVerification {
+    fun sendVerificationCode(
+        activity: Activity,
+        phone: String,
+        callbacks: PhoneAuthProvider.OnVerificationStateChangedCallbacks
+    ) {
+        val options = PhoneAuthOptions.newBuilder(FirebaseAuth.getInstance())
+            .setPhoneNumber(phone)
+            .setTimeout(60L, TimeUnit.SECONDS)
+            .setActivity(activity)
+            .setCallbacks(callbacks)
+            .build()
+        PhoneAuthProvider.verifyPhoneNumber(options)
+    }
+}

--- a/app/src/main/java/com/ioannapergamali/mysmartroute/view/ui/screens/AdminSignUpScreen.kt
+++ b/app/src/main/java/com/ioannapergamali/mysmartroute/view/ui/screens/AdminSignUpScreen.kt
@@ -9,6 +9,11 @@ import androidx.compose.runtime.*
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.LocalContext
+import android.app.Activity
+import androidx.activity.result.contract.ActivityResultContracts
+import androidx.activity.compose.rememberLauncherForActivityResult
+import com.google.android.gms.auth.api.signin.GoogleSignIn
+import com.google.android.gms.auth.api.signin.GoogleSignInOptions
 import androidx.compose.ui.text.input.KeyboardType
 import androidx.compose.ui.text.input.PasswordVisualTransformation
 import androidx.compose.ui.unit.dp
@@ -16,6 +21,7 @@ import androidx.lifecycle.viewmodel.compose.viewModel
 import androidx.navigation.NavController
 import android.widget.Toast
 import com.ioannapergamali.mysmartroute.view.ui.components.TopBar
+import com.ioannapergamali.mysmartroute.R
 import com.ioannapergamali.mysmartroute.model.enumerations.UserRole
 import com.ioannapergamali.mysmartroute.viewmodel.AuthenticationViewModel
 import com.ioannapergamali.mysmartroute.view.ui.components.ScreenContainer
@@ -30,6 +36,7 @@ fun AdminSignUpScreen(
     val viewModel: AuthenticationViewModel = viewModel()
     val uiState by viewModel.signUpState.collectAsState()
     val context = LocalContext.current
+    val activity = LocalContext.current as Activity
 
     var name by remember { mutableStateOf("") }
     var surname by remember { mutableStateOf("") }
@@ -152,6 +159,7 @@ fun AdminSignUpScreen(
 
                     if (streetNum != null && postalCode != null) {
                         viewModel.signUp(
+                            activity,
                             context,
                             name, surname, username, email, phoneNum, password,
                             com.ioannapergamali.mysmartroute.model.classes.users.UserAddress(
@@ -166,6 +174,42 @@ fun AdminSignUpScreen(
                 }) {
                     Text("Sign Up")
                 }
+
+                Spacer(modifier = Modifier.height(8.dp))
+                Button(onClick = {
+                    val gso = GoogleSignInOptions.Builder(GoogleSignInOptions.DEFAULT_SIGN_IN)
+                        .requestIdToken(context.getString(com.ioannapergamali.mysmartroute.R.string.default_web_client_id))
+                        .requestEmail()
+                        .build()
+                    val client = GoogleSignIn.getClient(activity, gso)
+                    val signInIntent = client.signInIntent
+                    val launcher = rememberLauncherForActivityResult(ActivityResultContracts.StartActivityForResult()) { result ->
+                        val task = GoogleSignIn.getSignedInAccountFromIntent(result.data)
+                        if (task.isSuccessful) {
+                            val idToken = task.result.idToken
+                            val streetNum = streetNumInput.toIntOrNull()
+                            val postalCode = postalCodeInput.toIntOrNull()
+                            if (idToken != null && streetNum != null && postalCode != null) {
+                                viewModel.signUpWithGoogle(
+                                    activity,
+                                    context,
+                                    idToken,
+                                    phoneNum,
+                                    com.ioannapergamali.mysmartroute.model.classes.users.UserAddress(
+                                        city,
+                                        streetName,
+                                        streetNum,
+                                        postalCode
+                                    ),
+                                    UserRole.ADMIN
+                                )
+                            }
+                        }
+                    }
+                    launcher.launch(signInIntent)
+                }) {
+                    Text("Google Sign Up")
+                }
             }
         }
 
@@ -179,7 +223,7 @@ fun AdminSignUpScreen(
                     ).show()
                     Toast.makeText(
                         context,
-                        "Παρακαλώ ενεργοποιήστε τον λογαριασμό σας μέσω e-mail",
+                        "Θα λάβετε SMS για επιβεβαίωση της εγγραφής",
                         Toast.LENGTH_LONG
                     ).show()
                     viewModel.signOut()

--- a/app/src/main/java/com/ioannapergamali/mysmartroute/view/ui/screens/HomeScreen.kt
+++ b/app/src/main/java/com/ioannapergamali/mysmartroute/view/ui/screens/HomeScreen.kt
@@ -78,7 +78,6 @@ fun HomeScreen(
                         uiState = uiState,
                         onLogin = { viewModel.login(email, password) },
                         onNavigateToSignUp = onNavigateToSignUp,
-                        onResendVerification = { viewModel.resendVerificationEmail() },
                         modifier = Modifier.weight(1f)
                     )
                 }
@@ -99,8 +98,7 @@ fun HomeScreen(
                         onPasswordChange = { password = it },
                         uiState = uiState,
                         onLogin = { viewModel.login(email, password) },
-                        onNavigateToSignUp = onNavigateToSignUp,
-                        onResendVerification = { viewModel.resendVerificationEmail() }
+                        onNavigateToSignUp = onNavigateToSignUp
                     )
                 }
             }
@@ -120,8 +118,8 @@ fun HomeScreen(
                     val message = (uiState as AuthenticationViewModel.LoginState.Error).message
                     Toast.makeText(context, message, Toast.LENGTH_SHORT).show()
                 }
-                is AuthenticationViewModel.LoginState.EmailVerificationSent -> {
-                    Toast.makeText(context, "Το email επιβεβαίωσης στάλθηκε", Toast.LENGTH_SHORT).show()
+                is AuthenticationViewModel.LoginState.SmsVerificationSent -> {
+                    Toast.makeText(context, "Το SMS επιβεβαίωσης στάλθηκε", Toast.LENGTH_SHORT).show()
                 }
                 else -> {}
             }
@@ -142,7 +140,6 @@ private fun HomeContent(
     uiState: AuthenticationViewModel.LoginState,
     onLogin: () -> Unit,
     onNavigateToSignUp: () -> Unit,
-    onResendVerification: () -> Unit,
     modifier: Modifier = Modifier
 ) {
     Column(
@@ -196,17 +193,7 @@ private fun HomeContent(
         )
     }
 
-    if (uiState is AuthenticationViewModel.LoginState.EmailNotVerified) {
-        Spacer(modifier = Modifier.height(8.dp))
-        Text(
-            text = "Το email σας δεν έχει επιβεβαιωθεί. Ελέγξτε το inbox σας.",
-            color = MaterialTheme.colorScheme.error
-        )
-        Spacer(modifier = Modifier.height(8.dp))
-        Button(onClick = onResendVerification) {
-            Text("Αποστολή ξανά email επιβεβαίωσης")
-        }
-    }
+
 
         Spacer(Modifier.height(16.dp))
 


### PR DESCRIPTION
## Περιγραφή
- υποστήριξη SMS verification μέσω Firebase
- δυνατότητα εγγραφής με Google λογαριασμό
- ενημέρωση οθονών SignUp για χρήση τηλεφώνου και Google
- απλοποιήθηκε το login χωρίς έλεγχο email
- προστέθηκε εξάρτηση play-services-auth

## Testing
- `./gradlew test` *(απέτυχε: λείπει το ANDROID_HOME)*

------
https://chatgpt.com/codex/tasks/task_e_68507b9498688328bb13412c2901da37