### PR TITLE
Fix build script import placement

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -1,3 +1,6 @@
+import java.util.Properties
+import java.io.FileInputStream
+
 plugins {
     id("com.android.application")
     id("org.jetbrains.kotlin.android")
@@ -7,8 +10,6 @@ plugins {
 }
 
 // Διαβάζουμε τα API keys από το local.properties ή από μεταβλητή περιβάλλοντος
-import java.util.Properties
-import java.io.FileInputStream
 
 val localProps = Properties()
 val localPropsFile = rootProject.file("local.properties")


### PR DESCRIPTION
## Summary
- ensure import statements are at the top of `app/build.gradle.kts`

## Testing
- `./gradlew tasks` *(fails: blocked on `maven.pkg.jetbrains.space`)*

------
https://chatgpt.com/codex/tasks/task_e_6855c3af2aa083289314e14cb3d74486