### PR TITLE
Υποστήριξη αποθήκευσης γλώσσας σε βάση

### DIFF
--- a/app/src/main/java/com/ioannapergamali/mysmartroute/data/local/LanguageSettingDao.kt
+++ b/app/src/main/java/com/ioannapergamali/mysmartroute/data/local/LanguageSettingDao.kt
@@ -1,0 +1,15 @@
+package com.ioannapergamali.mysmartroute.data.local
+
+import androidx.room.Dao
+import androidx.room.Insert
+import androidx.room.OnConflictStrategy
+import androidx.room.Query
+
+@Dao
+interface LanguageSettingDao {
+    @Insert(onConflict = OnConflictStrategy.REPLACE)
+    suspend fun insert(setting: LanguageSettingEntity)
+
+    @Query("SELECT * FROM app_language LIMIT 1")
+    suspend fun get(): LanguageSettingEntity?
+}

--- a/app/src/main/java/com/ioannapergamali/mysmartroute/data/local/LanguageSettingEntity.kt
+++ b/app/src/main/java/com/ioannapergamali/mysmartroute/data/local/LanguageSettingEntity.kt
@@ -1,0 +1,10 @@
+package com.ioannapergamali.mysmartroute.data.local
+
+import androidx.room.Entity
+import androidx.room.PrimaryKey
+
+@Entity(tableName = "app_language")
+data class LanguageSettingEntity(
+    @PrimaryKey val id: Int = 1,
+    var language: String = "el"
+)

--- a/app/src/main/java/com/ioannapergamali/mysmartroute/data/local/MySmartRouteDatabase.kt
+++ b/app/src/main/java/com/ioannapergamali/mysmartroute/data/local/MySmartRouteDatabase.kt
@@ -11,6 +11,8 @@ import androidx.sqlite.db.SupportSQLiteDatabase
 import com.ioannapergamali.mysmartroute.data.local.VehicleEntity
 import com.ioannapergamali.mysmartroute.data.local.PoIEntity
 import com.ioannapergamali.mysmartroute.data.local.MenuOptionEntity
+import com.ioannapergamali.mysmartroute.data.local.LanguageSettingEntity
+import com.ioannapergamali.mysmartroute.data.local.LanguageSettingDao
 
 @Database(
     entities = [
@@ -20,9 +22,10 @@ import com.ioannapergamali.mysmartroute.data.local.MenuOptionEntity
         SettingsEntity::class,
         RoleEntity::class,
         MenuEntity::class,
-        MenuOptionEntity::class
+        MenuOptionEntity::class,
+        LanguageSettingEntity::class
     ],
-    version = 18
+    version = 19
 )
 abstract class MySmartRouteDatabase : RoomDatabase() {
     abstract fun userDao(): UserDao
@@ -32,6 +35,7 @@ abstract class MySmartRouteDatabase : RoomDatabase() {
     abstract fun roleDao(): RoleDao
     abstract fun menuDao(): MenuDao
     abstract fun menuOptionDao(): MenuOptionDao
+    abstract fun languageSettingDao(): LanguageSettingDao
 
     companion object {
         @Volatile
@@ -252,6 +256,19 @@ abstract class MySmartRouteDatabase : RoomDatabase() {
             }
         }
 
+        private val MIGRATION_18_19 = object : Migration(18, 19) {
+            override fun migrate(database: SupportSQLiteDatabase) {
+                database.execSQL(
+                    "CREATE TABLE IF NOT EXISTS `app_language` (" +
+                        "`id` INTEGER NOT NULL, " +
+                        "`language` TEXT NOT NULL, " +
+                        "PRIMARY KEY(`id`)" +
+                        ")"
+                )
+                database.execSQL("INSERT INTO `app_language` (`id`, `language`) VALUES (1, 'el')")
+            }
+        }
+
         private fun prepopulate(db: SupportSQLiteDatabase) {
             Log.d(TAG, "Prepopulating database")
             db.execSQL(
@@ -316,6 +333,7 @@ abstract class MySmartRouteDatabase : RoomDatabase() {
             insertOption("opt_admin_13", adminMenuId, "advance_date", "advanceDate")
 
             Log.d(TAG, "Prepopulate complete")
+            db.execSQL("INSERT INTO app_language (id, language) VALUES (1, 'el')")
         }
 
         fun getInstance(context: Context): MySmartRouteDatabase {
@@ -334,7 +352,8 @@ abstract class MySmartRouteDatabase : RoomDatabase() {
                     MIGRATION_14_15,
                     MIGRATION_15_16,
                     MIGRATION_16_17,
-                    MIGRATION_17_18
+                    MIGRATION_17_18,
+                    MIGRATION_18_19
                 )
                     .addCallback(object : RoomDatabase.Callback() {
                         override fun onCreate(db: SupportSQLiteDatabase) {

--- a/app/src/main/java/com/ioannapergamali/mysmartroute/utils/LanguagePreferenceManager.kt
+++ b/app/src/main/java/com/ioannapergamali/mysmartroute/utils/LanguagePreferenceManager.kt
@@ -4,6 +4,8 @@ import android.content.Context
 import androidx.datastore.preferences.core.edit
 import androidx.datastore.preferences.core.stringPreferencesKey
 import androidx.datastore.preferences.preferencesDataStore
+import com.ioannapergamali.mysmartroute.data.local.LanguageSettingEntity
+import com.ioannapergamali.mysmartroute.data.local.MySmartRouteDatabase
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.flow.map
@@ -22,9 +24,19 @@ object LanguagePreferenceManager {
         context.languageDataStore.edit { prefs ->
             prefs[LANGUAGE_KEY] = language
         }
+        val db = MySmartRouteDatabase.getInstance(context)
+        db.languageSettingDao().insert(LanguageSettingEntity(language = language))
     }
 
     suspend fun getLanguage(context: Context): String {
+        val db = MySmartRouteDatabase.getInstance(context)
+        val stored = db.languageSettingDao().get()?.language
+        if (stored != null) {
+            context.languageDataStore.edit { prefs ->
+                prefs[LANGUAGE_KEY] = stored
+            }
+            return stored
+        }
         val prefs = context.languageDataStore.data.first()
         return prefs[LANGUAGE_KEY] ?: "el"
     }


### PR DESCRIPTION
## Summary
- προσθήκη `LanguageSettingEntity` και αντίστοιχου DAO
- ενημέρωση της βάσης `MySmartRouteDatabase` με νέο πίνακα και migration
- προσαρμογή `LanguagePreferenceManager` ώστε να αποθηκεύει τη γλώσσα σε DB και DataStore

## Testing
- `./gradlew test` *(αποτυχημένο: δεν επιτράπηκε η λήψη των εξαρτήσεων)*
- `./gradlew assembleDebug` *(αποτυχημένο: δεν επιτράπηκε η λήψη των εξαρτήσεων)*

------
https://chatgpt.com/codex/tasks/task_e_685fe1d2bb548328a30776fc6577659b