### PR TITLE
Enable full UI translation

### DIFF
--- a/app/src/main/java/com/ioannapergamali/mysmartroute/view/ui/components/NavigationDrawer.kt
+++ b/app/src/main/java/com/ioannapergamali/mysmartroute/view/ui/components/NavigationDrawer.kt
@@ -79,7 +79,7 @@ fun DrawerMenu(navController: NavController, closeDrawer: () -> Unit) {
             )
             Spacer(Modifier.size(8.dp))
             Text(
-                text = username.value ?: if (user != null) user.email ?: "" else "Guest",
+                text = username.value ?: if (user != null) user.email ?: "" else stringResource(R.string.guest),
                 style = MaterialTheme.typography.titleMedium.copy(fontWeight = FontWeight.Bold)
             )
         }
@@ -88,7 +88,7 @@ fun DrawerMenu(navController: NavController, closeDrawer: () -> Unit) {
 
         
         NavigationDrawerItem(
-            label = { Text("About") },
+            label = { Text(stringResource(R.string.about_title)) },
             selected = false,
             onClick = {
                 navController.navigate("about")
@@ -97,7 +97,7 @@ fun DrawerMenu(navController: NavController, closeDrawer: () -> Unit) {
             icon = { Icon(Icons.Filled.Info, contentDescription = null, tint = MaterialTheme.colorScheme.primary) }
         )
         NavigationDrawerItem(
-            label = { Text("Support") },
+            label = { Text(stringResource(R.string.support_title)) },
             selected = false,
             onClick = {
                 navController.navigate("support")
@@ -106,7 +106,7 @@ fun DrawerMenu(navController: NavController, closeDrawer: () -> Unit) {
             icon = { Icon(Icons.Filled.Email, contentDescription = null, tint = MaterialTheme.colorScheme.primary) }
         )
         NavigationDrawerItem(
-            label = { Text("Databases") },
+            label = { Text(stringResource(R.string.databases_title)) },
             selected = false,
             onClick = {
                 navController.navigate("databaseMenu")
@@ -115,7 +115,7 @@ fun DrawerMenu(navController: NavController, closeDrawer: () -> Unit) {
             icon = { Icon(Icons.Filled.Storage, contentDescription = null, tint = MaterialTheme.colorScheme.primary) }
         )
         NavigationDrawerItem(
-            label = { Text("Admin Option") },
+            label = { Text(stringResource(R.string.admin_option)) },
             selected = false,
             onClick = {
                 navController.navigate("adminSignup")
@@ -125,7 +125,7 @@ fun DrawerMenu(navController: NavController, closeDrawer: () -> Unit) {
         )
         if (user != null) {
             NavigationDrawerItem(
-                label = { Text("Profile") },
+                label = { Text(stringResource(R.string.profile)) },
                 selected = false,
                 onClick = {
                     navController.navigate("profile")
@@ -143,7 +143,7 @@ fun DrawerMenu(navController: NavController, closeDrawer: () -> Unit) {
                 icon = { Icon(Icons.Filled.Settings, contentDescription = null, tint = MaterialTheme.colorScheme.primary) }
             )
             NavigationDrawerItem(
-                label = { Text("Μενού") },
+                label = { Text(stringResource(R.string.menu_title)) },
                 selected = false,
                 onClick = {
                     navController.navigate("menu")
@@ -152,7 +152,7 @@ fun DrawerMenu(navController: NavController, closeDrawer: () -> Unit) {
                 icon = { Icon(Icons.Filled.Menu, contentDescription = null, tint = MaterialTheme.colorScheme.primary) }
             )
             NavigationDrawerItem(
-                label = { Text("Logout") },
+                label = { Text(stringResource(R.string.logout)) },
                 selected = false,
                 onClick = {
                     FirebaseAuth.getInstance().signOut()
@@ -165,7 +165,7 @@ fun DrawerMenu(navController: NavController, closeDrawer: () -> Unit) {
             )
         } else {
             NavigationDrawerItem(
-                label = { Text("Login") },
+                label = { Text(stringResource(R.string.login)) },
                 selected = false,
                 onClick = {
                     navController.navigate("home") {
@@ -178,7 +178,7 @@ fun DrawerMenu(navController: NavController, closeDrawer: () -> Unit) {
         }
         val activity = (LocalContext.current as? Activity)
         NavigationDrawerItem(
-            label = { Text("Exit") },
+            label = { Text(stringResource(R.string.exit)) },
             selected = false,
             onClick = {
                 activity?.finishAffinity()

--- a/app/src/main/java/com/ioannapergamali/mysmartroute/view/ui/screens/AboutScreen.kt
+++ b/app/src/main/java/com/ioannapergamali/mysmartroute/view/ui/screens/AboutScreen.kt
@@ -13,6 +13,7 @@ import com.ioannapergamali.mysmartroute.R
 import com.ioannapergamali.mysmartroute.view.ui.components.ScreenContainer
 import androidx.navigation.NavController
 import com.ioannapergamali.mysmartroute.view.ui.components.TopBar
+import androidx.compose.ui.res.stringResource
 import com.ioannapergamali.mysmartroute.view.ui.components.LogoImage
 import com.ioannapergamali.mysmartroute.view.ui.components.LogoAssets
 
@@ -21,7 +22,7 @@ fun AboutScreen(navController: NavController, openDrawer: () -> Unit) {
     Scaffold(
         topBar = {
             TopBar(
-                title = "About",
+                title = stringResource(R.string.about_title),
                 navController = navController,
                 showMenu = true,
                 onMenuClick = openDrawer
@@ -41,7 +42,7 @@ fun AboutScreen(navController: NavController, openDrawer: () -> Unit) {
                 Spacer(modifier = Modifier.height(16.dp))
 
                 Text(
-                    text = "Credits",
+                    text = stringResource(R.string.credits),
                     style = MaterialTheme.typography.titleLarge
                 )
 

--- a/app/src/main/java/com/ioannapergamali/mysmartroute/view/ui/screens/DatabaseMenuScreen.kt
+++ b/app/src/main/java/com/ioannapergamali/mysmartroute/view/ui/screens/DatabaseMenuScreen.kt
@@ -11,13 +11,15 @@ import androidx.compose.ui.unit.dp
 import androidx.navigation.NavController
 import com.ioannapergamali.mysmartroute.view.ui.components.ScreenContainer
 import com.ioannapergamali.mysmartroute.view.ui.components.TopBar
+import androidx.compose.ui.res.stringResource
+import com.ioannapergamali.mysmartroute.R
 
 @Composable
 fun DatabaseMenuScreen(navController: NavController, openDrawer: () -> Unit) {
     Scaffold(
         topBar = {
             TopBar(
-                title = "Databases",
+                title = stringResource(R.string.databases_title),
                 navController = navController,
                 showMenu = true,
                 onMenuClick = openDrawer
@@ -26,15 +28,15 @@ fun DatabaseMenuScreen(navController: NavController, openDrawer: () -> Unit) {
     ) { padding ->
         ScreenContainer(modifier = Modifier.padding(padding)) {
             Button(onClick = { navController.navigate("localDb") }) {
-                Text("Local DB")
+                Text(stringResource(R.string.local_db))
             }
             Spacer(modifier = Modifier.padding(8.dp))
             Button(onClick = { navController.navigate("firebaseDb") }) {
-                Text("Firestore DB")
+                Text(stringResource(R.string.firebase_db))
             }
             Spacer(modifier = Modifier.padding(8.dp))
             Button(onClick = { navController.navigate("syncDb") }) {
-                Text("Synchronization")
+                Text(stringResource(R.string.sync_db))
             }
         }
     }

--- a/app/src/main/java/com/ioannapergamali/mysmartroute/view/ui/screens/HomeScreen.kt
+++ b/app/src/main/java/com/ioannapergamali/mysmartroute/view/ui/screens/HomeScreen.kt
@@ -17,6 +17,7 @@ import com.ioannapergamali.mysmartroute.view.ui.components.TopBar
 import com.ioannapergamali.mysmartroute.view.ui.components.LogoImage
 import com.ioannapergamali.mysmartroute.view.ui.components.LogoAssets
 import com.ioannapergamali.mysmartroute.R
+import androidx.compose.ui.res.stringResource
 import com.ioannapergamali.mysmartroute.view.ui.animation.rememberBreathingAnimation
 import com.ioannapergamali.mysmartroute.view.ui.animation.rememberSlideFadeInAnimation
 import androidx.compose.ui.platform.LocalContext
@@ -36,7 +37,7 @@ fun HomeScreen(
     Scaffold(
         topBar = {
             TopBar(
-                title = "Home",
+                title = stringResource(R.string.home_title),
                 navController = navController,
                 showMenu = true,
                 showBack = false,
@@ -149,7 +150,7 @@ private fun HomeContent(
         horizontalAlignment = Alignment.CenterHorizontally
     ) {
         Text(
-            text = "Welcome",
+            text = stringResource(R.string.welcome),
             style = MaterialTheme.typography.headlineLarge,
             modifier = Modifier
                 .offset(y = textOffset)
@@ -174,7 +175,7 @@ private fun HomeContent(
             OutlinedTextField(
                 value = email,
                 onValueChange = onEmailChange,
-                label = { Text("Email") },
+                label = { Text(stringResource(R.string.email)) },
                 modifier = Modifier.fillMaxWidth(),
                 shape = MaterialTheme.shapes.small,
                 colors = OutlinedTextFieldDefaults.colors(
@@ -188,7 +189,7 @@ private fun HomeContent(
             OutlinedTextField(
                 value = password,
                 onValueChange = onPasswordChange,
-                label = { Text("Password") },
+                label = { Text(stringResource(R.string.password)) },
                 visualTransformation = PasswordVisualTransformation(),
                 modifier = Modifier.fillMaxWidth(),
                 shape = MaterialTheme.shapes.small,
@@ -209,15 +210,15 @@ private fun HomeContent(
             Spacer(Modifier.height(16.dp))
 
             Button(onClick = onLogin) {
-                Text("Login")
+                Text(stringResource(R.string.login))
             }
 
             Spacer(modifier = Modifier.height(8.dp))
 
             Row {
-                Text("If you don't have account ")
+                Text(stringResource(R.string.no_account))
                 Text(
-                    text = "Sign Up",
+                    text = stringResource(R.string.sign_up),
                     color = MaterialTheme.colorScheme.primary,
                     modifier = Modifier.clickable { onNavigateToSignUp() }
                 )
@@ -226,7 +227,7 @@ private fun HomeContent(
             Spacer(Modifier.height(16.dp))
 
             Button(onClick = onLogout) {
-                Text("Logout")
+                Text(stringResource(R.string.logout))
             }
         }
     }

--- a/app/src/main/java/com/ioannapergamali/mysmartroute/view/ui/screens/MenuScreen.kt
+++ b/app/src/main/java/com/ioannapergamali/mysmartroute/view/ui/screens/MenuScreen.kt
@@ -24,6 +24,8 @@ import com.ioannapergamali.mysmartroute.viewmodel.AuthenticationViewModel
 import com.ioannapergamali.mysmartroute.view.ui.components.ScreenContainer
 import com.ioannapergamali.mysmartroute.data.local.MenuWithOptions
 import com.ioannapergamali.mysmartroute.model.enumerations.UserRole
+import androidx.compose.ui.res.stringResource
+import com.ioannapergamali.mysmartroute.R
 
 @Composable
 fun MenuScreen(navController: NavController, openDrawer: () -> Unit) {
@@ -41,7 +43,7 @@ fun MenuScreen(navController: NavController, openDrawer: () -> Unit) {
     Scaffold(
         topBar = {
             TopBar(
-                title = "Menu",
+                title = stringResource(R.string.menu_title),
                 navController = navController,
                 showMenu = true,
                 onMenuClick = openDrawer,
@@ -76,7 +78,7 @@ private fun RoleMenu(
 ) {
     Column(modifier = Modifier.fillMaxWidth()) {
         Text(
-            text = "Μενού για τον ρόλο: ${role?.name ?: ""}",
+            text = stringResource(R.string.menu_role_prefix, role?.name ?: ""),
             style = MaterialTheme.typography.titleLarge
         )
         Spacer(Modifier.height(8.dp))

--- a/app/src/main/java/com/ioannapergamali/mysmartroute/view/ui/screens/ProfileScreen.kt
+++ b/app/src/main/java/com/ioannapergamali/mysmartroute/view/ui/screens/ProfileScreen.kt
@@ -13,6 +13,8 @@ import androidx.compose.ui.unit.dp
 import androidx.navigation.NavController
 import com.ioannapergamali.mysmartroute.view.ui.components.ScreenContainer
 import com.ioannapergamali.mysmartroute.view.ui.components.TopBar
+import androidx.compose.ui.res.stringResource
+import com.ioannapergamali.mysmartroute.R
 import com.google.firebase.auth.FirebaseAuth
 import com.google.firebase.firestore.FirebaseFirestore
 
@@ -36,7 +38,7 @@ fun ProfileScreen(navController: NavController, openDrawer: () -> Unit) {
     Scaffold(
         topBar = {
             TopBar(
-                title = "Profile",
+                title = stringResource(R.string.profile),
                 navController = navController,
                 showMenu = true,
                 onMenuClick = openDrawer

--- a/app/src/main/java/com/ioannapergamali/mysmartroute/view/ui/screens/RolesScreen.kt
+++ b/app/src/main/java/com/ioannapergamali/mysmartroute/view/ui/screens/RolesScreen.kt
@@ -17,6 +17,8 @@ import androidx.navigation.NavController
 import com.ioannapergamali.mysmartroute.view.ui.components.ScreenContainer
 import com.ioannapergamali.mysmartroute.view.ui.components.TopBar
 import com.ioannapergamali.mysmartroute.viewmodel.RoleViewModel
+import androidx.compose.ui.res.stringResource
+import com.ioannapergamali.mysmartroute.R
 
 @Composable
 fun RolesScreen(navController: NavController, openDrawer: () -> Unit) {
@@ -29,7 +31,7 @@ fun RolesScreen(navController: NavController, openDrawer: () -> Unit) {
     Scaffold(
         topBar = {
             TopBar(
-                title = "Roles",
+                title = stringResource(R.string.roles_title),
                 navController = navController,
                 showMenu = true,
                 onMenuClick = openDrawer

--- a/app/src/main/java/com/ioannapergamali/mysmartroute/view/ui/screens/SupportScreen.kt
+++ b/app/src/main/java/com/ioannapergamali/mysmartroute/view/ui/screens/SupportScreen.kt
@@ -9,13 +9,15 @@ import androidx.compose.ui.unit.dp
 import com.ioannapergamali.mysmartroute.view.ui.components.ScreenContainer
 import androidx.navigation.NavController
 import com.ioannapergamali.mysmartroute.view.ui.components.TopBar
+import androidx.compose.ui.res.stringResource
+import com.ioannapergamali.mysmartroute.R
 
 @Composable
 fun SupportScreen(navController: NavController, openDrawer: () -> Unit) {
     Scaffold(
         topBar = {
             TopBar(
-                title = "Support",
+                title = stringResource(R.string.support_title),
                 navController = navController,
                 showMenu = true,
                 onMenuClick = openDrawer
@@ -23,8 +25,8 @@ fun SupportScreen(navController: NavController, openDrawer: () -> Unit) {
         }
     ) { padding ->
         ScreenContainer(modifier = Modifier.padding(padding)) {
-            Text("Email: smartroute@info.gr")
-            Text("Address: Πάροδος Κρήτης 8, Γάζι, ΤΚ 71414")
+            Text(stringResource(R.string.support_email))
+            Text(stringResource(R.string.support_address))
         }
     }
 }

--- a/app/src/main/res/values-en/strings.xml
+++ b/app/src/main/res/values-en/strings.xml
@@ -19,4 +19,29 @@
     <string name="sound">Sound</string>
     <string name="apply">Apply</string>
     <string name="applying_settings">Applying settings...</string>
+    <!-- Generic UI strings -->
+    <string name="home_title">Home</string>
+    <string name="welcome">Welcome</string>
+    <string name="login">Login</string>
+    <string name="logout">Logout</string>
+    <string name="email">Email</string>
+    <string name="password">Password</string>
+    <string name="no_account">If you don't have account </string>
+    <string name="sign_up">Sign Up</string>
+    <string name="menu_title">Menu</string>
+    <string name="menu_role_prefix">Menu for role: %1$s</string>
+    <string name="roles_title">Roles</string>
+    <string name="about_title">About</string>
+    <string name="support_title">Support</string>
+    <string name="databases_title">Databases</string>
+    <string name="local_db">Local DB</string>
+    <string name="firebase_db">Firestore DB</string>
+    <string name="sync_db">Synchronization</string>
+    <string name="admin_option">Admin Option</string>
+    <string name="profile">Profile</string>
+    <string name="guest">Guest</string>
+    <string name="exit">Exit</string>
+    <string name="credits">Credits</string>
+    <string name="support_email">Email: smartroute@info.gr</string>
+    <string name="support_address">Address: Πάροδος Κρήτης 8, Γάζι, ΤΚ 71414</string>
 </resources>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -21,4 +21,29 @@
     <string name="sound">Ήχος</string>
     <string name="apply">Εφαρμογή</string>
     <string name="applying_settings">Εφαρμογή ρυθμίσεων...</string>
+    <!-- Generic UI strings -->
+    <string name="home_title">Αρχική</string>
+    <string name="welcome">Καλώς ήρθατε</string>
+    <string name="login">Σύνδεση</string>
+    <string name="logout">Αποσύνδεση</string>
+    <string name="email">Email</string>
+    <string name="password">Κωδικός</string>
+    <string name="no_account">Αν δεν έχετε λογαριασμό </string>
+    <string name="sign_up">Εγγραφή</string>
+    <string name="menu_title">Μενού</string>
+    <string name="menu_role_prefix">Μενού για τον ρόλο: %1$s</string>
+    <string name="roles_title">Ρόλοι</string>
+    <string name="about_title">Σχετικά</string>
+    <string name="support_title">Υποστήριξη</string>
+    <string name="databases_title">Βάσεις Δεδομένων</string>
+    <string name="local_db">Τοπική ΒΔ</string>
+    <string name="firebase_db">Firestore ΒΔ</string>
+    <string name="sync_db">Συγχρονισμός</string>
+    <string name="admin_option">Επιλογή Διαχειριστή</string>
+    <string name="profile">Προφίλ</string>
+    <string name="guest">Επισκέπτης</string>
+    <string name="exit">Έξοδος</string>
+    <string name="credits">Ευχαριστίες</string>
+    <string name="support_email">Email: smartroute@info.gr</string>
+    <string name="support_address">Address: Πάροδος Κρήτης 8, Γάζι, ΤΚ 71414</string>
 </resources>


### PR DESCRIPTION
## Summary
- add string resources for common UI labels
- update Home, Menu, DatabaseMenu, About, Support, Profile and Roles screens to use `stringResource`
- translate navigation drawer items

## Testing
- `./gradlew test --offline` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_685b289408dc8328a94a21b288d8c33a