### PR TITLE
Fix missing menu titles from Firebase

### DIFF
--- a/app/src/main/java/com/ioannapergamali/mysmartroute/viewmodel/AuthenticationViewModel.kt
+++ b/app/src/main/java/com/ioannapergamali/mysmartroute/viewmodel/AuthenticationViewModel.kt
@@ -243,21 +243,27 @@ class AuthenticationViewModel : ViewModel() {
                 val menuId = menuDoc.getString("id") ?: menuDoc.id
                 val optionsSnap = menuDoc.reference.collection("options").get().await()
                 val options = optionsSnap.documents.map { optDoc ->
+                    val titleKey = optDoc.getString("titleKey")
+                        ?: optDoc.getString("titleResKey")
+                        ?: ""
                     MenuOptionEntity(
                         id = optDoc.getString("id") ?: optDoc.id,
                         menuId = menuId,
-                        titleResKey = optDoc.getString("titleKey") ?: "",
+                        titleResKey = titleKey,
                         route = optDoc.getString("route") ?: ""
                     )
                 }
+                val menuTitleKey = menuDoc.getString("titleKey")
+                    ?: menuDoc.getString("titleResKey")
+                    ?: ""
                 insertMenuSafely(
                     menuDao,
                     dbLocal.roleDao(),
-                    MenuEntity(menuId, roleId, menuDoc.getString("titleKey") ?: "")
+                    MenuEntity(menuId, roleId, menuTitleKey)
                 )
                 options.forEach { optionDao.insert(it) }
                 menus += MenuWithOptions(
-                    MenuEntity(menuId, roleId, menuDoc.getString("titleKey") ?: ""),
+                    MenuEntity(menuId, roleId, menuTitleKey),
                     options
                 )
             }

--- a/app/src/main/java/com/ioannapergamali/mysmartroute/viewmodel/DatabaseViewModel.kt
+++ b/app/src/main/java/com/ioannapergamali/mysmartroute/viewmodel/DatabaseViewModel.kt
@@ -149,22 +149,26 @@ class DatabaseViewModel : ViewModel() {
                 Log.d(TAG, "Fetched ${menusSnap.documents.size} menus for role $roleId")
                 for (menuDoc in menusSnap.documents) {
                     val menuId = menuDoc.getString("id") ?: menuDoc.id
+                    val menuTitleKey = menuDoc.getString("titleKey")
+                        ?: menuDoc.getString("titleResKey")
+                        ?: ""
                     menus.add(
                         MenuEntity(
                             id = menuId,
                             roleId = roleId,
-                            titleResKey = menuDoc.getString("titleKey") ?: ""
+                            titleResKey = menuTitleKey
                         )
                     )
                     Log.d(TAG, "Fetching options for menu $menuId")
                     val optsSnap = menuDoc.reference.collection("options").get().await()
                     Log.d(TAG, "Fetched ${optsSnap.documents.size} options for menu $menuId")
                     for (optDoc in optsSnap.documents) {
+                        val optionTitleKey = optDoc.getString("titleKey") ?: optDoc.getString("titleResKey") ?: ""
                         menuOptions.add(
                             MenuOptionEntity(
                                 id = optDoc.getString("id") ?: optDoc.id,
                                 menuId = menuId,
-                                titleResKey = optDoc.getString("titleKey") ?: "",
+                                titleResKey = optionTitleKey,
                                 route = optDoc.getString("route") ?: ""
                             )
                         )


### PR DESCRIPTION
## Summary
- ensure menu options and titles fall back to `titleResKey` when `titleKey` is absent
- patch DatabaseViewModel and AuthenticationViewModel to read legacy keys

## Testing
- `./gradlew test` *(fails: maven.pkg.jetbrains.space blocked)*

------
https://chatgpt.com/codex/tasks/task_e_685b8ac2ae3883288cf1cbd9a236d8c6