### PR TITLE
Αφαίρεση API key από resources

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -23,6 +23,8 @@ android {
         versionCode = 5
         versionName = "1.4"
         testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"
+        buildConfigField("String", "MAPS_API_KEY", "\"$MAPS_API_KEY\"")
+        manifestPlaceholders["MAPS_API_KEY"] = MAPS_API_KEY
     }
 
     buildFeatures {

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -19,7 +19,7 @@
         tools:targetApi="31">
         <meta-data
             android:name="com.google.android.geo.API_KEY"
-            android:value="@string/google_maps_key" />
+            android:value="${MAPS_API_KEY}" />
         <activity
             android:name=".viewmodel.MainActivity"
             android:exported="true">

--- a/app/src/main/java/com/ioannapergamali/mysmartroute/view/ui/screens/AnnounceTransportScreen.kt
+++ b/app/src/main/java/com/ioannapergamali/mysmartroute/view/ui/screens/AnnounceTransportScreen.kt
@@ -144,12 +144,8 @@ fun AnnounceTransportScreen(navController: NavController, openDrawer: () -> Unit
         MapProperties(latLngBoundsForCameraTarget = heraklionBounds)
     }
 
-    val apiKey = context.getString(R.string.google_maps_key)
-    val isKeyMissing = apiKey.isBlank() || apiKey == "YOUR_API_KEY"
-
-    // Διαβάζουμε το API key μόνο από το BuildConfig
-//    val apiKey = BuildConfig.MAPS_API_KEY
-//    val isKeyMissing = apiKey.isBlank()
+    val apiKey = BuildConfig.MAPS_API_KEY
+    val isKeyMissing = apiKey.isBlank()
     Log.d(TAG, "API key loaded? ${!isKeyMissing}")
 
     LaunchedEffect(Unit) {

--- a/app/src/main/java/com/ioannapergamali/mysmartroute/viewmodel/MainActivity.kt
+++ b/app/src/main/java/com/ioannapergamali/mysmartroute/viewmodel/MainActivity.kt
@@ -27,6 +27,7 @@ import com.ioannapergamali.mysmartroute.utils.ThemePreferenceManager
 import com.ioannapergamali.mysmartroute.utils.SoundPreferenceManager
 import com.ioannapergamali.mysmartroute.utils.SoundManager
 import com.ioannapergamali.mysmartroute.viewmodel.SettingsViewModel
+import com.ioannapergamali.mysmartroute.BuildConfig
 import kotlinx.coroutines.launch
 
 
@@ -52,7 +53,7 @@ class MainActivity : ComponentActivity() {
         // Συγχρονισμός ρυθμίσεων από τη βάση
         settingsViewModel.syncSettings(this)
         // Έλεγχος φόρτωσης του Maps API key
-        val apiKey = getString(R.string.google_maps_key)
+        val apiKey = BuildConfig.MAPS_API_KEY
         Log.d("Maps", "API key loaded? ${apiKey.isNotEmpty()}")
         // Initialize the soundtrack and start playback based on saved preferences.
         SoundManager.initialize(applicationContext)

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -1,9 +1,5 @@
 <resources>
     <string name="app_name">mysmartroute</string>
-    <string name="google_maps_key">AIzaSyAjrLzdIcwjsQideLOI_Ly3oThdYVNr-5U</string>
-    <!-- Displayed when no Google Maps API key is provided -->
-    <!-- Avoid HTML character references that can trigger resource compilation issues -->
-    <string name="map_api_key_missing">Google Maps API key is missing. Please set "google_maps_key'" in res/values/strings.xml</string>
 
     <!-- Additional strings used in AnnounceTransportScreen -->
     <string name="invalid_coordinates">Μη έγκυρες συντεταγμένες</string>


### PR DESCRIPTION
## Summary
- απομάκρυνση του `google_maps_key` από τα resources
- χρήση του `BuildConfig.MAPS_API_KEY` στον κώδικα
- προσθήκη `buildConfigField` και `manifestPlaceholders` στο Gradle

## Testing
- `./gradlew test` *(απέτυχε: δεν βρέθηκε Android SDK)*

------
https://chatgpt.com/codex/tasks/task_e_6855be77e06483288518284a3ec641fc