### PR TITLE
Διόρθωση στην εμφάνιση ονομάτων ρόλων

### DIFF
--- a/app/src/main/java/com/ioannapergamali/mysmartroute/model/enumerations/UserRole.kt
+++ b/app/src/main/java/com/ioannapergamali/mysmartroute/model/enumerations/UserRole.kt
@@ -1,7 +1,24 @@
 package com.ioannapergamali.mysmartroute.model.enumerations
 
+import androidx.annotation.StringRes
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.res.stringResource
+import com.ioannapergamali.mysmartroute.R
+
 enum class UserRole {
     PASSENGER,
     DRIVER,
     ADMIN
 }
+
+/** Επιστρέφει το resource id της ονομασίας του ρόλου. */
+@StringRes
+fun UserRole.titleRes(): Int = when (this) {
+    UserRole.PASSENGER -> R.string.role_passenger
+    UserRole.DRIVER -> R.string.role_driver
+    UserRole.ADMIN -> R.string.role_admin
+}
+
+/** Επιστρέφει την τοπικοποιημένη ονομασία του ρόλου. */
+@Composable
+fun UserRole.localizedName(): String = stringResource(id = titleRes())

--- a/app/src/main/java/com/ioannapergamali/mysmartroute/view/ui/screens/FirebaseDatabaseScreen.kt
+++ b/app/src/main/java/com/ioannapergamali/mysmartroute/view/ui/screens/FirebaseDatabaseScreen.kt
@@ -20,6 +20,8 @@ import androidx.navigation.NavController
 import com.ioannapergamali.mysmartroute.view.ui.components.TopBar
 import com.ioannapergamali.mysmartroute.view.ui.components.ScreenContainer
 import com.ioannapergamali.mysmartroute.viewmodel.DatabaseViewModel
