### PR TITLE
Add Gson helper

### DIFF
--- a/app/src/main/java/com/ioannapergamali/mysmartroute/utils/GsonExtensions.kt
+++ b/app/src/main/java/com/ioannapergamali/mysmartroute/utils/GsonExtensions.kt
@@ -1,0 +1,9 @@
+package com.ioannapergamali.mysmartroute.utils
+
+import com.google.gson.Gson
+import com.google.gson.reflect.TypeToken
+
+/** Απλή συνάρτηση επέκτασης για χρήση της βιβλιοθήκης Gson με generics. */
+inline fun <reified T> Gson.fromJson(json: String): T =
+    fromJson(json, object : TypeToken<T>() {}.type)
+


### PR DESCRIPTION
## Summary
- add a simple extension function to use Gson with generics

## Testing
- `./gradlew assembleDebug` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_68578670e6f0832895ffaed0a3415b04