### PR TITLE
Add language selection

### DIFF
--- a/app/src/main/java/com/ioannapergamali/mysmartroute/data/local/MySmartRouteDatabase.kt
+++ b/app/src/main/java/com/ioannapergamali/mysmartroute/data/local/MySmartRouteDatabase.kt
@@ -22,7 +22,7 @@ import com.ioannapergamali.mysmartroute.data.local.MenuOptionEntity
         MenuEntity::class,
         MenuOptionEntity::class
     ],
-    version = 17
+    version = 18
 )
 abstract class MySmartRouteDatabase : RoomDatabase() {
     abstract fun userDao(): UserDao
@@ -104,13 +104,14 @@ abstract class MySmartRouteDatabase : RoomDatabase() {
                         "`font` TEXT NOT NULL, " +
                         "`soundEnabled` INTEGER NOT NULL, " +
                         "`soundVolume` REAL NOT NULL, " +
+                        "`language` TEXT NOT NULL DEFAULT 'el', " +
                         "FOREIGN KEY(`userId`) REFERENCES `users`(`id`) ON DELETE CASCADE, " +
                         "PRIMARY KEY(`userId`)" +
                     ")"
                 )
                 database.execSQL(
-                    "INSERT INTO `settings_new` (`userId`, `theme`, `darkTheme`, `font`, `soundEnabled`, `soundVolume`) " +
-                        "SELECT `userId`, `theme`, `darkTheme`, `font`, `soundEnabled`, `soundVolume` FROM `settings`"
+                    "INSERT INTO `settings_new` (`userId`, `theme`, `darkTheme`, `font`, `soundEnabled`, `soundVolume`, `language`) " +
+                        "SELECT `userId`, `theme`, `darkTheme`, `font`, `soundEnabled`, `soundVolume`, 'el' FROM `settings`"
                 )
                 database.execSQL("DROP TABLE `settings`")
                 database.execSQL("ALTER TABLE `settings_new` RENAME TO `settings`")
@@ -245,6 +246,12 @@ abstract class MySmartRouteDatabase : RoomDatabase() {
             }
         }
 
