### PR TITLE
Add API key properties

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -5,6 +5,10 @@ plugins {
     id("com.google.gms.google-services")
 }
 
+// Διαβάζουμε τα API keys από το local.properties
+val MAPS_API_KEY: String = project.findProperty("MAPS_API_KEY") as? String ?: ""
+val GOOGLE_CLIENT_ID: String = project.findProperty("GOOGLE_CLIENT_ID") as? String ?: ""
+
 android {
     namespace = "com.ioannapergamali.mysmartroute"
     compileSdk = 35
@@ -21,6 +25,10 @@ android {
         }
         buildConfigField("String", "FIREBASE_AUTH_DOMAIN", "\"mysmartroute-26a64.firebaseapp.com\"")
         buildConfigField("String", "DYNAMIC_LINK_DOMAIN", "\"mysmartroute.page.link\"")
+        buildConfigField("String", "MAPS_API_KEY", "\"$MAPS_API_KEY\"")
+        buildConfigField("String", "GOOGLE_CLIENT_ID", "\"$GOOGLE_CLIENT_ID\"")
+
+        manifestPlaceholders["GOOGLE_MAPS_API_KEY"] = MAPS_API_KEY
     }
 
     androidResources {

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -17,7 +17,7 @@
         tools:targetApi="31">
         <meta-data
             android:name="com.google.android.geo.API_KEY"
-            android:value="@string/google_maps_key" />
+            android:value="${GOOGLE_MAPS_API_KEY}" />
         <activity
             android:name=".viewmodel.MainActivity"
             android:exported="true">

--- a/app/src/main/java/com/ioannapergamali/mysmartroute/view/ui/screens/AnnounceTransportScreen.kt
+++ b/app/src/main/java/com/ioannapergamali/mysmartroute/view/ui/screens/AnnounceTransportScreen.kt
@@ -21,6 +21,7 @@ import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.res.stringResource
 import com.ioannapergamali.mysmartroute.view.ui.components.ScreenContainer
+import com.ioannapergamali.mysmartroute.BuildConfig
 import androidx.compose.foundation.layout.Row
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.Check
@@ -140,7 +141,7 @@ fun AnnounceTransportScreen(navController: NavController, openDrawer: () -> Unit
 
     val mapProperties = remember { MapProperties(latLngBoundsForCameraTarget = heraklionBounds) }
 
-    val apiKey = context.getString(R.string.google_maps_key)
+    val apiKey = BuildConfig.MAPS_API_KEY
     val isKeyMissing = apiKey.isBlank() || apiKey == "YOUR_API_KEY"
 
     LaunchedEffect(Unit) {

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -1,10 +1,10 @@
 <resources>
     <string name="app_name">mysmartroute</string>
-    <string name="google_maps_key">AIzaSyAjrLzdIcwjsQideLOI_Ly3oThdYVNr-5U</string>
+    <string name="google_maps_key">YOUR_API_KEY</string>
     <!-- Displayed when no Google Maps API key is provided -->
     <!-- Avoid HTML character references that can trigger resource compilation issues -->
     <string name="map_api_key_missing">
-    Google Maps API key is missing. Please set "google_maps_key" in res/values/strings.xml
+    Google Maps API key is missing. Please set "MAPS_API_KEY" in local.properties
 </string>
 
     <string name="open_in_maps">Άνοιγμα στο Google Maps</string>


### PR DESCRIPTION
## Summary
- read API keys from `local.properties`
- expose them via `BuildConfig`
- use `BuildConfig.MAPS_API_KEY` for Google Maps
- pass API key via manifest placeholder
- update instructions for missing key message

## Testing
- `./gradlew test` *(fails: maven.pkg.jetbrains.space blocked)*

------
https://chatgpt.com/codex/tasks/task_e_685099b690fc83288f3c01196684feee