### PR TITLE
Fix composable call in try-catch

### DIFF
--- a/app/src/main/java/com/ioannapergamali/mysmartroute/view/ui/screens/RolesScreen.kt
+++ b/app/src/main/java/com/ioannapergamali/mysmartroute/view/ui/screens/RolesScreen.kt
@@ -54,11 +54,12 @@ fun RolesScreen(navController: NavController, openDrawer: () -> Unit) {
             } else {
                 LazyColumn(modifier = Modifier.fillMaxSize()) {
                     items(roles) { role ->
-                        val displayName = try {
-                            UserRole.valueOf(role.name).localizedName()
+                        val roleEnum = try {
+                            UserRole.valueOf(role.name)
                         } catch (_: Exception) {
-                            role.name
+                            null
                         }
+                        val displayName = roleEnum?.localizedName() ?: role.name
                         Text("${'$'}{role.id} - ${'$'}displayName")
                     }
                 }


### PR DESCRIPTION
## Summary
- avoid calling `localizedName` inside a `try` block in `RolesScreen`

## Testing
- `./gradlew test --no-daemon` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_685bb579bb1c8328883f8a24e6d90011