### PR TITLE
Add script for Materialize themes

### DIFF
--- a/README.md
+++ b/README.md
@@ -99,3 +99,16 @@ val user: User = gson.fromJson(jsonString, type)
 
 Μετά την προσθήκη ή επιβεβαίωση της παραπάνω εξάρτησης, κάνε "Sync Project with Gradle Files" ώστε να κατέβει το library και να λυθούν τα σφάλματα.
 
+
+### Λήψη Materialize themes
+
+Για να κατεβάσεις αυτόματα τα διαθέσιμα Materialize θέματα από τους ιστότοπους ThemeForest και BootstrapMade, υπάρχει το script `scripts/fetch_materialize_themes.py`. Το script χρησιμοποιεί τις βιβλιοθήκες `requests` και `beautifulsoup4` για να ανακτήσει τις σελίδες και να δημιουργήσει το αρχείο `app/src/main/assets/themes.json` με τα ονόματα και τα χρώματα των θεμάτων.
+
+```bash
+pip install requests beautifulsoup4
+python scripts/fetch_materialize_themes.py
+```
+
+Λόγω περιορισμών δικτύου ενδέχεται να χρειαστεί να εκτελέσεις το script εκτός του περιβάλλοντος του Codex. Το παραγόμενο `themes.json` μπορεί στη συνέχεια να αντιγραφεί στο φάκελο `app/src/main/assets` της εφαρμογής, ώστε να χρησιμοποιηθεί στις ρυθμίσεις θεμάτων.
+
+Αφού δημιουργηθεί το `themes.json`, άνοιξε την εφαρμογή και στις ρυθμίσεις θα εμφανιστούν αυτόματα τα νέα θέματα δίπλα στα προεπιλεγμένα.

--- a/app/src/main/assets/themes.json
+++ b/app/src/main/assets/themes.json
@@ -1,0 +1,6 @@
+[
+  {
+    "label": "Demo Theme",
+    "seed": "#2196F3"
+  }
+]

--- a/app/src/main/java/com/ioannapergamali/mysmartroute/data/CustomTheme.kt
+++ b/app/src/main/java/com/ioannapergamali/mysmartroute/data/CustomTheme.kt
@@ -1,0 +1,15 @@
+package com.ioannapergamali.mysmartroute.data
+
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.text.font.FontFamily
+
+import com.ioannapergamali.mysmartroute.data.ThemeOption
+
+/**
+ * Δομή για δυναμικά θέματα που προέρχονται από το themes.json.
+ */
+data class CustomTheme(
+    override val label: String,
+    override val seed: Color,
+    override val fontFamily: FontFamily = FontFamily.SansSerif
+) : ThemeOption

--- a/app/src/main/java/com/ioannapergamali/mysmartroute/data/ThemeLoader.kt
+++ b/app/src/main/java/com/ioannapergamali/mysmartroute/data/ThemeLoader.kt
@@ -1,0 +1,38 @@
+package com.ioannapergamali.mysmartroute.data
+
+import android.content.Context
+import androidx.compose.ui.graphics.Color
+import com.google.gson.Gson
+import com.google.gson.reflect.TypeToken
+import java.io.InputStreamReader
+
+/**
+ * Φορτώνει τα εξωτερικά Materialize themes από το αρχείο assets/themes.json.
+ */
+object ThemeLoader {
+    private var cache: List<CustomTheme>? = null
+
+    fun load(context: Context): List<CustomTheme> {
+        cache?.let { return it }
+        return try {
+            context.assets.open("themes.json").use { stream ->
+                InputStreamReader(stream).use { reader ->
+                    val type = object : TypeToken<List<ThemeEntry>>() {}.type
+                    val entries: List<ThemeEntry> = Gson().fromJson(reader, type)
+                    val themes = entries.map {
+                        CustomTheme(
+                            label = it.label,
+                            seed = Color(android.graphics.Color.parseColor(it.seed))
+                        )
+                    }
+                    cache = themes
+                    themes
+                }
+            }
+        } catch (_: Exception) {
+            emptyList()
+        }
+    }
+
+    private data class ThemeEntry(val label: String, val seed: String)
+}

