### PR TITLE
Διόρθωση ελέγχου MAPS API key

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,3 +14,11 @@ MAPS_API_KEY=YOUR_API_KEY
 Αντικατέστησε το `YOUR_API_KEY` με το πραγματικό κλειδί από το Google Cloud Console.
 Επιπλέον, φρόντισε να έχεις ενεργοποιήσει το **Maps SDK for Android** στο Google Cloud
 και να μην περιορίζεται το κλειδί σε συγκεκριμένο package μέχρι να το προσθέσεις στο project.
+
+Μπορείς να επιβεβαιώσεις ότι το κλειδί φορτώθηκε σωστά προσθέτοντας στο κώδικα το παρακάτω απόσπασμα:
+
+```kotlin
+val apiKey = BuildConfig.MAPS_API_KEY
+Log.d("Maps", "API key loaded? ${apiKey.isNotEmpty()}")
+```
+Έτσι θα δεις ένα μήνυμα στο log που επιβεβαιώνει ότι η εφαρμογή διαβάζει το κλειδί. Αν το μήνυμα είναι `false`, τότε δεν έχει οριστεί η μεταβλητή `MAPS_API_KEY` στο `local.properties`.

--- a/app/src/main/java/com/ioannapergamali/mysmartroute/MySmartRouteApplication.kt
+++ b/app/src/main/java/com/ioannapergamali/mysmartroute/MySmartRouteApplication.kt
@@ -1,7 +1,9 @@
 package com.ioannapergamali.mysmartroute
 
 import android.app.Application
+import android.util.Log
 import com.google.firebase.FirebaseApp
+import com.ioannapergamali.mysmartroute.BuildConfig
 
 
 class MySmartRouteApplication : Application() {
@@ -9,5 +11,7 @@ class MySmartRouteApplication : Application() {
         super.onCreate()
         FirebaseApp.initializeApp(this)
         // Η υπηρεσία Firebase App Check απενεργοποιήθηκε προσωρινά
+        val apiKey = BuildConfig.MAPS_API_KEY
+        Log.d("MySmartRoute", "API key loaded? ${apiKey.isNotEmpty()}")
     }
 }

--- a/app/src/main/java/com/ioannapergamali/mysmartroute/view/ui/screens/AnnounceTransportScreen.kt
+++ b/app/src/main/java/com/ioannapergamali/mysmartroute/view/ui/screens/AnnounceTransportScreen.kt
@@ -141,9 +141,9 @@ fun AnnounceTransportScreen(navController: NavController, openDrawer: () -> Unit
 
     val mapProperties = remember { MapProperties(latLngBoundsForCameraTarget = heraklionBounds) }
 
-    // Διαβάζουμε το API key από το BuildConfig και, αν είναι κενό, από τα resources
-    val apiKey = BuildConfig.MAPS_API_KEY.ifBlank { stringResource(R.string.google_maps_key) }
-    val isKeyMissing = apiKey.isBlank() || apiKey == "YOUR_API_KEY"
+    // Διαβάζουμε το API key από το BuildConfig
+    val apiKey = BuildConfig.MAPS_API_KEY
+    val isKeyMissing = apiKey.isBlank()
     Log.d(TAG, "API key loaded? ${!isKeyMissing}")
 
     LaunchedEffect(Unit) {

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -1,6 +1,5 @@
 <resources>
     <string name="app_name">mysmartroute</string>
-    <string name="google_maps_key">MAPS_API_KEY</string>
     <!-- Displayed when no Google Maps API key is provided -->
     <!-- Avoid HTML character references that can trigger resource compilation issues -->
     <string name="map_api_key_missing">


### PR DESCRIPTION
## Τι άλλαξε
- Στο `AnnounceTransportScreen` το API key διαβάζεται μόνο από το `BuildConfig` για να αποφεύγονται λάθη.
- Αφαιρέθηκε το placeholder `google_maps_key` από τα resources.
- Στο README προστέθηκε σημείωση για το πότε εμφανίζεται μήνυμα `false` στο log.

## Οδηγίες
1. Ορίστε το `MAPS_API_KEY` στο `local.properties`.
2. Τρέξτε την εφαρμογή και ελέγξτε στα logs τη γραμμή: `API key loaded? true`.

## Δοκιμές
- `./gradlew test --no-daemon` απέτυχε επειδή δεν βρέθηκε Android SDK στο περιβάλλον.


------
https://chatgpt.com/codex/tasks/task_e_6852f75547c48328ac34b1afb1e3c922