### PR TITLE
Avoid storing Firestore roleId as DocumentReference

### DIFF
--- a/app/src/main/java/com/ioannapergamali/mysmartroute/viewmodel/AuthenticationViewModel.kt
+++ b/app/src/main/java/com/ioannapergamali/mysmartroute/viewmodel/AuthenticationViewModel.kt
@@ -122,6 +122,8 @@ class AuthenticationViewModel : ViewModel() {
                     val roleId = roleIds[role] ?: "role_passenger"
                     val roleRef = db.collection("roles").document(roleId)
 
+                    // Αποθηκεύουμε το roleId ως απλό String ώστε να είναι πάντα
+                    // συμβατό με την ανάγνωση από την εφαρμογή.
                     val userData = mapOf(
                         "id" to authRef,
                         "name" to name,
@@ -131,7 +133,7 @@ class AuthenticationViewModel : ViewModel() {
                         "phoneNum" to phoneNum,
                         "password" to password,
                         "role" to role.name,
-                        "roleId" to roleRef,
+                        "roleId" to roleId,
                         "city" to address.city,
                         "streetName" to address.streetName,
                         "streetNum" to address.streetNum,


### PR DESCRIPTION
## Summary
- ensure signup stores roleId as a simple string

## Testing
- `./gradlew test --no-daemon` *(fails: maven.pkg.jetbrains.space blocked)*

------
https://chatgpt.com/codex/tasks/task_e_685be589c7d483289563677a33bd1058