### PR TITLE
Dynamic menu translation

### DIFF
--- a/app/src/main/assets/menus.json
+++ b/app/src/main/assets/menus.json
@@ -3,20 +3,20 @@
     "inheritsFrom": null,
     "menus": [
       {
-        "title": "Passenger Menu",
+        "titleKey": "passenger_menu_title",
         "options": [
-          {"title": "Sign out", "route": "signOut"},
-          {"title": "Manage Favorite Means of Transport", "route": "manageFavorites"},
-          {"title": "Mode Of Transportation For A Specific Route", "route": "routeMode"},
-          {"title": "Find a Vehicle for a specific Transport", "route": "findVehicle"},
-          {"title": "Find Way of Transport", "route": "findWay"},
-          {"title": "Book a Seat or Buy a Ticket", "route": "bookSeat"},
-          {"title": "View Interesting Routes", "route": "viewRoutes"},
-          {"title": "View Transports", "route": "viewTransports"},
-          {"title": "Print Booked Seat or Ticket", "route": "printTicket"},
-          {"title": "Cancel Booked Seat", "route": "cancelSeat"},
-          {"title": "View, Rank and Comment on Completed Transports", "route": "rankTransports"},
-          {"title": "Shut Down the System", "route": "shutdown"}
+          {"titleKey": "sign_out", "route": "signOut"},
+          {"titleKey": "manage_favorites", "route": "manageFavorites"},
+          {"titleKey": "route_mode", "route": "routeMode"},
+          {"titleKey": "find_vehicle", "route": "findVehicle"},
+          {"titleKey": "find_way", "route": "findWay"},
+          {"titleKey": "book_seat", "route": "bookSeat"},
+          {"titleKey": "view_routes", "route": "viewRoutes"},
+          {"titleKey": "view_transports", "route": "viewTransports"},
+          {"titleKey": "print_ticket", "route": "printTicket"},
+          {"titleKey": "cancel_seat", "route": "cancelSeat"},
+          {"titleKey": "rank_transports", "route": "rankTransports"},
+          {"titleKey": "shutdown", "route": "shutdown"}
         ]
       }
     ]
@@ -25,14 +25,14 @@
     "inheritsFrom": "PASSENGER",
     "menus": [
       {
-        "title": "Driver Menu",
+        "titleKey": "driver_menu_title",
         "options": [
-          {"title": "Register Vehicle", "route": "registerVehicle"},
-          {"title": "Announce Availability for a specific Transport", "route": "announceAvailability"},
-          {"title": "Find Passengers", "route": "findPassengers"},
-          {"title": "Print Passenger List", "route": "printList"},
-          {"title": "Print Passenger List for Scheduled Transports", "route": "printScheduled"},
-          {"title": "Print Passenger List for Completed Transports", "route": "printCompleted"}
+          {"titleKey": "register_vehicle", "route": "registerVehicle"},
+          {"titleKey": "announce_availability", "route": "announceAvailability"},
+          {"titleKey": "find_passengers", "route": "findPassengers"},
+          {"titleKey": "print_list", "route": "printList"},
+          {"titleKey": "print_scheduled", "route": "printScheduled"},
+          {"titleKey": "print_completed", "route": "printCompleted"}
         ]
       }
     ]
