### PR TITLE
Fix missing DocumentReference import

### DIFF
--- a/app/src/main/java/com/ioannapergamali/mysmartroute/viewmodel/AuthenticationViewModel.kt
+++ b/app/src/main/java/com/ioannapergamali/mysmartroute/viewmodel/AuthenticationViewModel.kt
@@ -7,6 +7,7 @@ import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import com.google.firebase.auth.FirebaseAuth
 import com.google.firebase.firestore.FirebaseFirestore
+import com.google.firebase.firestore.DocumentReference
 import com.google.gson.Gson
 import com.google.gson.reflect.TypeToken
 import com.ioannapergamali.mysmartroute.data.local.MySmartRouteDatabase


### PR DESCRIPTION
## Summary
- import `DocumentReference` in `AuthenticationViewModel`

## Testing
- `./gradlew test` *(fails: maven.pkg.jetbrains.space blocked)*

------
https://chatgpt.com/codex/tasks/task_e_685ba22d35d0832880990a46a586d116