### PR TITLE
Fix try/catch around composables

### DIFF
--- a/app/src/main/java/com/ioannapergamali/mysmartroute/view/ui/screens/LocalDatabaseScreen.kt
+++ b/app/src/main/java/com/ioannapergamali/mysmartroute/view/ui/screens/LocalDatabaseScreen.kt
@@ -90,7 +90,12 @@ fun LocalDatabaseScreen(navController: NavController, openDrawer: () -> Unit) {
                     item { Text("Ο πίνακας είναι άδειος") }
                 } else {
                     items(data!!.roles) { role ->
-                        val name = try { UserRole.valueOf(role.name).localizedName() } catch (_: Exception) { role.name }
+                        val roleEnum = try {
+                            UserRole.valueOf(role.name)
+                        } catch (_: Exception) {
+                            null
+                        }
+                        val name = roleEnum?.localizedName() ?: role.name
                         Text("${'$'}{role.id} - ${'$'}name")
                     }
                 }


### PR DESCRIPTION
## Summary
- avoid calling composable `localizedName()` inside a try/catch block in `LocalDatabaseScreen.kt`

## Testing
- `./gradlew build` *(fails: maven.pkg.jetbrains.space blocked)*

------
https://chatgpt.com/codex/tasks/task_e_685bac0793f483288a9af7b2fb2bff0e