@@ -41,21 +41,21 @@
     "inheritsFrom": "DRIVER",
     "menus": [
       {
-        "title": "Admin Menu",
+        "titleKey": "admin_menu_title",
         "options": [
-          {"title": "Initialize System", "route": "initSystem"},
-          {"title": "Create User Account", "route": "createUser"},
-          {"title": "Promote or Demote User", "route": "editPrivileges"},
-          {"title": "Define Point of Interest", "route": "definePoi"},
-          {"title": "Define Duration of Travel by Foot", "route": "defineDuration"},
-          {"title": "View List of Unassigned Routes", "route": "viewUnassigned"},
-          {"title": "Review Point of Interest Names", "route": "reviewPoi"},
-          {"title": "Show 10 Best and Worst Drivers", "route": "rankDrivers"},
-          {"title": "View 10 Happiest/Least Happy Passengers", "route": "rankPassengers"},
-          {"title": "View Available Vehicles", "route": "viewVehicles"},
-          {"title": "View PoIs", "route": "viewPois"},
-          {"title": "View Users", "route": "viewUsers"},
-          {"title": "Advance Date", "route": "advanceDate"}
+          {"titleKey": "init_system", "route": "initSystem"},
+          {"titleKey": "create_user", "route": "createUser"},
+          {"titleKey": "edit_privileges", "route": "editPrivileges"},
+          {"titleKey": "define_poi", "route": "definePoi"},
+          {"titleKey": "define_duration", "route": "defineDuration"},
+          {"titleKey": "view_unassigned", "route": "viewUnassigned"},
+          {"titleKey": "review_poi", "route": "reviewPoi"},
+          {"titleKey": "rank_drivers", "route": "rankDrivers"},
+          {"titleKey": "rank_passengers", "route": "rankPassengers"},
+          {"titleKey": "view_vehicles", "route": "viewVehicles"},
+          {"titleKey": "view_pois", "route": "viewPois"},
+          {"titleKey": "view_users", "route": "viewUsers"},
+          {"titleKey": "advance_date", "route": "advanceDate"}
         ]
       }
     ]

--- a/app/src/main/java/com/ioannapergamali/mysmartroute/data/local/MenuEntity.kt
+++ b/app/src/main/java/com/ioannapergamali/mysmartroute/data/local/MenuEntity.kt
@@ -21,5 +21,6 @@ import androidx.room.PrimaryKey
 data class MenuEntity(
     @PrimaryKey var id: String = "",
     var roleId: String = "",
-    var title: String = ""
+    /** Κλειδί πόρου για τον τίτλο του μενού */
+    var titleResKey: String = ""
 )

--- a/app/src/main/java/com/ioannapergamali/mysmartroute/data/local/MenuOptionEntity.kt
+++ b/app/src/main/java/com/ioannapergamali/mysmartroute/data/local/MenuOptionEntity.kt
@@ -21,6 +21,7 @@ import androidx.room.PrimaryKey
 data class MenuOptionEntity(
     @PrimaryKey var id: String = "",
     var menuId: String = "",
-    var title: String = "",
+    /** Κλειδί πόρου για τον τίτλο της επιλογής */
+    var titleResKey: String = "",
     var route: String = ""
 )

--- a/app/src/main/java/com/ioannapergamali/mysmartroute/model/menus/MenuConfig.kt
+++ b/app/src/main/java/com/ioannapergamali/mysmartroute/model/menus/MenuConfig.kt
@@ -2,12 +2,14 @@ package com.ioannapergamali.mysmartroute.model.menus
 
 /** Δομή για το json των μενού ρόλων. */
 data class MenuConfig(
-    val title: String,
+    /** Κλειδί πόρου για τον τίτλο του μενού */
+    val titleKey: String,
     val options: List<OptionConfig>
 )
 
 data class OptionConfig(
-    val title: String,
+    /** Κλειδί πόρου για τον τίτλο της επιλογής */
+    val titleKey: String,
     val route: String
 )
 

--- a/app/src/main/java/com/ioannapergamali/mysmartroute/view/ui/screens/FirebaseDatabaseScreen.kt
+++ b/app/src/main/java/com/ioannapergamali/mysmartroute/view/ui/screens/FirebaseDatabaseScreen.kt
@@ -72,12 +72,12 @@ fun FirebaseDatabaseScreen(navController: NavController, openDrawer: () -> Unit)
                 item { Spacer(modifier = Modifier.padding(8.dp)) }
                 item { Text("Menus", style = MaterialTheme.typography.titleMedium) }
                 items(data!!.menus) { menu ->
-                    Text("${menu.id} (${menu.roleId}) - ${menu.title}")
+                    Text("${menu.id} (${menu.roleId}) - ${menu.titleResKey}")
                 }
                 item { Spacer(modifier = Modifier.padding(8.dp)) }
                 item { Text("Menu Options", style = MaterialTheme.typography.titleMedium) }
                 items(data!!.menuOptions) { opt ->
-                    Text("${opt.id} (${opt.menuId}) -> ${opt.title} -> ${opt.route}")
+                    Text("${opt.id} (${opt.menuId}) -> ${opt.titleResKey} -> ${opt.route}")
                 }
                 item { Spacer(modifier = Modifier.padding(8.dp)) }
                 item { Text("Authentication table δεν είναι διαθέσιμη από το client", color = MaterialTheme.colorScheme.error) }

