### PR TITLE
Ενεργοποίηση Debug App Check

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,8 @@
+# MySmartRoute
+
+Αυτό το project είναι παράδειγμα εφαρμογής Android. Για να βρείτε το **debug token** του Firebase App Check:
+
+1. Βεβαιωθείτε ότι η εξάρτηση `firebase-appcheck-debug` υπάρχει μόνο στο `debugImplementation` στο `app/build.gradle.kts`.
+2. Τρέξτε την εφαρμογή σε debug mode μέσα από το Android Studio.
+3. Στο Logcat θα εμφανιστεί μήνυμα με το debug token (`AppCheck debug token: ...`). Αντιγράψτε το και προσθέστε το στο Firebase Console (App Check → Debug tokens).
+

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -98,6 +98,7 @@ dependencies {
     implementation("com.google.firebase:firebase-auth-ktx")
     implementation("com.google.firebase:firebase-firestore-ktx")
     implementation("com.google.firebase:firebase-appcheck-playintegrity")
+    debugImplementation("com.google.firebase:firebase-appcheck-debug")
     implementation("com.google.android.gms:play-services-auth:21.3.0")
 
     // Room

--- a/app/src/main/java/com/ioannapergamali/mysmartroute/MySmartRouteApplication.kt
+++ b/app/src/main/java/com/ioannapergamali/mysmartroute/MySmartRouteApplication.kt
@@ -4,12 +4,17 @@ import android.app.Application
 import com.google.firebase.FirebaseApp
 import com.google.firebase.appcheck.FirebaseAppCheck
 import com.google.firebase.appcheck.playintegrity.PlayIntegrityAppCheckProviderFactory
+import com.google.firebase.appcheck.debug.DebugAppCheckProviderFactory
 
 class MySmartRouteApplication : Application() {
     override fun onCreate() {
         super.onCreate()
         FirebaseApp.initializeApp(this)
-        val factory = PlayIntegrityAppCheckProviderFactory.getInstance()
-        FirebaseAppCheck.getInstance().installAppCheckProviderFactory(factory)
+        val providerFactory = if (BuildConfig.DEBUG) {
+            DebugAppCheckProviderFactory.getInstance()
+        } else {
+            PlayIntegrityAppCheckProviderFactory.getInstance()
+        }
+        FirebaseAppCheck.getInstance().installAppCheckProviderFactory(providerFactory)
     }
 }


### PR DESCRIPTION
## Summary
- προστέθηκε η βιβλιοθήκη `firebase-appcheck-debug` μόνο για debug
- χρήση `DebugAppCheckProviderFactory` όταν τρέχουμε σε debug build
- προστέθηκε `README` με οδηγίες για το debug token

## Testing
- ❌ `./gradlew test` *(απέτυχε: δεν βρέθηκε Android SDK)*

------
https://chatgpt.com/codex/tasks/task_e_6850b3ee11c08328b2079291da625523