### PR TITLE
Show all tables in database screens

### DIFF
--- a/app/src/main/java/com/ioannapergamali/mysmartroute/data/local/MenuDao.kt
+++ b/app/src/main/java/com/ioannapergamali/mysmartroute/data/local/MenuDao.kt
@@ -14,4 +14,8 @@ interface MenuDao {
     @Transaction
     @Query("SELECT * FROM menus WHERE roleId = :roleId")
     suspend fun getMenusForRole(roleId: String): List<MenuWithOptions>
+
+    /** Επιστρέφει όλα τα μενού της βάσης. */
+    @Query("SELECT * FROM menus")
+    suspend fun getAllMenus(): List<MenuEntity>
 }

--- a/app/src/main/java/com/ioannapergamali/mysmartroute/data/local/MenuOptionDao.kt
+++ b/app/src/main/java/com/ioannapergamali/mysmartroute/data/local/MenuOptionDao.kt
@@ -12,4 +12,8 @@ interface MenuOptionDao {
 
     @Query("SELECT * FROM menu_options WHERE menuId = :menuId")
     suspend fun getOptionsForMenu(menuId: String): List<MenuOptionEntity>
+
+    /** Επιστρέφει όλες τις επιλογές μενού. */
+    @Query("SELECT * FROM menu_options")
+    suspend fun getAllMenuOptions(): List<MenuOptionEntity>
 }

--- a/app/src/main/java/com/ioannapergamali/mysmartroute/data/local/RoleDao.kt
+++ b/app/src/main/java/com/ioannapergamali/mysmartroute/data/local/RoleDao.kt
@@ -12,4 +12,8 @@ interface RoleDao {
 
     @Query("SELECT * FROM roles WHERE id = :id")
     suspend fun getRole(id: String): RoleEntity?
+
+    /** Επιστρέφει όλους τους ρόλους της βάσης. */
+    @Query("SELECT * FROM roles")
+    suspend fun getAllRoles(): List<RoleEntity>
 }

--- a/app/src/main/java/com/ioannapergamali/mysmartroute/utils/FirestoreMappers.kt
+++ b/app/src/main/java/com/ioannapergamali/mysmartroute/utils/FirestoreMappers.kt
@@ -4,6 +4,9 @@ import com.google.firebase.firestore.FirebaseFirestore
 import com.ioannapergamali.mysmartroute.data.local.SettingsEntity
 import com.ioannapergamali.mysmartroute.data.local.UserEntity
 import com.ioannapergamali.mysmartroute.data.local.VehicleEntity
+import com.ioannapergamali.mysmartroute.data.local.RoleEntity
+import com.ioannapergamali.mysmartroute.data.local.MenuEntity
+import com.ioannapergamali.mysmartroute.data.local.MenuOptionEntity
 
 /** Βοηθητικά extensions για μετατροπή οντοτήτων σε δομές κατάλληλες για το Firestore. */
 /** Μετατροπή ενός [UserEntity] σε Map. */
@@ -67,3 +70,19 @@ fun DocumentSnapshot.toUserEntity(): UserEntity? {
         postalCode = (getLong("postalCode") ?: 0L).toInt()
     )
 }
+
+fun RoleEntity.toFirestoreMap(): Map<String, Any> = mapOf(
+    "id" to id,
+    "name" to name
+)
+
+fun MenuEntity.toFirestoreMap(): Map<String, Any> = mapOf(
+    "id" to id,
+    "title" to title
+)
+
+fun MenuOptionEntity.toFirestoreMap(): Map<String, Any> = mapOf(
+    "id" to id,
+    "title" to title,
+    "route" to route
+)

--- a/app/src/main/java/com/ioannapergamali/mysmartroute/view/ui/screens/FirebaseDatabaseScreen.kt
+++ b/app/src/main/java/com/ioannapergamali/mysmartroute/view/ui/screens/FirebaseDatabaseScreen.kt
@@ -65,6 +65,21 @@ fun FirebaseDatabaseScreen(navController: NavController, openDrawer: () -> Unit)
                     Text("${setting.userId} -> ${setting.theme}, dark ${setting.darkTheme}")
                 }
                 item { Spacer(modifier = Modifier.padding(8.dp)) }
