### PR TITLE
Προσθήκη SettingsViewModel στο TopBar

### DIFF
--- a/app/src/main/java/com/ioannapergamali/mysmartroute/view/ui/components/TopBar.kt
+++ b/app/src/main/java/com/ioannapergamali/mysmartroute/view/ui/components/TopBar.kt
@@ -29,6 +29,8 @@ import com.ioannapergamali.mysmartroute.utils.LocaleUtils
 import com.ioannapergamali.mysmartroute.model.AppLanguage
 import kotlinx.coroutines.launch
 import com.google.firebase.auth.FirebaseAuth
+import androidx.lifecycle.viewmodel.compose.viewModel
+import com.ioannapergamali.mysmartroute.viewmodel.SettingsViewModel
 
 private const val TAG = "TopBar"
 
@@ -54,6 +56,7 @@ fun TopBar(
 ) {
     val context = LocalContext.current
     val coroutineScope = rememberCoroutineScope()
+    val settingsViewModel: SettingsViewModel = viewModel()
     val currentLanguage by LanguagePreferenceManager.languageFlow(context).collectAsState(initial = AppLanguage.Greek.code)
 
     Box(modifier = Modifier.statusBarsPadding()) {
@@ -112,6 +115,7 @@ fun TopBar(
                     coroutineScope.launch {
                         LanguagePreferenceManager.setLanguage(context, newLang)
                         LocaleUtils.updateLocale(context, newLang)
+                        settingsViewModel.saveCurrentSettings(context)
                         Log.d(TAG, "Locale updated to $newLang")
                         (context as? android.app.Activity)?.recreate()
                     }


### PR DESCRIPTION
## Περιγραφή
Προστέθηκε μεταβλητή `SettingsViewModel` στο `TopBar` και καλείται η μέθοδος `saveCurrentSettings` όταν αλλάζει η γλώσσα. Έτσι οι αλλαγές αποθηκεύονται και στο Firestore.

## Έλεγχοι
- Εκτελέστηκε `./gradlew test`, αλλά αποτυχία λόγω περιορισμών δικτύου.


------
https://chatgpt.com/codex/tasks/task_e_6860075ee34c83288c46da4209f181d3