### PR TITLE
Fix Firestore userId parsing

### DIFF
--- a/app/src/main/java/com/ioannapergamali/mysmartroute/viewmodel/DatabaseViewModel.kt
+++ b/app/src/main/java/com/ioannapergamali/mysmartroute/viewmodel/DatabaseViewModel.kt
@@ -120,11 +120,13 @@ class DatabaseViewModel : ViewModel() {
                     Log.d(TAG, "Fetching vehicles from Firestore")
                     val vehicles = firestore.collection("vehicles").get().await()
                         .documents.mapNotNull { doc ->
-                            val userRef = doc.getDocumentReference("userId") ?: return@mapNotNull null
+                            val userId = doc.getString("userId")
+                                ?: doc.getDocumentReference("userId")?.id
+                                ?: return@mapNotNull null
                             VehicleEntity(
                                 id = doc.getString("id") ?: "",
                                 description = doc.getString("description") ?: "",
-                                userId = userRef.id,
+                                userId = userId,
                                 type = doc.getString("type") ?: "",
                                 seat = (doc.getLong("seat") ?: 0L).toInt()
                             )
@@ -136,9 +138,11 @@ class DatabaseViewModel : ViewModel() {
                     Log.d(TAG, "Fetching settings from Firestore")
                     val settings = firestore.collection("user_settings").get().await()
                         .documents.mapNotNull { doc ->
-                            val userRef = doc.getDocumentReference("userId") ?: return@mapNotNull null
+                            val userId = doc.getString("userId")
+                                ?: doc.getDocumentReference("userId")?.id
+                                ?: return@mapNotNull null
                             SettingsEntity(
-                                userId = userRef.id,
+                                userId = userId,
                                 theme = doc.getString("theme") ?: "",
                                 darkTheme = doc.getBoolean("darkTheme") ?: false,
                                 font = doc.getString("font") ?: "",


### PR DESCRIPTION
## Summary
- handle userId field that may be string or DocumentReference during sync

## Testing
- `./gradlew test --daemon` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_6857d1b62a088328a61a08f5f80ed168