### PR TITLE
Fix for missing string resources

### DIFF
--- a/app/src/main/java/com/ioannapergamali/mysmartroute/view/ui/screens/MenuScreen.kt
+++ b/app/src/main/java/com/ioannapergamali/mysmartroute/view/ui/screens/MenuScreen.kt
@@ -138,5 +138,9 @@ private fun resolveString(key: String): String {
     val resId = remember(key) {
         context.resources.getIdentifier(key, "string", context.packageName)
     }
-    return stringResource(id = resId)
+    return if (resId != 0) {
+        stringResource(id = resId)
+    } else {
+        key
+    }
 }


### PR DESCRIPTION
## Summary
- avoid crash when a string key is not found in resources

## Testing
- `./gradlew test` *(fails: maven.pkg.jetbrains.space blocked)*

------
https://chatgpt.com/codex/tasks/task_e_685b8554a8d0832896be171de0ab206f