### PR TITLE
Διόρθωση εφαρμογής αλλαγής γλώσσας

### DIFF
--- a/app/src/main/java/com/ioannapergamali/mysmartroute/view/ui/screens/SettingsScreen.kt
+++ b/app/src/main/java/com/ioannapergamali/mysmartroute/view/ui/screens/SettingsScreen.kt
@@ -26,6 +26,8 @@ import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableFloatStateOf
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
+import androidx.compose.runtime.rememberCoroutineScope
+import kotlinx.coroutines.launch
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.LocalContext
@@ -79,6 +81,8 @@ fun SettingsScreen(navController: NavController, openDrawer: () -> Unit) {
     val volumeState = remember { mutableFloatStateOf(currentVolume) }
     val expandedLanguage = remember { mutableStateOf(false) }
     val selectedLanguage = remember { mutableStateOf(currentLanguage) }
+
+    val coroutineScope = rememberCoroutineScope()
 
 
     LaunchedEffect(currentTheme) { selectedTheme.value = currentTheme }
@@ -225,16 +229,18 @@ fun SettingsScreen(navController: NavController, openDrawer: () -> Unit) {
                     val applyMessage = context.getString(R.string.applying_settings)
                     Log.d("SettingsScreen", applyMessage)
                     Toast.makeText(context, applyMessage, Toast.LENGTH_SHORT).show()
-                    viewModel.applyAllSettings(
-                        context,
-                        selectedTheme.value,
-                        dark.value,
-                        selectedFont.value,
-                        soundState.value,
-                        volumeState.floatValue,
-                        selectedLanguage.value
-                    )
-                    (context as? android.app.Activity)?.recreate()
+                    coroutineScope.launch {
+                        viewModel.applyAllSettings(
+                            context,
+                            selectedTheme.value,
+                            dark.value,
+                            selectedFont.value,
+                            soundState.value,
+                            volumeState.floatValue,
+                            selectedLanguage.value
+                        )
+                        (context as? android.app.Activity)?.recreate()
+                    }
                 },
                 modifier = Modifier.padding(top = 8.dp)
             ) {

--- a/app/src/main/java/com/ioannapergamali/mysmartroute/viewmodel/SettingsViewModel.kt
+++ b/app/src/main/java/com/ioannapergamali/mysmartroute/viewmodel/SettingsViewModel.kt
@@ -110,7 +110,7 @@ class SettingsViewModel : ViewModel() {
         }
     }
 
-    fun applyAllSettings(
+    suspend fun applyAllSettings(
         context: Context,
         theme: ThemeOption,
         dark: Boolean,
@@ -119,24 +119,22 @@ class SettingsViewModel : ViewModel() {
         soundVolume: Float,
         language: String
     ) {
-        viewModelScope.launch {
-            ThemePreferenceManager.setTheme(context, theme)
-            ThemePreferenceManager.setDarkTheme(context, dark)
-            FontPreferenceManager.setFont(context, font)
-            SoundPreferenceManager.setSoundEnabled(context, soundEnabled)
-            SoundPreferenceManager.setSoundVolume(context, soundVolume)
-            LanguagePreferenceManager.setLanguage(context, language)
-            LocaleUtils.updateLocale(context, language)
-            updateSettings(context) {
-                it.copy(
-                    theme = (theme as? AppTheme)?.name ?: theme.label,
-                    darkTheme = dark,
-                    font = font.name,
-                    soundEnabled = soundEnabled,
-                    soundVolume = soundVolume,
-                    language = language
-                )
-            }
+        ThemePreferenceManager.setTheme(context, theme)
+        ThemePreferenceManager.setDarkTheme(context, dark)
+        FontPreferenceManager.setFont(context, font)
+        SoundPreferenceManager.setSoundEnabled(context, soundEnabled)
+        SoundPreferenceManager.setSoundVolume(context, soundVolume)
+        LanguagePreferenceManager.setLanguage(context, language)
+        LocaleUtils.updateLocale(context, language)
+        updateSettings(context) {
+            it.copy(
+                theme = (theme as? AppTheme)?.name ?: theme.label,
+                darkTheme = dark,
+                font = font.name,
+                soundEnabled = soundEnabled,
+                soundVolume = soundVolume,
+                language = language
+            )
         }
     }
 


### PR DESCRIPTION
## Περιγραφή
Επιδιορθώθηκε η λειτουργία αλλαγής γλώσσας μέσα από την οθόνη ρυθμίσεων. Η αποθήκευση των ρυθμίσεων γινόταν ασύγχρονα και το `Activity` αναδημιουργούταν πριν ενημερωθεί το `DataStore`, με αποτέλεσμα η γλώσσα να μην αλλάζει σωστά.

- Η `applyAllSettings` έγινε `suspend` και εκτελεί τις ενημερώσεις σειριακά.
- Στην οθόνη ρυθμίσεων χρησιμοποιείται `rememberCoroutineScope` ώστε να κληθεί η νέα συνάρτηση και μετά να γίνει `recreate()`.

## Έλεγχοι
Τρέξαμε `./gradlew test`, όμως η διαδικασία απέτυχε λόγω περιορισμών πρόσβασης στο δίκτυο κατά τη λήψη εξαρτήσεων.


------
https://chatgpt.com/codex/tasks/task_e_685beb0554808328a566c74e8250e78a