### PR TITLE
Βελτιώθηκε ο χειρισμός σφαλμάτων στο Google Sign Up

### DIFF
--- a/app/src/main/java/com/ioannapergamali/mysmartroute/view/ui/screens/AdminSignUpScreen.kt
+++ b/app/src/main/java/com/ioannapergamali/mysmartroute/view/ui/screens/AdminSignUpScreen.kt
@@ -20,6 +20,7 @@ import androidx.compose.ui.unit.dp
 import androidx.lifecycle.viewmodel.compose.viewModel
 import androidx.navigation.NavController
 import android.widget.Toast
+import android.util.Log
 import com.ioannapergamali.mysmartroute.view.ui.components.TopBar
 import com.ioannapergamali.mysmartroute.R
 import com.ioannapergamali.mysmartroute.model.enumerations.UserRole
@@ -74,6 +75,13 @@ fun AdminSignUpScreen(
                         UserRole.ADMIN
                     )
                 }
+            } else {
+                Toast.makeText(
+                    context,
+                    task.exception?.localizedMessage ?: "Google sign-in failed",
+                    Toast.LENGTH_LONG
+                ).show()
+                Log.e("AdminSignUp", "Google sign-in failed", task.exception)
             }
         }
 

--- a/app/src/main/java/com/ioannapergamali/mysmartroute/view/ui/screens/SignUpScreen.kt
+++ b/app/src/main/java/com/ioannapergamali/mysmartroute/view/ui/screens/SignUpScreen.kt
@@ -20,6 +20,7 @@ import androidx.activity.compose.rememberLauncherForActivityResult
 import com.google.android.gms.auth.api.signin.GoogleSignIn
 import com.google.android.gms.auth.api.signin.GoogleSignInOptions
 import android.widget.Toast
+import android.util.Log
 import com.ioannapergamali.mysmartroute.view.ui.components.TopBar
 import com.ioannapergamali.mysmartroute.R
 import com.ioannapergamali.mysmartroute.model.enumerations.UserRole
@@ -76,6 +77,13 @@ fun SignUpScreen(
                     selectedRole
                 )
             }
+        } else {
+            Toast.makeText(
+                context,
+                task.exception?.localizedMessage ?: "Google sign-in failed",
+                Toast.LENGTH_LONG
+            ).show()
+            Log.e("SignUp", "Google sign-in failed", task.exception)
         }
     }
 

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -1,6 +1,8 @@
 <resources>
     <string name="app_name">mysmartroute</string>
     <string name="google_maps_key">YOUR_API_KEY</string>
+    <!-- Ο κωδικός πελάτη για το Google Sign In -->
+    <string name="default_web_client_id" translatable="false">3402954436-jfsqbb93am2bhs2j9kqtpgfkfurldlne.apps.googleusercontent.com</string>
     <!-- Displayed when no Google Maps API key is provided -->
     <!-- Avoid HTML character references that can trigger resource compilation issues -->
     <string name="map_api_key_missing">


### PR DESCRIPTION
## Summary
- προστέθηκε εμφάνιση Toast και καταγραφή σφάλματος όταν αποτυγχάνει το Google Sign-In

## Testing
- `./gradlew --version`
- `timeout 30 ./gradlew test` *(απέτυχε λόγω μπλοκαρισμένης πρόσβασης στο διαδίκτυο)*

------
https://chatgpt.com/codex/tasks/task_e_68509f68b0108328846545a206ce9181