### PR TITLE
Προσθήκη καταγραφής ελέγχου MAPS API key

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,3 +14,12 @@ MAPS_API_KEY=YOUR_API_KEY
 Αντικατέστησε το `YOUR_API_KEY` με το πραγματικό κλειδί από το Google Cloud Console.
 Επιπλέον, φρόντισε να έχεις ενεργοποιήσει το **Maps SDK for Android** στο Google Cloud
 και να μην περιορίζεται το κλειδί σε συγκεκριμένο package μέχρι να το προσθέσεις στο project.
+
+Μπορείς να επιβεβαιώσεις ότι το κλειδί φορτώθηκε σωστά προσθέτοντας στο κώδικα το παρακάτω απόσπασμα:
+
+```kotlin
+val apiKey = BuildConfig.MAPS_API_KEY
+Log.d("Maps", "API key loaded? ${apiKey.isNotEmpty()}")
+```
+
+Έτσι θα δεις ένα μήνυμα στο log που επιβεβαιώνει ότι η εφαρμογή διαβάζει το κλειδί.

--- a/app/src/main/java/com/ioannapergamali/mysmartroute/MySmartRouteApplication.kt
+++ b/app/src/main/java/com/ioannapergamali/mysmartroute/MySmartRouteApplication.kt
@@ -1,7 +1,9 @@
 package com.ioannapergamali.mysmartroute
 
 import android.app.Application
+import android.util.Log
 import com.google.firebase.FirebaseApp
+import com.ioannapergamali.mysmartroute.BuildConfig
 
 
 class MySmartRouteApplication : Application() {
@@ -9,5 +11,7 @@ class MySmartRouteApplication : Application() {
         super.onCreate()
         FirebaseApp.initializeApp(this)
         // Η υπηρεσία Firebase App Check απενεργοποιήθηκε προσωρινά
+        val apiKey = BuildConfig.MAPS_API_KEY
+        Log.d("MySmartRoute", "API key loaded? ${apiKey.isNotEmpty()}")
     }
 }


### PR DESCRIPTION
## Τι άλλαξε
- Η `MySmartRouteApplication` κάνει πλέον log αν το Google Maps API key φορτώθηκε σωστά στην έναρξη της εφαρμογής.

## Οδηγίες
1. Ορίστε το `MAPS_API_KEY` στο `local.properties`.
2. Τρέξτε την εφαρμογή και ελέγξτε στα logs τη γραμμή: `API key loaded? true`.

## Δοκιμές
- `./gradlew test --no-daemon` απέτυχε γιατί δεν βρέθηκε Android SDK στο περιβάλλον.

------
https://chatgpt.com/codex/tasks/task_e_6852f75547c48328ac34b1afb1e3c922