### PR TITLE
Improve AnnounceTransport UI

### DIFF
--- a/app/src/main/java/com/ioannapergamali/mysmartroute/view/ui/components/ScreenContainer.kt
+++ b/app/src/main/java/com/ioannapergamali/mysmartroute/view/ui/components/ScreenContainer.kt
@@ -5,8 +5,13 @@ import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.ColumnScope
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.rememberScrollState
+import androidx.compose.foundation.verticalScroll
+import androidx.compose.foundation.text.selection.SelectionContainer
+import androidx.compose.material3.LocalContentColor
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.CompositionLocalProvider
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.res.dimensionResource
 import androidx.compose.ui.unit.dp
@@ -17,12 +22,18 @@ fun ScreenContainer(
     modifier: Modifier = Modifier,
     content: @Composable ColumnScope.() -> Unit
 ) {
-    Column(
-        modifier = modifier
-            .fillMaxSize()
-            .border(2.dp, MaterialTheme.colorScheme.primary)
-            .padding(dimensionResource(id = R.dimen.padding_screen)),
-        content = content
-    )
+    val scrollState = rememberScrollState()
+    CompositionLocalProvider(LocalContentColor provides MaterialTheme.colorScheme.primary) {
+        SelectionContainer {
+            Column(
+                modifier = modifier
+                    .verticalScroll(scrollState)
+                    .fillMaxSize()
+                    .border(2.dp, MaterialTheme.colorScheme.primary)
+                    .padding(dimensionResource(id = R.dimen.padding_screen)),
+                content = content
+            )
+        }
+    }
 }
 

--- a/app/src/main/java/com/ioannapergamali/mysmartroute/view/ui/screens/AnnounceTransportScreen.kt
+++ b/app/src/main/java/com/ioannapergamali/mysmartroute/view/ui/screens/AnnounceTransportScreen.kt
@@ -233,7 +233,10 @@ fun AnnounceTransportScreen(navController: NavController, openDrawer: () -> Unit
 
             // Removed external maps button; map is shown directly on screen
         } else {
-            Text(stringResource(R.string.map_api_key_missing))
+            Text(
+                stringResource(R.string.map_api_key_missing),
+                color = MaterialTheme.colorScheme.primary
+            )
         }
 
         if (startLatLng != null && endLatLng != null) {


### PR DESCRIPTION
## Summary
- make every screen scrollable and text selectable by updating `ScreenContainer`
- show "API key missing" warning with theme color in `AnnounceTransportScreen`

## Testing
- `./gradlew assembleDebug` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_68545f242eb48328a971c44237781de3