+                item { Text("Roles", style = MaterialTheme.typography.titleMedium) }
+                items(data!!.roles) { role ->
+                    Text("${role.id} - ${role.name}")
+                }
+                item { Spacer(modifier = Modifier.padding(8.dp)) }
+                item { Text("Menus", style = MaterialTheme.typography.titleMedium) }
+                items(data!!.menus) { menu ->
+                    Text("${menu.id} (${menu.roleId}) - ${menu.title}")
+                }
+                item { Spacer(modifier = Modifier.padding(8.dp)) }
+                item { Text("Menu Options", style = MaterialTheme.typography.titleMedium) }
+                items(data!!.menuOptions) { opt ->
+                    Text("${opt.id} (${opt.menuId}) -> ${opt.title} -> ${opt.route}")
+                }
+                item { Spacer(modifier = Modifier.padding(8.dp)) }
                 item { Text("Authentication table δεν είναι διαθέσιμη από το client", color = MaterialTheme.colorScheme.error) }
                 }
             }

--- a/app/src/main/java/com/ioannapergamali/mysmartroute/view/ui/screens/LocalDatabaseScreen.kt
+++ b/app/src/main/java/com/ioannapergamali/mysmartroute/view/ui/screens/LocalDatabaseScreen.kt
@@ -82,6 +82,33 @@ fun LocalDatabaseScreen(navController: NavController, openDrawer: () -> Unit) {
                         Text("${setting.userId} -> ${setting.theme}, dark ${setting.darkTheme}")
                     }
                 }
+                item { Spacer(modifier = Modifier.padding(8.dp)) }
+                item { Text("Roles", style = MaterialTheme.typography.titleMedium) }
+                if (data!!.roles.isEmpty()) {
+                    item { Text("Ο πίνακας είναι άδειος") }
+                } else {
+                    items(data!!.roles) { role ->
+                        Text("${role.id} - ${role.name}")
+                    }
+                }
+                item { Spacer(modifier = Modifier.padding(8.dp)) }
+                item { Text("Menus", style = MaterialTheme.typography.titleMedium) }
+                if (data!!.menus.isEmpty()) {
+                    item { Text("Ο πίνακας είναι άδειος") }
+                } else {
+                    items(data!!.menus) { menu ->
+                        Text("${menu.id} (${menu.roleId}) - ${menu.title}")
+                    }
+                }
+                item { Spacer(modifier = Modifier.padding(8.dp)) }
+                item { Text("Menu Options", style = MaterialTheme.typography.titleMedium) }
+                if (data!!.menuOptions.isEmpty()) {
+                    item { Text("Ο πίνακας είναι άδειος") }
+                } else {
+                    items(data!!.menuOptions) { opt ->
+                        Text("${opt.id} (${opt.menuId}) -> ${opt.title} -> ${opt.route}")
+                    }
+                }
                 }
             }
         }

--- a/app/src/main/java/com/ioannapergamali/mysmartroute/viewmodel/DatabaseViewModel.kt
+++ b/app/src/main/java/com/ioannapergamali/mysmartroute/viewmodel/DatabaseViewModel.kt
@@ -12,6 +12,9 @@ import com.ioannapergamali.mysmartroute.data.local.PoIEntity
 import com.ioannapergamali.mysmartroute.data.local.SettingsEntity
 import com.ioannapergamali.mysmartroute.data.local.insertSettingsSafely
 import com.ioannapergamali.mysmartroute.data.local.insertVehicleSafely
+import com.ioannapergamali.mysmartroute.data.local.RoleEntity
+import com.ioannapergamali.mysmartroute.data.local.MenuEntity
+import com.ioannapergamali.mysmartroute.data.local.MenuOptionEntity
 import com.ioannapergamali.mysmartroute.data.local.UserEntity
 import com.ioannapergamali.mysmartroute.data.local.VehicleEntity
 import com.ioannapergamali.mysmartroute.utils.NetworkUtils