--- a/app/src/main/java/com/ioannapergamali/mysmartroute/view/ui/screens/LocalDatabaseScreen.kt
+++ b/app/src/main/java/com/ioannapergamali/mysmartroute/view/ui/screens/LocalDatabaseScreen.kt
@@ -97,7 +97,7 @@ fun LocalDatabaseScreen(navController: NavController, openDrawer: () -> Unit) {
                     item { Text("Ο πίνακας είναι άδειος") }
                 } else {
                     items(data!!.menus) { menu ->
-                        Text("${menu.id} (${menu.roleId}) - ${menu.title}")
+                        Text("${menu.id} (${menu.roleId}) - ${menu.titleResKey}")
                     }
                 }
                 item { Spacer(modifier = Modifier.padding(8.dp)) }
@@ -106,7 +106,7 @@ fun LocalDatabaseScreen(navController: NavController, openDrawer: () -> Unit) {
                     item { Text("Ο πίνακας είναι άδειος") }
                 } else {
                     items(data!!.menuOptions) { opt ->
-                        Text("${opt.id} (${opt.menuId}) -> ${opt.title} -> ${opt.route}")
+                        Text("${opt.id} (${opt.menuId}) -> ${opt.titleResKey} -> ${opt.route}")
                     }
                 }
                 }

--- a/app/src/main/java/com/ioannapergamali/mysmartroute/view/ui/screens/MenuScreen.kt
+++ b/app/src/main/java/com/ioannapergamali/mysmartroute/view/ui/screens/MenuScreen.kt
@@ -26,6 +26,7 @@ import com.ioannapergamali.mysmartroute.data.local.MenuWithOptions
 import com.ioannapergamali.mysmartroute.model.enumerations.UserRole
 import androidx.compose.ui.res.stringResource
 import com.ioannapergamali.mysmartroute.R
