### PR TITLE
Fix missing import in MenuScreen

### DIFF
--- a/app/src/main/java/com/ioannapergamali/mysmartroute/view/ui/screens/MenuScreen.kt
+++ b/app/src/main/java/com/ioannapergamali/mysmartroute/view/ui/screens/MenuScreen.kt
@@ -5,6 +5,7 @@ import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.*
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.items
+import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.KeyboardArrowRight
 import androidx.compose.material3.*
 import androidx.compose.runtime.Composable


### PR DESCRIPTION
## Summary
- fix unresolved `Icons` reference by importing `androidx.compose.material.icons.Icons`

## Testing
- `./gradlew assembleDebug` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_685a21bfe3bc8328ab59adaf8ea0a2ef