### PR TITLE
Remove sign out step after signup

### DIFF
--- a/app/src/main/java/com/ioannapergamali/mysmartroute/view/ui/screens/AdminSignUpScreen.kt
+++ b/app/src/main/java/com/ioannapergamali/mysmartroute/view/ui/screens/AdminSignUpScreen.kt
@@ -185,7 +185,6 @@ fun AdminSignUpScreen(
                         "Η εγγραφή ολοκληρώθηκε με επιτυχία",
                         Toast.LENGTH_SHORT
                     ).show()
-                    viewModel.signOut()
                     onSignUpSuccess()
                 }
 

--- a/app/src/main/java/com/ioannapergamali/mysmartroute/view/ui/screens/SignUpScreen.kt
+++ b/app/src/main/java/com/ioannapergamali/mysmartroute/view/ui/screens/SignUpScreen.kt
@@ -200,7 +200,6 @@ fun SignUpScreen(
                         "Η εγγραφή ολοκληρώθηκε με επιτυχία",
                         Toast.LENGTH_SHORT
                     ).show()
-                    viewModel.signOut()
                     onSignUpSuccess()
                 }
 


### PR DESCRIPTION
## Summary
- remove sign-out call after successful signup

## Testing
- `./gradlew test` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_6850cd901c6c8328b15c5d77413dd8fd