### PR TITLE
Fix missing map api key string

### DIFF
--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -10,4 +10,5 @@
     <string name="check_coordinates">Έλεγχος συντεταγμένων</string>
     <string name="internet_available">Η σύνδεση στο διαδίκτυο είναι διαθέσιμη</string>
     <string name="check_internet">Έλεγχος σύνδεσης</string>
+    <string name="map_api_key_missing">Λείπει το κλειδί API των χαρτών</string>
 </resources>


### PR DESCRIPTION
## Summary
- add missing `map_api_key_missing` string for AnnounceTransportScreen

## Testing
- `./gradlew test` *(fails: could not download dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_6855c5caa9f08328b7b260f6163d8622