### PR TITLE
Ενημέρωση UI με καμπύλες γωνίες και περίγραμμα

### DIFF
--- a/app/src/main/java/com/ioannapergamali/mysmartroute/view/ui/Theme.kt
+++ b/app/src/main/java/com/ioannapergamali/mysmartroute/view/ui/Theme.kt
@@ -5,6 +5,9 @@ import androidx.compose.material3.darkColorScheme
 import androidx.compose.material3.lightColorScheme
 import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.runtime.Composable
+import androidx.compose.material3.Shapes
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.ui.unit.dp
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.text.font.FontFamily
 import androidx.compose.material3.Typography
@@ -95,6 +98,11 @@ fun MysmartrouteTheme(
     androidx.compose.material3.MaterialTheme(
         colorScheme = colorScheme,
         typography = typographyWithFont(font),
+        shapes = Shapes(
+            extraSmall = RoundedCornerShape(8.dp),
+            small = RoundedCornerShape(8.dp),
+            medium = RoundedCornerShape(12.dp)
+        ),
         content = content
     )
 }

--- a/app/src/main/java/com/ioannapergamali/mysmartroute/view/ui/components/ScreenContainer.kt
+++ b/app/src/main/java/com/ioannapergamali/mysmartroute/view/ui/components/ScreenContainer.kt
@@ -3,6 +3,7 @@ package com.ioannapergamali.mysmartroute.view.ui.components
 import androidx.compose.foundation.border
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.ColumnScope
+import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.rememberScrollState
@@ -26,14 +27,19 @@ fun ScreenContainer(
     val scrollState = rememberScrollState()
     CompositionLocalProvider(LocalContentColor provides MaterialTheme.colorScheme.primary) {
         SelectionContainer {
-            Column(
+            Box(
                 modifier = modifier
-                    .then(if (scrollable) Modifier.verticalScroll(scrollState) else Modifier)
                     .fillMaxSize()
                     .border(2.dp, MaterialTheme.colorScheme.primary)
-                    .padding(dimensionResource(id = R.dimen.padding_screen)),
-                content = content
-            )
+                    .padding(dimensionResource(id = R.dimen.padding_screen))
+            ) {
+                Column(
+                    modifier = Modifier
+                        .fillMaxSize()
+                        .then(if (scrollable) Modifier.verticalScroll(scrollState) else Modifier),
+                    content = content
+                )
+            }
         }
     }
 }

