### PR TITLE
Fix Firestore ID references

### DIFF
--- a/app/src/main/java/com/ioannapergamali/mysmartroute/utils/FirestoreMappers.kt
+++ b/app/src/main/java/com/ioannapergamali/mysmartroute/utils/FirestoreMappers.kt
@@ -29,14 +29,18 @@ fun UserEntity.toFirestoreMap(): Map<String, Any> = mapOf(
 fun VehicleEntity.toFirestoreMap(): Map<String, Any> = mapOf(
     "id" to id,
     "description" to description,
-    "userId" to userId,
+    "userId" to FirebaseFirestore.getInstance()
+        .collection("users")
+        .document(userId),
     "type" to type,
     "seat" to seat
 )
 
 /** Μετατροπή [SettingsEntity] σε Map. */
 fun SettingsEntity.toFirestoreMap(): Map<String, Any> = mapOf(
-    "userId" to userId,
+    "userId" to FirebaseFirestore.getInstance()
+        .collection("users")
+        .document(userId),
     "theme" to theme,
     "darkTheme" to darkTheme,
     "font" to font,

--- a/app/src/main/java/com/ioannapergamali/mysmartroute/viewmodel/DatabaseViewModel.kt
+++ b/app/src/main/java/com/ioannapergamali/mysmartroute/viewmodel/DatabaseViewModel.kt
@@ -54,8 +54,8 @@ class DatabaseViewModel : ViewModel() {
                 .documents.mapNotNull { it.toUserEntity() }
             val vehicles = firestore.collection("vehicles").get().await()
                 .documents.mapNotNull { doc ->
-                    val userId = doc.getString("userId")
-                        ?: doc.getDocumentReference("userId")?.id
+                    val userId = doc.getDocumentReference("userId")?.id
+                        ?: doc.getString("userId")
                         ?: return@mapNotNull null
                     VehicleEntity(
                         id = doc.getString("id") ?: "",
@@ -69,8 +69,8 @@ class DatabaseViewModel : ViewModel() {
                 .documents.mapNotNull { it.toObject(PoIEntity::class.java) }
             val settings = firestore.collection("user_settings").get().await()
                 .documents.mapNotNull { doc ->
-                    val userId = doc.getString("userId")
-                        ?: doc.getDocumentReference("userId")?.id
+                    val userId = doc.getDocumentReference("userId")?.id
+                        ?: doc.getString("userId")
                         ?: return@mapNotNull null
                     SettingsEntity(
                         userId = userId,
@@ -120,11 +120,13 @@ class DatabaseViewModel : ViewModel() {
                     Log.d(TAG, "Fetching vehicles from Firestore")
                     val vehicles = firestore.collection("vehicles").get().await()
                         .documents.mapNotNull { doc ->
-                            val userRef = doc.getDocumentReference("userId") ?: return@mapNotNull null
+                            val userId = doc.getDocumentReference("userId")?.id
+                                ?: doc.getString("userId")
+                                ?: return@mapNotNull null
                             VehicleEntity(
                                 id = doc.getString("id") ?: "",
                                 description = doc.getString("description") ?: "",
-                                userId = userRef.id,
+                                userId = userId,
                                 type = doc.getString("type") ?: "",
                                 seat = (doc.getLong("seat") ?: 0L).toInt()
                             )
@@ -136,9 +138,11 @@ class DatabaseViewModel : ViewModel() {
                     Log.d(TAG, "Fetching settings from Firestore")
                     val settings = firestore.collection("user_settings").get().await()
                         .documents.mapNotNull { doc ->
-                            val userRef = doc.getDocumentReference("userId") ?: return@mapNotNull null
+                            val userId = doc.getDocumentReference("userId")?.id
+                                ?: doc.getString("userId")
+                                ?: return@mapNotNull null
                             SettingsEntity(
-                                userId = userRef.id,
+                                userId = userId,
                                 theme = doc.getString("theme") ?: "",
                                 darkTheme = doc.getBoolean("darkTheme") ?: false,
                                 font = doc.getString("font") ?: "",


### PR DESCRIPTION
## Summary
- store userId as DocumentReference when uploading vehicles and settings
- prefer DocumentReference when reading userId during sync

## Testing
- `./gradlew test --daemon` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_6857d1b62a088328a61a08f5f80ed168