### PR TITLE
Fix string xml for missing escape

### DIFF
--- a/app/src/main/res/values-en/strings.xml
+++ b/app/src/main/res/values-en/strings.xml
@@ -26,7 +26,7 @@
     <string name="logout">Logout</string>
     <string name="email">Email</string>
     <string name="password">Password</string>
-    <string name="no_account">If you don't have account </string>
+    <string name="no_account">If you don\'t have an account</string>
     <string name="sign_up">Sign Up</string>
     <string name="menu_title">Menu</string>
     <string name="menu_role_prefix">Menu for role: %1$s</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -28,7 +28,7 @@
     <string name="logout">Αποσύνδεση</string>
     <string name="email">Email</string>
     <string name="password">Κωδικός</string>
-    <string name="no_account">Αν δεν έχετε λογαριασμό </string>
+    <string name="no_account">Αν δεν έχετε λογαριασμό</string>
     <string name="sign_up">Εγγραφή</string>
     <string name="menu_title">Μενού</string>
     <string name="menu_role_prefix">Μενού για τον ρόλο: %1$s</string>


### PR DESCRIPTION
## Summary
- escape apostrophe in `no_account` string for English
- remove trailing space from Greek `no_account`

## Testing
- `./gradlew test` *(fails: could not download from JetBrains due to network)*

------
https://chatgpt.com/codex/tasks/task_e_685b538a31b8832889c37eee2ea846a8