### PR TITLE
Προσθήκη ForeignKey και Firestore references

### DIFF
--- a/app/src/main/java/com/ioannapergamali/mysmartroute/data/local/MenuEntity.kt
+++ b/app/src/main/java/com/ioannapergamali/mysmartroute/data/local/MenuEntity.kt
@@ -1,12 +1,21 @@
 package com.ioannapergamali.mysmartroute.data.local
 
 import androidx.room.Entity
+import androidx.room.ForeignKey
 import androidx.room.Index
 import androidx.room.PrimaryKey
 
 /** Στοιχείο μενού συνδεδεμένο με ρόλο. */
 @Entity(
     tableName = "menus",
+    foreignKeys = [
+        ForeignKey(
+            entity = RoleEntity::class,
+            parentColumns = ["id"],
+            childColumns = ["roleId"],
+            onDelete = ForeignKey.CASCADE
+        )
+    ],
     indices = [Index("roleId")]
 )
 data class MenuEntity(

--- a/app/src/main/java/com/ioannapergamali/mysmartroute/data/local/MenuOptionEntity.kt
+++ b/app/src/main/java/com/ioannapergamali/mysmartroute/data/local/MenuOptionEntity.kt
@@ -1,12 +1,21 @@
 package com.ioannapergamali.mysmartroute.data.local
 
 import androidx.room.Entity
+import androidx.room.ForeignKey
 import androidx.room.Index
 import androidx.room.PrimaryKey
 
 /** Επιλογή ενός μενού. */
 @Entity(
     tableName = "menu_options",
+    foreignKeys = [
+        ForeignKey(
+            entity = MenuEntity::class,
+            parentColumns = ["id"],
+            childColumns = ["menuId"],
+            onDelete = ForeignKey.CASCADE
+        )
+    ],
     indices = [Index("menuId")]
 )
 data class MenuOptionEntity(

--- a/app/src/main/java/com/ioannapergamali/mysmartroute/data/local/SettingsEntity.kt
+++ b/app/src/main/java/com/ioannapergamali/mysmartroute/data/local/SettingsEntity.kt
@@ -1,11 +1,20 @@
 package com.ioannapergamali.mysmartroute.data.local
 
 import androidx.room.Entity
+import androidx.room.ForeignKey
 import androidx.room.Index
 import androidx.room.PrimaryKey
 
 @Entity(
     tableName = "settings",
+    foreignKeys = [
+        ForeignKey(
+            entity = UserEntity::class,
+            parentColumns = ["id"],
+            childColumns = ["userId"],
+            onDelete = ForeignKey.CASCADE
+        )
+    ],
     indices = [Index("userId")]
 )
 data class SettingsEntity(

--- a/app/src/main/java/com/ioannapergamali/mysmartroute/data/local/VehicleEntity.kt
+++ b/app/src/main/java/com/ioannapergamali/mysmartroute/data/local/VehicleEntity.kt
@@ -1,11 +1,20 @@
 package com.ioannapergamali.mysmartroute.data.local
 
 import androidx.room.Entity
+import androidx.room.ForeignKey
 import androidx.room.Index
 import androidx.room.PrimaryKey
 
 @Entity(
     tableName = "vehicles",
+    foreignKeys = [
+        ForeignKey(
+            entity = UserEntity::class,
+            parentColumns = ["id"],
+            childColumns = ["userId"],
+            onDelete = ForeignKey.CASCADE
+        )
+    ],
     indices = [Index("userId")]
 )
 data class VehicleEntity(

--- a/app/src/main/java/com/ioannapergamali/mysmartroute/utils/FirestoreMappers.kt
+++ b/app/src/main/java/com/ioannapergamali/mysmartroute/utils/FirestoreMappers.kt
@@ -29,14 +29,18 @@ fun UserEntity.toFirestoreMap(): Map<String, Any> = mapOf(
 fun VehicleEntity.toFirestoreMap(): Map<String, Any> = mapOf(
     "id" to id,
     "description" to description,
-    "userId" to userId,
+    "userId" to FirebaseFirestore.getInstance()
+        .collection("users")
+        .document(userId),
     "type" to type,
     "seat" to seat
 )
 
 /** Μετατροπή [SettingsEntity] σε Map. */
 fun SettingsEntity.toFirestoreMap(): Map<String, Any> = mapOf(
-    "userId" to userId,
+    "userId" to FirebaseFirestore.getInstance()
+        .collection("users")
+        .document(userId),
     "theme" to theme,
     "darkTheme" to darkTheme,
     "font" to font,


### PR DESCRIPTION
## Περιγραφή
Προστέθηκαν αναφορές `ForeignKey` στα τοπικά entities και τροποποιήθηκαν οι Firestore mappers ώστε τα `userId` να αποθηκεύονται ως references. Επιβεβαιώθηκε ο μηχανισμός συγχρονισμού μέσω της μεθόδου `synchronized`.

## Οδηγίες ελέγχου
- `./gradlew test` *(αποτυγχάνει λόγω περιορισμών δικτύου)*

------
https://chatgpt.com/codex/tasks/task_e_6857d64ee1e48328a588893d60e42805