### PR TITLE
Language selection with Firestore persistence

### DIFF
--- a/app/src/main/java/com/ioannapergamali/mysmartroute/data/local/MySmartRouteDatabase.kt
+++ b/app/src/main/java/com/ioannapergamali/mysmartroute/data/local/MySmartRouteDatabase.kt
@@ -22,7 +22,7 @@ import com.ioannapergamali.mysmartroute.data.local.MenuOptionEntity
         MenuEntity::class,
         MenuOptionEntity::class
     ],
-    version = 17
+    version = 18
 )
 abstract class MySmartRouteDatabase : RoomDatabase() {
     abstract fun userDao(): UserDao
@@ -245,6 +245,12 @@ abstract class MySmartRouteDatabase : RoomDatabase() {
             }
         }
 
+        private val MIGRATION_17_18 = object : Migration(17, 18) {
+            override fun migrate(database: SupportSQLiteDatabase) {
+                database.execSQL("ALTER TABLE `settings` ADD COLUMN `language` TEXT NOT NULL DEFAULT 'ENGLISH'")
+            }
+        }
+
         private fun prepopulate(db: SupportSQLiteDatabase) {
             Log.d(TAG, "Prepopulating database")
             db.execSQL(
@@ -326,7 +332,8 @@ abstract class MySmartRouteDatabase : RoomDatabase() {
                     MIGRATION_13_14,
                     MIGRATION_14_15,
                     MIGRATION_15_16,
-                    MIGRATION_16_17
+                    MIGRATION_16_17,
+                    MIGRATION_17_18
                 )
                     .addCallback(object : RoomDatabase.Callback() {
                         override fun onCreate(db: SupportSQLiteDatabase) {

--- a/app/src/main/java/com/ioannapergamali/mysmartroute/data/local/SettingsEntity.kt
+++ b/app/src/main/java/com/ioannapergamali/mysmartroute/data/local/SettingsEntity.kt
@@ -22,6 +22,7 @@ data class SettingsEntity(
     var theme: String = "",
     var darkTheme: Boolean = false,
     var font: String = "",
+    var language: String = "",
     var soundEnabled: Boolean = false,
     var soundVolume: Float = 0f
 )

--- a/app/src/main/java/com/ioannapergamali/mysmartroute/model/enumerations/AppLanguage.kt
+++ b/app/src/main/java/com/ioannapergamali/mysmartroute/model/enumerations/AppLanguage.kt
@@ -1,0 +1,8 @@
+package com.ioannapergamali.mysmartroute.model.enumerations
+
+import java.util.Locale
+
+enum class AppLanguage(val label: String, val locale: Locale) {
+    ENGLISH("English", Locale.ENGLISH),
+    GREEK("Ελληνικά", Locale("el"))
+}

--- a/app/src/main/java/com/ioannapergamali/mysmartroute/utils/FirestoreMappers.kt
+++ b/app/src/main/java/com/ioannapergamali/mysmartroute/utils/FirestoreMappers.kt
@@ -47,6 +47,7 @@ fun SettingsEntity.toFirestoreMap(): Map<String, Any> = mapOf(
     "theme" to theme,
     "darkTheme" to darkTheme,
     "font" to font,
+    "language" to language,
     "soundEnabled" to soundEnabled,
     "soundVolume" to soundVolume
 )

--- a/app/src/main/java/com/ioannapergamali/mysmartroute/utils/LanguagePreferenceManager.kt
+++ b/app/src/main/java/com/ioannapergamali/mysmartroute/utils/LanguagePreferenceManager.kt
@@ -1,0 +1,37 @@
+package com.ioannapergamali.mysmartroute.utils
+
+import android.content.Context
+import androidx.datastore.preferences.core.edit
+import androidx.datastore.preferences.core.stringPreferencesKey
+import androidx.datastore.preferences.preferencesDataStore
+import com.ioannapergamali.mysmartroute.model.enumerations.AppLanguage
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.map
+import java.util.Locale
+
+private val Context.languageDataStore by preferencesDataStore(name = "language_settings")
+
+object LanguagePreferenceManager {
+    private val LANG_KEY = stringPreferencesKey("language")
+
+    fun languageFlow(context: Context): Flow<AppLanguage> =
+        context.languageDataStore.data.map { prefs ->
+            val name = prefs[LANG_KEY] ?: AppLanguage.ENGLISH.name
+            AppLanguage.values().firstOrNull { it.name == name } ?: AppLanguage.ENGLISH
+        }
+
+    suspend fun setLanguage(context: Context, language: AppLanguage) {
+        context.languageDataStore.edit { prefs ->
+            prefs[LANG_KEY] = language.name
+        }
+    }
+
+    fun applyLanguage(context: Context, language: AppLanguage) {
+        val locale = language.locale
+        Locale.setDefault(locale)
+        val resources = context.resources
+        val config = resources.configuration
+        config.setLocale(locale)
+        resources.updateConfiguration(config, resources.displayMetrics)
+    }
+}

--- a/app/src/main/java/com/ioannapergamali/mysmartroute/view/ui/screens/SettingsScreen.kt
+++ b/app/src/main/java/com/ioannapergamali/mysmartroute/view/ui/screens/SettingsScreen.kt
@@ -41,6 +41,7 @@ import com.ioannapergamali.mysmartroute.utils.SoundManager
 import com.ioannapergamali.mysmartroute.utils.SoundPreferenceManager
 import com.ioannapergamali.mysmartroute.utils.ThemePreferenceManager
 import com.ioannapergamali.mysmartroute.utils.FontPreferenceManager
+import com.ioannapergamali.mysmartroute.utils.LanguagePreferenceManager
 import com.ioannapergamali.mysmartroute.view.ui.AppFont
 import com.ioannapergamali.mysmartroute.view.ui.AppTheme
 import com.ioannapergamali.mysmartroute.view.ui.MysmartrouteTheme
@@ -49,6 +50,7 @@ import com.ioannapergamali.mysmartroute.view.ui.components.ScreenContainer
 import com.ioannapergamali.mysmartroute.viewmodel.SettingsViewModel
 import com.ioannapergamali.mysmartroute.model.interfaces.ThemeOption
 import com.ioannapergamali.mysmartroute.data.ThemeLoader
+import com.ioannapergamali.mysmartroute.model.enumerations.AppLanguage
 
 @Composable
 @OptIn(ExperimentalMaterial3Api::class)
@@ -59,6 +61,7 @@ fun SettingsScreen(navController: NavController, openDrawer: () -> Unit) {
     val currentTheme by ThemePreferenceManager.themeFlow(context).collectAsState(initial = AppTheme.Ocean)
     val currentDark by ThemePreferenceManager.darkThemeFlow(context).collectAsState(initial = false)
     val currentFont by FontPreferenceManager.fontFlow(context).collectAsState(initial = AppFont.SansSerif)
+    val currentLanguage by LanguagePreferenceManager.languageFlow(context).collectAsState(initial = AppLanguage.ENGLISH)
     val soundEnabled by SoundPreferenceManager.soundEnabledFlow(context).collectAsState(initial = true)
     val currentVolume by SoundPreferenceManager.soundVolumeFlow(context).collectAsState(initial = 1f)
 
@@ -70,6 +73,9 @@ fun SettingsScreen(navController: NavController, openDrawer: () -> Unit) {
     val expandedFont = remember { mutableStateOf(false) }
     val selectedFont = remember { mutableStateOf(currentFont) }
 
+    val expandedLanguage = remember { mutableStateOf(false) }
+    val selectedLanguage = remember { mutableStateOf(currentLanguage) }
+
     val soundState = remember { mutableStateOf(soundEnabled) }
     val volumeState = remember { mutableFloatStateOf(currentVolume) }
 
@@ -77,6 +83,7 @@ fun SettingsScreen(navController: NavController, openDrawer: () -> Unit) {
     LaunchedEffect(currentTheme) { selectedTheme.value = currentTheme }
     LaunchedEffect(currentDark) { dark.value = currentDark }
     LaunchedEffect(currentFont) { selectedFont.value = currentFont }
+    LaunchedEffect(currentLanguage) { selectedLanguage.value = currentLanguage }
     LaunchedEffect(soundEnabled) { soundState.value = soundEnabled }
     LaunchedEffect(currentVolume) { volumeState.floatValue = currentVolume }
 
@@ -156,6 +163,35 @@ fun SettingsScreen(navController: NavController, openDrawer: () -> Unit) {
                 }
             }
 
+            Text("Γλώσσα", modifier = Modifier.padding(top = 16.dp))
+            Divider(
+                modifier = Modifier.padding(vertical = 4.dp),
+                color = MaterialTheme.colorScheme.outline
+            )
+            ExposedDropdownMenuBox(expanded = expandedLanguage.value, onExpandedChange = { expandedLanguage.value = !expandedLanguage.value }) {
+                OutlinedTextField(
+                    readOnly = true,
+                    value = selectedLanguage.value.label,
+                    onValueChange = {},
+                    label = { Text("Language") },
+                    trailingIcon = { ExposedDropdownMenuDefaults.TrailingIcon(expanded = expandedLanguage.value) },
+                    modifier = Modifier.menuAnchor(),
+                    shape = MaterialTheme.shapes.small,
+                    colors = OutlinedTextFieldDefaults.colors(
+                        focusedBorderColor = MaterialTheme.colorScheme.primary,
+                        unfocusedBorderColor = MaterialTheme.colorScheme.primary
+                    )
+                )
+                DropdownMenu(expanded = expandedLanguage.value, onDismissRequest = { expandedLanguage.value = false }) {
+                    AppLanguage.values().forEach { lang ->
+                        DropdownMenuItem(text = { Text(lang.label) }, onClick = {
+                            selectedLanguage.value = lang
+                            expandedLanguage.value = false
+                        })
+                    }
+                }
+            }
+
             Text("Ήχος", modifier = Modifier.padding(top = 16.dp))
             Divider(
                 modifier = Modifier.padding(vertical = 4.dp),
@@ -193,6 +229,7 @@ fun SettingsScreen(navController: NavController, openDrawer: () -> Unit) {
                         selectedTheme.value,
                         dark.value,
                         selectedFont.value,
+                        selectedLanguage.value,
                         soundState.value,
                         volumeState.floatValue
                     )

--- a/app/src/main/java/com/ioannapergamali/mysmartroute/viewmodel/DatabaseViewModel.kt
+++ b/app/src/main/java/com/ioannapergamali/mysmartroute/viewmodel/DatabaseViewModel.kt
@@ -18,6 +18,7 @@ import com.ioannapergamali.mysmartroute.data.local.RoleEntity
 import com.ioannapergamali.mysmartroute.data.local.MenuEntity
 import com.ioannapergamali.mysmartroute.data.local.MenuOptionEntity
 import com.ioannapergamali.mysmartroute.data.local.UserEntity
+import com.ioannapergamali.mysmartroute.model.enumerations.AppLanguage
 import com.ioannapergamali.mysmartroute.data.local.VehicleEntity
 import com.ioannapergamali.mysmartroute.utils.NetworkUtils
 import kotlinx.coroutines.flow.MutableStateFlow
@@ -122,6 +123,7 @@ class DatabaseViewModel : ViewModel() {
                         theme = doc.getString("theme") ?: "",
                         darkTheme = doc.getBoolean("darkTheme") ?: false,
                         font = doc.getString("font") ?: "",
+                        language = doc.getString("language") ?: AppLanguage.ENGLISH.name,
                         soundEnabled = doc.getBoolean("soundEnabled") ?: false,
                         soundVolume = (doc.getDouble("soundVolume") ?: 0.0).toFloat()
                     )
@@ -241,6 +243,7 @@ class DatabaseViewModel : ViewModel() {
                                 theme = doc.getString("theme") ?: "",
                                 darkTheme = doc.getBoolean("darkTheme") ?: false,
                                 font = doc.getString("font") ?: "",
+                                language = doc.getString("language") ?: AppLanguage.ENGLISH.name,
                                 soundEnabled = doc.getBoolean("soundEnabled") ?: false,
                                 soundVolume = (doc.getDouble("soundVolume") ?: 0.0).toFloat()
                             )

--- a/app/src/main/java/com/ioannapergamali/mysmartroute/viewmodel/MainActivity.kt
+++ b/app/src/main/java/com/ioannapergamali/mysmartroute/viewmodel/MainActivity.kt
@@ -28,6 +28,8 @@ import com.ioannapergamali.mysmartroute.utils.SoundPreferenceManager
 import com.ioannapergamali.mysmartroute.utils.SoundManager
 import com.ioannapergamali.mysmartroute.viewmodel.SettingsViewModel
 import com.ioannapergamali.mysmartroute.utils.MapsUtils
+import com.ioannapergamali.mysmartroute.utils.LanguagePreferenceManager
+import com.ioannapergamali.mysmartroute.model.enumerations.AppLanguage
 import kotlinx.coroutines.launch
 import com.ioannapergamali.mysmartroute.model.interfaces.ThemeOption
 
@@ -69,6 +71,7 @@ class MainActivity : ComponentActivity() {
             val theme by ThemePreferenceManager.themeFlow(context).collectAsState(initial = AppTheme.Ocean)
             val dark by ThemePreferenceManager.darkThemeFlow(context).collectAsState(initial = false)
             val font by FontPreferenceManager.fontFlow(context).collectAsState(initial = AppFont.SansSerif)
+            val language by LanguagePreferenceManager.languageFlow(context).collectAsState(initial = AppLanguage.ENGLISH)
             val soundEnabled by SoundPreferenceManager.soundEnabledFlow(context).collectAsState(initial = true)
             val soundVolume by SoundPreferenceManager.soundVolumeFlow(context).collectAsState(initial = 1f)
 
@@ -79,6 +82,10 @@ class MainActivity : ComponentActivity() {
                 } else {
                     if (SoundManager.isPlaying) SoundManager.pause()
                 }
+            }
+
+            LaunchedEffect(language) {
+                LanguagePreferenceManager.applyLanguage(context, language)
             }
 
             MysmartrouteTheme(theme = theme, darkTheme = dark, font = font.fontFamily) {

--- a/app/src/main/java/com/ioannapergamali/mysmartroute/viewmodel/SettingsViewModel.kt
+++ b/app/src/main/java/com/ioannapergamali/mysmartroute/viewmodel/SettingsViewModel.kt
@@ -17,9 +17,11 @@ import com.ioannapergamali.mysmartroute.utils.NetworkUtils
 import kotlinx.coroutines.tasks.await
 import com.ioannapergamali.mysmartroute.utils.ThemePreferenceManager
 import com.ioannapergamali.mysmartroute.utils.FontPreferenceManager
+import com.ioannapergamali.mysmartroute.utils.LanguagePreferenceManager
 import com.ioannapergamali.mysmartroute.view.ui.AppFont
 import com.ioannapergamali.mysmartroute.model.interfaces.ThemeOption
 import com.ioannapergamali.mysmartroute.utils.SoundPreferenceManager
+import com.ioannapergamali.mysmartroute.model.enumerations.AppLanguage
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.withContext
@@ -51,6 +53,7 @@ class SettingsViewModel : ViewModel() {
             theme = AppTheme.Ocean.name,
             darkTheme = false,
             font = AppFont.SansSerif.name,
+            language = AppLanguage.ENGLISH.name,
             soundEnabled = true,
             soundVolume = 1f
         )
@@ -112,6 +115,7 @@ class SettingsViewModel : ViewModel() {
         theme: ThemeOption,
         dark: Boolean,
         font: AppFont,
+        language: AppLanguage,
         soundEnabled: Boolean,
         soundVolume: Float
     ) {
@@ -119,6 +123,8 @@ class SettingsViewModel : ViewModel() {
             ThemePreferenceManager.setTheme(context, theme)
             ThemePreferenceManager.setDarkTheme(context, dark)
             FontPreferenceManager.setFont(context, font)
+            LanguagePreferenceManager.setLanguage(context, language)
+            LanguagePreferenceManager.applyLanguage(context, language)
             SoundPreferenceManager.setSoundEnabled(context, soundEnabled)
             SoundPreferenceManager.setSoundVolume(context, soundVolume)
             updateSettings(context) {
@@ -126,6 +132,7 @@ class SettingsViewModel : ViewModel() {
                     theme = (theme as? AppTheme)?.name ?: theme.label,
                     darkTheme = dark,
                     font = font.name,
+                    language = language.name,
                     soundEnabled = soundEnabled,
                     soundVolume = soundVolume
                 )
@@ -179,6 +186,7 @@ class SettingsViewModel : ViewModel() {
                             theme = doc.getString("theme") ?: AppTheme.Ocean.name,
                             darkTheme = doc.getBoolean("darkTheme") ?: false,
                             font = doc.getString("font") ?: AppFont.SansSerif.name,
+                            language = doc.getString("language") ?: AppLanguage.ENGLISH.name,
                             soundEnabled = doc.getBoolean("soundEnabled") ?: true,
                             soundVolume = (doc.getDouble("soundVolume") ?: 1.0).toFloat()
                         )
@@ -194,6 +202,8 @@ class SettingsViewModel : ViewModel() {
             ThemePreferenceManager.setTheme(context, AppTheme.valueOf(settings.theme))
             ThemePreferenceManager.setDarkTheme(context, settings.darkTheme)
             FontPreferenceManager.setFont(context, AppFont.valueOf(settings.font))
+            LanguagePreferenceManager.setLanguage(context, AppLanguage.valueOf(settings.language))
+            LanguagePreferenceManager.applyLanguage(context, AppLanguage.valueOf(settings.language))
             SoundPreferenceManager.setSoundEnabled(context, settings.soundEnabled)
             SoundPreferenceManager.setSoundVolume(context, settings.soundVolume)
         }
@@ -208,6 +218,7 @@ class SettingsViewModel : ViewModel() {
             val theme = ThemePreferenceManager.themeFlow(context).first()
             val dark = ThemePreferenceManager.darkThemeFlow(context).first()
             val font = FontPreferenceManager.fontFlow(context).first()
+            val language = LanguagePreferenceManager.languageFlow(context).first()
             val soundEnabled = SoundPreferenceManager.getSoundEnabled(context)
             val soundVolume = SoundPreferenceManager.getSoundVolume(context)
             updateSettings(context) {
@@ -215,6 +226,7 @@ class SettingsViewModel : ViewModel() {
                     theme = (theme as? AppTheme)?.name ?: theme.label,
                     darkTheme = dark,
                     font = font.name,
+                    language = language.name,
                     soundEnabled = soundEnabled,
                     soundVolume = soundVolume
                 )
@@ -230,6 +242,7 @@ class SettingsViewModel : ViewModel() {
                     theme = AppTheme.Ocean.name,
                     darkTheme = false,
                     font = AppFont.SansSerif.name,
+                    language = AppLanguage.ENGLISH.name,
                     soundEnabled = true,
                     soundVolume = 1f
                 )

--- a/app/src/main/res/values-en/strings.xml
+++ b/app/src/main/res/values-en/strings.xml
@@ -1,0 +1,12 @@
+<resources>
+    <string name="app_name">mysmartroute</string>
+    <string name="invalid_coordinates">Invalid coordinates</string>
+    <string name="no_internet">No internet connection</string>
+    <string name="directions">Get directions</string>
+    <string name="coordinates_valid">Coordinates are valid</string>
+    <string name="coordinates_missing">Coordinates missing</string>
+    <string name="check_coordinates">Check coordinates</string>
+    <string name="internet_available">Internet connection available</string>
+    <string name="check_internet">Check connection</string>
+    <string name="map_api_key_missing">Missing map API key</string>
+</resources>


### PR DESCRIPTION
## Summary
- add `AppLanguage` enumeration and `LanguagePreferenceManager`
- store selected language in settings entity and Firestore
- update settings screen with language picker
- sync language preference in main activity
- provide migrations and English translations

## Testing
- `./gradlew test` *(fails: maven.pkg.jetbrains.space blocked)*

------
https://chatgpt.com/codex/tasks/task_e_685b22a68264832886d22926656a4897