### PR TITLE
Fix language toggle refresh

### DIFF
--- a/app/src/main/java/com/ioannapergamali/mysmartroute/view/ui/components/TopBar.kt
+++ b/app/src/main/java/com/ioannapergamali/mysmartroute/view/ui/components/TopBar.kt
@@ -108,6 +108,7 @@ fun TopBar(
                     coroutineScope.launch {
                         LanguagePreferenceManager.setLanguage(context, newLang)
                         LocaleUtils.updateLocale(context, newLang)
+                        (context as? android.app.Activity)?.recreate()
                     }
                 }) {
                     Text(AppLanguage.values().first { it.code == currentLanguage }.flag)


### PR DESCRIPTION
## Summary
- refresh `MainActivity` when changing language from the top bar so new strings load

## Testing
- `./gradlew test --no-daemon` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_685fe5adfa4c8328b069ed47e51ee979