### PR TITLE
Βελτίωση τεκμηρίωσης και σχολίων για Gson

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,7 +79,20 @@ Log.d("Maps", "API key loaded? ${apiKey.isNotEmpty()}")
 Εάν η IDE εμφανίζει σφάλματα του τύπου *Unresolved reference: Gson* ή *TypeToken*, έλεγξε ότι στο αρχείο `app/build.gradle.kts` υπάρχει η γραμμή
 
 ```kotlin
-implementation("com.google.code.gson:gson:2.13.1")
+implementation("com.google.code.gson:gson:2.13.1") // τελευταία διαθέσιμη έκδοση
+```
+
+Στη συνέχεια, στις κλάσεις Kotlin πρόσθεσε τα κατάλληλα imports:
+
+```kotlin
+import com.google.gson.Gson
+import com.google.gson.reflect.TypeToken
+
+private val gson = Gson()
+
+// Μετατροπή JSON σε αντικείμενο Kotlin
+val type = object : TypeToken<User>() {}.type
+val user: User = gson.fromJson(jsonString, type)
 ```
 
 Μετά την προσθήκη ή επιβεβαίωση της παραπάνω εξάρτησης, κάνε "Sync Project with Gradle Files" ώστε να κατέβει το library και να λυθούν τα σφάλματα.

--- a/app/src/main/java/com/ioannapergamali/mysmartroute/viewmodel/AuthenticationViewModel.kt
+++ b/app/src/main/java/com/ioannapergamali/mysmartroute/viewmodel/AuthenticationViewModel.kt
@@ -33,6 +33,14 @@ class AuthenticationViewModel : ViewModel() {
     // Χρήση του Gson για μετατροπή JSON σε αντικείμενα Kotlin
     private val gson = Gson()
 
+    /**
+     * Παράδειγμα μετατροπής JSON σε αντικείμενο [UserAddress].
+     */
+    private fun parseUserAddressJson(json: String): UserAddress {
+        val type = object : TypeToken<UserAddress>() {}.type
+        return gson.fromJson(json, type)
+    }
+
     private val _signUpState = MutableStateFlow<SignUpState>(SignUpState.Idle)
     val signUpState: StateFlow<SignUpState> = _signUpState
 

--- a/app/src/main/java/com/ioannapergamali/mysmartroute/viewmodel/AuthenticationViewModel.kt
+++ b/app/src/main/java/com/ioannapergamali/mysmartroute/viewmodel/AuthenticationViewModel.kt
@@ -30,6 +30,7 @@ class AuthenticationViewModel : ViewModel() {
 
     private val db = FirebaseFirestore.getInstance()
     private val auth = FirebaseAuth.getInstance()
+    // Χρήση του Gson για μετατροπή JSON σε αντικείμενα Kotlin
     private val gson = Gson()
 
     private val _signUpState = MutableStateFlow<SignUpState>(SignUpState.Idle)
@@ -262,6 +263,7 @@ class AuthenticationViewModel : ViewModel() {
         return try {
             val json = context.assets.open("menus.json").bufferedReader().use { it.readText() }
             val type = object : TypeToken<Map<String, List<MenuConfig>>>() {}.type
+            // Παράδειγμα χρήσης του Gson για ανάγνωση του menus.json
             val map: Map<String, List<MenuConfig>> = gson.fromJson(json, type)
             val roleMenus = map[role.name].orEmpty()
             roleMenus.map { menu ->


### PR DESCRIPTION
## Summary
- ενημέρωση παραδείγματος Gson στο README
- προσθήκη σχολίου χρήσης Gson στο `AuthenticationViewModel`

## Testing
- `./gradlew test --console=plain` *(αποτυχημένο: λείπει το Android SDK)*

------
https://chatgpt.com/codex/tasks/task_e_68571791569c8328b9aba9901a99302a