### PR TITLE
Τροποποίηση μεγέθους λογότυπου στο μενού

### DIFF
--- a/app/src/main/java/com/ioannapergamali/mysmartroute/view/ui/components/LogoImage.kt
+++ b/app/src/main/java/com/ioannapergamali/mysmartroute/view/ui/components/LogoImage.kt
@@ -8,14 +8,16 @@ import androidx.compose.ui.layout.ContentScale
 import androidx.compose.ui.res.painterResource
 import androidx.annotation.DrawableRes
 import com.ioannapergamali.mysmartroute.view.ui.util.rememberLogoSize
+import androidx.compose.ui.unit.Dp
 
 @Composable
 fun LogoImage(
     @DrawableRes drawableRes: Int,
     contentDescription: String?,
-    modifier: Modifier = Modifier
+    modifier: Modifier = Modifier,
+    size: Dp? = null
 ) {
-    val targetSize = rememberLogoSize()
+    val targetSize = size ?: rememberLogoSize()
 
     Image(
         painter = painterResource(drawableRes),

--- a/app/src/main/java/com/ioannapergamali/mysmartroute/view/ui/components/NavigationDrawer.kt
+++ b/app/src/main/java/com/ioannapergamali/mysmartroute/view/ui/components/NavigationDrawer.kt
@@ -12,6 +12,7 @@ import com.ioannapergamali.mysmartroute.view.ui.components.LogoAssets
 import com.google.firebase.auth.FirebaseAuth
 import androidx.compose.material3.*
 import androidx.compose.material3.MaterialTheme
+import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.padding
 import androidx.compose.runtime.Composable
@@ -34,9 +35,13 @@ fun DrawerMenu(navController: NavController, closeDrawer: () -> Unit) {
             LogoImage(
                 drawableRes = LogoAssets.LOGO,
                 contentDescription = "logo",
-                modifier = Modifier.padding(end = 8.dp)
+                modifier = Modifier.padding(end = 8.dp),
+                size = 36.dp
             )
-            Text("Menu")
+            Text(
+                "Menu",
+                style = MaterialTheme.typography.titleMedium.copy(fontWeight = FontWeight.Bold)
+            )
         }
         val context = LocalContext.current
         val user = FirebaseAuth.getInstance().currentUser


### PR DESCRIPTION
## Summary
- προστέθηκε optional παράμετρος `size` στο `LogoImage` ώστε να μπορεί να ορίζεται προσαρμοσμένο μέγεθος
- το λογότυπο στο πλευρικό μενού μειώθηκε σε 36dp και η επικεφαλίδα έγινε bold

## Testing
- `./gradlew build -x test` *(απέτυχε: λείπει το Android SDK)*

------
https://chatgpt.com/codex/tasks/task_e_685a6e8f3ef483289f41c107d35226fa