### PR TITLE
Allow logout from all screens

### DIFF
--- a/app/src/main/java/com/ioannapergamali/mysmartroute/view/ui/components/TopBar.kt
+++ b/app/src/main/java/com/ioannapergamali/mysmartroute/view/ui/components/TopBar.kt
@@ -39,7 +39,12 @@ fun TopBar(
     showLogout: Boolean = false,
     showBack: Boolean = true,
     onMenuClick: () -> Unit = {},
-    onLogout: () -> Unit = {}
+    onLogout: () -> Unit = {
+        FirebaseAuth.getInstance().signOut()
+        navController.navigate("home") {
+            popUpTo("home") { inclusive = true }
+        }
+    }
 ) {
     val username = remember { mutableStateOf<String?>(null) }
 


### PR DESCRIPTION
## Summary
- add a default logout implementation in `TopBar`

## Testing
- `./gradlew test --daemon` *(fails: maven.pkg.jetbrains.space blocked)*

------
https://chatgpt.com/codex/tasks/task_e_6855d3c710c88328ab5f0721cb309e74