--- a/app/src/main/java/com/ioannapergamali/mysmartroute/view/ui/screens/AdminSignUpScreen.kt
+++ b/app/src/main/java/com/ioannapergamali/mysmartroute/view/ui/screens/AdminSignUpScreen.kt
@@ -64,80 +64,130 @@ fun AdminSignUpScreen(
                 verticalArrangement = Arrangement.Top,
                 horizontalAlignment = Alignment.CenterHorizontally
             ) {
-                TextField(
+                OutlinedTextField(
                     value = name,
                     onValueChange = { name = it },
                     label = { Text("Name") },
-                    modifier = Modifier.fillMaxWidth()
+                    modifier = Modifier.fillMaxWidth(),
+                    shape = MaterialTheme.shapes.small,
+                    colors = TextFieldDefaults.outlinedTextFieldColors(
+                        focusedBorderColor = MaterialTheme.colorScheme.primary,
+                        unfocusedBorderColor = MaterialTheme.colorScheme.primary
+                    )
                 )
                 Spacer(Modifier.height(8.dp))
-                TextField(
+                OutlinedTextField(
                     value = surname,
                     onValueChange = { surname = it },
                     label = { Text("Surname") },
-                    modifier = Modifier.fillMaxWidth()
+                    modifier = Modifier.fillMaxWidth(),
+                    shape = MaterialTheme.shapes.small,
+                    colors = TextFieldDefaults.outlinedTextFieldColors(
+                        focusedBorderColor = MaterialTheme.colorScheme.primary,
+                        unfocusedBorderColor = MaterialTheme.colorScheme.primary
+                    )
                 )
                 Spacer(Modifier.height(8.dp))
-                TextField(
+                OutlinedTextField(
                     value = username,
                     onValueChange = { username = it },
                     label = { Text("Username") },
-                    modifier = Modifier.fillMaxWidth()
+                    modifier = Modifier.fillMaxWidth(),
+                    shape = MaterialTheme.shapes.small,
+                    colors = TextFieldDefaults.outlinedTextFieldColors(
+                        focusedBorderColor = MaterialTheme.colorScheme.primary,
+                        unfocusedBorderColor = MaterialTheme.colorScheme.primary
+                    )
                 )
                 Spacer(Modifier.height(8.dp))
-                TextField(
+                OutlinedTextField(
                     value = email,
                     onValueChange = { email = it },
                     label = { Text("Email") },
-                    modifier = Modifier.fillMaxWidth()
+                    modifier = Modifier.fillMaxWidth(),
+                    shape = MaterialTheme.shapes.small,
+                    colors = TextFieldDefaults.outlinedTextFieldColors(
+                        focusedBorderColor = MaterialTheme.colorScheme.primary,
+                        unfocusedBorderColor = MaterialTheme.colorScheme.primary
+                    )
                 )
                 Spacer(Modifier.height(8.dp))
-                TextField(
+                OutlinedTextField(
                     value = phoneNum,
                     onValueChange = { phoneNum = it },
                     label = { Text("Phone Number") },
                     modifier = Modifier.fillMaxWidth(),
-                    keyboardOptions = KeyboardOptions(keyboardType = KeyboardType.Phone)
+                    keyboardOptions = KeyboardOptions(keyboardType = KeyboardType.Phone),
+                    shape = MaterialTheme.shapes.small,
+                    colors = TextFieldDefaults.outlinedTextFieldColors(
+                        focusedBorderColor = MaterialTheme.colorScheme.primary,
+                        unfocusedBorderColor = MaterialTheme.colorScheme.primary
+                    )
                 )
                 Spacer(Modifier.height(8.dp))
-                TextField(
+                OutlinedTextField(
                     value = password,
                     onValueChange = { password = it },
                     label = { Text("Password") },
                     modifier = Modifier.fillMaxWidth(),
-                    visualTransformation = PasswordVisualTransformation()
+                    visualTransformation = PasswordVisualTransformation(),
+                    shape = MaterialTheme.shapes.small,
+                    colors = TextFieldDefaults.outlinedTextFieldColors(
+                        focusedBorderColor = MaterialTheme.colorScheme.primary,
+                        unfocusedBorderColor = MaterialTheme.colorScheme.primary
+                    )
                 )
 
                 Spacer(Modifier.height(16.dp))
                 Text("Address", style = MaterialTheme.typography.titleMedium)
-                TextField(
+                OutlinedTextField(
                     value = city,
                     onValueChange = { city = it },
                     label = { Text("City") },
-                    modifier = Modifier.fillMaxWidth()
+                    modifier = Modifier.fillMaxWidth(),
+                    shape = MaterialTheme.shapes.small,
+                    colors = TextFieldDefaults.outlinedTextFieldColors(
+                        focusedBorderColor = MaterialTheme.colorScheme.primary,
+                        unfocusedBorderColor = MaterialTheme.colorScheme.primary
+                    )
                 )
                 Spacer(Modifier.height(8.dp))
-                TextField(
+                OutlinedTextField(
                     value = streetName,
                     onValueChange = { streetName = it },
                     label = { Text("Street Name") },
-                    modifier = Modifier.fillMaxWidth()
+                    modifier = Modifier.fillMaxWidth(),
+                    shape = MaterialTheme.shapes.small,
+                    colors = TextFieldDefaults.outlinedTextFieldColors(
+                        focusedBorderColor = MaterialTheme.colorScheme.primary,
+                        unfocusedBorderColor = MaterialTheme.colorScheme.primary
+                    )
                 )
                 Spacer(Modifier.height(8.dp))
-                TextField(
+                OutlinedTextField(
                     value = streetNumInput,
                     onValueChange = { streetNumInput = it },
                     label = { Text("Street Number") },
                     modifier = Modifier.fillMaxWidth(),
-                    keyboardOptions = KeyboardOptions(keyboardType = KeyboardType.Number)
+                    keyboardOptions = KeyboardOptions(keyboardType = KeyboardType.Number),
+                    shape = MaterialTheme.shapes.small,
+                    colors = TextFieldDefaults.outlinedTextFieldColors(
+                        focusedBorderColor = MaterialTheme.colorScheme.primary,
+                        unfocusedBorderColor = MaterialTheme.colorScheme.primary
+                    )
                 )
                 Spacer(Modifier.height(8.dp))
-                TextField(
+                OutlinedTextField(
                     value = postalCodeInput,
                     onValueChange = { postalCodeInput = it },
                     label = { Text("Postal Code") },
                     modifier = Modifier.fillMaxWidth(),
-                    keyboardOptions = KeyboardOptions(keyboardType = KeyboardType.Number)
+                    keyboardOptions = KeyboardOptions(keyboardType = KeyboardType.Number),
+                    shape = MaterialTheme.shapes.small,
+                    colors = TextFieldDefaults.outlinedTextFieldColors(
+                        focusedBorderColor = MaterialTheme.colorScheme.primary,
+                        unfocusedBorderColor = MaterialTheme.colorScheme.primary
+                    )
                 )
 
                 if (uiState is AuthenticationViewModel.SignUpState.Error) {

--- a/app/src/main/java/com/ioannapergamali/mysmartroute/view/ui/screens/AnnounceTransportScreen.kt
+++ b/app/src/main/java/com/ioannapergamali/mysmartroute/view/ui/screens/AnnounceTransportScreen.kt
@@ -333,7 +333,7 @@ fun AnnounceTransportScreen(navController: NavController, openDrawer: () -> Unit
         Spacer(modifier = Modifier.height(8.dp))
 
         ExposedDropdownMenuBox(expanded = fromExpanded, onExpandedChange = { fromExpanded = !fromExpanded }) {
-            TextField(
+            OutlinedTextField(
                 value = fromQuery,
                 onValueChange = {
                     fromQuery = it
@@ -411,7 +411,12 @@ fun AnnounceTransportScreen(navController: NavController, openDrawer: () -> Unit
                         ExposedDropdownMenuDefaults.TrailingIcon(expanded = fromExpanded)
                     }
                 },
-                modifier = Modifier.menuAnchor().fillMaxWidth()
+                modifier = Modifier.menuAnchor().fillMaxWidth(),
+                shape = MaterialTheme.shapes.small,
+                colors = TextFieldDefaults.outlinedTextFieldColors(
+                    focusedBorderColor = MaterialTheme.colorScheme.primary,
+                    unfocusedBorderColor = MaterialTheme.colorScheme.primary
+                )
             )
             DropdownMenu(expanded = fromExpanded, onDismissRequest = { fromExpanded = false }) {
                 fromSuggestions.forEach { address ->
@@ -450,7 +455,7 @@ fun AnnounceTransportScreen(navController: NavController, openDrawer: () -> Unit
         Spacer(modifier = Modifier.height(8.dp))
 
         ExposedDropdownMenuBox(expanded = toExpanded, onExpandedChange = { toExpanded = !toExpanded }) {
-            TextField(
+            OutlinedTextField(
                 value = toQuery,
                 onValueChange = {
                     toQuery = it
@@ -528,7 +533,12 @@ fun AnnounceTransportScreen(navController: NavController, openDrawer: () -> Unit
                         ExposedDropdownMenuDefaults.TrailingIcon(expanded = toExpanded)
                     }
                 },
-                modifier = Modifier.menuAnchor().fillMaxWidth()
+                modifier = Modifier.menuAnchor().fillMaxWidth(),
+                shape = MaterialTheme.shapes.small,
+                colors = TextFieldDefaults.outlinedTextFieldColors(
+                    focusedBorderColor = MaterialTheme.colorScheme.primary,
+                    unfocusedBorderColor = MaterialTheme.colorScheme.primary
+                )
             )
             DropdownMenu(expanded = toExpanded, onDismissRequest = { toExpanded = false }) {
                 toSuggestions.forEach { address ->
@@ -569,13 +579,18 @@ fun AnnounceTransportScreen(navController: NavController, openDrawer: () -> Unit
         var vehicleMenuExpanded by remember { mutableStateOf(false) }
 
         ExposedDropdownMenuBox(expanded = vehicleMenuExpanded, onExpandedChange = { vehicleMenuExpanded = !vehicleMenuExpanded }) {
-            TextField(
+            OutlinedTextField(
                 value = selectedVehicleType?.name ?: "",
                 onValueChange = {},
                 readOnly = true,
                 label = { Text("Vehicle") },
                 trailingIcon = { ExposedDropdownMenuDefaults.TrailingIcon(expanded = vehicleMenuExpanded) },
-                modifier = Modifier.menuAnchor().fillMaxWidth()
+                modifier = Modifier.menuAnchor().fillMaxWidth(),
+                shape = MaterialTheme.shapes.small,
+                colors = TextFieldDefaults.outlinedTextFieldColors(
+                    focusedBorderColor = MaterialTheme.colorScheme.primary,
+                    unfocusedBorderColor = MaterialTheme.colorScheme.primary
+                )
             )
             DropdownMenu(expanded = vehicleMenuExpanded, onDismissRequest = { vehicleMenuExpanded = false }) {
                 vehicles.forEach { entity ->
@@ -595,11 +610,29 @@ fun AnnounceTransportScreen(navController: NavController, openDrawer: () -> Unit
         }
 
         Spacer(modifier = Modifier.height(8.dp))
-        TextField(value = costInput, onValueChange = { costInput = it }, label = { Text("Cost") })
+        OutlinedTextField(
+            value = costInput,
+            onValueChange = { costInput = it },
+            label = { Text("Cost") },
+            shape = MaterialTheme.shapes.small,
+            colors = TextFieldDefaults.outlinedTextFieldColors(
+                focusedBorderColor = MaterialTheme.colorScheme.primary,
+                unfocusedBorderColor = MaterialTheme.colorScheme.primary
+            )
+        )
         Spacer(modifier = Modifier.height(8.dp))
         Text(text = "Duration: $durationMinutes min")
         Spacer(modifier = Modifier.height(8.dp))
-        TextField(value = dateInput, onValueChange = { dateInput = it }, label = { Text("Date") })
+        OutlinedTextField(
+            value = dateInput,
+            onValueChange = { dateInput = it },
+            label = { Text("Date") },
+            shape = MaterialTheme.shapes.small,
+            colors = TextFieldDefaults.outlinedTextFieldColors(
+                focusedBorderColor = MaterialTheme.colorScheme.primary,
+                unfocusedBorderColor = MaterialTheme.colorScheme.primary
+            )
+        )
         Spacer(modifier = Modifier.height(16.dp))
         Button(onClick = {
             if (fromQuery.isBlank() || startLatLng == null || toQuery.isBlank() || endLatLng == null) {

--- a/app/src/main/java/com/ioannapergamali/mysmartroute/view/ui/screens/FontPickerScreen.kt
+++ b/app/src/main/java/com/ioannapergamali/mysmartroute/view/ui/screens/FontPickerScreen.kt
@@ -6,7 +6,8 @@ import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.ExposedDropdownMenuBox
 import androidx.compose.material3.ExposedDropdownMenuDefaults
 import androidx.compose.material3.Text
-import androidx.compose.material3.TextField
+import androidx.compose.material3.OutlinedTextField
+import androidx.compose.material3.TextFieldDefaults
 import androidx.compose.material3.DropdownMenu
 import androidx.compose.material3.DropdownMenuItem
 import androidx.compose.material3.Scaffold
@@ -56,13 +57,18 @@ fun FontPickerScreen(navController: NavController) {
             ScreenContainer(modifier = Modifier.padding(padding)) {
                 Text("Γραμματοσειρές")
                 ExposedDropdownMenuBox(expanded = expanded, onExpandedChange = { expanded = !expanded }) {
-                    TextField(
+                    OutlinedTextField(
                         readOnly = true,
                         value = selectedFont.label,
                         onValueChange = {},
                         label = { Text("Fonts") },
                         trailingIcon = { ExposedDropdownMenuDefaults.TrailingIcon(expanded = expanded) },
-                        modifier = Modifier.menuAnchor()
+                        modifier = Modifier.menuAnchor(),
+                        shape = MaterialTheme.shapes.small,
+                        colors = TextFieldDefaults.outlinedTextFieldColors(
+                            focusedBorderColor = MaterialTheme.colorScheme.primary,
+                            unfocusedBorderColor = MaterialTheme.colorScheme.primary
+                        )
                     )
                     DropdownMenu(expanded = expanded, onDismissRequest = { expanded = false }) {
                         AppFont.values().forEach { font ->

--- a/app/src/main/java/com/ioannapergamali/mysmartroute/view/ui/screens/HomeScreen.kt
+++ b/app/src/main/java/com/ioannapergamali/mysmartroute/view/ui/screens/HomeScreen.kt
@@ -170,21 +170,31 @@ private fun HomeContent(
         Spacer(modifier = Modifier.height(16.dp))
 
         if (FirebaseAuth.getInstance().currentUser == null) {
-            TextField(
+            OutlinedTextField(
                 value = email,
                 onValueChange = onEmailChange,
                 label = { Text("Email") },
-                modifier = Modifier.fillMaxWidth()
+                modifier = Modifier.fillMaxWidth(),
+                shape = MaterialTheme.shapes.small,
+                colors = TextFieldDefaults.outlinedTextFieldColors(
+                    focusedBorderColor = MaterialTheme.colorScheme.primary,
+                    unfocusedBorderColor = MaterialTheme.colorScheme.primary
+                )
             )
 
             Spacer(Modifier.height(8.dp))
 
-            TextField(
+            OutlinedTextField(
                 value = password,
                 onValueChange = onPasswordChange,
                 label = { Text("Password") },
                 visualTransformation = PasswordVisualTransformation(),
-                modifier = Modifier.fillMaxWidth()
+                modifier = Modifier.fillMaxWidth(),
+                shape = MaterialTheme.shapes.small,
+                colors = TextFieldDefaults.outlinedTextFieldColors(
+                    focusedBorderColor = MaterialTheme.colorScheme.primary,
+                    unfocusedBorderColor = MaterialTheme.colorScheme.primary
+                )
             )
 
             if (uiState is AuthenticationViewModel.LoginState.Error) {

--- a/app/src/main/java/com/ioannapergamali/mysmartroute/view/ui/screens/RegisterVehicleScreen.kt
+++ b/app/src/main/java/com/ioannapergamali/mysmartroute/view/ui/screens/RegisterVehicleScreen.kt
@@ -40,13 +40,18 @@ fun RegisterVehicleScreen(navController: NavController, openDrawer: () -> Unit) 
     ) { paddingValues ->
         ScreenContainer(modifier = Modifier.padding(paddingValues)) {
             ExposedDropdownMenuBox(expanded = expanded, onExpandedChange = { expanded = !expanded }) {
-                TextField(
+                OutlinedTextField(
                     value = type.name,
                     onValueChange = {},
                     readOnly = true,
                     label = { Text("Type") },
                     trailingIcon = { ExposedDropdownMenuDefaults.TrailingIcon(expanded = expanded) },
-                    modifier = Modifier.menuAnchor().fillMaxWidth()
+                    modifier = Modifier.menuAnchor().fillMaxWidth(),
+                    shape = MaterialTheme.shapes.small,
+                    colors = TextFieldDefaults.outlinedTextFieldColors(
+                        focusedBorderColor = MaterialTheme.colorScheme.primary,
+                        unfocusedBorderColor = MaterialTheme.colorScheme.primary
+                    )
                 )
                 DropdownMenu(expanded = expanded, onDismissRequest = { expanded = false }) {
                     VehicleType.values().forEach { option ->
@@ -61,19 +66,29 @@ fun RegisterVehicleScreen(navController: NavController, openDrawer: () -> Unit) 
                 }
             }
             Spacer(Modifier.height(8.dp))
-            TextField(
+            OutlinedTextField(
                 value = description,
                 onValueChange = { description = it },
                 label = { Text("Description") },
-                modifier = Modifier.fillMaxWidth()
+                modifier = Modifier.fillMaxWidth(),
+                shape = MaterialTheme.shapes.small,
+                colors = TextFieldDefaults.outlinedTextFieldColors(
+                    focusedBorderColor = MaterialTheme.colorScheme.primary,
+                    unfocusedBorderColor = MaterialTheme.colorScheme.primary
+                )
             )
             Spacer(Modifier.height(8.dp))
-            TextField(
+            OutlinedTextField(
                 value = seatInput,
                 onValueChange = { seatInput = it },
                 label = { Text("Seats") },
                 keyboardOptions = KeyboardOptions(keyboardType = KeyboardType.Number),
-                modifier = Modifier.fillMaxWidth()
+                modifier = Modifier.fillMaxWidth(),
+                shape = MaterialTheme.shapes.small,
+                colors = TextFieldDefaults.outlinedTextFieldColors(
+                    focusedBorderColor = MaterialTheme.colorScheme.primary,
+                    unfocusedBorderColor = MaterialTheme.colorScheme.primary
+                )
             )
 
             if (state is VehicleViewModel.RegisterState.Error) {

--- a/app/src/main/java/com/ioannapergamali/mysmartroute/view/ui/screens/SettingsScreen.kt
+++ b/app/src/main/java/com/ioannapergamali/mysmartroute/view/ui/screens/SettingsScreen.kt
@@ -9,7 +9,8 @@ import androidx.compose.material3.DropdownMenuItem
 import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.ExposedDropdownMenuBox
 import androidx.compose.material3.ExposedDropdownMenuDefaults
-import androidx.compose.material3.TextField
+import androidx.compose.material3.OutlinedTextField
+import androidx.compose.material3.TextFieldDefaults
 import androidx.compose.material3.Icon
 import androidx.compose.material3.IconButton
 import androidx.compose.material3.Scaffold
@@ -93,13 +94,18 @@ fun SettingsScreen(navController: NavController, openDrawer: () -> Unit) {
             Text("Θέμα")
             Divider(modifier = Modifier.padding(vertical = 4.dp))
             ExposedDropdownMenuBox(expanded = expandedTheme.value, onExpandedChange = { expandedTheme.value = !expandedTheme.value }) {
-                TextField(
+                OutlinedTextField(
                     readOnly = true,
                     value = selectedTheme.value.label,
                     onValueChange = {},
                     label = { Text("Theme") },
                     trailingIcon = { ExposedDropdownMenuDefaults.TrailingIcon(expanded = expandedTheme.value) },
-                    modifier = Modifier.menuAnchor()
+                    modifier = Modifier.menuAnchor(),
+                    shape = MaterialTheme.shapes.small,
+                    colors = TextFieldDefaults.outlinedTextFieldColors(
+                        focusedBorderColor = MaterialTheme.colorScheme.primary,
+                        unfocusedBorderColor = MaterialTheme.colorScheme.primary
+                    )
                 )
                 DropdownMenu(expanded = expandedTheme.value, onDismissRequest = { expandedTheme.value = false }) {
                     AppTheme.values().forEach { theme ->
@@ -116,13 +122,18 @@ fun SettingsScreen(navController: NavController, openDrawer: () -> Unit) {
             Text("Γραμματοσειρά", modifier = Modifier.padding(top = 16.dp))
             Divider(modifier = Modifier.padding(vertical = 4.dp))
             ExposedDropdownMenuBox(expanded = expandedFont.value, onExpandedChange = { expandedFont.value = !expandedFont.value }) {
-                TextField(
+                OutlinedTextField(
                     readOnly = true,
                     value = selectedFont.value.label,
                     onValueChange = {},
                     label = { Text("Fonts") },
                     trailingIcon = { ExposedDropdownMenuDefaults.TrailingIcon(expanded = expandedFont.value) },
-                    modifier = Modifier.menuAnchor()
+                    modifier = Modifier.menuAnchor(),
+                    shape = MaterialTheme.shapes.small,
+                    colors = TextFieldDefaults.outlinedTextFieldColors(
+                        focusedBorderColor = MaterialTheme.colorScheme.primary,
+                        unfocusedBorderColor = MaterialTheme.colorScheme.primary
+                    )
                 )
                 DropdownMenu(expanded = expandedFont.value, onDismissRequest = { expandedFont.value = false }) {
                     AppFont.values().forEach { font ->

--- a/app/src/main/java/com/ioannapergamali/mysmartroute/view/ui/screens/SignUpScreen.kt
+++ b/app/src/main/java/com/ioannapergamali/mysmartroute/view/ui/screens/SignUpScreen.kt
@@ -66,80 +66,130 @@ fun SignUpScreen(
                 verticalArrangement = Arrangement.Top,
                 horizontalAlignment = Alignment.CenterHorizontally
             ) {
-                TextField(
+                OutlinedTextField(
                     value = name,
                     onValueChange = { name = it },
                     label = { Text("Name") },
-                    modifier = Modifier.fillMaxWidth()
+                    modifier = Modifier.fillMaxWidth(),
+                    shape = MaterialTheme.shapes.small,
+                    colors = TextFieldDefaults.outlinedTextFieldColors(
+                        focusedBorderColor = MaterialTheme.colorScheme.primary,
+                        unfocusedBorderColor = MaterialTheme.colorScheme.primary
+                    )
                 )
                 Spacer(Modifier.height(8.dp))
-                TextField(
+                OutlinedTextField(
                     value = surname,
                     onValueChange = { surname = it },
                     label = { Text("Surname") },
-                    modifier = Modifier.fillMaxWidth()
+                    modifier = Modifier.fillMaxWidth(),
+                    shape = MaterialTheme.shapes.small,
+                    colors = TextFieldDefaults.outlinedTextFieldColors(
+                        focusedBorderColor = MaterialTheme.colorScheme.primary,
+                        unfocusedBorderColor = MaterialTheme.colorScheme.primary
+                    )
                 )
                 Spacer(Modifier.height(8.dp))
-                TextField(
+                OutlinedTextField(
                     value = username,
                     onValueChange = { username = it },
                     label = { Text("Username") },
-                    modifier = Modifier.fillMaxWidth()
+                    modifier = Modifier.fillMaxWidth(),
+                    shape = MaterialTheme.shapes.small,
+                    colors = TextFieldDefaults.outlinedTextFieldColors(
+                        focusedBorderColor = MaterialTheme.colorScheme.primary,
+                        unfocusedBorderColor = MaterialTheme.colorScheme.primary
+                    )
                 )
                 Spacer(Modifier.height(8.dp))
-                TextField(
+                OutlinedTextField(
                     value = email,
                     onValueChange = { email = it },
                     label = { Text("Email") },
-                    modifier = Modifier.fillMaxWidth()
+                    modifier = Modifier.fillMaxWidth(),
+                    shape = MaterialTheme.shapes.small,
+                    colors = TextFieldDefaults.outlinedTextFieldColors(
+                        focusedBorderColor = MaterialTheme.colorScheme.primary,
+                        unfocusedBorderColor = MaterialTheme.colorScheme.primary
+                    )
                 )
                 Spacer(Modifier.height(8.dp))
-                TextField(
+                OutlinedTextField(
                     value = phoneNum,
                     onValueChange = { phoneNum = it },
                     label = { Text("Phone Number") },
                     modifier = Modifier.fillMaxWidth(),
-                    keyboardOptions = KeyboardOptions(keyboardType = KeyboardType.Phone)
+                    keyboardOptions = KeyboardOptions(keyboardType = KeyboardType.Phone),
+                    shape = MaterialTheme.shapes.small,
+                    colors = TextFieldDefaults.outlinedTextFieldColors(
+                        focusedBorderColor = MaterialTheme.colorScheme.primary,
+                        unfocusedBorderColor = MaterialTheme.colorScheme.primary
+                    )
                 )
                 Spacer(Modifier.height(8.dp))
-                TextField(
+                OutlinedTextField(
                     value = password,
                     onValueChange = { password = it },
                     label = { Text("Password") },
                     modifier = Modifier.fillMaxWidth(),
-                    visualTransformation = PasswordVisualTransformation()
+                    visualTransformation = PasswordVisualTransformation(),
+                    shape = MaterialTheme.shapes.small,
+                    colors = TextFieldDefaults.outlinedTextFieldColors(
+                        focusedBorderColor = MaterialTheme.colorScheme.primary,
+                        unfocusedBorderColor = MaterialTheme.colorScheme.primary
+                    )
                 )
 
                 Spacer(Modifier.height(16.dp))
                 Text("Address", style = MaterialTheme.typography.titleMedium)
-                TextField(
+                OutlinedTextField(
                     value = city,
                     onValueChange = { city = it },
                     label = { Text("City") },
-                    modifier = Modifier.fillMaxWidth()
+                    modifier = Modifier.fillMaxWidth(),
+                    shape = MaterialTheme.shapes.small,
+                    colors = TextFieldDefaults.outlinedTextFieldColors(
+                        focusedBorderColor = MaterialTheme.colorScheme.primary,
+                        unfocusedBorderColor = MaterialTheme.colorScheme.primary
+                    )
                 )
                 Spacer(Modifier.height(8.dp))
-                TextField(
+                OutlinedTextField(
                     value = streetName,
                     onValueChange = { streetName = it },
                     label = { Text("Street Name") },
-                    modifier = Modifier.fillMaxWidth()
+                    modifier = Modifier.fillMaxWidth(),
+                    shape = MaterialTheme.shapes.small,
+                    colors = TextFieldDefaults.outlinedTextFieldColors(
+                        focusedBorderColor = MaterialTheme.colorScheme.primary,
+                        unfocusedBorderColor = MaterialTheme.colorScheme.primary
+                    )
                 )
                 Spacer(Modifier.height(8.dp))
-                TextField(
+                OutlinedTextField(
                     value = streetNumInput,
                     onValueChange = { streetNumInput = it },
                     label = { Text("Street Number") },
                     modifier = Modifier.fillMaxWidth(),
-                    keyboardOptions = KeyboardOptions(keyboardType = KeyboardType.Number)
+                    keyboardOptions = KeyboardOptions(keyboardType = KeyboardType.Number),
+                    shape = MaterialTheme.shapes.small,
+                    colors = TextFieldDefaults.outlinedTextFieldColors(
+                        focusedBorderColor = MaterialTheme.colorScheme.primary,
+                        unfocusedBorderColor = MaterialTheme.colorScheme.primary
+                    )
                 )
                 Spacer(Modifier.height(8.dp))
-                TextField(
+                OutlinedTextField(
                     value = postalCodeInput,
                     onValueChange = { postalCodeInput = it },
                     label = { Text("Postal Code") },
                     modifier = Modifier.fillMaxWidth(),
-                    keyboardOptions = KeyboardOptions(keyboardType = KeyboardType.Number)
+                    keyboardOptions = KeyboardOptions(keyboardType = KeyboardType.Number),
+                    shape = MaterialTheme.shapes.small,
+                    colors = TextFieldDefaults.outlinedTextFieldColors(
+                        focusedBorderColor = MaterialTheme.colorScheme.primary,
+                        unfocusedBorderColor = MaterialTheme.colorScheme.primary
+                    )
                 )
 
                 Spacer(Modifier.height(16.dp))

--- a/app/src/main/java/com/ioannapergamali/mysmartroute/view/ui/screens/ThemePickerScreen.kt
+++ b/app/src/main/java/com/ioannapergamali/mysmartroute/view/ui/screens/ThemePickerScreen.kt
@@ -6,7 +6,8 @@ import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.ExposedDropdownMenuBox
 import androidx.compose.material3.ExposedDropdownMenuDefaults
 import androidx.compose.material3.Text
-import androidx.compose.material3.TextField
+import androidx.compose.material3.OutlinedTextField
+import androidx.compose.material3.TextFieldDefaults
 import androidx.compose.material3.DropdownMenu
 import androidx.compose.material3.DropdownMenuItem
 import androidx.compose.material3.Switch
@@ -59,13 +60,18 @@ fun ThemePickerScreen(navController: NavController) {
             ScreenContainer(modifier = Modifier.padding(padding)) {
                 Text("Themes")
                 ExposedDropdownMenuBox(expanded = expanded, onExpandedChange = { expanded = !expanded }) {
-                    TextField(
+                    OutlinedTextField(
                         readOnly = true,
                         value = selectedTheme.label,
                         onValueChange = {},
                         label = { Text("Theme") },
                         trailingIcon = { ExposedDropdownMenuDefaults.TrailingIcon(expanded = expanded) },
-                        modifier = Modifier.menuAnchor()
+                        modifier = Modifier.menuAnchor(),
+                        shape = MaterialTheme.shapes.small,
+                        colors = TextFieldDefaults.outlinedTextFieldColors(
+                            focusedBorderColor = MaterialTheme.colorScheme.primary,
+                            unfocusedBorderColor = MaterialTheme.colorScheme.primary
+                        )
                     )
                     DropdownMenu(expanded = expanded, onDismissRequest = { expanded = false }) {
                         AppTheme.values().forEach { theme ->


### PR DESCRIPTION
## Summary
- make `ScreenContainer` use a full-screen bordered box
- provide rounded shapes in `MysmartrouteTheme`
- replace all `TextField` usages with `OutlinedTextField`
- style dropdown anchors with rounded borders

## Testing
- `./gradlew test` *(failed: could not download dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_6857a25f596883288566b6e34727f798