### PR TITLE
Προσθήκη αποθήκευσης γλώσσας στο Firestore

### DIFF
--- a/app/src/main/java/com/ioannapergamali/mysmartroute/view/ui/components/TopBar.kt
+++ b/app/src/main/java/com/ioannapergamali/mysmartroute/view/ui/components/TopBar.kt
@@ -6,6 +6,7 @@ import androidx.compose.material.icons.automirrored.filled.ArrowBack
 import androidx.compose.material.icons.filled.Menu
 import androidx.compose.material.icons.filled.Logout
 import androidx.compose.material.icons.filled.Home
+import android.util.Log
 import androidx.compose.foundation.layout.Row
 import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.Icon
@@ -28,6 +29,10 @@ import com.ioannapergamali.mysmartroute.utils.LocaleUtils
 import com.ioannapergamali.mysmartroute.model.AppLanguage
 import kotlinx.coroutines.launch
 import com.google.firebase.auth.FirebaseAuth
+import androidx.lifecycle.viewmodel.compose.viewModel
+import com.ioannapergamali.mysmartroute.viewmodel.SettingsViewModel
+
+private const val TAG = "TopBar"
 
 
 
@@ -51,6 +56,7 @@ fun TopBar(
 ) {
     val context = LocalContext.current
     val coroutineScope = rememberCoroutineScope()
+    val settingsViewModel: SettingsViewModel = viewModel()
     val currentLanguage by LanguagePreferenceManager.languageFlow(context).collectAsState(initial = AppLanguage.Greek.code)
 
     Box(modifier = Modifier.statusBarsPadding()) {
@@ -105,9 +111,12 @@ fun TopBar(
             if (showLanguageToggle) {
                 IconButton(onClick = {
                     val newLang = if (currentLanguage == AppLanguage.Greek.code) AppLanguage.English.code else AppLanguage.Greek.code
+                    Log.d(TAG, "Language toggle pressed. Current: $currentLanguage, switching to: $newLang")
                     coroutineScope.launch {
                         LanguagePreferenceManager.setLanguage(context, newLang)
                         LocaleUtils.updateLocale(context, newLang)
+                        Log.d(TAG, "Locale updated to $newLang")
+                        settingsViewModel.saveCurrentSettings(context)
                         (context as? android.app.Activity)?.recreate()
                     }
                 }) {


### PR DESCRIPTION
## Περιγραφή
Η αλλαγή γλώσσας μέσω του `TopBar` πλέον αποθηκεύει την επιλογή και στο Firestore καλώντας `SettingsViewModel.saveCurrentSettings`. Έτσι η προτίμηση συγχρονίζεται με το cloud.

## Οδηγίες δοκιμών
1. Η εντολή `./gradlew assembleDebug` αποτυγχάνει λόγω περιορισμένης πρόσβασης στο διαδίκτυο.
2. Εκτελέστε την εφαρμογή και πατήστε το κουμπί γλώσσας. Στο log θα εμφανιστεί μήνυμα αλλαγής και η ρύθμιση θα αποθηκευτεί στο Firestore (εφόσον υπάρχει σύνδεση).

------
https://chatgpt.com/codex/tasks/task_e_685ff009c7488328a6199c80b54a45e8