### PR TITLE
Fix missing Maps API key

### DIFF
--- a/local.properties
+++ b/local.properties
@@ -8,3 +8,4 @@
 # For customization when using a Version Control System, please read the
 # header note.
 sdk.dir=/home/jope/Android/Sdk
+MAPS_API_KEY=AIzaSyAjrLzdIcwjsQideLOI_Ly3oThdYVNr-5U


### PR DESCRIPTION
## Summary
- fix missing API key error by adding `MAPS_API_KEY` to `local.properties`

## Testing
- `./gradlew test` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_6850d15ac46c83288ea380da9d45597f