### PR TITLE
Fix signup navigation crash

### DIFF
--- a/app/src/main/java/com/ioannapergamali/mysmartroute/model/navigation/NavigationHost.kt
+++ b/app/src/main/java/com/ioannapergamali/mysmartroute/model/navigation/NavigationHost.kt
@@ -44,10 +44,10 @@ fun NavigationHost(navController : NavHostController, openDrawer: () -> Unit) {
 
         composable("Signup") {
             SignUpScreen(
-                navController = navController ,
+                navController = navController,
                 onSignUpSuccess = {
                     navController.navigate("home") {
-                        popUpTo("signup") { inclusive = true }
+                        popUpTo("Signup") { inclusive = true }
                     }
                 },
                 openDrawer = openDrawer


### PR DESCRIPTION
## Summary
- fix incorrect casing in popUpTo route name

## Testing
- `./gradlew test --no-daemon` *(fails: maven.pkg.jetbrains.space blocked)*

------
https://chatgpt.com/codex/tasks/task_e_6855d9a9e93c8328a6280447e773d5c9