### PR TITLE
Δυναμικό shortcut & ενημέρωση gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,14 @@
+*.iml
+.gradle
+/.idea/caches
+/.idea/libraries
+/.idea/modules.xml
+/.idea/workspace.xml
+/.idea/navEditor.xml
+/.idea/assetWizardSettings.xml
+.DS_Store
+/build
+/captures
+.externalNativeBuild
+.cxx
+local.properties

--- a/app/src/main/java/com/ioannapergamali/mysmartroute/MySmartRouteApplication.kt
+++ b/app/src/main/java/com/ioannapergamali/mysmartroute/MySmartRouteApplication.kt
@@ -4,6 +4,7 @@ import android.app.Application
 import android.util.Log
 import com.google.firebase.FirebaseApp
 import com.ioannapergamali.mysmartroute.BuildConfig
+import com.ioannapergamali.mysmartroute.utils.ShortcutUtils
 
 
 class MySmartRouteApplication : Application() {
@@ -16,5 +17,6 @@ class MySmartRouteApplication : Application() {
         if (apiKey.isBlank()) {
             Log.w("MySmartRoute", "MAPS_API_KEY is blank. Ελέγξτε το local.properties")
         }
+        ShortcutUtils.addMainShortcut(this)
     }
 }

--- a/app/src/main/java/com/ioannapergamali/mysmartroute/utils/ShortcutUtils.kt
+++ b/app/src/main/java/com/ioannapergamali/mysmartroute/utils/ShortcutUtils.kt
@@ -1,0 +1,26 @@
+package com.ioannapergamali.mysmartroute.utils
+
+import android.content.Context
+import android.content.Intent
+import android.content.pm.ShortcutManager
+import androidx.core.content.pm.ShortcutInfoCompat
+import androidx.core.content.pm.ShortcutManagerCompat
+import androidx.core.graphics.drawable.IconCompat
+import com.ioannapergamali.mysmartroute.R
+import com.ioannapergamali.mysmartroute.viewmodel.MainActivity
+
+object ShortcutUtils {
+    fun addMainShortcut(context: Context) {
+        val shortcutManager = context.getSystemService(ShortcutManager::class.java)
+        if (shortcutManager?.isRequestPinShortcutSupported == false) return
+
+        val shortcut = ShortcutInfoCompat.Builder(context, "main_shortcut")
+            .setShortLabel(context.getString(R.string.app_name))
+            .setLongLabel(context.getString(R.string.app_name))
+            .setIcon(IconCompat.createWithResource(context, R.drawable.ic_launcher_foreground))
+            .setIntent(Intent(context, MainActivity::class.java).setAction(Intent.ACTION_VIEW))
+            .build()
+
+        ShortcutManagerCompat.pushDynamicShortcut(context, shortcut)
+    }
+}


### PR DESCRIPTION
## Συνοπτικά
- δημιουργία βοηθητικού `ShortcutUtils` ώστε το app να προσθέτει δυναμικό shortcut με εικονίδιο πόρου
- κλήση του helper από την `MySmartRouteApplication`
- ενημέρωση `.gitignore` ώστε να αγνοεί αρχεία build και το `local.properties`

## Έλεγχοι
- `./gradlew testDebug` απέτυχε λόγω έλλειψης Android SDK στον runner

------
https://chatgpt.com/codex/tasks/task_e_68558e13abac832892d27979f78ae932