### PR TITLE
Improve user menu UI

### DIFF
--- a/app/src/main/java/com/ioannapergamali/mysmartroute/view/ui/screens/MenuScreen.kt
+++ b/app/src/main/java/com/ioannapergamali/mysmartroute/view/ui/screens/MenuScreen.kt
@@ -1,12 +1,17 @@
 package com.ioannapergamali.mysmartroute.view.ui.screens
 
+import androidx.compose.foundation.BorderStroke
 import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.*
+import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.lazy.items
+import androidx.compose.material.icons.filled.KeyboardArrowRight
 import androidx.compose.material3.*
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
+import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.unit.dp
 import androidx.lifecycle.viewmodel.compose.viewModel
@@ -17,11 +22,13 @@ import com.ioannapergamali.mysmartroute.view.ui.components.TopBar
 import com.ioannapergamali.mysmartroute.viewmodel.AuthenticationViewModel
 import com.ioannapergamali.mysmartroute.view.ui.components.ScreenContainer
 import com.ioannapergamali.mysmartroute.data.local.MenuWithOptions
+import com.ioannapergamali.mysmartroute.model.enumerations.UserRole
 
 @Composable
 fun MenuScreen(navController: NavController, openDrawer: () -> Unit) {
     val viewModel: AuthenticationViewModel = viewModel()
     val menus by viewModel.currentMenus.collectAsState()
+    val role by viewModel.currentUserRole.collectAsState()
 
     val context = LocalContext.current
 
@@ -51,7 +58,7 @@ fun MenuScreen(navController: NavController, openDrawer: () -> Unit) {
             if (menus.isEmpty()) {
                 CircularProgressIndicator()
             } else {
-                MenuEntityTable(menus) { route ->
+                RoleMenu(role, menus) { route ->
                     if (route.isNotEmpty()) navController.navigate(route)
                     else Toast.makeText(context, "Η λειτουργία δεν είναι διαθέσιμη", Toast.LENGTH_SHORT).show()
                 }
@@ -61,20 +68,48 @@ fun MenuScreen(navController: NavController, openDrawer: () -> Unit) {
 }
 
 @Composable
-private fun MenuEntityTable(menus: List<MenuWithOptions>, onRouteSelected: (String) -> Unit) {
+private fun RoleMenu(
+    role: UserRole?,
+    menus: List<MenuWithOptions>,
+    onOptionClick: (String) -> Unit
+) {
     Column(modifier = Modifier.fillMaxWidth()) {
-        menus.forEachIndexed { index, menuWithOptions ->
-            Text(text = "${index + 1}. ${menuWithOptions.menu.title}", style = MaterialTheme.typography.titleMedium)
-            menuWithOptions.options.forEach { option ->
-                Row(modifier = Modifier
-                    .fillMaxWidth()
-                    .padding(start = 24.dp, top = 2.dp, bottom = 2.dp)) {
-                    Text(
-                        text = option.title,
-                        modifier = Modifier
-                            .clickable { onRouteSelected(option.route) }
-                            .weight(1f)
-                    )
+        Text(
+            text = "Μενού για τον ρόλο: ${role?.name ?: ""}",
+            style = MaterialTheme.typography.titleLarge
+        )
+        Spacer(Modifier.height(8.dp))
+        Card(
+            modifier = Modifier.fillMaxWidth(),
+            border = BorderStroke(1.dp, MaterialTheme.colorScheme.outline)
+        ) {
+            LazyColumn {
+                menus.forEach { menuWithOptions ->
+                    item {
+                        Text(
+                            text = menuWithOptions.menu.title,
+                            style = MaterialTheme.typography.titleMedium,
+                            modifier = Modifier.padding(horizontal = 16.dp, vertical = 8.dp)
+                        )
+                        Divider()
+                    }
+                    items(menuWithOptions.options) { option ->
+                        Row(
+                            modifier = Modifier
+                                .fillMaxWidth()
+                                .clickable { onOptionClick(option.route) }
+                                .padding(16.dp),
+                            verticalAlignment = Alignment.CenterVertically
+                        ) {
+                            Icon(
+                                imageVector = Icons.Filled.KeyboardArrowRight,
+                                contentDescription = null
+                            )
+                            Spacer(Modifier.width(12.dp))
+                            Text(text = option.title, style = MaterialTheme.typography.bodyLarge)
+                        }
+                        Divider()
+                    }
                 }
             }
         }


### PR DESCRIPTION
## Summary
- show the user's role at the top of the menu screen
- display menu items inside a card with icons and dividers

## Testing
- `./gradlew test --no-daemon` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_6859db26fe348328bf39c7515744b5c5