### PR TITLE
Fix missing RoleMenuConfig import

### DIFF
--- a/app/src/main/java/com/ioannapergamali/mysmartroute/viewmodel/AuthenticationViewModel.kt
+++ b/app/src/main/java/com/ioannapergamali/mysmartroute/viewmodel/AuthenticationViewModel.kt
@@ -22,6 +22,7 @@ import com.ioannapergamali.mysmartroute.model.classes.users.UserAddress
 import com.ioannapergamali.mysmartroute.model.enumerations.UserRole
 import com.ioannapergamali.mysmartroute.utils.NetworkUtils
 import com.ioannapergamali.mysmartroute.model.menus.MenuConfig
+import com.ioannapergamali.mysmartroute.model.menus.RoleMenuConfig
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.launch


### PR DESCRIPTION
## Summary
- import `RoleMenuConfig` so AuthenticationViewModel builds

## Testing
- `./gradlew tasks --all` *(fails: could not download dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_685832acdffc832898199847f2cdbd22