### PR TITLE
UI: dividers follow theme

### DIFF
--- a/app/src/main/java/com/ioannapergamali/mysmartroute/view/ui/components/NavigationDrawer.kt
+++ b/app/src/main/java/com/ioannapergamali/mysmartroute/view/ui/components/NavigationDrawer.kt
@@ -34,8 +34,8 @@ fun DrawerMenu(navController: NavController, closeDrawer: () -> Unit) {
 
         user?.email?.let { email ->
             Text(email, modifier = Modifier.padding(start = 16.dp, bottom = 8.dp))
-            Divider()
-        } ?: Divider()
+            Divider(color = MaterialTheme.colorScheme.outline)
+        } ?: Divider(color = MaterialTheme.colorScheme.outline)
 
         if (user != null) {
             NavigationDrawerItem(

--- a/app/src/main/java/com/ioannapergamali/mysmartroute/view/ui/screens/SettingsScreen.kt
+++ b/app/src/main/java/com/ioannapergamali/mysmartroute/view/ui/screens/SettingsScreen.kt
@@ -94,7 +94,10 @@ fun SettingsScreen(navController: NavController, openDrawer: () -> Unit) {
         ) { padding ->
             ScreenContainer(modifier = Modifier.padding(padding)) {
             Text("Θέμα")
-            Divider(modifier = Modifier.padding(vertical = 4.dp))
+            Divider(
+                modifier = Modifier.padding(vertical = 4.dp),
+                color = MaterialTheme.colorScheme.outline
+            )
             ExposedDropdownMenuBox(expanded = expandedTheme.value, onExpandedChange = { expandedTheme.value = !expandedTheme.value }) {
                 OutlinedTextField(
                     readOnly = true,
@@ -122,7 +125,10 @@ fun SettingsScreen(navController: NavController, openDrawer: () -> Unit) {
             Switch(checked = dark.value, onCheckedChange = { dark.value = it })
 
             Text("Γραμματοσειρά", modifier = Modifier.padding(top = 16.dp))
-            Divider(modifier = Modifier.padding(vertical = 4.dp))
+            Divider(
+                modifier = Modifier.padding(vertical = 4.dp),
+                color = MaterialTheme.colorScheme.outline
+            )
             ExposedDropdownMenuBox(expanded = expandedFont.value, onExpandedChange = { expandedFont.value = !expandedFont.value }) {
                 OutlinedTextField(
                     readOnly = true,
@@ -148,7 +154,10 @@ fun SettingsScreen(navController: NavController, openDrawer: () -> Unit) {
             }
 
             Text("Ήχος", modifier = Modifier.padding(top = 16.dp))
-            Divider(modifier = Modifier.padding(vertical = 4.dp))
+            Divider(
+                modifier = Modifier.padding(vertical = 4.dp),
+                color = MaterialTheme.colorScheme.outline
+            )
             Row(verticalAlignment = Alignment.CenterVertically) {
                 IconButton(onClick = {
                     val newState = !soundState.value


### PR DESCRIPTION
## Summary
- ensure dividers in navigation drawer use theme outline color
- style settings screen dividers with theme color

## Testing
- `./gradlew test --quiet` *(fails: maven.pkg.jetbrains.space blocked)*

------
https://chatgpt.com/codex/tasks/task_e_685a402212fc8328973296af418c36fd