### PR TITLE
Update role hierarchy

### DIFF
--- a/app/src/main/assets/menus.json
+++ b/app/src/main/assets/menus.json
@@ -1,54 +1,62 @@
 {
-  "PASSENGER": [
-    {
-      "title": "Passenger Menu",
-      "options": [
-        {"title": "Sign out", "route": "signOut"},
-        {"title": "Manage Favorite Means of Transport", "route": "manageFavorites"},
-        {"title": "Mode Of Transportation For A Specific Route", "route": "routeMode"},
-        {"title": "Find a Vehicle for a specific Transport", "route": "findVehicle"},
-        {"title": "Find Way of Transport", "route": "findWay"},
-        {"title": "Book a Seat or Buy a Ticket", "route": "bookSeat"},
-        {"title": "View Interesting Routes", "route": "viewRoutes"},
-        {"title": "View Transports", "route": "viewTransports"},
-        {"title": "Print Booked Seat or Ticket", "route": "printTicket"},
-        {"title": "Cancel Booked Seat", "route": "cancelSeat"},
-        {"title": "View, Rank and Comment on Completed Transports", "route": "rankTransports"},
-        {"title": "Shut Down the System", "route": "shutdown"}
-      ]
-    }
-  ],
-  "DRIVER": [
-    {
-      "title": "Driver Menu",
-      "options": [
-        {"title": "Register Vehicle", "route": "registerVehicle"},
-        {"title": "Announce Availability for a specific Transport", "route": "announceAvailability"},
-        {"title": "Find Passengers", "route": "findPassengers"},
-        {"title": "Print Passenger List", "route": "printList"},
-        {"title": "Print Passenger List for Scheduled Transports", "route": "printScheduled"},
-        {"title": "Print Passenger List for Completed Transports", "route": "printCompleted"}
-      ]
-    }
-  ],
-  "ADMIN": [
-    {
-      "title": "Admin Menu",
-      "options": [
-        {"title": "Initialize System", "route": "initSystem"},
-        {"title": "Create User Account", "route": "createUser"},
-        {"title": "Promote or Demote User", "route": "editPrivileges"},
-        {"title": "Define Point of Interest", "route": "definePoi"},
-        {"title": "Define Duration of Travel by Foot", "route": "defineDuration"},
-        {"title": "View List of Unassigned Routes", "route": "viewUnassigned"},
-        {"title": "Review Point of Interest Names", "route": "reviewPoi"},
-        {"title": "Show 10 Best and Worst Drivers", "route": "rankDrivers"},
-        {"title": "View 10 Happiest/Least Happy Passengers", "route": "rankPassengers"},
-        {"title": "View Available Vehicles", "route": "viewVehicles"},
-        {"title": "View PoIs", "route": "viewPois"},
-        {"title": "View Users", "route": "viewUsers"},
-        {"title": "Advance Date", "route": "advanceDate"}
-      ]
-    }
-  ]
+  "PASSENGER": {
+    "menus": [
+      {
+        "title": "Passenger Menu",
+        "options": [
+          {"title": "Sign out", "route": "signOut"},
+          {"title": "Manage Favorite Means of Transport", "route": "manageFavorites"},
+          {"title": "Mode Of Transportation For A Specific Route", "route": "routeMode"},
+          {"title": "Find a Vehicle for a specific Transport", "route": "findVehicle"},
+          {"title": "Find Way of Transport", "route": "findWay"},
+          {"title": "Book a Seat or Buy a Ticket", "route": "bookSeat"},
+          {"title": "View Interesting Routes", "route": "viewRoutes"},
+          {"title": "View Transports", "route": "viewTransports"},
+          {"title": "Print Booked Seat or Ticket", "route": "printTicket"},
+          {"title": "Cancel Booked Seat", "route": "cancelSeat"},
+          {"title": "View, Rank and Comment on Completed Transports", "route": "rankTransports"},
+          {"title": "Shut Down the System", "route": "shutdown"}
+        ]
+      }
+    ]
+  },
+  "DRIVER": {
+    "inheritsFrom": "PASSENGER",
+    "menus": [
+      {
+        "title": "Driver Menu",
+        "options": [
+          {"title": "Register Vehicle", "route": "registerVehicle"},
+          {"title": "Announce Availability for a specific Transport", "route": "announceAvailability"},
+          {"title": "Find Passengers", "route": "findPassengers"},
+          {"title": "Print Passenger List", "route": "printList"},
+          {"title": "Print Passenger List for Scheduled Transports", "route": "printScheduled"},
+          {"title": "Print Passenger List for Completed Transports", "route": "printCompleted"}
+        ]
+      }
+    ]
+  },
+  "ADMIN": {
+    "inheritsFrom": "DRIVER",
+    "menus": [
+      {
+        "title": "Admin Menu",
+        "options": [
+          {"title": "Initialize System", "route": "initSystem"},
+          {"title": "Create User Account", "route": "createUser"},
+          {"title": "Promote or Demote User", "route": "editPrivileges"},
+          {"title": "Define Point of Interest", "route": "definePoi"},
+          {"title": "Define Duration of Travel by Foot", "route": "defineDuration"},
+          {"title": "View List of Unassigned Routes", "route": "viewUnassigned"},
+          {"title": "Review Point of Interest Names", "route": "reviewPoi"},
+          {"title": "Show 10 Best and Worst Drivers", "route": "rankDrivers"},
+          {"title": "View 10 Happiest/Least Happy Passengers", "route": "rankPassengers"},
+          {"title": "View Available Vehicles", "route": "viewVehicles"},
+          {"title": "View PoIs", "route": "viewPois"},
+          {"title": "View Users", "route": "viewUsers"},
+          {"title": "Advance Date", "route": "advanceDate"}
+        ]
+      }
+    ]
+  }
 }

