### PR TITLE
Initialize Firebase roles and inherit menus

### DIFF
--- a/app/src/main/java/com/ioannapergamali/mysmartroute/utils/FirestoreMappers.kt
+++ b/app/src/main/java/com/ioannapergamali/mysmartroute/utils/FirestoreMappers.kt
@@ -81,7 +81,8 @@ fun DocumentSnapshot.toUserEntity(): UserEntity? {
 
 fun RoleEntity.toFirestoreMap(): Map<String, Any> = mapOf(
     "id" to id,
-    "name" to name
+    "name" to name,
+    "parentRoleId" to (parentRoleId ?: "")
 )
 
 fun MenuEntity.toFirestoreMap(): Map<String, Any> = mapOf(

--- a/app/src/main/java/com/ioannapergamali/mysmartroute/viewmodel/DatabaseViewModel.kt
+++ b/app/src/main/java/com/ioannapergamali/mysmartroute/viewmodel/DatabaseViewModel.kt
@@ -134,7 +134,8 @@ class DatabaseViewModel : ViewModel() {
             val roles = rolesSnap.documents.map { doc ->
                 RoleEntity(
                     id = doc.getString("id") ?: doc.id,
-                    name = doc.getString("name") ?: ""
+                    name = doc.getString("name") ?: "",
+                    parentRoleId = doc.getString("parentRoleId")?.takeIf { it.isNotEmpty() }
                 )
             }
             Log.d(TAG, "Fetched ${roles.size} roles from Firebase")
@@ -251,7 +252,8 @@ class DatabaseViewModel : ViewModel() {
                     val roles = rolesSnap.documents.map { doc ->
                         RoleEntity(
                             id = doc.getString("id") ?: doc.id,
-                            name = doc.getString("name") ?: ""
+                            name = doc.getString("name") ?: "",
+                            parentRoleId = doc.getString("parentRoleId")?.takeIf { it.isNotEmpty() }
                         )
                     }
                     val menus = mutableListOf<MenuEntity>()


### PR DESCRIPTION
## Summary
- include parent role id when saving roles to Firestore
- create all default roles and menus on first sign-up
- load menus recursively via role inheritance
- parse parentRoleId from Firestore

## Testing
- `./gradlew test` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_6858372258bc83289bdb2a1761f8e438