### PR TITLE
Fix Maps API key placeholder

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,3 +12,5 @@ MAPS_API_KEY=YOUR_API_KEY
 ```
 
 Αντικατέστησε το `YOUR_API_KEY` με το πραγματικό κλειδί από το Google Cloud Console.
+Επιπλέον, φρόντισε να έχεις ενεργοποιήσει το **Maps SDK for Android** στο Google Cloud
+και να μην περιορίζεται το κλειδί σε συγκεκριμένο package μέχρι να το προσθέσεις στο project.

--- a/app/local.properties
+++ b/app/local.properties
@@ -6,4 +6,4 @@
 # header note.
 #Sun May 25 20:53:30 EEST 2025
 sdk.dir=/home/jope/Android/Sdk
-MAPS_API_KEY="AIzaSyAjrLzdIcwjsQideLOI_Ly3oThdYVNr-5U"
+MAPS_API_KEY="YOUR_API_KEY"

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -1,6 +1,6 @@
 <resources>
     <string name="app_name">mysmartroute</string>
-    <string name="google_maps_key">AIzaSyAjrLzdIcwjsQideLOI_Ly3oThdYVNr-5U</string>
+    <string name="google_maps_key">YOUR_API_KEY</string>
     <!-- Displayed when no Google Maps API key is provided -->
     <!-- Avoid HTML character references that can trigger resource compilation issues -->
     <string name="map_api_key_missing">

--- a/local.properties
+++ b/local.properties
@@ -6,4 +6,4 @@
 # header note.
 #Sun May 25 20:53:30 EEST 2025
 sdk.dir=/home/jope/Android/Sdk
-MAPS_API_KEY=AIzaSyAjrLzdIcwjsQideLOI_Ly3oThdYVNr-5U
+MAPS_API_KEY=YOUR_API_KEY


### PR DESCRIPTION
## Summary
- remove hardcoded Maps API key from `local.properties` files and resources
- clarify map configuration steps in `README`

## Testing
- `./gradlew test` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_6850dc8c1d3c8328bb71615408500cb3