### PR TITLE
Fix menu title mapping in Firestore

### DIFF
--- a/app/src/main/java/com/ioannapergamali/mysmartroute/utils/FirestoreMappers.kt
+++ b/app/src/main/java/com/ioannapergamali/mysmartroute/utils/FirestoreMappers.kt
@@ -88,11 +88,11 @@ fun RoleEntity.toFirestoreMap(): Map<String, Any> = mapOf(
 
 fun MenuEntity.toFirestoreMap(): Map<String, Any> = mapOf(
     "id" to id,
-    "title" to title
+    "titleKey" to titleResKey
 )
 
 fun MenuOptionEntity.toFirestoreMap(): Map<String, Any> = mapOf(
     "id" to id,
-    "title" to title,
+    "titleKey" to titleResKey,
     "route" to route
 )


### PR DESCRIPTION
## Summary
- fix Firestore mapping for `MenuEntity` and `MenuOptionEntity`

## Testing
- `./gradlew test` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_685b595ce9008328b316e5b8d8c3c7b8