### PR TITLE
Ανάγνωση κλειδιού χαρτών από Manifest

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ MAPS_API_KEY=YOUR_API_KEY
 Μπορείς να επιβεβαιώσεις ότι το κλειδί φορτώθηκε σωστά προσθέτοντας στο κώδικα το παρακάτω απόσπασμα:
 
 ```kotlin
-val apiKey = BuildConfig.MAPS_API_KEY
+val apiKey = MapsUtils.getApiKey(context)
 Log.d("Maps", "API key loaded? ${apiKey.isNotEmpty()}")
 ```
 

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -30,8 +30,8 @@ android {
         applicationId = "com.ioannapergamali.mysmartroute"
         minSdk = 33
         targetSdk = 35
-        versionCode = 5
-        versionName = "1.4"
+        versionCode = 6
+        versionName = "1.5"
         testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"
         buildConfigField("String", "MAPS_API_KEY", "\"$MAPS_API_KEY\"")
         manifestPlaceholders["MAPS_API_KEY"] = MAPS_API_KEY

--- a/app/src/main/java/com/ioannapergamali/mysmartroute/utils/MapsUtils.kt
+++ b/app/src/main/java/com/ioannapergamali/mysmartroute/utils/MapsUtils.kt
@@ -1,5 +1,7 @@
 package com.ioannapergamali.mysmartroute.utils
 
+import android.content.Context
+import android.content.pm.PackageManager
 import com.google.android.gms.maps.model.LatLng
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.withContext
@@ -10,6 +12,16 @@ import com.ioannapergamali.mysmartroute.model.enumerations.VehicleType
 
 object MapsUtils {
     private val client = OkHttpClient()
+
+    fun getApiKey(context: Context): String {
+        return try {
+            val info = context.packageManager
+                .getApplicationInfo(context.packageName, PackageManager.GET_META_DATA)
+            info.metaData?.getString("com.google.android.geo.API_KEY") ?: ""
+        } catch (e: Exception) {
+            ""
+        }
+    }
 
     /** Result from a Directions API request */
     data class DirectionsData(

--- a/app/src/main/java/com/ioannapergamali/mysmartroute/view/ui/screens/AnnounceTransportScreen.kt
+++ b/app/src/main/java/com/ioannapergamali/mysmartroute/view/ui/screens/AnnounceTransportScreen.kt
@@ -21,7 +21,6 @@ import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.res.stringResource
 import com.ioannapergamali.mysmartroute.view.ui.components.ScreenContainer
-import com.ioannapergamali.mysmartroute.BuildConfig
 import androidx.compose.foundation.layout.Row
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.Check
@@ -144,7 +143,7 @@ fun AnnounceTransportScreen(navController: NavController, openDrawer: () -> Unit
         MapProperties(latLngBoundsForCameraTarget = heraklionBounds)
     }
 
-    val apiKey = BuildConfig.MAPS_API_KEY
+    val apiKey = MapsUtils.getApiKey(context)
     val isKeyMissing = apiKey.isBlank()
     Log.d(TAG, "API key loaded? ${!isKeyMissing}")
 

--- a/app/src/main/java/com/ioannapergamali/mysmartroute/viewmodel/MainActivity.kt
+++ b/app/src/main/java/com/ioannapergamali/mysmartroute/viewmodel/MainActivity.kt
@@ -27,7 +27,7 @@ import com.ioannapergamali.mysmartroute.utils.ThemePreferenceManager
 import com.ioannapergamali.mysmartroute.utils.SoundPreferenceManager
 import com.ioannapergamali.mysmartroute.utils.SoundManager
 import com.ioannapergamali.mysmartroute.viewmodel.SettingsViewModel
-import com.ioannapergamali.mysmartroute.BuildConfig
+import com.ioannapergamali.mysmartroute.utils.MapsUtils
 import kotlinx.coroutines.launch
 
 
@@ -53,7 +53,7 @@ class MainActivity : ComponentActivity() {
         // Συγχρονισμός ρυθμίσεων από τη βάση
         settingsViewModel.syncSettings(this)
         // Έλεγχος φόρτωσης του Maps API key
-        val apiKey = BuildConfig.MAPS_API_KEY
+        val apiKey = MapsUtils.getApiKey(this)
         Log.d("Maps", "API key loaded? ${apiKey.isNotEmpty()}")
         // Initialize the soundtrack and start playback based on saved preferences.
         SoundManager.initialize(applicationContext)


### PR DESCRIPTION
## Summary
- αναζήτηση του Google Maps API key από το Manifest
- ενημέρωση έκδοσης εφαρμογής σε 1.5
- προσαρμογή παραδειγμάτων στο README

## Testing
- `./gradlew test` *(απέτυχε λόγω περιορισμών δικτύου)*

------
https://chatgpt.com/codex/tasks/task_e_6855c78eff348328bd3114badb002370