### PR TITLE
Δρομολόγηση επιλογής Announce Availability

### DIFF
--- a/app/src/main/java/com/ioannapergamali/mysmartroute/model/navigation/NavigationHost.kt
+++ b/app/src/main/java/com/ioannapergamali/mysmartroute/model/navigation/NavigationHost.kt
@@ -65,6 +65,10 @@ fun NavigationHost(navController : NavHostController, openDrawer: () -> Unit) {
             AnnounceTransportScreen(navController = navController, openDrawer = openDrawer)
         }
 
+        composable("announceAvailability") {
+            AnnounceTransportScreen(navController = navController, openDrawer = openDrawer)
+        }
+
         composable("poiList") {
             PoIListScreen(navController = navController, openDrawer = openDrawer)
         }


### PR DESCRIPTION
## Summary
- προστέθηκε νέο composable `announceAvailability` στο `NavigationHost`
- η επιλογή **Announce Availability for a specific Transport** κατευθύνεται πλέον στην οθόνη `AnnounceTransportScreen`

## Testing
- `./gradlew test` *(απέτυχε λόγω περιορισμών δικτύου)*

------
https://chatgpt.com/codex/tasks/task_e_6855efd4d2bc8328acdad6b686b62468