### PR TITLE
Fix context usage in MainActivity

### DIFF
--- a/app/src/main/java/com/ioannapergamali/mysmartroute/viewmodel/MainActivity.kt
+++ b/app/src/main/java/com/ioannapergamali/mysmartroute/viewmodel/MainActivity.kt
@@ -46,7 +46,7 @@ class MainActivity : ComponentActivity() {
     {
         super.onCreate(savedInstanceState)
         // Εφαρμογή αποθηκευμένης γλώσσας πριν δημιουργηθεί το UI
-        val startLang = runBlocking { LanguagePreferenceManager.getLanguage(this) }
+        val startLang = runBlocking { LanguagePreferenceManager.getLanguage(this@MainActivity) }
         LocaleUtils.updateLocale(this, startLang)
         if (ContextCompat.checkSelfPermission(
                 this,


### PR DESCRIPTION
## Summary
- ensure `getLanguage()` uses MainActivity context

## Testing
- `./gradlew tasks --all` *(fails: Could not download due to network access)*

------
https://chatgpt.com/codex/tasks/task_e_685bdd625d8083288350769cddc1d302