--- a/app/src/main/java/com/ioannapergamali/mysmartroute/data/local/RoleEntity.kt
+++ b/app/src/main/java/com/ioannapergamali/mysmartroute/data/local/RoleEntity.kt
@@ -8,5 +8,6 @@ import androidx.room.PrimaryKey
 @Entity(tableName = "roles")
 data class RoleEntity(
     @PrimaryKey var id: String = "",
-    var name: String = ""
+    var name: String = "",
+    var parentRoleId: String? = null
 )

--- a/app/src/main/java/com/ioannapergamali/mysmartroute/model/classes/users/Admin.kt
+++ b/app/src/main/java/com/ioannapergamali/mysmartroute/model/classes/users/Admin.kt
@@ -1,18 +1,16 @@
 package com.ioannapergamali.mysmartroute.model.classes.users
 
 import com.ioannapergamali.mysmartroute.model.enumerations.UserRole
-import com.ioannapergamali.mysmartroute.model.interfaces.User
 
 class Admin(
-    override val id: String,
-    override val name: String,
-    override val email: String,
-    override val surname: String,
-    override val address: UserAddress,
-    override val phoneNum: String,
-    override val username: String,
-    override val password: String
-
-) : User {
+    id: String,
+    name: String,
+    email: String,
+    surname: String,
+    address: UserAddress,
+    phoneNum: String,
+    username: String,
+    password: String
+) : Driver(id, name, email, surname, address, phoneNum, username, password) {
     override fun getRole() = UserRole.ADMIN
 }

--- a/app/src/main/java/com/ioannapergamali/mysmartroute/model/classes/users/Driver.kt
+++ b/app/src/main/java/com/ioannapergamali/mysmartroute/model/classes/users/Driver.kt
@@ -1,18 +1,16 @@
 package com.ioannapergamali.mysmartroute.model.classes.users
 
 import com.ioannapergamali.mysmartroute.model.enumerations.UserRole
-import com.ioannapergamali.mysmartroute.model.interfaces.User
 
-class Driver (
-    override val id: String,
-    override val name: String,
-    override val email: String,
-    override val surname: String,
-    override val address: UserAddress,
-    override val phoneNum: String,
-    override val username: String,
-    override val password: String
-
-) : User {
+open class Driver(
+    id: String,
+    name: String,
+    email: String,
+    surname: String,
+    address: UserAddress,
+    phoneNum: String,
+    username: String,
+    password: String
+) : Passenger(id, name, email, surname, address, phoneNum, username, password) {
     override fun getRole() = UserRole.DRIVER
 }

--- a/app/src/main/java/com/ioannapergamali/mysmartroute/model/classes/users/Passenger.kt
+++ b/app/src/main/java/com/ioannapergamali/mysmartroute/model/classes/users/Passenger.kt
@@ -3,7 +3,7 @@ package com.ioannapergamali.mysmartroute.model.classes.users
 import com.ioannapergamali.mysmartroute.model.enumerations.UserRole
 import com.ioannapergamali.mysmartroute.model.interfaces.User
 
-class Passenger (
+open class Passenger(
     override val id: String,
     override val name: String,
     override val email: String,
@@ -12,7 +12,6 @@ class Passenger (
     override val phoneNum: String,
     override val username: String,
     override val password: String
-
 ) : User {
     override fun getRole() = UserRole.PASSENGER
 }

--- a/app/src/main/java/com/ioannapergamali/mysmartroute/model/menus/MenuConfig.kt
+++ b/app/src/main/java/com/ioannapergamali/mysmartroute/model/menus/MenuConfig.kt
@@ -10,3 +10,9 @@ data class OptionConfig(
     val title: String,
     val route: String
 )
+
+/** Δομή για τα μενού που αντιστοιχούν σε έναν ρόλο. */
+data class RoleMenuConfig(
+    val inheritsFrom: String? = null,
+    val menus: List<MenuConfig> = emptyList()
+)


### PR DESCRIPTION
## Summary
- implement role hierarchy with inheritsFrom
- update MenuConfig data classes
- add RoleMenuConfig parsing logic
- support inheritance in default menus
- add parentRoleId to roles table and migration
- adjust prepopulate data
- implement class inheritance for User classes

## Testing
- `./gradlew test` *(fails: Maven repo blocked)*

------
https://chatgpt.com/codex/tasks/task_e_685830a835dc83288aa054b6c7cb1639