@@ -53,7 +56,10 @@ class DatabaseViewModel : ViewModel() {
             val vehicles = db.vehicleDao().getAllVehicles()
             val pois = db.poIDao().getAll()
             val settings = db.settingsDao().getAllSettings()
-            _localData.value = DatabaseData(users, vehicles, pois, settings)
+            val roles = db.roleDao().getAllRoles()
+            val menus = db.menuDao().getAllMenus()
+            val options = db.menuOptionDao().getAllMenuOptions()
+            _localData.value = DatabaseData(users, vehicles, pois, settings, roles, menus, options)
         }
     }
 
@@ -90,7 +96,43 @@ class DatabaseViewModel : ViewModel() {
                         soundVolume = (doc.getDouble("soundVolume") ?: 0.0).toFloat()
                     )
                 }
-            _firebaseData.value = DatabaseData(users, vehicles, pois, settings)
+
+            val rolesSnap = firestore.collection("roles").get().await()
+            val roles = rolesSnap.documents.map { doc ->
+                RoleEntity(
+                    id = doc.getString("id") ?: doc.id,
+                    name = doc.getString("name") ?: ""
+                )
+            }
+            val menus = mutableListOf<MenuEntity>()
+            val menuOptions = mutableListOf<MenuOptionEntity>()
+            for (roleDoc in rolesSnap.documents) {
+                val roleId = roleDoc.getString("id") ?: roleDoc.id
+                val menusSnap = roleDoc.reference.collection("menus").get().await()
+                for (menuDoc in menusSnap.documents) {
+                    val menuId = menuDoc.getString("id") ?: menuDoc.id
+                    menus.add(
+                        MenuEntity(
+                            id = menuId,
+                            roleId = roleId,
+                            title = menuDoc.getString("title") ?: ""
+                        )
+                    )
+                    val optsSnap = menuDoc.reference.collection("options").get().await()
+                    for (optDoc in optsSnap.documents) {
+                        menuOptions.add(
+                            MenuOptionEntity(
+                                id = optDoc.getString("id") ?: optDoc.id,
+                                menuId = menuId,
+                                title = optDoc.getString("title") ?: "",
+                                route = optDoc.getString("route") ?: ""
+                            )
+                        )
+                    }
+                }
+            }
+
+            _firebaseData.value = DatabaseData(users, vehicles, pois, settings, roles, menus, menuOptions)
         }
     }
 
@@ -160,14 +202,52 @@ class DatabaseViewModel : ViewModel() {
                             )
                         }
 
+                    val rolesSnap = firestore.collection("roles").get().await()
+                    val roles = rolesSnap.documents.map { doc ->
+                        RoleEntity(
+                            id = doc.getString("id") ?: doc.id,
+                            name = doc.getString("name") ?: ""
+                        )
+                    }
+                    val menus = mutableListOf<MenuEntity>()
+                    val menuOptions = mutableListOf<MenuOptionEntity>()
+                    for (roleDoc in rolesSnap.documents) {
+                        val roleId = roleDoc.getString("id") ?: roleDoc.id
+                        val menusSnap = roleDoc.reference.collection("menus").get().await()
+                        for (menuDoc in menusSnap.documents) {
+                            val menuId = menuDoc.getString("id") ?: menuDoc.id
+                            menus.add(
+                                MenuEntity(
+                                    id = menuId,
+                                    roleId = roleId,
+                                    title = menuDoc.getString("title") ?: ""
+                                )
+                            )
+                            val optsSnap = menuDoc.reference.collection("options").get().await()
+                            for (optDoc in optsSnap.documents) {
+                                menuOptions.add(
+                                    MenuOptionEntity(
+                                        id = optDoc.getString("id") ?: optDoc.id,
+                                        menuId = menuId,
+                                        title = optDoc.getString("title") ?: "",
+                                        route = optDoc.getString("route") ?: ""
+                                    )
+                                )
+                            }
+                        }
+                    }
+
                     Log.d(
                         TAG,
-                        "Remote data -> users:${'$'}{users.size} vehicles:${'$'}{vehicles.size} pois:${'$'}{pois.size} settings:${'$'}{settings.size}"
+                        "Remote data -> users:${'$'}{users.size} vehicles:${'$'}{vehicles.size} pois:${'$'}{pois.size} settings:${'$'}{settings.size} roles:${'$'}{roles.size} menus:${'$'}{menus.size} options:${'$'}{menuOptions.size}"
                     )
                     users.forEach { db.userDao().insert(it) }
                     vehicles.forEach { insertVehicleSafely(db.vehicleDao(), db.userDao(), it) }
                     pois.forEach { db.poIDao().insert(it) }
                     settings.forEach { insertSettingsSafely(db.settingsDao(), db.userDao(), it) }