--- a/app/src/main/java/com/ioannapergamali/mysmartroute/data/ThemeOption.kt
+++ b/app/src/main/java/com/ioannapergamali/mysmartroute/data/ThemeOption.kt
@@ -1,0 +1,13 @@
+package com.ioannapergamali.mysmartroute.data
+
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.text.font.FontFamily
+
+/**
+ * Κοινή διεπαφή για όλα τα θέματα της εφαρμογής.
+ */
+interface ThemeOption {
+    val label: String
+    val seed: Color
+    val fontFamily: FontFamily
+}

--- a/app/src/main/java/com/ioannapergamali/mysmartroute/utils/ThemePreferenceManager.kt
+++ b/app/src/main/java/com/ioannapergamali/mysmartroute/utils/ThemePreferenceManager.kt
@@ -2,10 +2,14 @@ package com.ioannapergamali.mysmartroute.utils
 
 import android.content.Context
 import android.content.res.Configuration
-import androidx.datastore.preferences.core.intPreferencesKey
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.toArgb
 import androidx.datastore.preferences.core.booleanPreferencesKey
 import androidx.datastore.preferences.core.edit
+import androidx.datastore.preferences.core.preferencesKey
 import androidx.datastore.preferences.preferencesDataStore
+import com.ioannapergamali.mysmartroute.data.CustomTheme
+import com.ioannapergamali.mysmartroute.data.ThemeOption
 import com.ioannapergamali.mysmartroute.view.ui.AppTheme
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.map
@@ -13,7 +17,7 @@ import kotlinx.coroutines.flow.map
 private val Context.dataStore by preferencesDataStore(name = "settings")
 
 object ThemePreferenceManager {
-    private val THEME_KEY = intPreferencesKey("theme")
+    private val THEME_KEY = preferencesKey<String>("theme_name")
     private val DARK_MODE_KEY = booleanPreferencesKey("dark_mode")
 
     private fun Context.isSystemDarkTheme(): Boolean {
@@ -21,10 +25,10 @@ object ThemePreferenceManager {
         return mode == Configuration.UI_MODE_NIGHT_YES
     }
 
-    fun themeFlow(context: Context): Flow<AppTheme> =
+    fun themeFlow(context: Context): Flow<ThemeOption> =
         context.dataStore.data.map { prefs ->
-            val index = prefs[THEME_KEY] ?: 0
-            AppTheme.values().getOrElse(index) { AppTheme.Ocean }
+            val raw = prefs[THEME_KEY] ?: AppTheme.Ocean.name
+            decodeTheme(raw)
         }
 
     fun darkThemeFlow(context: Context): Flow<Boolean> =
@@ -32,9 +36,9 @@ object ThemePreferenceManager {
             prefs[DARK_MODE_KEY] ?: context.isSystemDarkTheme()
         }
 
-    suspend fun setTheme(context: Context, theme: AppTheme) {
+    suspend fun setTheme(context: Context, theme: ThemeOption) {
         context.dataStore.edit { prefs ->
-            prefs[THEME_KEY] = theme.ordinal
+            prefs[THEME_KEY] = encodeTheme(theme)
         }
     }
 
@@ -42,5 +46,26 @@ object ThemePreferenceManager {
         context.dataStore.edit { prefs ->
             prefs[DARK_MODE_KEY] = dark
         }
+    }
+
+    fun encodeTheme(theme: ThemeOption): String = when (theme) {
+        is AppTheme -> theme.name
+        is CustomTheme -> "${theme.label}|${colorToHex(theme.seed)}"
+        else -> AppTheme.Ocean.name
+    }
+
+    fun decodeTheme(value: String): ThemeOption =
+        if ("|" in value) {
+            val parts = value.split("|", limit = 2)
+            val label = parts.getOrNull(0) ?: "Custom"
+            val color = runCatching { Color(android.graphics.Color.parseColor(parts.getOrElse(1) { "#2196F3" })) }.getOrElse { Color(0xFF2196F3) }
+            CustomTheme(label, color)
+        } else {
+            runCatching { AppTheme.valueOf(value) }.getOrDefault(AppTheme.Ocean)
+        }
+
+    private fun colorToHex(color: Color): String {
+        val intColor = color.toArgb() and 0xFFFFFF
+        return "#%06X".format(intColor)
     }
 }

--- a/app/src/main/java/com/ioannapergamali/mysmartroute/view/ui/Theme.kt
+++ b/app/src/main/java/com/ioannapergamali/mysmartroute/view/ui/Theme.kt
@@ -12,7 +12,9 @@ import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.text.font.FontFamily
 import androidx.compose.material3.Typography
 
-enum class AppTheme(val label: String, val seed: Color, val fontFamily: FontFamily) {
+import com.ioannapergamali.mysmartroute.data.ThemeOption
+
+enum class AppTheme(override val label: String, override val seed: Color, override val fontFamily: FontFamily) : ThemeOption {
     Ocean("Ocean", Color(0xFF2196F3), FontFamily.SansSerif),
     Sunset("Sunset", Color(0xFFEF5350), FontFamily.Serif),
     Forest("Forest", Color(0xFF2E7D32), FontFamily.Monospace),
@@ -89,12 +91,35 @@ private fun typographyWithFont(font: FontFamily): Typography {
 @Composable
 @OptIn(ExperimentalMaterial3Api::class)
 fun MysmartrouteTheme(
-    theme: AppTheme,
+    theme: ThemeOption,
     darkTheme: Boolean,
     font: FontFamily,
     content: @Composable () -> Unit
 ) {
-    val colorScheme = if (darkTheme) theme.darkColors else theme.lightColors
+    fun onColor(seed: Color): Color {
+        val darkness = 1 - (0.299 * seed.red + 0.587 * seed.green + 0.114 * seed.blue)
+        return if (darkness >= 0.5) Color.White else Color.Black
+    }
+    val seed = theme.seed
+    val colorScheme = if (darkTheme) {
+        darkColorScheme(
+            primary = seed,
+            secondary = seed,
+            tertiary = seed,
+            onPrimary = onColor(seed),
+            onSecondary = onColor(seed),
+            onTertiary = onColor(seed)
+        )
+    } else {
+        lightColorScheme(
+            primary = seed,
+            secondary = seed,
+            tertiary = seed,
+            onPrimary = onColor(seed),
+            onSecondary = onColor(seed),
+            onTertiary = onColor(seed)
+        )
+    }
     androidx.compose.material3.MaterialTheme(
         colorScheme = colorScheme,
         typography = typographyWithFont(font),

--- a/app/src/main/java/com/ioannapergamali/mysmartroute/view/ui/screens/SettingsScreen.kt
+++ b/app/src/main/java/com/ioannapergamali/mysmartroute/view/ui/screens/SettingsScreen.kt
@@ -47,6 +47,8 @@ import com.ioannapergamali.mysmartroute.view.ui.MysmartrouteTheme
 import com.ioannapergamali.mysmartroute.view.ui.components.TopBar
 import com.ioannapergamali.mysmartroute.view.ui.components.ScreenContainer
 import com.ioannapergamali.mysmartroute.viewmodel.SettingsViewModel
+import com.ioannapergamali.mysmartroute.data.ThemeLoader
+import com.ioannapergamali.mysmartroute.data.ThemeOption
 
 @Composable
 @OptIn(ExperimentalMaterial3Api::class)
@@ -60,8 +62,10 @@ fun SettingsScreen(navController: NavController, openDrawer: () -> Unit) {
     val soundEnabled by SoundPreferenceManager.soundEnabledFlow(context).collectAsState(initial = true)
     val currentVolume by SoundPreferenceManager.soundVolumeFlow(context).collectAsState(initial = 1f)
 
+    val customThemes = remember { ThemeLoader.load(context) }
+    val themeOptions = remember(customThemes) { AppTheme.values().toList<ThemeOption>() + customThemes }
     val expandedTheme = remember { mutableStateOf(false) }
-    val selectedTheme = remember { mutableStateOf(currentTheme) }
+    val selectedTheme = remember { mutableStateOf<ThemeOption>(currentTheme) }
     val dark = remember { mutableStateOf(currentDark) }
 
     val expandedFont = remember { mutableStateOf(false) }
@@ -113,7 +117,7 @@ fun SettingsScreen(navController: NavController, openDrawer: () -> Unit) {
                     )
                 )
                 DropdownMenu(expanded = expandedTheme.value, onDismissRequest = { expandedTheme.value = false }) {
-                    AppTheme.values().forEach { theme ->
+                    themeOptions.forEach { theme ->
                         DropdownMenuItem(text = { Text(theme.label) }, onClick = {
                             selectedTheme.value = theme
                             expandedTheme.value = false

--- a/app/src/main/java/com/ioannapergamali/mysmartroute/view/ui/screens/ThemePickerScreen.kt
+++ b/app/src/main/java/com/ioannapergamali/mysmartroute/view/ui/screens/ThemePickerScreen.kt
@@ -32,6 +32,8 @@ import com.ioannapergamali.mysmartroute.view.ui.AppFont
 import com.ioannapergamali.mysmartroute.viewmodel.SettingsViewModel
 import com.ioannapergamali.mysmartroute.utils.ThemePreferenceManager
 import com.ioannapergamali.mysmartroute.utils.FontPreferenceManager
+import com.ioannapergamali.mysmartroute.data.ThemeLoader
+import com.ioannapergamali.mysmartroute.data.ThemeOption
 import com.ioannapergamali.mysmartroute.view.ui.components.TopBar
 import com.ioannapergamali.mysmartroute.view.ui.components.ScreenContainer
 
@@ -44,8 +46,11 @@ fun ThemePickerScreen(navController: NavController) {
     val currentDark by ThemePreferenceManager.darkThemeFlow(context).collectAsState(initial = false)
     val currentFont by FontPreferenceManager.fontFlow(context).collectAsState(initial = AppFont.SansSerif)
 
+    val customThemes = remember { ThemeLoader.load(context) }
+    val themeOptions = remember(customThemes) { AppTheme.values().toList<ThemeOption>() + customThemes }
+
     var expanded by remember { mutableStateOf(false) }
-    var selectedTheme by remember { mutableStateOf(currentTheme) }
+    var selectedTheme by remember { mutableStateOf<ThemeOption>(currentTheme) }
     var dark by remember { mutableStateOf(currentDark) }
 
     LaunchedEffect(currentTheme) { selectedTheme = currentTheme }
@@ -75,7 +80,7 @@ fun ThemePickerScreen(navController: NavController) {
                         )
                     )
                     DropdownMenu(expanded = expanded, onDismissRequest = { expanded = false }) {
-                        AppTheme.values().forEach { theme ->
+                        themeOptions.forEach { theme ->
                             DropdownMenuItem(text = { Text(theme.label) }, onClick = {
                                 selectedTheme = theme
                                 expanded = false

--- a/app/src/main/java/com/ioannapergamali/mysmartroute/viewmodel/SettingsViewModel.kt
+++ b/app/src/main/java/com/ioannapergamali/mysmartroute/viewmodel/SettingsViewModel.kt
@@ -14,6 +14,7 @@ import com.ioannapergamali.mysmartroute.data.local.UserEntity
 import com.ioannapergamali.mysmartroute.data.local.insertSettingsSafely
 import com.ioannapergamali.mysmartroute.view.ui.AppTheme
 import com.ioannapergamali.mysmartroute.utils.NetworkUtils
+import com.ioannapergamali.mysmartroute.data.ThemeOption
 import kotlinx.coroutines.tasks.await
 import com.ioannapergamali.mysmartroute.utils.ThemePreferenceManager
 import com.ioannapergamali.mysmartroute.utils.FontPreferenceManager
@@ -108,7 +109,7 @@ class SettingsViewModel : ViewModel() {
 
     fun applyAllSettings(
         context: Context,
-        theme: AppTheme,
+        theme: ThemeOption,
         dark: Boolean,
         font: AppFont,
         soundEnabled: Boolean,
@@ -122,7 +123,7 @@ class SettingsViewModel : ViewModel() {
             SoundPreferenceManager.setSoundVolume(context, soundVolume)
             updateSettings(context) {
                 it.copy(
-                    theme = theme.name,
+                    theme = ThemePreferenceManager.encodeTheme(theme),
                     darkTheme = dark,
                     font = font.name,
                     soundEnabled = soundEnabled,
@@ -132,7 +133,7 @@ class SettingsViewModel : ViewModel() {
         }
     }
 
-    fun applyTheme(context: Context, theme: AppTheme, dark: Boolean) {
+    fun applyTheme(context: Context, theme: ThemeOption, dark: Boolean) {
         viewModelScope.launch {
             ThemePreferenceManager.setTheme(context, theme)
             ThemePreferenceManager.setDarkTheme(context, dark)
@@ -190,7 +191,7 @@ class SettingsViewModel : ViewModel() {
             val settings = remote ?: local ?: return@launch
 
             insertSettingsSafely(dao, userDao, settings)
-            ThemePreferenceManager.setTheme(context, AppTheme.valueOf(settings.theme))
+            ThemePreferenceManager.setTheme(context, ThemePreferenceManager.decodeTheme(settings.theme))
             ThemePreferenceManager.setDarkTheme(context, settings.darkTheme)
             FontPreferenceManager.setFont(context, AppFont.valueOf(settings.font))
             SoundPreferenceManager.setSoundEnabled(context, settings.soundEnabled)
@@ -211,7 +212,7 @@ class SettingsViewModel : ViewModel() {
             val soundVolume = SoundPreferenceManager.getSoundVolume(context)
             updateSettings(context) {
                 it.copy(
-                    theme = theme.name,
+                    theme = ThemePreferenceManager.encodeTheme(theme),
                     darkTheme = dark,
                     font = font.name,
                     soundEnabled = soundEnabled,
@@ -226,7 +227,7 @@ class SettingsViewModel : ViewModel() {
             Log.d("SettingsViewModel", "Επαναφορά ρυθμίσεων στα προεπιλεγμένα")
             updateSettings(context) {
                 it.copy(
-                    theme = AppTheme.Ocean.name,
+                    theme = ThemePreferenceManager.encodeTheme(AppTheme.Ocean),
                     darkTheme = false,
                     font = AppFont.SansSerif.name,
                     soundEnabled = true,

--- a/scripts/fetch_materialize_themes.py
+++ b/scripts/fetch_materialize_themes.py
@@ -1,0 +1,65 @@
+import json
+import re
+from pathlib import Path
+import requests
+from bs4 import BeautifulSoup
+
+# Αυτή η δέσμη ενεργειών κατεβάζει τις σελίδες Materialize Themes
+# από ThemeForest και BootstrapMade και δημιουργεί αρχείο JSON
+# με το όνομα και το βασικό χρώμα κάθε θέματος.
+
+HEADERS = {
+    "User-Agent": "Mozilla/5.0"
+}
+
+def fetch_themeforest_themes():
+    url = "https://themeforest.net/category/site-templates/material-design"
+    r = requests.get(url, headers=HEADERS)
+    r.raise_for_status()
+    soup = BeautifulSoup(r.text, "html.parser")
+    items = []
+    for item in soup.select("a.thumb"):
+        name = item.get("title")
+        if not name:
+            continue
+        name = name.strip()
+        if not name:
+            continue
+        items.append({"label": name, "seed": "#2196F3"})
+    return items
+
+def fetch_bootstrapmade_themes():
+    url = "https://bootstrapmade.com/bootstrap-template-categories/material-design/"
+    r = requests.get(url, headers=HEADERS)
+    r.raise_for_status()
+    soup = BeautifulSoup(r.text, "html.parser")
+    items = []
+    for card in soup.select("div.item"):
+        name_tag = card.select_one("h3")
+        if not name_tag:
+            continue
+        name = name_tag.get_text(strip=True)
+        items.append({"label": name, "seed": "#2196F3"})
+    return items
+
+
+def main():
+    themes = []
+    try:
+        themes += fetch_themeforest_themes()
+    except Exception as e:
+        print(f"ThemeForest error: {e}")
+    try:
+        themes += fetch_bootstrapmade_themes()
+    except Exception as e:
+        print(f"BootstrapMade error: {e}")
+    if themes:
+        Path("app/src/main/assets").mkdir(parents=True, exist_ok=True)
+        with open("app/src/main/assets/themes.json", "w", encoding="utf-8") as f:
+            json.dump(themes, f, ensure_ascii=False, indent=2)
+        print(f"Saved {len(themes)} themes to themes.json")
+    else:
+        print("Δεν βρέθηκαν θέματα")
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
- add script to fetch Materialize themes
- store fetched themes in `themes.json`
- document how to run the script
- load Materialize themes dynamically in settings

## Testing
- `./gradlew test --no-daemon` *(fails: blocked maven.pkg.jetbrains.space)*

------
https://chatgpt.com/codex/tasks/task_e_685a48e474008328bb97c811037050b2