### PR TITLE
Fix scrollable constraint crash

### DIFF
--- a/app/src/main/java/com/ioannapergamali/mysmartroute/view/ui/screens/MenuScreen.kt
+++ b/app/src/main/java/com/ioannapergamali/mysmartroute/view/ui/screens/MenuScreen.kt
@@ -55,7 +55,7 @@ fun MenuScreen(navController: NavController, openDrawer: () -> Unit) {
             )
         }
     ) { paddingValues ->
-        ScreenContainer(modifier = Modifier.padding(paddingValues)) {
+        ScreenContainer(modifier = Modifier.padding(paddingValues), scrollable = false) {
             if (menus.isEmpty()) {
                 CircularProgressIndicator()
             } else {


### PR DESCRIPTION
## Summary
- fix Compose crash by disabling ScreenContainer scroll for MenuScreen

## Testing
- `./gradlew test` *(fails: maven.pkg.jetbrains.space blocked)*

------
https://chatgpt.com/codex/tasks/task_e_685a2514dc748328bd95c63476d726cc