### PR TITLE
Προσθήκη επιλογών προφίλ στο μενού

### DIFF
--- a/app/src/main/java/com/ioannapergamali/mysmartroute/model/navigation/NavigationHost.kt
+++ b/app/src/main/java/com/ioannapergamali/mysmartroute/model/navigation/NavigationHost.kt
@@ -24,6 +24,7 @@ import com.ioannapergamali.mysmartroute.view.ui.screens.FirebaseDatabaseScreen
 import com.ioannapergamali.mysmartroute.view.ui.screens.AdminSignUpScreen
 import com.ioannapergamali.mysmartroute.view.ui.screens.DatabaseSyncScreen
 import com.ioannapergamali.mysmartroute.view.ui.screens.RolesScreen
+import com.ioannapergamali.mysmartroute.view.ui.screens.ProfileScreen
 
 
 
@@ -101,6 +102,10 @@ fun NavigationHost(navController : NavHostController, openDrawer: () -> Unit) {
 
         composable("roles") {
             RolesScreen(navController = navController, openDrawer = openDrawer)
+        }
+
+        composable("profile") {
+            ProfileScreen(navController = navController, openDrawer = openDrawer)
         }
 
         composable("soundPicker") {

--- a/app/src/main/java/com/ioannapergamali/mysmartroute/view/ui/components/NavigationDrawer.kt
+++ b/app/src/main/java/com/ioannapergamali/mysmartroute/view/ui/components/NavigationDrawer.kt
@@ -9,6 +9,8 @@ import androidx.compose.material.icons.filled.Storage
 import androidx.compose.material.icons.filled.AdminPanelSettings
 import androidx.compose.material.icons.filled.Person
 import androidx.compose.material.icons.filled.Login
+import androidx.compose.material.icons.filled.Settings
+import androidx.compose.material.icons.filled.People
 import com.google.firebase.auth.FirebaseAuth
 import androidx.compose.material3.*
 import androidx.compose.material3.MaterialTheme
@@ -117,6 +119,33 @@ fun DrawerMenu(navController: NavController, closeDrawer: () -> Unit) {
             icon = { Icon(Icons.Filled.AdminPanelSettings, contentDescription = null, tint = MaterialTheme.colorScheme.primary) }
         )
         if (user != null) {
+            NavigationDrawerItem(
+                label = { Text("Profile") },
+                selected = false,
+                onClick = {
+                    navController.navigate("profile")
+                    closeDrawer()
+                },
+                icon = { Icon(Icons.Filled.Person, contentDescription = null, tint = MaterialTheme.colorScheme.primary) }
+            )
+            NavigationDrawerItem(
+                label = { Text("Settings") },
+                selected = false,
+                onClick = {
+                    navController.navigate("settings")
+                    closeDrawer()
+                },
+                icon = { Icon(Icons.Filled.Settings, contentDescription = null, tint = MaterialTheme.colorScheme.primary) }
+            )
+            NavigationDrawerItem(
+                label = { Text("Roles") },
+                selected = false,
+                onClick = {
+                    navController.navigate("roles")
+                    closeDrawer()
+                },
+                icon = { Icon(Icons.Filled.People, contentDescription = null, tint = MaterialTheme.colorScheme.primary) }
+            )
             NavigationDrawerItem(
                 label = { Text("Logout") },
                 selected = false,

--- a/app/src/main/java/com/ioannapergamali/mysmartroute/view/ui/screens/ProfileScreen.kt
+++ b/app/src/main/java/com/ioannapergamali/mysmartroute/view/ui/screens/ProfileScreen.kt
@@ -1,0 +1,53 @@
+package com.ioannapergamali.mysmartroute.view.ui.screens
+
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.padding
+import androidx.compose.material3.Scaffold
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.unit.dp
+import androidx.navigation.NavController
+import com.ioannapergamali.mysmartroute.view.ui.components.ScreenContainer
+import com.ioannapergamali.mysmartroute.view.ui.components.TopBar
+import com.google.firebase.auth.FirebaseAuth
+import com.google.firebase.firestore.FirebaseFirestore
+
+@Composable
+fun ProfileScreen(navController: NavController, openDrawer: () -> Unit) {
+    val user = FirebaseAuth.getInstance().currentUser
+    val username = remember { mutableStateOf<String?>(null) }
+
+    LaunchedEffect(user) {
+        val uid = user?.uid
+        if (uid != null) {
+            FirebaseFirestore.getInstance().collection("users")
+                .document(uid)
+                .get()
+                .addOnSuccessListener { doc ->
+                    username.value = doc.getString("username")
+                }
+        }
+    }
+
+    Scaffold(
+        topBar = {
+            TopBar(
+                title = "Profile",
+                navController = navController,
+                showMenu = true,
+                onMenuClick = openDrawer
+            )
+        }
+    ) { padding ->
+        ScreenContainer(modifier = Modifier.padding(padding)) {
+            Column(modifier = Modifier.padding(16.dp)) {
+                Text(text = "Email: ${user?.email ?: ""}")
+                username.value?.let { Text(text = "Username: $it") }
+            }
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- δημιουργήθηκε νέο `ProfileScreen`
- προστέθηκε στο NavigationHost η διαδρομή `profile`
- στο πλάγιο μενού εμφανίζονται επιπλέον οι επιλογές Προφίλ, Ρυθμίσεις και Ρόλοι όταν ο χρήστης είναι συνδεδεμένος

## Testing
- `./gradlew assembleDebug` *(απέτυχε: δεν βρέθηκε Android SDK)*

------
https://chatgpt.com/codex/tasks/task_e_685a8327c62c8328b6353e25f6ecb7bb