### PR TITLE
Fix coroutine context usage

### DIFF
--- a/app/src/main/java/com/ioannapergamali/mysmartroute/MySmartRouteApplication.kt
+++ b/app/src/main/java/com/ioannapergamali/mysmartroute/MySmartRouteApplication.kt
@@ -14,7 +14,7 @@ import kotlinx.coroutines.runBlocking
 class MySmartRouteApplication : Application() {
     override fun onCreate() {
         super.onCreate()
-        val lang = runBlocking { LanguagePreferenceManager.getLanguage(this) }
+        val lang = runBlocking { LanguagePreferenceManager.getLanguage(this@MySmartRouteApplication) }
         LocaleUtils.updateLocale(this, lang)
         FirebaseApp.initializeApp(this)
         AuthenticationViewModel().ensureMenusInitialized(this)


### PR DESCRIPTION
## Summary
- fix context usage in MySmartRouteApplication

## Testing
- `./gradlew test --no-daemon` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_685fd183064c83288b8b1223c46f0c6f