### PR TITLE
Διορθώθηκε το sign up με Google

### DIFF
--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -1,6 +1,8 @@
 <resources>
     <string name="app_name">mysmartroute</string>
     <string name="google_maps_key">YOUR_API_KEY</string>
+    <!-- Ο κωδικός πελάτη για το Google Sign In -->
+    <string name="default_web_client_id" translatable="false">3402954436-jfsqbb93am2bhs2j9kqtpgfkfurldlne.apps.googleusercontent.com</string>
     <!-- Displayed when no Google Maps API key is provided -->
     <!-- Avoid HTML character references that can trigger resource compilation issues -->
     <string name="map_api_key_missing">


### PR DESCRIPTION
## Summary
- πρόσθεσα το `default_web_client_id` στα resources έτσι ώστε να χρησιμοποιείται το σωστό web client ID κατά το Google Sign In

## Testing
- `./gradlew test` *(απέτυχε λόγω περιορισμένης πρόσβασης στο διαδίκτυο)*

------
https://chatgpt.com/codex/tasks/task_e_68509f68b0108328846545a206ce9181