+                    roles.forEach { db.roleDao().insert(it) }
+                    menus.forEach { db.menuDao().insert(it) }
+                    menuOptions.forEach { db.menuOptionDao().insert(it) }
                     Log.d(TAG, "Inserted remote data to local DB")
                     prefs.edit().putLong("last_sync", remoteTs).apply()
                     _lastSyncTime.value = remoteTs
@@ -181,10 +261,16 @@ class DatabaseViewModel : ViewModel() {
                     Log.d(TAG, "Fetched ${pois.size} local pois")
                     val settings = db.settingsDao().getAllSettings()
                     Log.d(TAG, "Fetched ${settings.size} local settings")
+                    val roles = db.roleDao().getAllRoles()
+                    Log.d(TAG, "Fetched ${roles.size} local roles")
+                    val menus = db.menuDao().getAllMenus()
+                    Log.d(TAG, "Fetched ${menus.size} local menus")
+                    val menuOptions = db.menuOptionDao().getAllMenuOptions()
+                    Log.d(TAG, "Fetched ${menuOptions.size} local options")
 
                     Log.d(
                         TAG,
-                        "Local data -> users:${'$'}{users.size} vehicles:${'$'}{vehicles.size} pois:${'$'}{pois.size} settings:${'$'}{settings.size}"
+                        "Local data -> users:${'$'}{users.size} vehicles:${'$'}{vehicles.size} pois:${'$'}{pois.size} settings:${'$'}{settings.size} roles:${'$'}{roles.size} menus:${'$'}{menus.size} options:${'$'}{menuOptions.size}"
                     )
 
                     users.forEach {
@@ -202,6 +288,23 @@ class DatabaseViewModel : ViewModel() {
                         firestore.collection("user_settings")
                             .document(it.userId)
                             .set(it.toFirestoreMap()).await()
+                    }
+                    roles.forEach {
+                        firestore.collection("roles")
+                            .document(it.id)
+                            .set(it.toFirestoreMap()).await()
+                    }
+                    menus.forEach { menu ->
+                        val ref = firestore.collection("roles")
+                            .document(menu.roleId)
+                            .collection("menus")
+                            .document(menu.id)
+                        ref.set(menu.toFirestoreMap()).await()
+                        menuOptions.filter { it.menuId == menu.id }.forEach { opt ->
+                            ref.collection("options")
+                                .document(opt.id)
+                                .set(opt.toFirestoreMap()).await()
+                        }
                     }
 
                     Log.d(TAG, "Uploaded local data to Firebase")
@@ -225,7 +328,10 @@ data class DatabaseData(
     val users: List<UserEntity>,
     val vehicles: List<VehicleEntity>,
     val pois: List<PoIEntity>,
-    val settings: List<SettingsEntity>
+    val settings: List<SettingsEntity>,
+    val roles: List<RoleEntity>,
+    val menus: List<MenuEntity>,
+    val menuOptions: List<MenuOptionEntity>
 )
 
 sealed class SyncState {


### PR DESCRIPTION
## Summary
- add DAO queries for roles, menus and options
- extend `DatabaseData` to include all tables
- fetch roles, menus and options in `DatabaseViewModel`
- expose all tables in local and Firebase DB screens
- add Firestore mappers for new entities

## Testing
- `./gradlew test` *(fails: maven.pkg.jetbrains.space blocked)*

------
https://chatgpt.com/codex/tasks/task_e_6857ffb274bc83288c4d0c7d6eec577e