### PR TITLE
Handle Firestore roleId string

### DIFF
--- a/app/src/main/java/com/ioannapergamali/mysmartroute/view/ui/screens/RolesScreen.kt
+++ b/app/src/main/java/com/ioannapergamali/mysmartroute/view/ui/screens/RolesScreen.kt
@@ -6,6 +6,7 @@ import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.items
 import androidx.compose.material3.Scaffold
 import androidx.compose.material3.Text
+import androidx.compose.material3.CircularProgressIndicator
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.collectAsState
@@ -17,16 +18,23 @@ import androidx.navigation.NavController
 import com.ioannapergamali.mysmartroute.view.ui.components.ScreenContainer
 import com.ioannapergamali.mysmartroute.view.ui.components.TopBar
 import com.ioannapergamali.mysmartroute.viewmodel.RoleViewModel
+import com.ioannapergamali.mysmartroute.viewmodel.DatabaseViewModel
+import com.ioannapergamali.mysmartroute.viewmodel.SyncState
 import androidx.compose.ui.res.stringResource
 import com.ioannapergamali.mysmartroute.R
 
 @Composable
 fun RolesScreen(navController: NavController, openDrawer: () -> Unit) {
     val viewModel: RoleViewModel = viewModel()
+    val dbViewModel: DatabaseViewModel = viewModel()
     val roles by viewModel.roles.collectAsState()
+    val syncState by dbViewModel.syncState.collectAsState()
     val context = LocalContext.current
 
-    LaunchedEffect(Unit) { viewModel.loadRoles(context) }
+    LaunchedEffect(Unit) {
+        dbViewModel.syncDatabases(context)
+        viewModel.loadRoles(context)
+    }
 
     Scaffold(
         topBar = {
@@ -39,9 +47,13 @@ fun RolesScreen(navController: NavController, openDrawer: () -> Unit) {
         }
     ) { padding ->
         ScreenContainer(modifier = Modifier.padding(padding), scrollable = false) {
-            LazyColumn(modifier = Modifier.fillMaxSize()) {
-                items(roles) { role ->
-                    Text("${'$'}{role.id} - ${'$'}{role.name}")
+            if (roles.isEmpty() && syncState is SyncState.Loading) {
+                CircularProgressIndicator()
+            } else {
+                LazyColumn(modifier = Modifier.fillMaxSize()) {
+                    items(roles) { role ->
+                        Text("${'$'}{role.id} - ${'$'}{role.name}")
+                    }
                 }
             }
         }

--- a/app/src/main/java/com/ioannapergamali/mysmartroute/viewmodel/AuthenticationViewModel.kt
+++ b/app/src/main/java/com/ioannapergamali/mysmartroute/viewmodel/AuthenticationViewModel.kt
@@ -280,10 +280,15 @@ class AuthenticationViewModel : ViewModel() {
             val uid = auth.currentUser?.uid ?: return@launch
             val dbLocal = MySmartRouteDatabase.getInstance(context)
             val user = dbLocal.userDao().getUser(uid)
-            val roleId = user?.roleId.takeIf { !it.isNullOrEmpty() } ?: run {
+            val roleId = user?.roleId.takeIf { it.isNotEmpty() } ?: run {
                 val doc = db.collection("users").document(uid).get().await()
-                val ref = doc.getDocumentReference("roleId") ?: return@launch
-                ref.id
+                val remoteRoleId = when (val field = doc.get("roleId")) {
+                    is String -> field
+                    is DocumentReference -> field.id
+                    else -> null
+                } ?: return@launch
+                user?.let { dbLocal.userDao().insert(it.copy(roleId = remoteRoleId)) }
+                remoteRoleId
             }
 
             Log.d(TAG, "Using roleId: $roleId")


### PR DESCRIPTION
## Summary
- handle `roleId` stored as `String` or `DocumentReference` when loading user menus

## Testing
- `./gradlew test --no-daemon` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_685b994072d08328bb0b68c2e0572c34