### PR TITLE
Ελέγχει το Maps API key από το BuildConfig

### DIFF
--- a/app/src/main/java/com/ioannapergamali/mysmartroute/MySmartRouteApplication.kt
+++ b/app/src/main/java/com/ioannapergamali/mysmartroute/MySmartRouteApplication.kt
@@ -12,6 +12,6 @@ class MySmartRouteApplication : Application() {
         FirebaseApp.initializeApp(this)
         // Η υπηρεσία Firebase App Check απενεργοποιήθηκε προσωρινά
         val apiKey = BuildConfig.MAPS_API_KEY
-        Log.d("MySmartRoute", "API key loaded? ${apiKey.isNotEmpty()}")
+        Log.d("MySmartRoute", "Maps API key loaded: ${apiKey.isNotBlank()}")
     }
 }

--- a/app/src/main/java/com/ioannapergamali/mysmartroute/view/ui/screens/AnnounceTransportScreen.kt
+++ b/app/src/main/java/com/ioannapergamali/mysmartroute/view/ui/screens/AnnounceTransportScreen.kt
@@ -141,9 +141,9 @@ fun AnnounceTransportScreen(navController: NavController, openDrawer: () -> Unit
 
     val mapProperties = remember { MapProperties(latLngBoundsForCameraTarget = heraklionBounds) }
 
-    // Διαβάζουμε το API key από το BuildConfig και, αν είναι κενό, από τα resources
-    val apiKey = BuildConfig.MAPS_API_KEY.ifBlank { stringResource(R.string.google_maps_key) }
-    val isKeyMissing = apiKey.isBlank() || apiKey == "YOUR_API_KEY"
+    // Διαβάζουμε το API key μόνο από το BuildConfig
+    val apiKey = BuildConfig.MAPS_API_KEY
+    val isKeyMissing = apiKey.isBlank()
     Log.d(TAG, "API key loaded? ${!isKeyMissing}")
 
     LaunchedEffect(Unit) {

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -1,6 +1,5 @@
 <resources>
     <string name="app_name">mysmartroute</string>
-    <string name="google_maps_key">MAPS_API_KEY</string>
     <!-- Displayed when no Google Maps API key is provided -->
     <!-- Avoid HTML character references that can trigger resource compilation issues -->
     <string name="map_api_key_missing">


### PR DESCRIPTION
## Περιγραφή
- Το `AnnounceTransportScreen` διαβάζει πλέον το API key μόνο από το `BuildConfig` και ελέγχει αν είναι κενό.
- Αφαιρέθηκε το placeholder `google_maps_key` από το `strings.xml` για να μην υπάρχει σύγχυση.
- Στο `MySmartRouteApplication` προστέθηκε logging που εμφανίζει αν το Maps API key φορτώθηκε.

## Έλεγχος
- `./gradlew test` (αποτυγχάνει λόγω έλλειψης Android SDK)


------
https://chatgpt.com/codex/tasks/task_e_6853003f01d0832881748f6be9addef8