### PR TITLE
Προσθήκη επιπλέον logs σε ViewModels

### DIFF
--- a/app/src/main/java/com/ioannapergamali/mysmartroute/viewmodel/AuthenticationViewModel.kt
+++ b/app/src/main/java/com/ioannapergamali/mysmartroute/viewmodel/AuthenticationViewModel.kt
@@ -33,6 +33,7 @@ class AuthenticationViewModel : ViewModel() {
     private val auth = FirebaseAuth.getInstance()
     // Χρήση του Gson για μετατροπή JSON σε αντικείμενα Kotlin
     private val gson: Gson = Gson()
+    private companion object { const val TAG = "AuthenticationViewModel" }
 
     /**
      * Παράδειγμα μετατροπής JSON σε αντικείμενο [UserAddress].
@@ -233,19 +234,22 @@ class AuthenticationViewModel : ViewModel() {
                 ref.id
             }
 
+            Log.d(TAG, "Using roleId: $roleId")
             val menusLocal = dbLocal.menuDao().getMenusForRole(roleId)
             if (menusLocal.isNotEmpty()) {
                 _currentMenus.value = menusLocal
             } else {
                 val roleRef = db.collection("roles").document(roleId)
+                Log.d(TAG, "Fetching menus for role $roleId")
                 val snapshot = roleRef.collection("menus").get().await()
+                Log.d(TAG, "Fetched ${snapshot.documents.size} menus for role $roleId")
                 val menuDao = dbLocal.menuDao()
                 val optionDao = dbLocal.menuOptionDao()
                 val menusRemote = snapshot.documents.map { doc ->
                     val menuId = doc.getString("id") ?: doc.id
-                    val optionsSnap = roleRef.collection("menus").document(menuId)
-                        .collection("options").get().await()
-                    val options = optionsSnap.documents.map { optDoc ->
+                    Log.d(TAG, "Fetching options for menu $menuId")
+                    val optionsSnap = roleRef.collection("menus").document(menuId).collection("options").get().await()
+                    Log.d(TAG, "Fetched ${optionsSnap.documents.size} options for menu $menuId")
                         MenuOptionEntity(
                             id = optDoc.getString("id") ?: optDoc.id,
                             menuId = menuId,

--- a/app/src/main/java/com/ioannapergamali/mysmartroute/viewmodel/DatabaseViewModel.kt
+++ b/app/src/main/java/com/ioannapergamali/mysmartroute/viewmodel/DatabaseViewModel.kt
@@ -128,7 +128,9 @@ class DatabaseViewModel : ViewModel() {
                 }
             Log.d(TAG, "Fetched ${'$'}{settings.size} settings from Firebase")
 
+            Log.d(TAG, "Fetching roles from Firestore")
             val rolesSnap = firestore.collection("roles").get().await()
+            Log.d(TAG, "Fetched ${rolesSnap.documents.size} role documents")
             val roles = rolesSnap.documents.map { doc ->
                 RoleEntity(
                     id = doc.getString("id") ?: doc.id,
@@ -140,7 +142,9 @@ class DatabaseViewModel : ViewModel() {
             val menuOptions = mutableListOf<MenuOptionEntity>()
             for (roleDoc in rolesSnap.documents) {
                 val roleId = roleDoc.getString("id") ?: roleDoc.id
+                Log.d(TAG, "Fetching menus for role $roleId")
                 val menusSnap = roleDoc.reference.collection("menus").get().await()
+                Log.d(TAG, "Fetched ${menusSnap.documents.size} menus for role $roleId")
                 for (menuDoc in menusSnap.documents) {
                     val menuId = menuDoc.getString("id") ?: menuDoc.id
                     menus.add(
@@ -150,7 +154,9 @@ class DatabaseViewModel : ViewModel() {
                             title = menuDoc.getString("title") ?: ""
                         )
                     )
+                    Log.d(TAG, "Fetching options for menu $menuId")
                     val optsSnap = menuDoc.reference.collection("options").get().await()
+                    Log.d(TAG, "Fetched ${optsSnap.documents.size} options for menu $menuId")
                     for (optDoc in optsSnap.documents) {
                         menuOptions.add(
                             MenuOptionEntity(
@@ -239,7 +245,9 @@ class DatabaseViewModel : ViewModel() {
                             )
                         }
 
+            Log.d(TAG, "Fetching roles from Firestore")
                     val rolesSnap = firestore.collection("roles").get().await()
+            Log.d(TAG, "Fetched ${rolesSnap.documents.size} role documents")
                     val roles = rolesSnap.documents.map { doc ->
                         RoleEntity(
                             id = doc.getString("id") ?: doc.id,
@@ -250,7 +258,9 @@ class DatabaseViewModel : ViewModel() {
                     val menuOptions = mutableListOf<MenuOptionEntity>()
                     for (roleDoc in rolesSnap.documents) {
                         val roleId = roleDoc.getString("id") ?: roleDoc.id
+                Log.d(TAG, "Fetching menus for role $roleId")
                         val menusSnap = roleDoc.reference.collection("menus").get().await()
+                Log.d(TAG, "Fetched ${menusSnap.documents.size} menus for role $roleId")
                         for (menuDoc in menusSnap.documents) {
                             val menuId = menuDoc.getString("id") ?: menuDoc.id
                             menus.add(
@@ -260,7 +270,9 @@ class DatabaseViewModel : ViewModel() {
                                     title = menuDoc.getString("title") ?: ""
                                 )
                             )
+                    Log.d(TAG, "Fetching options for menu $menuId")
                             val optsSnap = menuDoc.reference.collection("options").get().await()
+                    Log.d(TAG, "Fetched ${optsSnap.documents.size} options for menu $menuId")
                             for (optDoc in optsSnap.documents) {
                                 menuOptions.add(
                                     MenuOptionEntity(


### PR DESCRIPTION
## Τι άλλαξε
- Προστέθηκε σταθερά TAG και μηνύματα καταγραφής στη `AuthenticationViewModel`
- Προστέθηκαν αναλυτικά logs στη `DatabaseViewModel` για φόρτωση ρόλων, μενού και επιλογών

## Οδηγίες δοκιμών
- Εκτέλεση `./gradlew test` (αποτυγχάνει λόγω έλλειψης Android SDK)


------
https://chatgpt.com/codex/tasks/task_e_68582777f2008328878be3d66bbd99c1