### PR TITLE
Fix missing Google Maps key

### DIFF
--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -1,6 +1,6 @@
 <resources>
     <string name="app_name">mysmartroute</string>
-    <string name="google_maps_key">YOUR_API_KEY</string>
+    <string name="google_maps_key">AIzaSyAjrLzdIcwjsQideLOI_Ly3oThdYVNr-5U</string>
     <!-- Displayed when no Google Maps API key is provided -->
     <!-- Avoid HTML character references that can trigger resource compilation issues -->
     <string name="map_api_key_missing">Google Maps API key is missing. Please set "google_maps_key'" in res/values/strings.xml</string>


### PR DESCRIPTION
## Summary
- set the `google_maps_key` string with an API key

## Testing
- `./gradlew test --continue` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_6855b36144d48328ad5f24e2789c440b