### PR TITLE
Προσθήκη RolesScreen και RoleViewModel

### DIFF
--- a/app/src/main/java/com/ioannapergamali/mysmartroute/model/navigation/NavigationHost.kt
+++ b/app/src/main/java/com/ioannapergamali/mysmartroute/model/navigation/NavigationHost.kt
@@ -23,6 +23,7 @@ import com.ioannapergamali.mysmartroute.view.ui.screens.LocalDatabaseScreen
 import com.ioannapergamali.mysmartroute.view.ui.screens.FirebaseDatabaseScreen
 import com.ioannapergamali.mysmartroute.view.ui.screens.AdminSignUpScreen
 import com.ioannapergamali.mysmartroute.view.ui.screens.DatabaseSyncScreen
+import com.ioannapergamali.mysmartroute.view.ui.screens.RolesScreen
 
 
 
@@ -96,6 +97,10 @@ fun NavigationHost(navController : NavHostController, openDrawer: () -> Unit) {
 
         composable("fontPicker") {
             FontPickerScreen(navController = navController)
+        }
+
+        composable("roles") {
+            RolesScreen(navController = navController, openDrawer = openDrawer)
         }
 
         composable("soundPicker") {

--- a/app/src/main/java/com/ioannapergamali/mysmartroute/view/ui/screens/RolesScreen.kt
+++ b/app/src/main/java/com/ioannapergamali/mysmartroute/view/ui/screens/RolesScreen.kt
@@ -1,0 +1,47 @@
+package com.ioannapergamali.mysmartroute.view.ui.screens
+
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.lazy.items
+import androidx.compose.material3.Scaffold
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.collectAsState
+import androidx.compose.runtime.getValue
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.platform.LocalContext
+import androidx.lifecycle.viewmodel.compose.viewModel
+import androidx.navigation.NavController
+import com.ioannapergamali.mysmartroute.view.ui.components.ScreenContainer
+import com.ioannapergamali.mysmartroute.view.ui.components.TopBar
+import com.ioannapergamali.mysmartroute.viewmodel.RoleViewModel
+
+@Composable
+fun RolesScreen(navController: NavController, openDrawer: () -> Unit) {
+    val viewModel: RoleViewModel = viewModel()
+    val roles by viewModel.roles.collectAsState()
+    val context = LocalContext.current
+
+    LaunchedEffect(Unit) { viewModel.loadRoles(context) }
+
+    Scaffold(
+        topBar = {
+            TopBar(
+                title = "Roles",
+                navController = navController,
+                showMenu = true,
+                onMenuClick = openDrawer
+            )
+        }
+    ) { padding ->
+        ScreenContainer(modifier = Modifier.padding(padding), scrollable = false) {
+            LazyColumn(modifier = Modifier.fillMaxSize()) {
+                items(roles) { role ->
+                    Text("${'$'}{role.id} - ${'$'}{role.name}")
+                }
+            }
+        }
+    }
+}

--- a/app/src/main/java/com/ioannapergamali/mysmartroute/viewmodel/RoleViewModel.kt
+++ b/app/src/main/java/com/ioannapergamali/mysmartroute/viewmodel/RoleViewModel.kt
@@ -1,0 +1,27 @@
+package com.ioannapergamali.mysmartroute.viewmodel
+
+import android.content.Context
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.viewModelScope
+import com.ioannapergamali.mysmartroute.data.local.MySmartRouteDatabase
+import com.ioannapergamali.mysmartroute.data.local.RoleEntity
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.launch
+
+/**
+ * Απλό ViewModel για ανάκτηση των ρόλων από τη βάση.
+ */
+class RoleViewModel : ViewModel() {
+    private val _roles = MutableStateFlow<List<RoleEntity>>(emptyList())
+    val roles: StateFlow<List<RoleEntity>> = _roles
+
+    fun loadRoles(context: Context) {
+        viewModelScope.launch {
+            val db = MySmartRouteDatabase.getInstance(context)
+            db.roleDao().getAllRoles().collect { list ->
+                _roles.value = list
+            }
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- δημιουργήθηκε `RoleViewModel` για να φορτώνει τους ρόλους από τη βάση
- προστέθηκε νέα οθόνη `RolesScreen` που εμφανίζει τους ρόλους
- ενημερώθηκε το `NavigationHost` ώστε να περιλαμβάνει την καινούρια διαδρομή

## Testing
- `./gradlew test --no-daemon` *(απέτυχε: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_68581ee769708328a7c50016dce6fc00