### PR TITLE
Fix directions map url encoding

### DIFF
--- a/app/src/main/java/com/ioannapergamali/mysmartroute/view/ui/screens/DirectionsMapScreen.kt
+++ b/app/src/main/java/com/ioannapergamali/mysmartroute/view/ui/screens/DirectionsMapScreen.kt
@@ -2,6 +2,8 @@ package com.ioannapergamali.mysmartroute.view.ui.screens
 
 import android.webkit.WebView
 import android.webkit.WebViewClient
+import java.net.URLEncoder
+import java.nio.charset.StandardCharsets
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.border
@@ -38,7 +40,9 @@ fun DirectionsMapScreen(
                 WebView(context).apply {
                     webViewClient = WebViewClient()
                     settings.javaScriptEnabled = true
-                    loadUrl("https://www.google.com/maps/dir/$start/$end")
+                    val encodedStart = URLEncoder.encode(start, StandardCharsets.UTF_8.toString())
+                    val encodedEnd = URLEncoder.encode(end, StandardCharsets.UTF_8.toString())
+                    loadUrl("https://www.google.com/maps/dir/$encodedStart/$encodedEnd")
                 }
             },
             modifier = Modifier


### PR DESCRIPTION
## Summary
- encode start and end parameters in DirectionsMapScreen

## Testing
- `./gradlew test --no-daemon` *(fails to resolve dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_6850e1cfe4d8832888a3a4ef275efabd