### PR TITLE
Δυναμικός πίνακας menu options

### DIFF
--- a/app/src/main/java/com/ioannapergamali/mysmartroute/data/local/MenuDao.kt
+++ b/app/src/main/java/com/ioannapergamali/mysmartroute/data/local/MenuDao.kt
@@ -4,12 +4,14 @@ import androidx.room.Dao
 import androidx.room.Insert
 import androidx.room.OnConflictStrategy
 import androidx.room.Query
+import androidx.room.Transaction
 
 @Dao
 interface MenuDao {
     @Insert(onConflict = OnConflictStrategy.REPLACE)
     suspend fun insert(menu: MenuEntity)
 
+    @Transaction
     @Query("SELECT * FROM menus WHERE roleId = :roleId")
-    suspend fun getMenusForRole(roleId: String): List<MenuEntity>
+    suspend fun getMenusForRole(roleId: String): List<MenuWithOptions>
 }

--- a/app/src/main/java/com/ioannapergamali/mysmartroute/data/local/MenuEntity.kt
+++ b/app/src/main/java/com/ioannapergamali/mysmartroute/data/local/MenuEntity.kt
@@ -12,6 +12,5 @@ import androidx.room.PrimaryKey
 data class MenuEntity(
     @PrimaryKey var id: String = "",
     var roleId: String = "",
-    var title: String = "",
-    var route: String = ""
+    var title: String = ""
 )

--- a/app/src/main/java/com/ioannapergamali/mysmartroute/data/local/MenuOptionDao.kt
+++ b/app/src/main/java/com/ioannapergamali/mysmartroute/data/local/MenuOptionDao.kt
@@ -1,0 +1,15 @@
+package com.ioannapergamali.mysmartroute.data.local
+
+import androidx.room.Dao
+import androidx.room.Insert
+import androidx.room.OnConflictStrategy
+import androidx.room.Query
+
+@Dao
+interface MenuOptionDao {
+    @Insert(onConflict = OnConflictStrategy.REPLACE)
+    suspend fun insert(option: MenuOptionEntity)
+
+    @Query("SELECT * FROM menu_options WHERE menuId = :menuId")
+    suspend fun getOptionsForMenu(menuId: String): List<MenuOptionEntity>
+}

--- a/app/src/main/java/com/ioannapergamali/mysmartroute/data/local/MenuOptionEntity.kt
+++ b/app/src/main/java/com/ioannapergamali/mysmartroute/data/local/MenuOptionEntity.kt
@@ -1,0 +1,17 @@
+package com.ioannapergamali.mysmartroute.data.local
+
+import androidx.room.Entity
+import androidx.room.Index
+import androidx.room.PrimaryKey
+
+/** Επιλογή ενός μενού. */
+@Entity(
+    tableName = "menu_options",
+    indices = [Index("menuId")]
+)
+data class MenuOptionEntity(
+    @PrimaryKey var id: String = "",
+    var menuId: String = "",
+    var title: String = "",
+    var route: String = ""
+)

--- a/app/src/main/java/com/ioannapergamali/mysmartroute/data/local/MenuWithOptions.kt
+++ b/app/src/main/java/com/ioannapergamali/mysmartroute/data/local/MenuWithOptions.kt
@@ -1,0 +1,11 @@
+package com.ioannapergamali.mysmartroute.data.local
+
+import androidx.room.Embedded
+import androidx.room.Relation
+
+/** Σχέση μενού με τις επιλογές του. */
+data class MenuWithOptions(
+    @Embedded val menu: MenuEntity,
+    @Relation(parentColumn = "id", entityColumn = "menuId")
+    val options: List<MenuOptionEntity>
+)

--- a/app/src/main/java/com/ioannapergamali/mysmartroute/data/local/RoleEntity.kt
+++ b/app/src/main/java/com/ioannapergamali/mysmartroute/data/local/RoleEntity.kt
@@ -5,12 +5,8 @@ import androidx.room.Index
 import androidx.room.PrimaryKey
 
 /** Οντότητα ρόλου χρήστη. */
-@Entity(
-    tableName = "roles",
-    indices = [Index("userId")]
-)
+@Entity(tableName = "roles")
 data class RoleEntity(
     @PrimaryKey var id: String = "",
-    var userId: String = "",
     var name: String = ""
 )

--- a/app/src/main/java/com/ioannapergamali/mysmartroute/view/ui/screens/MenuScreen.kt
+++ b/app/src/main/java/com/ioannapergamali/mysmartroute/view/ui/screens/MenuScreen.kt
@@ -16,7 +16,7 @@ import androidx.navigation.NavController
 import com.ioannapergamali.mysmartroute.view.ui.components.TopBar
 import com.ioannapergamali.mysmartroute.viewmodel.AuthenticationViewModel
 import com.ioannapergamali.mysmartroute.view.ui.components.ScreenContainer
-import com.ioannapergamali.mysmartroute.data.local.MenuEntity
+import com.ioannapergamali.mysmartroute.data.local.MenuWithOptions
 
 @Composable
 fun MenuScreen(navController: NavController, openDrawer: () -> Unit) {
@@ -61,19 +61,21 @@ fun MenuScreen(navController: NavController, openDrawer: () -> Unit) {
 }
 
 @Composable
-private fun MenuEntityTable(menus: List<MenuEntity>, onRouteSelected: (String) -> Unit) {
+private fun MenuEntityTable(menus: List<MenuWithOptions>, onRouteSelected: (String) -> Unit) {
     Column(modifier = Modifier.fillMaxWidth()) {
-        menus.forEachIndexed { index, menu ->
-            Row(modifier = Modifier
-                .fillMaxWidth()
-                .padding(vertical = 4.dp)) {
-                Text(text = "${index + 1}.", modifier = Modifier.width(24.dp))
-                Text(
-                    text = menu.title,
-                    modifier = Modifier
-                        .clickable { onRouteSelected(menu.route) }
-                        .weight(1f)
-                )
+        menus.forEachIndexed { index, menuWithOptions ->
+            Text(text = "${index + 1}. ${menuWithOptions.menu.title}", style = MaterialTheme.typography.titleMedium)
+            menuWithOptions.options.forEach { option ->
+                Row(modifier = Modifier
+                    .fillMaxWidth()
+                    .padding(start = 24.dp, top = 2.dp, bottom = 2.dp)) {
+                    Text(
+                        text = option.title,
+                        modifier = Modifier
+                            .clickable { onRouteSelected(option.route) }
+                            .weight(1f)
+                    )
+                }
             }
         }
     }


### PR DESCRIPTION
## Summary
- προσθήκη `MenuOptionEntity` και `MenuOptionDao`
- νέο `MenuWithOptions` για τις σχέσεις μενού/επιλογών
- ανανέωση οντοτήτων `Role` και `Menu`
- εισαγωγή προκαθορισμένων ρόλων κατά το migration
- δημιουργία πίνακα `menu_options` και migration 14→15
- ενημέρωση `AuthenticationViewModel` και `MenuScreen` για χρήση των επιλογών

## Testing
- `./gradlew test` *(απέτυχε: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_6855e81568cc8328937a4397ed4cc70a