### PR TITLE
Add language toggle in top bar

### DIFF
--- a/app/src/main/java/com/ioannapergamali/mysmartroute/view/ui/components/TopBar.kt
+++ b/app/src/main/java/com/ioannapergamali/mysmartroute/view/ui/components/TopBar.kt
@@ -22,6 +22,11 @@ import androidx.compose.material3.MaterialTheme
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.statusBarsPadding
 import androidx.compose.foundation.layout.padding
+import androidx.compose.ui.platform.LocalContext
+import com.ioannapergamali.mysmartroute.utils.LanguagePreferenceManager
+import com.ioannapergamali.mysmartroute.utils.LocaleUtils
+import com.ioannapergamali.mysmartroute.model.AppLanguage
+import kotlinx.coroutines.launch
 import com.google.firebase.auth.FirebaseAuth
 
 
@@ -35,6 +40,7 @@ fun TopBar(
     showLogout: Boolean = false,
     showBack: Boolean = true,
     showHomeIcon: Boolean = true,
+    showLanguageToggle: Boolean = true,
     onMenuClick: () -> Unit = {},
     onLogout: () -> Unit = {
         FirebaseAuth.getInstance().signOut()
@@ -43,7 +49,9 @@ fun TopBar(
         }
     }
 ) {
-
+    val context = LocalContext.current
+    val coroutineScope = rememberCoroutineScope()
+    val currentLanguage by LanguagePreferenceManager.languageFlow(context).collectAsState(initial = AppLanguage.Greek.code)
 
     Box(modifier = Modifier.statusBarsPadding()) {
         TopAppBar(
@@ -94,6 +102,17 @@ fun TopBar(
             }
         },
         actions = {
+            if (showLanguageToggle) {
+                IconButton(onClick = {
+                    val newLang = if (currentLanguage == AppLanguage.Greek.code) AppLanguage.English.code else AppLanguage.Greek.code
+                    coroutineScope.launch {
+                        LanguagePreferenceManager.setLanguage(context, newLang)
+                        LocaleUtils.updateLocale(context, newLang)
+                    }
+                }) {
+                    Text(AppLanguage.values().first { it.code == currentLanguage }.flag)
+                }
+            }
             if (showLogout) {
                 IconButton(onClick = onLogout) {
                     Icon(

--- a/app/src/main/java/com/ioannapergamali/mysmartroute/view/ui/screens/SettingsScreen.kt
+++ b/app/src/main/java/com/ioannapergamali/mysmartroute/view/ui/screens/SettingsScreen.kt
@@ -44,8 +44,6 @@ import com.ioannapergamali.mysmartroute.utils.SoundManager
 import com.ioannapergamali.mysmartroute.utils.SoundPreferenceManager
 import com.ioannapergamali.mysmartroute.utils.ThemePreferenceManager
 import com.ioannapergamali.mysmartroute.utils.FontPreferenceManager
-import com.ioannapergamali.mysmartroute.utils.LanguagePreferenceManager
-import com.ioannapergamali.mysmartroute.model.AppLanguage
 import com.ioannapergamali.mysmartroute.view.ui.AppFont
 import com.ioannapergamali.mysmartroute.view.ui.AppTheme
 import com.ioannapergamali.mysmartroute.view.ui.MysmartrouteTheme
@@ -67,8 +65,6 @@ fun SettingsScreen(navController: NavController, openDrawer: () -> Unit) {
     val currentFont by FontPreferenceManager.fontFlow(context).collectAsState(initial = AppFont.SansSerif)
     val soundEnabled by SoundPreferenceManager.soundEnabledFlow(context).collectAsState(initial = true)
     val currentVolume by SoundPreferenceManager.soundVolumeFlow(context).collectAsState(initial = 1f)
-    val currentLanguage by LanguagePreferenceManager.languageFlow(context).collectAsState(initial = AppLanguage.Greek.code)
-
     val expandedTheme = remember { mutableStateOf(false) }
     val selectedTheme = remember { mutableStateOf<ThemeOption>(currentTheme) }
     val customThemes = remember { ThemeLoader.load(context) }
@@ -79,8 +75,6 @@ fun SettingsScreen(navController: NavController, openDrawer: () -> Unit) {
 
     val soundState = remember { mutableStateOf(soundEnabled) }
     val volumeState = remember { mutableFloatStateOf(currentVolume) }
-    val expandedLanguage = remember { mutableStateOf(false) }
-    val selectedLanguage = remember { mutableStateOf(currentLanguage) }
 
     val coroutineScope = rememberCoroutineScope()
 
@@ -90,7 +84,6 @@ fun SettingsScreen(navController: NavController, openDrawer: () -> Unit) {
     LaunchedEffect(currentFont) { selectedFont.value = currentFont }
     LaunchedEffect(soundEnabled) { soundState.value = soundEnabled }
     LaunchedEffect(currentVolume) { volumeState.floatValue = currentVolume }
-    LaunchedEffect(currentLanguage) { selectedLanguage.value = currentLanguage }
 
     MysmartrouteTheme(
         theme = selectedTheme.value,
@@ -168,34 +161,7 @@ fun SettingsScreen(navController: NavController, openDrawer: () -> Unit) {
                 }
             }
 
-            Text(stringResource(R.string.language), modifier = Modifier.padding(top = 16.dp))
-            Divider(
-                modifier = Modifier.padding(vertical = 4.dp),
-                color = MaterialTheme.colorScheme.outline
-            )
-            ExposedDropdownMenuBox(expanded = expandedLanguage.value, onExpandedChange = { expandedLanguage.value = !expandedLanguage.value }) {
-                OutlinedTextField(
-                    readOnly = true,
-                    value = AppLanguage.values().first { it.code == selectedLanguage.value }.let { it.flag + " " + it.label },
-                    onValueChange = {},
-                    label = { Text(stringResource(R.string.language)) },
-                    trailingIcon = { ExposedDropdownMenuDefaults.TrailingIcon(expanded = expandedLanguage.value) },
-                    modifier = Modifier.menuAnchor(),
-                    shape = MaterialTheme.shapes.small,
-                    colors = OutlinedTextFieldDefaults.colors(
-                        focusedBorderColor = MaterialTheme.colorScheme.primary,
-                        unfocusedBorderColor = MaterialTheme.colorScheme.primary
-                    )
-                )
-                DropdownMenu(expanded = expandedLanguage.value, onDismissRequest = { expandedLanguage.value = false }) {
-                    AppLanguage.values().forEach { lang ->
-                        DropdownMenuItem(text = { Text(lang.flag + " " + lang.label) }, onClick = {
-                            selectedLanguage.value = lang.code
-                            expandedLanguage.value = false
-                        })
-                    }
-                }
-            }
+
 
             Text(stringResource(R.string.sound), modifier = Modifier.padding(top = 16.dp))
             Divider(
@@ -236,8 +202,7 @@ fun SettingsScreen(navController: NavController, openDrawer: () -> Unit) {
                             dark.value,
                             selectedFont.value,
                             soundState.value,
-                            volumeState.floatValue,
-                            selectedLanguage.value
+                            volumeState.floatValue
                         )
                         (context as? android.app.Activity)?.recreate()
                     }

--- a/app/src/main/java/com/ioannapergamali/mysmartroute/viewmodel/SettingsViewModel.kt
+++ b/app/src/main/java/com/ioannapergamali/mysmartroute/viewmodel/SettingsViewModel.kt
@@ -116,16 +116,14 @@ class SettingsViewModel : ViewModel() {
         dark: Boolean,
         font: AppFont,
         soundEnabled: Boolean,
-        soundVolume: Float,
-        language: String
+        soundVolume: Float
     ) {
         ThemePreferenceManager.setTheme(context, theme)
         ThemePreferenceManager.setDarkTheme(context, dark)
         FontPreferenceManager.setFont(context, font)
         SoundPreferenceManager.setSoundEnabled(context, soundEnabled)
         SoundPreferenceManager.setSoundVolume(context, soundVolume)
-        LanguagePreferenceManager.setLanguage(context, language)
-        LocaleUtils.updateLocale(context, language)
+        val language = LanguagePreferenceManager.languageFlow(context).first()
         updateSettings(context) {
             it.copy(
                 theme = (theme as? AppTheme)?.name ?: theme.label,


### PR DESCRIPTION
## Summary
- remove language dropdown from Settings screen
- show a language toggle button in TopBar
- adjust SettingsViewModel to keep existing language when applying other settings

## Testing
- `./gradlew assembleDebug` *(fails: domain maven.pkg.jetbrains.space blocked)*

------
https://chatgpt.com/codex/tasks/task_e_685fd67c7090832896b2f1e01be13638