### PR TITLE
Fix roles menu by syncing database first

### DIFF
--- a/app/src/main/java/com/ioannapergamali/mysmartroute/view/ui/screens/RolesScreen.kt
+++ b/app/src/main/java/com/ioannapergamali/mysmartroute/view/ui/screens/RolesScreen.kt
@@ -6,6 +6,7 @@ import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.items
 import androidx.compose.material3.Scaffold
 import androidx.compose.material3.Text
+import androidx.compose.material3.CircularProgressIndicator
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.collectAsState
@@ -17,16 +18,23 @@ import androidx.navigation.NavController
 import com.ioannapergamali.mysmartroute.view.ui.components.ScreenContainer
 import com.ioannapergamali.mysmartroute.view.ui.components.TopBar
 import com.ioannapergamali.mysmartroute.viewmodel.RoleViewModel
+import com.ioannapergamali.mysmartroute.viewmodel.DatabaseViewModel
+import com.ioannapergamali.mysmartroute.viewmodel.SyncState
 import androidx.compose.ui.res.stringResource
 import com.ioannapergamali.mysmartroute.R
 
 @Composable
 fun RolesScreen(navController: NavController, openDrawer: () -> Unit) {
     val viewModel: RoleViewModel = viewModel()
+    val dbViewModel: DatabaseViewModel = viewModel()
     val roles by viewModel.roles.collectAsState()
+    val syncState by dbViewModel.syncState.collectAsState()
     val context = LocalContext.current
 
-    LaunchedEffect(Unit) { viewModel.loadRoles(context) }
+    LaunchedEffect(Unit) {
+        dbViewModel.syncDatabases(context)
+        viewModel.loadRoles(context)
+    }
 
     Scaffold(
         topBar = {
@@ -39,9 +47,13 @@ fun RolesScreen(navController: NavController, openDrawer: () -> Unit) {
         }
     ) { padding ->
         ScreenContainer(modifier = Modifier.padding(padding), scrollable = false) {
-            LazyColumn(modifier = Modifier.fillMaxSize()) {
-                items(roles) { role ->
-                    Text("${'$'}{role.id} - ${'$'}{role.name}")
+            if (roles.isEmpty() && syncState is SyncState.Loading) {
+                CircularProgressIndicator()
+            } else {
+                LazyColumn(modifier = Modifier.fillMaxSize()) {
+                    items(roles) { role ->
+                        Text("${'$'}{role.id} - ${'$'}{role.name}")
+                    }
                 }
             }
         }


### PR DESCRIPTION
## Summary
- ensure database synchronization happens before listing roles
- show progress while syncing

## Testing
- `./gradlew test --no-daemon` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_685b994072d08328bb0b68c2e0572c34