### PR TITLE
Handle settings save with no user

### DIFF
--- a/app/src/main/java/com/ioannapergamali/mysmartroute/viewmodel/SettingsViewModel.kt
+++ b/app/src/main/java/com/ioannapergamali/mysmartroute/viewmodel/SettingsViewModel.kt
@@ -224,6 +224,22 @@ class SettingsViewModel : ViewModel() {
             val soundEnabled = SoundPreferenceManager.getSoundEnabled(context)
             val soundVolume = SoundPreferenceManager.getSoundVolume(context)
             val language = LanguagePreferenceManager.languageFlow(context).first()
+
+            // Αν δεν υπάρχει συνδεδεμένος χρήστης, αποθηκεύουμε μόνο τοπικά
+            if (auth.currentUser?.uid == null) {
+                ThemePreferenceManager.setTheme(context, theme)
+                ThemePreferenceManager.setDarkTheme(context, dark)
+                FontPreferenceManager.setFont(context, font)
+                SoundPreferenceManager.setSoundEnabled(context, soundEnabled)
+                SoundPreferenceManager.setSoundVolume(context, soundVolume)
+                LanguagePreferenceManager.setLanguage(context, language)
+                LocaleUtils.updateLocale(context, language)
+                Log.d("SettingsViewModel", "Αποθήκευση μόνο τοπικά καθώς δεν βρέθηκε χρήστης")
+                withContext(Dispatchers.Main) {
+                    Toast.makeText(context, "Αποθηκεύτηκαν τοπικά", Toast.LENGTH_SHORT).show()
+                }
+                return@launch
+            }
             updateSettings(context) {
                 it.copy(
                     theme = (theme as? AppTheme)?.name ?: theme.label,


### PR DESCRIPTION
## Summary
- avoid user not found error when saving settings without a logged-in user

## Testing
- `./gradlew test --no-daemon --offline` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_68600c00456c83289b0f6483f19b1b4f