### PR TITLE
Enable Compose compiler plugin

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -1,6 +1,7 @@
 plugins {
     id("com.android.application")
     id("org.jetbrains.kotlin.android")
+    id("org.jetbrains.kotlin.plugin.compose")
     id("kotlin-kapt")
     id("com.google.gms.google-services")
 }

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -2,9 +2,9 @@
 
 plugins {
     id("com.android.application") version "8.9.3" apply false
-    // Compose compiler plugin is bundled with Kotlin 1.9.x so we don't need the
-    // separate Compose plugin. Use the Kotlin version from the version catalog
-    // to keep it aligned with the rest of the project.
+    // Το plugin Compose απαιτείται σε Kotlin 2.x για να ενεργοποιηθεί ο
+    // compiler του Jetpack Compose.
+    id("org.jetbrains.kotlin.plugin.compose") version "2.1.21" apply false
     kotlin("kapt") version "2.1.21" apply false
 
     id("org.jetbrains.kotlin.android") version "2.1.21" apply false


### PR DESCRIPTION
## Summary
- add `org.jetbrains.kotlin.plugin.compose` plugin in top-level build
- apply the Compose plugin in `app/build.gradle.kts`

## Testing
- `./gradlew tasks --no-daemon` *(fails: domain `maven.pkg.jetbrains.space` blocked)*

------
https://chatgpt.com/codex/tasks/task_e_6850b0778be88328b5137fb13aa9f93c