### PR TITLE
Fix missing stringResource import

### DIFF
--- a/app/src/main/java/com/ioannapergamali/mysmartroute/view/ui/screens/SignUpScreen.kt
+++ b/app/src/main/java/com/ioannapergamali/mysmartroute/view/ui/screens/SignUpScreen.kt
@@ -12,6 +12,7 @@ import androidx.compose.ui.unit.dp
 import androidx.lifecycle.viewmodel.compose.viewModel
 import androidx.navigation.NavController
 import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.res.stringResource
 import android.app.Activity
 import android.widget.Toast
 import com.ioannapergamali.mysmartroute.view.ui.components.TopBar


### PR DESCRIPTION
## Summary
- fix SignUpScreen compilation by importing `stringResource`

## Testing
- `./gradlew test` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_685bb6be0a508328807ee8da492ecb7a