### PR TITLE
Fix Google sign-up missing surname parameter

### DIFF
--- a/app/src/main/java/com/ioannapergamali/mysmartroute/view/ui/screens/AdminSignUpScreen.kt
+++ b/app/src/main/java/com/ioannapergamali/mysmartroute/view/ui/screens/AdminSignUpScreen.kt
@@ -64,6 +64,7 @@ fun AdminSignUpScreen(
                         context,
                         idToken,
                         phoneNum,
+                        surname,
                         com.ioannapergamali.mysmartroute.model.classes.users.UserAddress(
                             city,
                             streetName,

--- a/app/src/main/java/com/ioannapergamali/mysmartroute/view/ui/screens/SignUpScreen.kt
+++ b/app/src/main/java/com/ioannapergamali/mysmartroute/view/ui/screens/SignUpScreen.kt
@@ -66,6 +66,7 @@ fun SignUpScreen(
                     context,
                     idToken,
                     phoneNum,
+                    surname,
                     com.ioannapergamali.mysmartroute.model.classes.users.UserAddress(
                         city,
                         streetName,

--- a/app/src/main/java/com/ioannapergamali/mysmartroute/viewmodel/AuthenticationViewModel.kt
+++ b/app/src/main/java/com/ioannapergamali/mysmartroute/viewmodel/AuthenticationViewModel.kt
@@ -145,6 +145,7 @@ class AuthenticationViewModel : ViewModel() {
         context: Context,
         idToken: String,
         phoneNum: String,
+        surname: String,
         address: UserAddress,
         role: UserRole
     ) {


### PR DESCRIPTION
## Summary
- pass surname in `signUpWithGoogle` so the ViewModel can access it
- update SignUpScreen and AdminSignUpScreen to forward surname

## Testing
- `./gradlew assembleDebug` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_685090de791883289e14b0f004d5c0b7