### PR TITLE
Fix foreign key inserts for menus

### DIFF
--- a/app/src/main/java/com/ioannapergamali/mysmartroute/data/local/MenuDao.kt
+++ b/app/src/main/java/com/ioannapergamali/mysmartroute/data/local/MenuDao.kt
@@ -11,6 +11,9 @@ interface MenuDao {
     @Insert(onConflict = OnConflictStrategy.REPLACE)
     suspend fun insert(menu: MenuEntity)
 
+    @Query("SELECT * FROM menus WHERE id = :id LIMIT 1")
+    suspend fun getMenu(id: String): MenuEntity?
+
     @Transaction
     @Query("SELECT * FROM menus WHERE roleId = :roleId")
     suspend fun getMenusForRole(roleId: String): List<MenuWithOptions>

--- a/app/src/main/java/com/ioannapergamali/mysmartroute/data/local/MenuOperations.kt
+++ b/app/src/main/java/com/ioannapergamali/mysmartroute/data/local/MenuOperations.kt
@@ -1,0 +1,20 @@
+package com.ioannapergamali.mysmartroute.data.local
+
+import androidx.room.Transaction
+
+/**
+ * Εισάγει μενού μόνο εφόσον υπάρχει ο αντίστοιχος ρόλος.
+ * Αν δεν υπάρχει, δημιουργείται placeholder ρόλος με το συγκεκριμένο id.
+ */
+@Transaction
+suspend fun insertMenuSafely(
+    menuDao: MenuDao,
+    roleDao: RoleDao,
+    menu: MenuEntity
+) {
+    val roleId = menu.roleId
+    if (roleDao.getRole(roleId) == null) {
+        roleDao.insert(RoleEntity(id = roleId))
+    }
+    menuDao.insert(menu)
+}

--- a/app/src/main/java/com/ioannapergamali/mysmartroute/viewmodel/AuthenticationViewModel.kt
+++ b/app/src/main/java/com/ioannapergamali/mysmartroute/viewmodel/AuthenticationViewModel.kt
@@ -13,6 +13,7 @@ import com.ioannapergamali.mysmartroute.data.local.UserEntity
 import com.ioannapergamali.mysmartroute.data.local.MenuEntity
 import com.ioannapergamali.mysmartroute.data.local.MenuOptionEntity
 import com.ioannapergamali.mysmartroute.data.local.MenuWithOptions
+import com.ioannapergamali.mysmartroute.data.local.insertMenuSafely
 import com.ioannapergamali.mysmartroute.model.classes.users.Admin
 import com.ioannapergamali.mysmartroute.model.classes.users.Driver
 import com.ioannapergamali.mysmartroute.model.classes.users.Passenger
@@ -252,7 +253,7 @@ class AuthenticationViewModel : ViewModel() {
                             route = optDoc.getString("route") ?: ""
                         )
                     }
-                    menuDao.insert(MenuEntity(menuId, roleId, doc.getString("title") ?: ""))
+                    insertMenuSafely(menuDao, dbLocal.roleDao(), MenuEntity(menuId, roleId, doc.getString("title") ?: ""))
                     options.forEach { optionDao.insert(it) }
                     MenuWithOptions(MenuEntity(menuId, roleId, doc.getString("title") ?: ""), options)
                 }

--- a/app/src/main/java/com/ioannapergamali/mysmartroute/viewmodel/DatabaseViewModel.kt
+++ b/app/src/main/java/com/ioannapergamali/mysmartroute/viewmodel/DatabaseViewModel.kt
@@ -12,6 +12,7 @@ import com.ioannapergamali.mysmartroute.data.local.PoIEntity
 import com.ioannapergamali.mysmartroute.data.local.SettingsEntity
 import com.ioannapergamali.mysmartroute.data.local.insertSettingsSafely
 import com.ioannapergamali.mysmartroute.data.local.insertVehicleSafely
+import com.ioannapergamali.mysmartroute.data.local.insertMenuSafely
 import com.ioannapergamali.mysmartroute.data.local.RoleEntity
 import com.ioannapergamali.mysmartroute.data.local.MenuEntity
 import com.ioannapergamali.mysmartroute.data.local.MenuOptionEntity
@@ -259,7 +260,7 @@ class DatabaseViewModel : ViewModel() {
                     pois.forEach { db.poIDao().insert(it) }
                     settings.forEach { insertSettingsSafely(db.settingsDao(), db.userDao(), it) }
                     roles.forEach { db.roleDao().insert(it) }
-                    menus.forEach { db.menuDao().insert(it) }
+                    menus.forEach { insertMenuSafely(db.menuDao(), db.roleDao(), it) }
                     menuOptions.forEach { db.menuOptionDao().insert(it) }
                     Log.d(TAG, "Inserted remote data to local DB")
                     prefs.edit().putLong("last_sync", remoteTs).apply()


### PR DESCRIPTION
## Summary
- ensure role exists before inserting a menu
- add helper `insertMenuSafely`
- use it when syncing or loading menus

## Testing
- `./gradlew test` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_685819382c848328a0a10d9f53e17315