+        private val MIGRATION_17_18 = object : Migration(17, 18) {
+            override fun migrate(database: SupportSQLiteDatabase) {
+                database.execSQL("ALTER TABLE `settings` ADD COLUMN `language` TEXT NOT NULL DEFAULT 'el'")
+            }
+        }
+
         private fun prepopulate(db: SupportSQLiteDatabase) {
             Log.d(TAG, "Prepopulating database")
             db.execSQL(
@@ -326,7 +333,8 @@ abstract class MySmartRouteDatabase : RoomDatabase() {
                     MIGRATION_13_14,
                     MIGRATION_14_15,
                     MIGRATION_15_16,
-                    MIGRATION_16_17
+                    MIGRATION_16_17,
+                    MIGRATION_17_18
                 )
                     .addCallback(object : RoomDatabase.Callback() {
                         override fun onCreate(db: SupportSQLiteDatabase) {

--- a/app/src/main/java/com/ioannapergamali/mysmartroute/data/local/SettingsEntity.kt
+++ b/app/src/main/java/com/ioannapergamali/mysmartroute/data/local/SettingsEntity.kt
@@ -23,5 +23,6 @@ data class SettingsEntity(
     var darkTheme: Boolean = false,
     var font: String = "",
     var soundEnabled: Boolean = false,
-    var soundVolume: Float = 0f
+    var soundVolume: Float = 0f,
+    var language: String = "el"
 )

--- a/app/src/main/java/com/ioannapergamali/mysmartroute/model/AppLanguage.kt
+++ b/app/src/main/java/com/ioannapergamali/mysmartroute/model/AppLanguage.kt
@@ -1,0 +1,6 @@
+package com.ioannapergamali.mysmartroute.model
+
+enum class AppLanguage(val code: String, val label: String, val flag: String) {
+    Greek("el", "Ελληνικά", "\uD83C\uDDEC\uD83C\uDDF7"),
+    English("en", "English", "\uD83C\uDDEC\uD83C\uDDE7")
+}

--- a/app/src/main/java/com/ioannapergamali/mysmartroute/utils/FirestoreMappers.kt
+++ b/app/src/main/java/com/ioannapergamali/mysmartroute/utils/FirestoreMappers.kt
@@ -48,7 +48,8 @@ fun SettingsEntity.toFirestoreMap(): Map<String, Any> = mapOf(
     "darkTheme" to darkTheme,
     "font" to font,
     "soundEnabled" to soundEnabled,
-    "soundVolume" to soundVolume
+    "soundVolume" to soundVolume,
+    "language" to language
 )
 
 /** Μετατροπή εγγράφου Firestore σε [UserEntity]. */

--- a/app/src/main/java/com/ioannapergamali/mysmartroute/utils/LanguagePreferenceManager.kt
+++ b/app/src/main/java/com/ioannapergamali/mysmartroute/utils/LanguagePreferenceManager.kt
@@ -1,0 +1,25 @@
+package com.ioannapergamali.mysmartroute.utils
+
+import android.content.Context
+import androidx.datastore.preferences.core.edit
+import androidx.datastore.preferences.core.stringPreferencesKey
+import androidx.datastore.preferences.preferencesDataStore
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.map
+
+private val Context.languageDataStore by preferencesDataStore(name = "language_settings")
+
+object LanguagePreferenceManager {
+    private val LANGUAGE_KEY = stringPreferencesKey("language")
+
+    fun languageFlow(context: Context): Flow<String> =
+        context.languageDataStore.data.map { prefs ->
+            prefs[LANGUAGE_KEY] ?: "el"
+        }
+
+    suspend fun setLanguage(context: Context, language: String) {
+        context.languageDataStore.edit { prefs ->
+            prefs[LANGUAGE_KEY] = language
+        }
+    }
+}

--- a/app/src/main/java/com/ioannapergamali/mysmartroute/utils/LocaleUtils.kt
+++ b/app/src/main/java/com/ioannapergamali/mysmartroute/utils/LocaleUtils.kt
@@ -1,0 +1,15 @@
+package com.ioannapergamali.mysmartroute.utils
+
+import android.content.Context
+import android.content.res.Configuration
+import java.util.Locale
+
+object LocaleUtils {
+    fun updateLocale(context: Context, language: String) {
+        val locale = Locale(language)
+        Locale.setDefault(locale)
+        val config = Configuration(context.resources.configuration)
+        config.setLocale(locale)
+        context.resources.updateConfiguration(config, context.resources.displayMetrics)
+    }
+}

--- a/app/src/main/java/com/ioannapergamali/mysmartroute/view/ui/screens/SettingsScreen.kt
+++ b/app/src/main/java/com/ioannapergamali/mysmartroute/view/ui/screens/SettingsScreen.kt
@@ -41,6 +41,8 @@ import com.ioannapergamali.mysmartroute.utils.SoundManager
 import com.ioannapergamali.mysmartroute.utils.SoundPreferenceManager
 import com.ioannapergamali.mysmartroute.utils.ThemePreferenceManager
 import com.ioannapergamali.mysmartroute.utils.FontPreferenceManager
+import com.ioannapergamali.mysmartroute.utils.LanguagePreferenceManager
+import com.ioannapergamali.mysmartroute.model.AppLanguage
 import com.ioannapergamali.mysmartroute.view.ui.AppFont
 import com.ioannapergamali.mysmartroute.view.ui.AppTheme
 import com.ioannapergamali.mysmartroute.view.ui.MysmartrouteTheme
@@ -61,6 +63,7 @@ fun SettingsScreen(navController: NavController, openDrawer: () -> Unit) {
     val currentFont by FontPreferenceManager.fontFlow(context).collectAsState(initial = AppFont.SansSerif)
     val soundEnabled by SoundPreferenceManager.soundEnabledFlow(context).collectAsState(initial = true)
     val currentVolume by SoundPreferenceManager.soundVolumeFlow(context).collectAsState(initial = 1f)
+    val currentLanguage by LanguagePreferenceManager.languageFlow(context).collectAsState(initial = AppLanguage.Greek.code)
 
     val expandedTheme = remember { mutableStateOf(false) }
     val selectedTheme = remember { mutableStateOf<ThemeOption>(currentTheme) }
@@ -72,6 +75,8 @@ fun SettingsScreen(navController: NavController, openDrawer: () -> Unit) {
 
     val soundState = remember { mutableStateOf(soundEnabled) }
     val volumeState = remember { mutableFloatStateOf(currentVolume) }
+    val expandedLanguage = remember { mutableStateOf(false) }
+    val selectedLanguage = remember { mutableStateOf(currentLanguage) }
 
 
     LaunchedEffect(currentTheme) { selectedTheme.value = currentTheme }
@@ -79,6 +84,7 @@ fun SettingsScreen(navController: NavController, openDrawer: () -> Unit) {
     LaunchedEffect(currentFont) { selectedFont.value = currentFont }
     LaunchedEffect(soundEnabled) { soundState.value = soundEnabled }
     LaunchedEffect(currentVolume) { volumeState.floatValue = currentVolume }
+    LaunchedEffect(currentLanguage) { selectedLanguage.value = currentLanguage }
 
     MysmartrouteTheme(
         theme = selectedTheme.value,
@@ -156,6 +162,35 @@ fun SettingsScreen(navController: NavController, openDrawer: () -> Unit) {
                 }
             }
 
+            Text("Γλώσσα", modifier = Modifier.padding(top = 16.dp))
+            Divider(
+                modifier = Modifier.padding(vertical = 4.dp),
+                color = MaterialTheme.colorScheme.outline
+            )
+            ExposedDropdownMenuBox(expanded = expandedLanguage.value, onExpandedChange = { expandedLanguage.value = !expandedLanguage.value }) {
+                OutlinedTextField(
+                    readOnly = true,
+                    value = AppLanguage.values().first { it.code == selectedLanguage.value }.let { it.flag + " " + it.label },
+                    onValueChange = {},
+                    label = { Text("Language") },
+                    trailingIcon = { ExposedDropdownMenuDefaults.TrailingIcon(expanded = expandedLanguage.value) },
+                    modifier = Modifier.menuAnchor(),
+                    shape = MaterialTheme.shapes.small,
+                    colors = OutlinedTextFieldDefaults.colors(
+                        focusedBorderColor = MaterialTheme.colorScheme.primary,
+                        unfocusedBorderColor = MaterialTheme.colorScheme.primary
+                    )
+                )
+                DropdownMenu(expanded = expandedLanguage.value, onDismissRequest = { expandedLanguage.value = false }) {
+                    AppLanguage.values().forEach { lang ->
+                        DropdownMenuItem(text = { Text(lang.flag + " " + lang.label) }, onClick = {
+                            selectedLanguage.value = lang.code
+                            expandedLanguage.value = false
+                        })
+                    }
+                }
+            }
+
             Text("Ήχος", modifier = Modifier.padding(top = 16.dp))
             Divider(
                 modifier = Modifier.padding(vertical = 4.dp),
@@ -194,7 +229,8 @@ fun SettingsScreen(navController: NavController, openDrawer: () -> Unit) {
                         dark.value,
                         selectedFont.value,
                         soundState.value,
-                        volumeState.floatValue
+                        volumeState.floatValue,
+                        selectedLanguage.value
                     )
                 },
                 modifier = Modifier.padding(top = 8.dp)

--- a/app/src/main/java/com/ioannapergamali/mysmartroute/viewmodel/DatabaseViewModel.kt
+++ b/app/src/main/java/com/ioannapergamali/mysmartroute/viewmodel/DatabaseViewModel.kt
@@ -123,7 +123,8 @@ class DatabaseViewModel : ViewModel() {
                         darkTheme = doc.getBoolean("darkTheme") ?: false,
                         font = doc.getString("font") ?: "",
                         soundEnabled = doc.getBoolean("soundEnabled") ?: false,
-                        soundVolume = (doc.getDouble("soundVolume") ?: 0.0).toFloat()
+                        soundVolume = (doc.getDouble("soundVolume") ?: 0.0).toFloat(),
+                        language = doc.getString("language") ?: "el"
                     )
                 }
             Log.d(TAG, "Fetched ${'$'}{settings.size} settings from Firebase")
@@ -242,7 +243,8 @@ class DatabaseViewModel : ViewModel() {
                                 darkTheme = doc.getBoolean("darkTheme") ?: false,
                                 font = doc.getString("font") ?: "",
                                 soundEnabled = doc.getBoolean("soundEnabled") ?: false,
-                                soundVolume = (doc.getDouble("soundVolume") ?: 0.0).toFloat()
+                                soundVolume = (doc.getDouble("soundVolume") ?: 0.0).toFloat(),
+                                language = doc.getString("language") ?: "el"
                             )
                         }
 

--- a/app/src/main/java/com/ioannapergamali/mysmartroute/viewmodel/MainActivity.kt
+++ b/app/src/main/java/com/ioannapergamali/mysmartroute/viewmodel/MainActivity.kt
@@ -28,6 +28,8 @@ import com.ioannapergamali.mysmartroute.utils.SoundPreferenceManager
 import com.ioannapergamali.mysmartroute.utils.SoundManager
 import com.ioannapergamali.mysmartroute.viewmodel.SettingsViewModel
 import com.ioannapergamali.mysmartroute.utils.MapsUtils
+import com.ioannapergamali.mysmartroute.utils.LanguagePreferenceManager
+import com.ioannapergamali.mysmartroute.utils.LocaleUtils
 import kotlinx.coroutines.launch
 import com.ioannapergamali.mysmartroute.model.interfaces.ThemeOption
 
@@ -71,6 +73,11 @@ class MainActivity : ComponentActivity() {
             val font by FontPreferenceManager.fontFlow(context).collectAsState(initial = AppFont.SansSerif)
             val soundEnabled by SoundPreferenceManager.soundEnabledFlow(context).collectAsState(initial = true)
             val soundVolume by SoundPreferenceManager.soundVolumeFlow(context).collectAsState(initial = 1f)
+            val language by LanguagePreferenceManager.languageFlow(context).collectAsState(initial = "el")
+
+            LaunchedEffect(language) {
+                LocaleUtils.updateLocale(context, language)
+            }
 
             LaunchedEffect(soundEnabled, soundVolume) {
                 SoundManager.setVolume(soundVolume)

--- a/app/src/main/java/com/ioannapergamali/mysmartroute/viewmodel/SettingsViewModel.kt
+++ b/app/src/main/java/com/ioannapergamali/mysmartroute/viewmodel/SettingsViewModel.kt
@@ -20,6 +20,8 @@ import com.ioannapergamali.mysmartroute.utils.FontPreferenceManager
 import com.ioannapergamali.mysmartroute.view.ui.AppFont
 import com.ioannapergamali.mysmartroute.model.interfaces.ThemeOption
 import com.ioannapergamali.mysmartroute.utils.SoundPreferenceManager
+import com.ioannapergamali.mysmartroute.utils.LanguagePreferenceManager
+import com.ioannapergamali.mysmartroute.utils.LocaleUtils
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.withContext
@@ -52,7 +54,8 @@ class SettingsViewModel : ViewModel() {
             darkTheme = false,
             font = AppFont.SansSerif.name,
             soundEnabled = true,
-            soundVolume = 1f
+            soundVolume = 1f,
+            language = "el"
         )
         val updated = transform(current)
         val checkingMessage = "Γίνονται έλεγχοι αποθήκευσης"
@@ -113,7 +116,8 @@ class SettingsViewModel : ViewModel() {
         dark: Boolean,
         font: AppFont,
         soundEnabled: Boolean,
-        soundVolume: Float
+        soundVolume: Float,
+        language: String
     ) {
         viewModelScope.launch {
             ThemePreferenceManager.setTheme(context, theme)
@@ -121,13 +125,16 @@ class SettingsViewModel : ViewModel() {
             FontPreferenceManager.setFont(context, font)
             SoundPreferenceManager.setSoundEnabled(context, soundEnabled)
             SoundPreferenceManager.setSoundVolume(context, soundVolume)
+            LanguagePreferenceManager.setLanguage(context, language)
+            LocaleUtils.updateLocale(context, language)
             updateSettings(context) {
                 it.copy(
                     theme = (theme as? AppTheme)?.name ?: theme.label,
                     darkTheme = dark,
                     font = font.name,
                     soundEnabled = soundEnabled,
-                    soundVolume = soundVolume
+                    soundVolume = soundVolume,
+                    language = language
                 )
             }
         }
@@ -158,6 +165,13 @@ class SettingsViewModel : ViewModel() {
         }
     }
 
+    fun applyLanguage(context: Context, language: String) {
+        viewModelScope.launch {
+            LanguagePreferenceManager.setLanguage(context, language)
+            LocaleUtils.updateLocale(context, language)
+        }
+    }
+
     fun syncSettings(context: Context) {
         viewModelScope.launch {
             val userId = auth.currentUser?.uid ?: return@launch
@@ -180,7 +194,8 @@ class SettingsViewModel : ViewModel() {
                             darkTheme = doc.getBoolean("darkTheme") ?: false,
                             font = doc.getString("font") ?: AppFont.SansSerif.name,
                             soundEnabled = doc.getBoolean("soundEnabled") ?: true,
-                            soundVolume = (doc.getDouble("soundVolume") ?: 1.0).toFloat()
+                            soundVolume = (doc.getDouble("soundVolume") ?: 1.0).toFloat(),
+                            language = doc.getString("language") ?: "el"
                         )
                     } else null
                 } catch (_: Exception) {
@@ -196,6 +211,8 @@ class SettingsViewModel : ViewModel() {
             FontPreferenceManager.setFont(context, AppFont.valueOf(settings.font))
             SoundPreferenceManager.setSoundEnabled(context, settings.soundEnabled)
             SoundPreferenceManager.setSoundVolume(context, settings.soundVolume)
+            LanguagePreferenceManager.setLanguage(context, settings.language)
+            LocaleUtils.updateLocale(context, settings.language)
         }
     }
 
@@ -210,13 +227,15 @@ class SettingsViewModel : ViewModel() {
             val font = FontPreferenceManager.fontFlow(context).first()
             val soundEnabled = SoundPreferenceManager.getSoundEnabled(context)
             val soundVolume = SoundPreferenceManager.getSoundVolume(context)
+            val language = LanguagePreferenceManager.languageFlow(context).first()
             updateSettings(context) {
                 it.copy(
                     theme = (theme as? AppTheme)?.name ?: theme.label,
                     darkTheme = dark,
                     font = font.name,
                     soundEnabled = soundEnabled,
-                    soundVolume = soundVolume
+                    soundVolume = soundVolume,
+                    language = language
                 )
             }
         }
@@ -231,7 +250,8 @@ class SettingsViewModel : ViewModel() {
                     darkTheme = false,
                     font = AppFont.SansSerif.name,
                     soundEnabled = true,
-                    soundVolume = 1f
+                    soundVolume = 1f,
+                    language = "el"
                 )
             }
         }

--- a/app/src/main/res/values-en/strings.xml
+++ b/app/src/main/res/values-en/strings.xml
@@ -1,0 +1,12 @@
+<resources>
+    <string name="app_name">mysmartroute</string>
+    <string name="invalid_coordinates">Invalid coordinates</string>
+    <string name="no_internet">No internet connection</string>
+    <string name="directions">Get Directions</string>
+    <string name="coordinates_valid">Coordinates are valid</string>
+    <string name="coordinates_missing">Missing coordinates</string>
+    <string name="check_coordinates">Check coordinates</string>
+    <string name="internet_available">Internet connection available</string>
+    <string name="check_internet">Check connection</string>
+    <string name="map_api_key_missing">Maps API key missing</string>
+</resources>


### PR DESCRIPTION
## Summary
- add `LanguagePreferenceManager` and `LocaleUtils`
- add `AppLanguage` enum
- update `SettingsViewModel` with language handling
- update `SettingsScreen` UI with language dropdown
- persist language in local database and Firestore
- apply language on startup in `MainActivity`
- handle DB migration for new language column
- add English string resources

## Testing
- `./gradlew test` *(fails: domain not in allowlist)*

------
https://chatgpt.com/codex/tasks/task_e_685b1ac21d4c8328863b475b47a16877