### PR TITLE
Fix maps API placeholder

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -27,7 +27,8 @@ android {
         buildConfigField("String", "DYNAMIC_LINK_DOMAIN", "\"mysmartroute.page.link\"")
         buildConfigField("String", "MAPS_API_KEY", "\"$MAPS_API_KEY\"")
 
-        manifestPlaceholders["GOOGLE_MAPS_API_KEY"] = MAPS_API_KEY
+        // περνάμε το API Key στο AndroidManifest μέσω placeholder
+        manifestPlaceholders["MAPS_API_KEY"] = MAPS_API_KEY
     }
 
     androidResources {


### PR DESCRIPTION
## Summary
- pass MAPS_API_KEY placeholder correctly to manifest

## Testing
- `./gradlew -q help` *(fails: maven.pkg.jetbrains.space blocked)*

------
https://chatgpt.com/codex/tasks/task_e_68555ca1735083288298c5c257185b87