### PR TITLE
Implement user dropdown and logout in home

### DIFF
--- a/app/src/main/java/com/ioannapergamali/mysmartroute/view/ui/components/TopBar.kt
+++ b/app/src/main/java/com/ioannapergamali/mysmartroute/view/ui/components/TopBar.kt
@@ -11,6 +11,8 @@ import androidx.compose.foundation.layout.Row
 import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.Icon
 import androidx.compose.material3.IconButton
+import androidx.compose.material3.DropdownMenu
+import androidx.compose.material3.DropdownMenuItem
 import androidx.compose.material3.Text
 import androidx.compose.material3.TopAppBar
 import androidx.compose.material3.TopAppBarDefaults
@@ -50,6 +52,8 @@ fun TopBar(
                 }
         }
     }
+
+    var menuExpanded by remember { mutableStateOf(false) }
 
     Box(modifier = Modifier.statusBarsPadding()) {
         TopAppBar(
@@ -94,7 +98,33 @@ fun TopBar(
             }
         },
         actions = {
-            username.value?.let { Text(it, modifier = Modifier.padding(end = 8.dp)) }
+            username.value?.let { name ->
+                Box {
+                    Text(
+                        name,
+                        modifier = Modifier
+                            .padding(end = 8.dp)
+                            .clickable { menuExpanded = true }
+                    )
+                    DropdownMenu(
+                        expanded = menuExpanded,
+                        onDismissRequest = { menuExpanded = false }
+                    ) {
+                        DropdownMenuItem(text = { Text("Προφίλ") }, onClick = {
+                            menuExpanded = false
+                            navController.navigate("profile")
+                        })
+                        DropdownMenuItem(text = { Text("Μενού χρήστη") }, onClick = {
+                            menuExpanded = false
+                            navController.navigate("menu")
+                        })
+                        DropdownMenuItem(text = { Text("Logout") }, onClick = {
+                            menuExpanded = false
+                            onLogout()
+                        })
+                    }
+                }
+            }
             if (FirebaseAuth.getInstance().currentUser != null) {
                 IconButton(onClick = { navController.navigate("settings") }) {
                     Icon(
@@ -103,8 +133,7 @@ fun TopBar(
                         tint = MaterialTheme.colorScheme.primary
                     )
                 }
-            }
-            if (showLogout) {
+            } else if (showLogout) {
                 IconButton(onClick = onLogout) {
                     Icon(
                         Icons.Filled.Logout,

--- a/app/src/main/java/com/ioannapergamali/mysmartroute/view/ui/screens/HomeScreen.kt
+++ b/app/src/main/java/com/ioannapergamali/mysmartroute/view/ui/screens/HomeScreen.kt
@@ -25,6 +25,7 @@ import androidx.lifecycle.viewmodel.compose.viewModel
 import com.ioannapergamali.mysmartroute.viewmodel.AuthenticationViewModel
 import androidx.compose.ui.text.input.PasswordVisualTransformation
 import com.ioannapergamali.mysmartroute.view.ui.components.ScreenContainer
+import com.google.firebase.auth.FirebaseAuth
 
 @Composable
 fun HomeScreen(
@@ -78,6 +79,7 @@ fun HomeScreen(
                         uiState = uiState,
                         onLogin = { viewModel.login(email, password) },
                         onNavigateToSignUp = onNavigateToSignUp,
+                        onLogout = { viewModel.signOut() },
                         modifier = Modifier.weight(1f)
                     )
                 }
@@ -98,7 +100,8 @@ fun HomeScreen(
                         onPasswordChange = { password = it },
                         uiState = uiState,
                         onLogin = { viewModel.login(email, password) },
-                        onNavigateToSignUp = onNavigateToSignUp
+                        onNavigateToSignUp = onNavigateToSignUp,
+                        onLogout = { viewModel.signOut() }
                     )
                 }
             }
@@ -137,6 +140,7 @@ private fun HomeContent(
     uiState: AuthenticationViewModel.LoginState,
     onLogin: () -> Unit,
     onNavigateToSignUp: () -> Unit,
+    onLogout: () -> Unit = {},
     modifier: Modifier = Modifier
 ) {
     Column(
@@ -165,48 +169,54 @@ private fun HomeContent(
 
         Spacer(modifier = Modifier.height(16.dp))
 
-        TextField(
-            value = email,
-            onValueChange = onEmailChange,
-            label = { Text("Email") },
-            modifier = Modifier.fillMaxWidth()
-        )
-
-        Spacer(Modifier.height(8.dp))
-
-        TextField(
-            value = password,
-            onValueChange = onPasswordChange,
-            label = { Text("Password") },
-            visualTransformation = PasswordVisualTransformation(),
-            modifier = Modifier.fillMaxWidth()
-        )
-
-    if (uiState is AuthenticationViewModel.LoginState.Error) {
-        Spacer(modifier = Modifier.height(8.dp))
-        Text(
-            text = uiState.message,
-            color = MaterialTheme.colorScheme.error
-        )
-    }
-
-
-
-        Spacer(Modifier.height(16.dp))
-
-        Button(onClick = onLogin) {
-            Text("Login")
-        }
-
-        Spacer(modifier = Modifier.height(8.dp))
-
-        Row {
-            Text("If you don't have account ")
-            Text(
-                text = "Sign Up",
-                color = MaterialTheme.colorScheme.primary,
-                modifier = Modifier.clickable { onNavigateToSignUp() }
+        if (FirebaseAuth.getInstance().currentUser == null) {
+            TextField(
+                value = email,
+                onValueChange = onEmailChange,
+                label = { Text("Email") },
+                modifier = Modifier.fillMaxWidth()
             )
+
+            Spacer(Modifier.height(8.dp))
+
+            TextField(
+                value = password,
+                onValueChange = onPasswordChange,
+                label = { Text("Password") },
+                visualTransformation = PasswordVisualTransformation(),
+                modifier = Modifier.fillMaxWidth()
+            )
+
+            if (uiState is AuthenticationViewModel.LoginState.Error) {
+                Spacer(modifier = Modifier.height(8.dp))
+                Text(
+                    text = uiState.message,
+                    color = MaterialTheme.colorScheme.error
+                )
+            }
+
+            Spacer(Modifier.height(16.dp))
+
+            Button(onClick = onLogin) {
+                Text("Login")
+            }
+
+            Spacer(modifier = Modifier.height(8.dp))
+
+            Row {
+                Text("If you don't have account ")
+                Text(
+                    text = "Sign Up",
+                    color = MaterialTheme.colorScheme.primary,
+                    modifier = Modifier.clickable { onNavigateToSignUp() }
+                )
+            }
+        } else {
+            Spacer(Modifier.height(16.dp))
+
+            Button(onClick = onLogout) {
+                Text("Logout")
+            }
         }
     }
 }

--- a/app/src/main/java/com/ioannapergamali/mysmartroute/view/ui/screens/MenuScreen.kt
+++ b/app/src/main/java/com/ioannapergamali/mysmartroute/view/ui/screens/MenuScreen.kt
@@ -35,7 +35,6 @@ fun MenuScreen(navController: NavController, openDrawer: () -> Unit) {
                 title = "Menu",
                 navController = navController,
                 showMenu = true,
-                showLogout = true,
                 onMenuClick = openDrawer,
                 onLogout = {
                     viewModel.signOut()


### PR DESCRIPTION
## Summary
- add dropdown menu next to username with options "Προφίλ", "Μενού χρήστη" and "Logout"
- change home screen to show logout button when user is logged in
- remove logout icon from menu screen top bar

## Testing
- `./gradlew test --quiet` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_6855cc6f94288328b4ebc5f712294a2f