### PR TITLE
Fix kapt failure with updated Room

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -101,9 +101,9 @@ dependencies {
     implementation("com.google.android.gms:play-services-auth:21.3.0")
 
     // Room
-    implementation("androidx.room:room-runtime:2.6.1")
-    implementation("androidx.room:room-ktx:2.6.1")
-    kapt("androidx.room:room-compiler:2.6.1")
+    implementation("androidx.room:room-runtime:2.7.1")
+    implementation("androidx.room:room-ktx:2.7.1")
+    kapt("androidx.room:room-compiler:2.7.1")
 
     // Google Maps
     implementation("com.google.android.gms:play-services-maps:19.2.0")


### PR DESCRIPTION
## Summary
- use Room 2.7.1 to support Kotlin 2.1.21 metadata

## Testing
- `./gradlew clean build -x test` *(fails: network access to `maven.pkg.jetbrains.space` blocked)*

------
https://chatgpt.com/codex/tasks/task_e_6850b24fcd3c832883df679bf67c9039