+import com.ioannapergamali.mysmartroute.model.enumerations.UserRole
+import com.ioannapergamali.mysmartroute.model.enumerations.localizedName
 
 @Composable
 fun FirebaseDatabaseScreen(navController: NavController, openDrawer: () -> Unit) {
@@ -67,7 +69,8 @@ fun FirebaseDatabaseScreen(navController: NavController, openDrawer: () -> Unit)
                 item { Spacer(modifier = Modifier.padding(8.dp)) }
                 item { Text("Roles", style = MaterialTheme.typography.titleMedium) }
                 items(data!!.roles) { role ->
-                    Text("${role.id} - ${role.name}")
+                    val name = try { UserRole.valueOf(role.name).localizedName() } catch (_: Exception) { role.name }
+                    Text("${'$'}{role.id} - ${'$'}name")
                 }
                 item { Spacer(modifier = Modifier.padding(8.dp)) }
                 item { Text("Menus", style = MaterialTheme.typography.titleMedium) }

--- a/app/src/main/java/com/ioannapergamali/mysmartroute/view/ui/screens/LocalDatabaseScreen.kt
+++ b/app/src/main/java/com/ioannapergamali/mysmartroute/view/ui/screens/LocalDatabaseScreen.kt
@@ -21,6 +21,8 @@ import androidx.navigation.NavController
 import com.ioannapergamali.mysmartroute.view.ui.components.TopBar
 import com.ioannapergamali.mysmartroute.view.ui.components.ScreenContainer
 import com.ioannapergamali.mysmartroute.viewmodel.DatabaseViewModel
+import com.ioannapergamali.mysmartroute.model.enumerations.UserRole
+import com.ioannapergamali.mysmartroute.model.enumerations.localizedName
 
 @Composable
 fun LocalDatabaseScreen(navController: NavController, openDrawer: () -> Unit) {
@@ -88,7 +90,8 @@ fun LocalDatabaseScreen(navController: NavController, openDrawer: () -> Unit) {
                     item { Text("Ο πίνακας είναι άδειος") }
                 } else {
                     items(data!!.roles) { role ->
-                        Text("${role.id} - ${role.name}")
+                        val name = try { UserRole.valueOf(role.name).localizedName() } catch (_: Exception) { role.name }
+                        Text("${'$'}{role.id} - ${'$'}name")
                     }
                 }
                 item { Spacer(modifier = Modifier.padding(8.dp)) }

--- a/app/src/main/java/com/ioannapergamali/mysmartroute/view/ui/screens/MenuScreen.kt
+++ b/app/src/main/java/com/ioannapergamali/mysmartroute/view/ui/screens/MenuScreen.kt
@@ -24,6 +24,7 @@ import com.ioannapergamali.mysmartroute.viewmodel.AuthenticationViewModel
 import com.ioannapergamali.mysmartroute.view.ui.components.ScreenContainer
 import com.ioannapergamali.mysmartroute.data.local.MenuWithOptions
 import com.ioannapergamali.mysmartroute.model.enumerations.UserRole
+import com.ioannapergamali.mysmartroute.model.enumerations.localizedName
 import androidx.compose.ui.res.stringResource
 import com.ioannapergamali.mysmartroute.R
 import androidx.compose.runtime.remember
@@ -79,7 +80,7 @@ private fun RoleMenu(
 ) {
     Column(modifier = Modifier.fillMaxWidth()) {
         Text(
-            text = stringResource(R.string.menu_role_prefix, role?.name ?: ""),
+            text = stringResource(R.string.menu_role_prefix, role?.localizedName() ?: ""),
             style = MaterialTheme.typography.titleLarge
         )
         Spacer(Modifier.height(8.dp))

--- a/app/src/main/java/com/ioannapergamali/mysmartroute/view/ui/screens/RolesScreen.kt
+++ b/app/src/main/java/com/ioannapergamali/mysmartroute/view/ui/screens/RolesScreen.kt
@@ -22,6 +22,8 @@ import com.ioannapergamali.mysmartroute.viewmodel.DatabaseViewModel
 import com.ioannapergamali.mysmartroute.viewmodel.SyncState
 import androidx.compose.ui.res.stringResource
 import com.ioannapergamali.mysmartroute.R
+import com.ioannapergamali.mysmartroute.model.enumerations.UserRole
+import com.ioannapergamali.mysmartroute.model.enumerations.localizedName
 
 @Composable
 fun RolesScreen(navController: NavController, openDrawer: () -> Unit) {
@@ -52,7 +54,12 @@ fun RolesScreen(navController: NavController, openDrawer: () -> Unit) {
             } else {
                 LazyColumn(modifier = Modifier.fillMaxSize()) {
                     items(roles) { role ->
-                        Text("${'$'}{role.id} - ${'$'}{role.name}")
+                        val displayName = try {
+                            UserRole.valueOf(role.name).localizedName()
+                        } catch (_: Exception) {
+                            role.name
+                        }
+                        Text("${'$'}{role.id} - ${'$'}displayName")
                     }
                 }
             }

--- a/app/src/main/java/com/ioannapergamali/mysmartroute/view/ui/screens/SignUpScreen.kt
+++ b/app/src/main/java/com/ioannapergamali/mysmartroute/view/ui/screens/SignUpScreen.kt
@@ -193,16 +193,16 @@ fun SignUpScreen(
                 )
 
                 Spacer(Modifier.height(16.dp))
-                Text("Select Role", style = MaterialTheme.typography.titleMedium)
+                Text(stringResource(R.string.select_role), style = MaterialTheme.typography.titleMedium)
                 Row {
                     RadioButton(
                         selected = selectedRole == UserRole.DRIVER,
                         onClick = { selectedRole = UserRole.DRIVER })
-                    Text("Driver", modifier = Modifier.padding(end = 16.dp))
+                    Text(stringResource(R.string.role_driver), modifier = Modifier.padding(end = 16.dp))
                     RadioButton(
                         selected = selectedRole == UserRole.PASSENGER,
                         onClick = { selectedRole = UserRole.PASSENGER })
-                    Text("Passenger")
+                    Text(stringResource(R.string.role_passenger))
                 }
 
                 if (uiState is AuthenticationViewModel.SignUpState.Error) {

--- a/app/src/main/res/values-en/strings.xml
+++ b/app/src/main/res/values-en/strings.xml
@@ -44,6 +44,11 @@
     <string name="credits">Credits</string>
     <string name="support_email">Email: smartroute@info.gr</string>
     <string name="support_address">Address: Πάροδος Κρήτης 8, Γάζι, ΤΚ 71414</string>
+    <!-- Role names -->
+    <string name="role_passenger">Passenger</string>
+    <string name="role_driver">Driver</string>
+    <string name="role_admin">Administrator</string>
+    <string name="select_role">Select Role</string>
     <!-- Dynamic menu titles -->
     <string name="passenger_menu_title">Passenger Menu</string>
     <string name="driver_menu_title">Driver Menu</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -46,6 +46,11 @@
     <string name="credits">Ευχαριστίες</string>
     <string name="support_email">Email: smartroute@info.gr</string>
     <string name="support_address">Address: Πάροδος Κρήτης 8, Γάζι, ΤΚ 71414</string>
+    <!-- Ονομασίες ρόλων -->
+    <string name="role_passenger">Επιβάτης</string>
+    <string name="role_driver">Οδηγός</string>
+    <string name="role_admin">Διαχειριστής</string>
+    <string name="select_role">Επιλογή ρόλου</string>
     <!-- Titles μενού δυναμικών επιλογών -->
     <string name="passenger_menu_title">Μενού Επιβάτη</string>
     <string name="driver_menu_title">Μενού Οδηγού</string>


### PR DESCRIPTION
## Summary
- προστέθηκαν πόροι κειμένου για τα ονόματα ρόλων
- δημιουργήθηκε συνάρτηση `localizedName` για το `UserRole`
- εμφανίζονται τα ονόματα ρόλων μεταφρασμένα στο μενού και στις οθόνες βάσης
- ενημερώθηκε η φόρμα εγγραφής με μεταφράσεις

## Testing
- `./gradlew test` *(απέτυχε: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_685ba3da8ad08328866a5da5adc94089