### PR TITLE
Fix BuildConfig API key

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,6 +14,10 @@ MAPS_API_KEY=YOUR_API_KEY
 ```
 
 Αντικατέστησε το `YOUR_API_KEY` με το πραγματικό κλειδί από το Google Cloud Console.
+
+Το `app/build.gradle.kts` πλέον διαβάζει αυτόματα την τιμή από το `local.properties`,
+οπότε αρκεί να προσθέσεις τη γραμμή με το κλειδί και να κάνεις "Sync Project" ή
+"Rebuild" για να παραχθεί το `BuildConfig`.
 Επιπλέον, φρόντισε να έχεις ενεργοποιήσει το **Maps SDK for Android** στο Google Cloud
 και να μην περιορίζεται το κλειδί σε συγκεκριμένο package μέχρι να το προσθέσεις στο project.
 

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -7,8 +7,17 @@ plugins {
 }
 
 // Διαβάζουμε τα API keys από το local.properties ή από μεταβλητή περιβάλλοντος
+import java.util.Properties
+import java.io.FileInputStream
+
+val localProps = Properties()
+val localPropsFile = rootProject.file("local.properties")
+if (localPropsFile.exists()) {
+    localProps.load(FileInputStream(localPropsFile))
+}
+
 val MAPS_API_KEY: String =
-    (project.findProperty("MAPS_API_KEY") as? String)
+    (localProps.getProperty("MAPS_API_KEY"))
         ?: System.getenv("MAPS_API_KEY")
         ?: ""
 


### PR DESCRIPTION
## Summary
- load `MAPS_API_KEY` from `local.properties` if present
- document automatic loading of API key

## Testing
- `./gradlew :app:generateDebugBuildConfig --offline`

------
https://chatgpt.com/codex/tasks/task_e_6855c0815d288328b09ad2e59ba108a1