+import androidx.compose.runtime.remember
 
 @Composable
 fun MenuScreen(navController: NavController, openDrawer: () -> Unit) {
@@ -92,14 +93,14 @@ private fun RoleMenu(
                 menus.forEach { menuWithOptions ->
                     item {
                         Text(
-                            text = menuWithOptions.menu.title,
+                            text = resolveString(menuWithOptions.menu.titleResKey),
                             style = MaterialTheme.typography.titleMedium,
                             modifier = Modifier.padding(horizontal = 16.dp, vertical = 8.dp)
                         )
-                        Divider(color = MaterialTheme.colorScheme.outline)
+                    Divider(color = MaterialTheme.colorScheme.outline)
                     }
                     items(menuWithOptions.options) { option ->
-                        MenuItemRow(option.title) { onOptionClick(option.route) }
+                        MenuItemRow(option.titleResKey) { onOptionClick(option.route) }
                         Divider(color = MaterialTheme.colorScheme.outline)
                     }
                 }
@@ -109,7 +110,7 @@ private fun RoleMenu(
 }
 
 @Composable
-private fun MenuItemRow(title: String, onClick: () -> Unit) {
+private fun MenuItemRow(titleKey: String, onClick: () -> Unit) {
     Row(
         modifier = Modifier
             .fillMaxWidth()
@@ -124,9 +125,18 @@ private fun MenuItemRow(title: String, onClick: () -> Unit) {
         )
         Spacer(Modifier.width(12.dp))
         Text(
-            text = title,
+            text = resolveString(titleKey),
             style = MaterialTheme.typography.bodyLarge,
             color = MaterialTheme.colorScheme.onSurface
         )
     }
+}
+
+@Composable
+private fun resolveString(key: String): String {
+    val context = LocalContext.current
+    val resId = remember(key) {
+        context.resources.getIdentifier(key, "string", context.packageName)
+    }
+    return stringResource(id = resId)
 }

--- a/app/src/main/java/com/ioannapergamali/mysmartroute/viewmodel/AuthenticationViewModel.kt
+++ b/app/src/main/java/com/ioannapergamali/mysmartroute/viewmodel/AuthenticationViewModel.kt
@@ -147,12 +147,12 @@ class AuthenticationViewModel : ViewModel() {
                         defaultMenus(context, role).forEach { (menuTitle, options) ->
                             val menuId = UUID.randomUUID().toString()
                             val menuDoc = roleMenusRef.document(menuId)
-                            batch.set(menuDoc, mapOf("id" to menuId, "title" to menuTitle))
+                            batch.set(menuDoc, mapOf("id" to menuId, "titleKey" to menuTitle))
                             options.forEach { (optTitle, route) ->
                                 val optId = UUID.randomUUID().toString()
                                 batch.set(
                                     menuDoc.collection("options").document(optId),
-                                    mapOf("id" to optId, "title" to optTitle, "route" to route)
+                                    mapOf("id" to optId, "titleKey" to optTitle, "route" to route)
                                 )
                             }
                         }
@@ -246,13 +246,20 @@ class AuthenticationViewModel : ViewModel() {
                     MenuOptionEntity(
                         id = optDoc.getString("id") ?: optDoc.id,
                         menuId = menuId,
-                        title = optDoc.getString("title") ?: "",
+                        titleResKey = optDoc.getString("titleKey") ?: "",
                         route = optDoc.getString("route") ?: ""
                     )
                 }
-                insertMenuSafely(menuDao, dbLocal.roleDao(), MenuEntity(menuId, roleId, menuDoc.getString("title") ?: ""))
+                insertMenuSafely(
+                    menuDao,
+                    dbLocal.roleDao(),
+                    MenuEntity(menuId, roleId, menuDoc.getString("titleKey") ?: "")
+                )
                 options.forEach { optionDao.insert(it) }
-                menus += MenuWithOptions(MenuEntity(menuId, roleId, menuDoc.getString("title") ?: ""), options)
+                menus += MenuWithOptions(
+                    MenuEntity(menuId, roleId, menuDoc.getString("titleKey") ?: ""),
+                    options
+                )
             }
             val parent = roleDoc.getString("parentRoleId")
             if (!parent.isNullOrEmpty()) {
@@ -334,16 +341,16 @@ class AuthenticationViewModel : ViewModel() {
                 cfg.menus.forEach { menu ->
                     val menuId = UUID.randomUUID().toString()
                     val menuDoc = roleRef.collection("menus").document(menuId)
-                    batch.set(menuDoc, mapOf("id" to menuId, "title" to menu.title))
+                    batch.set(menuDoc, mapOf("id" to menuId, "titleKey" to menu.titleKey))
                     commitNeeded = true
-                    menuDao.insert(MenuEntity(menuId, roleId, menu.title))
+                    menuDao.insert(MenuEntity(menuId, roleId, menu.titleKey))
                     menu.options.forEach { opt ->
                         val optId = UUID.randomUUID().toString()
                         batch.set(
                             menuDoc.collection("options").document(optId),
-                            mapOf("id" to optId, "title" to opt.title, "route" to opt.route),
+                            mapOf("id" to optId, "titleKey" to opt.titleKey, "route" to opt.route),
                         )
-                        optionDao.insert(MenuOptionEntity(optId, menuId, opt.title, opt.route))
+                        optionDao.insert(MenuOptionEntity(optId, menuId, opt.titleKey, opt.route))
                     }
                 }
             }
@@ -368,7 +375,7 @@ class AuthenticationViewModel : ViewModel() {
             val allMenus = mutableListOf<MenuConfig>()
             collect(role.name, allMenus)
             allMenus.map { menu ->
-                menu.title to menu.options.map { it.title to it.route }
+                menu.titleKey to menu.options.map { it.titleKey to it.route }
             }
         } catch (e: Exception) {
             emptyList()

--- a/app/src/main/java/com/ioannapergamali/mysmartroute/viewmodel/DatabaseViewModel.kt
+++ b/app/src/main/java/com/ioannapergamali/mysmartroute/viewmodel/DatabaseViewModel.kt
@@ -153,7 +153,7 @@ class DatabaseViewModel : ViewModel() {
                         MenuEntity(
                             id = menuId,
                             roleId = roleId,
-                            title = menuDoc.getString("title") ?: ""
+                            titleResKey = menuDoc.getString("titleKey") ?: ""
                         )
                     )
                     Log.d(TAG, "Fetching options for menu $menuId")
@@ -164,7 +164,7 @@ class DatabaseViewModel : ViewModel() {
                             MenuOptionEntity(
                                 id = optDoc.getString("id") ?: optDoc.id,
                                 menuId = menuId,
-                                title = optDoc.getString("title") ?: "",
+                                titleResKey = optDoc.getString("titleKey") ?: "",
                                 route = optDoc.getString("route") ?: ""
                             )
                         )
@@ -271,7 +271,7 @@ class DatabaseViewModel : ViewModel() {
                                 MenuEntity(
                                     id = menuId,
                                     roleId = roleId,
-                                    title = menuDoc.getString("title") ?: ""
+                                    titleResKey = menuDoc.getString("titleKey") ?: ""
                                 )
                             )
                     Log.d(TAG, "Fetching options for menu $menuId")
@@ -282,7 +282,7 @@ class DatabaseViewModel : ViewModel() {
                                     MenuOptionEntity(
                                         id = optDoc.getString("id") ?: optDoc.id,
                                         menuId = menuId,
-                                        title = optDoc.getString("title") ?: "",
+                                        titleResKey = optDoc.getString("titleKey") ?: "",
                                         route = optDoc.getString("route") ?: ""
                                     )
                                 )

--- a/app/src/main/res/values-en/strings.xml
+++ b/app/src/main/res/values-en/strings.xml
@@ -44,4 +44,41 @@
     <string name="credits">Credits</string>
     <string name="support_email">Email: smartroute@info.gr</string>
     <string name="support_address">Address: Πάροδος Κρήτης 8, Γάζι, ΤΚ 71414</string>
+    <!-- Dynamic menu titles -->
+    <string name="passenger_menu_title">Passenger Menu</string>
+    <string name="driver_menu_title">Driver Menu</string>
+    <string name="admin_menu_title">Admin Menu</string>
+
+    <!-- Menu options -->
+    <string name="sign_out">Sign out</string>
+    <string name="manage_favorites">Manage Favorite Means of Transport</string>
+    <string name="route_mode">Mode Of Transportation For A Specific Route</string>
+    <string name="find_vehicle">Find a Vehicle for a specific Transport</string>
+    <string name="find_way">Find Way of Transport</string>
+    <string name="book_seat">Book a Seat or Buy a Ticket</string>
+    <string name="view_routes">View Interesting Routes</string>
+    <string name="view_transports">View Transports</string>
+    <string name="print_ticket">Print Booked Seat or Ticket</string>
+    <string name="cancel_seat">Cancel Booked Seat</string>
+    <string name="rank_transports">View, Rank and Comment on Completed Transports</string>
+    <string name="shutdown">Shut Down the System</string>
+    <string name="register_vehicle">Register Vehicle</string>
+    <string name="announce_availability">Announce Availability for a specific Transport</string>
+    <string name="find_passengers">Find Passengers</string>
+    <string name="print_list">Print Passenger List</string>
+    <string name="print_scheduled">Print Passenger List for Scheduled Transports</string>
+    <string name="print_completed">Print Passenger List for Completed Transports</string>
+    <string name="init_system">Initialize System</string>
+    <string name="create_user">Create User Account</string>
+    <string name="edit_privileges">Promote or Demote User</string>
+    <string name="define_poi">Define Point of Interest</string>
+    <string name="define_duration">Define Duration of Travel by Foot</string>
+    <string name="view_unassigned">View List of Unassigned Routes</string>
+    <string name="review_poi">Review Point of Interest Names</string>
+    <string name="rank_drivers">Show 10 Best and Worst Drivers</string>
+    <string name="rank_passengers">View 10 Happiest/Least Happy Passengers</string>
+    <string name="view_vehicles">View Available Vehicles</string>
+    <string name="view_pois">View PoIs</string>
+    <string name="view_users">View Users</string>
+    <string name="advance_date">Advance Date</string>
 </resources>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -46,4 +46,41 @@
     <string name="credits">Ευχαριστίες</string>
     <string name="support_email">Email: smartroute@info.gr</string>
     <string name="support_address">Address: Πάροδος Κρήτης 8, Γάζι, ΤΚ 71414</string>
+    <!-- Titles μενού δυναμικών επιλογών -->
+    <string name="passenger_menu_title">Μενού Επιβάτη</string>
+    <string name="driver_menu_title">Μενού Οδηγού</string>
+    <string name="admin_menu_title">Μενού Διαχειριστή</string>
+
+    <!-- Επιλογές μενού -->
+    <string name="sign_out">Αποσύνδεση</string>
+    <string name="manage_favorites">Διαχείριση αγαπημένων μέσων μεταφοράς</string>
+    <string name="route_mode">Τρόπος μεταφοράς για συγκεκριμένη διαδρομή</string>
+    <string name="find_vehicle">Εύρεση οχήματος για συγκεκριμένη μεταφορά</string>
+    <string name="find_way">Εύρεση μέσου μεταφοράς</string>
+    <string name="book_seat">Κράτηση θέσης ή αγορά εισιτηρίου</string>
+    <string name="view_routes">Προβολή ενδιαφερουσών διαδρομών</string>
+    <string name="view_transports">Προβολή μεταφορών</string>
+    <string name="print_ticket">Εκτύπωση κράτησης ή εισιτηρίου</string>
+    <string name="cancel_seat">Ακύρωση κράτησης</string>
+    <string name="rank_transports">Βαθμολόγηση και σχόλια μεταφορών</string>
+    <string name="shutdown">Τερματισμός συστήματος</string>
+    <string name="register_vehicle">Καταχώρηση οχήματος</string>
+    <string name="announce_availability">Δήλωση διαθεσιμότητας για μεταφορά</string>
+    <string name="find_passengers">Εύρεση επιβατών</string>
+    <string name="print_list">Εκτύπωση λίστας επιβατών</string>
+    <string name="print_scheduled">Εκτύπωση λίστας για προγραμματισμένες μεταφορές</string>
+    <string name="print_completed">Εκτύπωση λίστας για ολοκληρωμένες μεταφορές</string>
+    <string name="init_system">Αρχικοποίηση συστήματος</string>
+    <string name="create_user">Δημιουργία λογαριασμού χρήστη</string>
+    <string name="edit_privileges">Αλλαγή δικαιωμάτων χρήστη</string>
+    <string name="define_poi">Ορισμός σημείου ενδιαφέροντος</string>
+    <string name="define_duration">Ορισμός διάρκειας μετακίνησης με τα πόδια</string>
+    <string name="view_unassigned">Προβολή μη εκχωρημένων διαδρομών</string>
+    <string name="review_poi">Έλεγχος ονομάτων σημείων ενδιαφέροντος</string>
+    <string name="rank_drivers">Προβολή 10 καλύτερων και χειρότερων οδηγών</string>
+    <string name="rank_passengers">Προβολή 10 πιο και λιγότερο ικανοποιημένων επιβατών</string>
+    <string name="view_vehicles">Προβολή διαθέσιμων οχημάτων</string>
+    <string name="view_pois">Προβολή σημείων ενδιαφέροντος</string>
+    <string name="view_users">Προβολή χρηστών</string>
+    <string name="advance_date">Μεταφορά ημερομηνίας</string>
 </resources>


### PR DESCRIPTION
## Summary
- store resource keys in MenuEntity and MenuOptionEntity
- update JSON and data models for key-based titles
- show translated strings in MenuScreen
- expose keys in database debug screens
- add translations for all dynamic menu items (en, el)

## Testing
- `./gradlew test` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_685b554bf92c83288ba2f873b455ab5f