### PR TITLE
Υποστήριξη συγχρονισμού βάσεων

### DIFF
--- a/app/src/main/java/com/ioannapergamali/mysmartroute/model/navigation/NavigationHost.kt
+++ b/app/src/main/java/com/ioannapergamali/mysmartroute/model/navigation/NavigationHost.kt
@@ -22,6 +22,7 @@ import com.ioannapergamali.mysmartroute.view.ui.screens.DatabaseMenuScreen
 import com.ioannapergamali.mysmartroute.view.ui.screens.LocalDatabaseScreen
 import com.ioannapergamali.mysmartroute.view.ui.screens.FirebaseDatabaseScreen
 import com.ioannapergamali.mysmartroute.view.ui.screens.AdminSignUpScreen
+import com.ioannapergamali.mysmartroute.view.ui.screens.DatabaseSyncScreen
 
 
 
@@ -119,6 +120,10 @@ fun NavigationHost(navController : NavHostController, openDrawer: () -> Unit) {
 
         composable("firebaseDb") {
             FirebaseDatabaseScreen(navController = navController, openDrawer = openDrawer)
+        }
+
+        composable("syncDb") {
+            DatabaseSyncScreen(navController = navController, openDrawer = openDrawer)
         }
 
         composable("adminSignup") {

--- a/app/src/main/java/com/ioannapergamali/mysmartroute/view/ui/screens/DatabaseMenuScreen.kt
+++ b/app/src/main/java/com/ioannapergamali/mysmartroute/view/ui/screens/DatabaseMenuScreen.kt
@@ -3,39 +3,17 @@ package com.ioannapergamali.mysmartroute.view.ui.screens
 import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.padding
 import androidx.compose.material3.Button
-import androidx.compose.material3.CircularProgressIndicator
-import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Scaffold
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
-import androidx.compose.runtime.LaunchedEffect
-import androidx.compose.runtime.collectAsState
-import androidx.compose.runtime.getValue
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.unit.dp
-import android.widget.Toast
 import androidx.navigation.NavController
-import androidx.lifecycle.viewmodel.compose.viewModel
-import com.ioannapergamali.mysmartroute.view.ui.components.TopBar
 import com.ioannapergamali.mysmartroute.view.ui.components.ScreenContainer
-import com.ioannapergamali.mysmartroute.viewmodel.DatabaseViewModel
-import com.ioannapergamali.mysmartroute.viewmodel.SyncState
+import com.ioannapergamali.mysmartroute.view.ui.components.TopBar
 
 @Composable
 fun DatabaseMenuScreen(navController: NavController, openDrawer: () -> Unit) {
-    val viewModel: DatabaseViewModel = viewModel()
-    val syncState by viewModel.syncState.collectAsState()
-    val context = LocalContext.current
-
-    val localData by viewModel.localData.collectAsState()
-    val firebaseData by viewModel.firebaseData.collectAsState()
-
-    LaunchedEffect(Unit) {
-        viewModel.loadLocalData(context)
-        viewModel.loadFirebaseData()
-    }
-
     Scaffold(
         topBar = {
             TopBar(
@@ -47,74 +25,17 @@ fun DatabaseMenuScreen(navController: NavController, openDrawer: () -> Unit) {
         }
     ) { padding ->
         ScreenContainer(modifier = Modifier.padding(padding)) {
-            DatabaseDataSection(title = "Local DB", data = localData)
+            Button(onClick = { navController.navigate("localDb") }) {
+                Text("Local DB")
+            }
             Spacer(modifier = Modifier.padding(8.dp))
-            DatabaseDataSection(title = "Firebase DB", data = firebaseData)
-            Spacer(modifier = Modifier.padding(top = 8.dp))
-            Button(onClick = { viewModel.syncDatabases(context) }) {
+            Button(onClick = { navController.navigate("firebaseDb") }) {
+                Text("Firestore DB")
+            }
+            Spacer(modifier = Modifier.padding(8.dp))
+            Button(onClick = { navController.navigate("syncDb") }) {
                 Text("Synchronization")
             }
-        }
-    }
-
-    LaunchedEffect(syncState) {
-        when (syncState) {
-            is SyncState.Success -> Toast.makeText(context, "Sync completed", Toast.LENGTH_SHORT).show()
-            is SyncState.Error -> Toast.makeText(
-                context,
-                (syncState as SyncState.Error).message,
-                Toast.LENGTH_SHORT
-            ).show()
-            else -> {}
-        }
-    }
-}
-
-@Composable
-private fun DatabaseDataSection(title: String, data: com.ioannapergamali.mysmartroute.viewmodel.DatabaseData?) {
-    Text(title, style = MaterialTheme.typography.titleLarge)
-    if (data == null) {
-        CircularProgressIndicator(modifier = Modifier.padding(16.dp))
-    } else {
-        DatabaseDataList(data)
-    }
-}
-
-@Composable
-private fun DatabaseDataList(data: com.ioannapergamali.mysmartroute.viewmodel.DatabaseData) {
-    Text("Users", style = MaterialTheme.typography.titleMedium)
-    if (data.users.isEmpty()) {
-        Text("Ο πίνακας είναι άδειος")
-    } else {
-        data.users.forEach { user ->
-            Text("${'$'}{user.id} - ${'$'}{user.username}")
-        }
-    }
-    Spacer(modifier = Modifier.padding(8.dp))
-    Text("Vehicles", style = MaterialTheme.typography.titleMedium)
-    if (data.vehicles.isEmpty()) {
-        Text("Ο πίνακας είναι άδειος")
-    } else {
-        data.vehicles.forEach { vehicle ->
-            Text("${'$'}{vehicle.id} - ${'$'}{vehicle.description}")
-        }
-    }
-    Spacer(modifier = Modifier.padding(8.dp))
-    Text("PoIs", style = MaterialTheme.typography.titleMedium)
-    if (data.pois.isEmpty()) {
-        Text("Ο πίνακας είναι άδειος")
-    } else {
-        data.pois.forEach { poi ->
-            Text("${'$'}{poi.id} - ${'$'}{poi.name}")
-        }
-    }
-    Spacer(modifier = Modifier.padding(8.dp))
-    Text("Settings", style = MaterialTheme.typography.titleMedium)
-    if (data.settings.isEmpty()) {
-        Text("Ο πίνακας είναι άδειος")
-    } else {
-        data.settings.forEach { setting ->
-            Text("${'$'}{setting.userId} - ${'$'}{setting.theme}")
         }
     }
 }

--- a/app/src/main/java/com/ioannapergamali/mysmartroute/view/ui/screens/DatabaseSyncScreen.kt
+++ b/app/src/main/java/com/ioannapergamali/mysmartroute/view/ui/screens/DatabaseSyncScreen.kt
@@ -1,0 +1,60 @@
+package com.ioannapergamali.mysmartroute.view.ui.screens
+
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.padding
+import androidx.compose.material3.Button
+import androidx.compose.material3.CircularProgressIndicator
+import androidx.compose.material3.Scaffold
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.collectAsState
+import androidx.compose.runtime.getValue
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.unit.dp
+import androidx.lifecycle.viewmodel.compose.viewModel
+import androidx.navigation.NavController
+import com.ioannapergamali.mysmartroute.view.ui.components.ScreenContainer
+import com.ioannapergamali.mysmartroute.view.ui.components.TopBar
+import com.ioannapergamali.mysmartroute.viewmodel.DatabaseViewModel
+import com.ioannapergamali.mysmartroute.viewmodel.SyncState
+import java.text.SimpleDateFormat
+import java.util.Date
+import java.util.Locale
+
+@Composable
+fun DatabaseSyncScreen(navController: NavController, openDrawer: () -> Unit) {
+    val viewModel: DatabaseViewModel = viewModel()
+    val syncState by viewModel.syncState.collectAsState()
+    val lastSync by viewModel.lastSyncTime.collectAsState()
+    val context = LocalContext.current
+
+    LaunchedEffect(Unit) { viewModel.loadLastSync(context) }
+
+    Scaffold(
+        topBar = {
+            TopBar(
+                title = "Synchronization",
+                navController = navController,
+                showMenu = true,
+                onMenuClick = openDrawer
+            )
+        }
+    ) { padding ->
+        ScreenContainer(modifier = Modifier.padding(padding)) {
+            Button(onClick = { viewModel.syncDatabases(context) }) {
+                Text("Sync Now")
+            }
+            Spacer(modifier = Modifier.padding(8.dp))
+            Text(
+                text = "Τελευταίος συγχρονισμός: " +
+                    (if (lastSync == 0L) "-" else SimpleDateFormat("dd/MM/yyyy HH:mm", Locale.getDefault()).format(Date(lastSync)))
+            )
+            if (syncState is SyncState.Loading) {
+                Spacer(modifier = Modifier.padding(8.dp))
+                CircularProgressIndicator()
+            }
+        }
+    }
+}

--- a/app/src/main/java/com/ioannapergamali/mysmartroute/view/ui/screens/FirebaseDatabaseScreen.kt
+++ b/app/src/main/java/com/ioannapergamali/mysmartroute/view/ui/screens/FirebaseDatabaseScreen.kt
@@ -47,22 +47,22 @@ fun FirebaseDatabaseScreen(navController: NavController, openDrawer: () -> Unit)
                 LazyColumn(modifier = Modifier.fillMaxSize()) {
                 item { Text("Users", style = MaterialTheme.typography.titleMedium) }
                 items(data!!.users) { user ->
-                    Text("${user.id} - ${user.username}")
+                    Text("ID: ${user.id}, ${user.name} ${user.surname}, ${user.username}")
                 }
                 item { Spacer(modifier = Modifier.padding(8.dp)) }
                 item { Text("Vehicles", style = MaterialTheme.typography.titleMedium) }
                 items(data!!.vehicles) { vehicle ->
-                    Text("${vehicle.id} - ${vehicle.description}")
+                    Text("${vehicle.description}, τύπος ${vehicle.type}, θέσεις ${vehicle.seat}")
                 }
                 item { Spacer(modifier = Modifier.padding(8.dp)) }
                 item { Text("PoIs", style = MaterialTheme.typography.titleMedium) }
                 items(data!!.pois) { poi ->
-                    Text("${poi.id} - ${poi.name}")
+                    Text("${poi.name} (${poi.type}) - ${poi.description}")
                 }
                 item { Spacer(modifier = Modifier.padding(8.dp)) }
                 item { Text("Settings", style = MaterialTheme.typography.titleMedium) }
                 items(data!!.settings) { setting ->
-                    Text("${setting.userId} - ${setting.theme}")
+                    Text("${setting.userId} -> ${setting.theme}, dark ${setting.darkTheme}")
                 }
                 item { Spacer(modifier = Modifier.padding(8.dp)) }
                 item { Text("Authentication table δεν είναι διαθέσιμη από το client", color = MaterialTheme.colorScheme.error) }

--- a/app/src/main/java/com/ioannapergamali/mysmartroute/view/ui/screens/LocalDatabaseScreen.kt
+++ b/app/src/main/java/com/ioannapergamali/mysmartroute/view/ui/screens/LocalDatabaseScreen.kt
@@ -52,7 +52,7 @@ fun LocalDatabaseScreen(navController: NavController, openDrawer: () -> Unit) {
                     item { Text("Ο πίνακας είναι άδειος") }
                 } else {
                     items(data!!.users) { user ->
-                        Text("${user.id} - ${user.username}")
+                        Text("ID: ${user.id}, ${user.name} ${user.surname}, ${user.username}")
                     }
                 }
                 item { Spacer(modifier = Modifier.padding(8.dp)) }
@@ -61,7 +61,7 @@ fun LocalDatabaseScreen(navController: NavController, openDrawer: () -> Unit) {
                     item { Text("Ο πίνακας είναι άδειος") }
                 } else {
                     items(data!!.vehicles) { vehicle ->
-                        Text("${vehicle.id} - ${vehicle.description}")
+                        Text("${vehicle.description}, τύπος ${vehicle.type}, θέσεις ${vehicle.seat}")
                     }
                 }
                 item { Spacer(modifier = Modifier.padding(8.dp)) }
@@ -70,7 +70,7 @@ fun LocalDatabaseScreen(navController: NavController, openDrawer: () -> Unit) {
                     item { Text("Ο πίνακας είναι άδειος") }
                 } else {
                     items(data!!.pois) { poi ->
-                        Text("${poi.id} - ${poi.name}")
+                        Text("${poi.name} (${poi.type}) - ${poi.description}")
                     }
                 }
                 item { Spacer(modifier = Modifier.padding(8.dp)) }
@@ -79,7 +79,7 @@ fun LocalDatabaseScreen(navController: NavController, openDrawer: () -> Unit) {
                     item { Text("Ο πίνακας είναι άδειος") }
                 } else {
                     items(data!!.settings) { setting ->
-                        Text("${setting.userId} - ${setting.theme}")
+                        Text("${setting.userId} -> ${setting.theme}, dark ${setting.darkTheme}")
                     }
                 }
                 }


### PR DESCRIPTION
## Summary
- create DatabaseSyncScreen with last sync info
- show menu options for Local DB, Firestore DB and sync
- show more details for database entries
- track last sync time in DatabaseViewModel
- wire new screen in NavigationHost

## Testing
- `./gradlew test --no-daemon` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_6857f37b642083288f0afd9cd79cdc5d