### PR TITLE
Fix language application

### DIFF
--- a/app/src/main/java/com/ioannapergamali/mysmartroute/MySmartRouteApplication.kt
+++ b/app/src/main/java/com/ioannapergamali/mysmartroute/MySmartRouteApplication.kt
@@ -6,11 +6,16 @@ import com.google.firebase.FirebaseApp
 import com.ioannapergamali.mysmartroute.BuildConfig
 import com.ioannapergamali.mysmartroute.utils.ShortcutUtils
 import com.ioannapergamali.mysmartroute.viewmodel.AuthenticationViewModel
+import com.ioannapergamali.mysmartroute.utils.LanguagePreferenceManager
+import com.ioannapergamali.mysmartroute.utils.LocaleUtils
+import kotlinx.coroutines.runBlocking
 
 
 class MySmartRouteApplication : Application() {
     override fun onCreate() {
         super.onCreate()
+        val lang = runBlocking { LanguagePreferenceManager.getLanguage(this) }
+        LocaleUtils.updateLocale(this, lang)
         FirebaseApp.initializeApp(this)
         AuthenticationViewModel().ensureMenusInitialized(this)
         // Η υπηρεσία Firebase App Check απενεργοποιήθηκε προσωρινά

--- a/app/src/main/java/com/ioannapergamali/mysmartroute/utils/LocaleUtils.kt
+++ b/app/src/main/java/com/ioannapergamali/mysmartroute/utils/LocaleUtils.kt
@@ -3,10 +3,13 @@ package com.ioannapergamali.mysmartroute.utils
 import android.content.Context
 import androidx.appcompat.app.AppCompatDelegate
 import androidx.core.os.LocaleListCompat
+import java.util.Locale
 
 object LocaleUtils {
     fun updateLocale(context: Context, language: String) {
-        val locales = LocaleListCompat.forLanguageTags(language)
+        val locale = Locale(language)
+        Locale.setDefault(locale)
+        val locales = LocaleListCompat.create(locale)
         AppCompatDelegate.setApplicationLocales(locales)
     }
 }


### PR DESCRIPTION
## Summary
- call `LocaleUtils.updateLocale` earlier when the application starts
- set default `Locale` before setting `ApplicationLocales`

## Testing
- `./gradlew test -q` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_685fcc8baba48328970804685d855eda