### PR TITLE
Fix AuthenticationViewModel syntax

### DIFF
--- a/app/src/main/java/com/ioannapergamali/mysmartroute/viewmodel/AuthenticationViewModel.kt
+++ b/app/src/main/java/com/ioannapergamali/mysmartroute/viewmodel/AuthenticationViewModel.kt
@@ -248,8 +248,13 @@ class AuthenticationViewModel : ViewModel() {
                 val menusRemote = snapshot.documents.map { doc ->
                     val menuId = doc.getString("id") ?: doc.id
                     Log.d(TAG, "Fetching options for menu $menuId")
-                    val optionsSnap = roleRef.collection("menus").document(menuId).collection("options").get().await()
+                    val optionsSnap = roleRef.collection("menus")
+                        .document(menuId)
+                        .collection("options")
+                        .get()
+                        .await()
                     Log.d(TAG, "Fetched ${optionsSnap.documents.size} options for menu $menuId")
+                    val options = optionsSnap.documents.map { optDoc ->
                         MenuOptionEntity(
                             id = optDoc.getString("id") ?: optDoc.id,
                             menuId = menuId,
@@ -257,9 +262,16 @@ class AuthenticationViewModel : ViewModel() {
                             route = optDoc.getString("route") ?: ""
                         )
                     }
-                    insertMenuSafely(menuDao, dbLocal.roleDao(), MenuEntity(menuId, roleId, doc.getString("title") ?: ""))
+                    insertMenuSafely(
+                        menuDao,
+                        dbLocal.roleDao(),
+                        MenuEntity(menuId, roleId, doc.getString("title") ?: "")
+                    )
                     options.forEach { optionDao.insert(it) }
-                    MenuWithOptions(MenuEntity(menuId, roleId, doc.getString("title") ?: ""), options)
+                    MenuWithOptions(
+                        MenuEntity(menuId, roleId, doc.getString("title") ?: ""),
+                        options
+                    )
                 }
                 _currentMenus.value = menusRemote
             }


### PR DESCRIPTION
## Summary
- properly initialize `options` list when fetching remote menu data
- improve indentation and formatting

## Testing
- `./gradlew build` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_68582c8038c88328b66579712e816564