### PR TITLE
Fix map height so it renders

### DIFF
--- a/app/src/main/java/com/ioannapergamali/mysmartroute/view/ui/screens/AnnounceTransportScreen.kt
+++ b/app/src/main/java/com/ioannapergamali/mysmartroute/view/ui/screens/AnnounceTransportScreen.kt
@@ -211,7 +211,9 @@ fun AnnounceTransportScreen(navController: NavController, openDrawer: () -> Unit
 
         if (!isKeyMissing) {
             GoogleMap(
-                modifier = Modifier.weight(1f),
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .height(300.dp),
                 cameraPositionState = cameraPositionState,
                 properties = mapProperties,
                 onMapLoaded = { Log.d(TAG, "Map loaded") },


### PR DESCRIPTION
## Summary
- ensure GoogleMap composable has a fixed height so it is visible

## Testing
- `./gradlew test --no-daemon` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_6855ba6d36a08328b07d6a943dea84ec