### PR TITLE
Improve language storage and translations

### DIFF
--- a/app/src/main/java/com/ioannapergamali/mysmartroute/data/local/LanguageSettingDao.kt
+++ b/app/src/main/java/com/ioannapergamali/mysmartroute/data/local/LanguageSettingDao.kt
@@ -12,4 +12,7 @@ interface LanguageSettingDao {
 
     @Query("SELECT * FROM app_language LIMIT 1")
     suspend fun get(): LanguageSettingEntity?
+
+    @Query("SELECT * FROM app_language")
+    suspend fun getAll(): List<LanguageSettingEntity>
 }

--- a/app/src/main/java/com/ioannapergamali/mysmartroute/utils/LanguagePreferenceManager.kt
+++ b/app/src/main/java/com/ioannapergamali/mysmartroute/utils/LanguagePreferenceManager.kt
@@ -6,6 +6,11 @@ import androidx.datastore.preferences.core.stringPreferencesKey
 import androidx.datastore.preferences.preferencesDataStore
 import com.ioannapergamali.mysmartroute.data.local.LanguageSettingEntity
 import com.ioannapergamali.mysmartroute.data.local.MySmartRouteDatabase
+import com.google.firebase.firestore.FirebaseFirestore
+import kotlinx.coroutines.tasks.await
+import android.widget.Toast
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.withContext
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.flow.map
@@ -26,6 +31,20 @@ object LanguagePreferenceManager {
         }
         val db = MySmartRouteDatabase.getInstance(context)
         db.languageSettingDao().insert(LanguageSettingEntity(language = language))
+        try {
+            FirebaseFirestore.getInstance()
+                .collection("app_language")
+                .document("current")
+                .set(mapOf("language" to language))
+                .await()
+            withContext(Dispatchers.Main) {
+                Toast.makeText(context, "Η γλώσσα αποθηκεύτηκε στο cloud", Toast.LENGTH_SHORT).show()
+            }
+        } catch (_: Exception) {
+            withContext(Dispatchers.Main) {
+                Toast.makeText(context, "Σφάλμα αποθήκευσης γλώσσας στο cloud", Toast.LENGTH_SHORT).show()
+            }
+        }
     }
 
     suspend fun getLanguage(context: Context): String {

--- a/app/src/main/java/com/ioannapergamali/mysmartroute/view/ui/screens/AnnounceTransportScreen.kt
+++ b/app/src/main/java/com/ioannapergamali/mysmartroute/view/ui/screens/AnnounceTransportScreen.kt
@@ -19,7 +19,6 @@ import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.unit.dp
-import androidx.compose.ui.res.stringResource
 import com.ioannapergamali.mysmartroute.view.ui.components.ScreenContainer
 import androidx.compose.foundation.layout.Row
 import androidx.compose.material.icons.Icons
@@ -42,11 +41,11 @@ import androidx.lifecycle.viewmodel.compose.viewModel
 import androidx.navigation.NavController
 import com.ioannapergamali.mysmartroute.model.classes.routes.Route
 import com.ioannapergamali.mysmartroute.model.enumerations.VehicleType
-import com.ioannapergamali.mysmartroute.R
 import com.ioannapergamali.mysmartroute.utils.MapsUtils
 import com.ioannapergamali.mysmartroute.utils.NetworkUtils
 import com.ioannapergamali.mysmartroute.utils.CoordinateUtils
 import com.ioannapergamali.mysmartroute.view.ui.components.TopBar
+import com.ioannapergamali.mysmartroute.R
 import com.ioannapergamali.mysmartroute.viewmodel.TransportAnnouncementViewModel
 import com.ioannapergamali.mysmartroute.viewmodel.VehicleViewModel
 import com.ioannapergamali.mysmartroute.viewmodel.PoIViewModel
@@ -197,7 +196,7 @@ fun AnnounceTransportScreen(navController: NavController, openDrawer: () -> Unit
 
     ScreenContainer(modifier = Modifier.padding(0.dp)) {
         TopBar(
-            title = "Announce Transport",
+            title = stringResource(R.string.announce_transport),
             navController = navController,
             showMenu = true,
             onMenuClick = openDrawer
@@ -345,7 +344,7 @@ fun AnnounceTransportScreen(navController: NavController, openDrawer: () -> Unit
                         showRoute = false
                     }
                 },
-                label = { Text("From") },
+                label = { Text(stringResource(R.string.from)) },
                 isError = fromError,
                 trailingIcon = {
                     Row {
@@ -467,7 +466,7 @@ fun AnnounceTransportScreen(navController: NavController, openDrawer: () -> Unit
                         showRoute = false
                     }
                 },
-                label = { Text("To") },
+                label = { Text(stringResource(R.string.to)) },
                 isError = toError,
                 trailingIcon = {
                     Row {
@@ -583,7 +582,7 @@ fun AnnounceTransportScreen(navController: NavController, openDrawer: () -> Unit
                 value = selectedVehicleType?.name ?: "",
                 onValueChange = {},
                 readOnly = true,
-                label = { Text("Vehicle") },
+                label = { Text(stringResource(R.string.vehicle)) },
                 trailingIcon = { ExposedDropdownMenuDefaults.TrailingIcon(expanded = vehicleMenuExpanded) },
                 modifier = Modifier.menuAnchor().fillMaxWidth(),
                 shape = MaterialTheme.shapes.small,
@@ -613,7 +612,7 @@ fun AnnounceTransportScreen(navController: NavController, openDrawer: () -> Unit
         OutlinedTextField(
             value = costInput,
             onValueChange = { costInput = it },
-            label = { Text("Cost") },
+            label = { Text(stringResource(R.string.cost)) },
             shape = MaterialTheme.shapes.small,
             colors = OutlinedTextFieldDefaults.colors(
                 focusedBorderColor = MaterialTheme.colorScheme.primary,
@@ -621,12 +620,12 @@ fun AnnounceTransportScreen(navController: NavController, openDrawer: () -> Unit
             )
         )
         Spacer(modifier = Modifier.height(8.dp))
-        Text(text = "Duration: $durationMinutes min")
+        Text(text = stringResource(R.string.duration_format, durationMinutes))
         Spacer(modifier = Modifier.height(8.dp))
         OutlinedTextField(
             value = dateInput,
             onValueChange = { dateInput = it },
-            label = { Text("Date") },
+            label = { Text(stringResource(R.string.date)) },
             shape = MaterialTheme.shapes.small,
             colors = OutlinedTextFieldDefaults.colors(
                 focusedBorderColor = MaterialTheme.colorScheme.primary,
@@ -647,7 +646,7 @@ fun AnnounceTransportScreen(navController: NavController, openDrawer: () -> Unit
                 viewModel.announce(route, type, date, cost, durationMinutes)
             }
         }) {
-            Text("Announce")
+            Text(stringResource(R.string.announce))
         }
 
         if (state is TransportAnnouncementViewModel.AnnouncementState.Error) {

--- a/app/src/main/java/com/ioannapergamali/mysmartroute/view/ui/screens/FirebaseDatabaseScreen.kt
+++ b/app/src/main/java/com/ioannapergamali/mysmartroute/view/ui/screens/FirebaseDatabaseScreen.kt
@@ -18,6 +18,8 @@ import androidx.compose.ui.unit.dp
 import androidx.lifecycle.viewmodel.compose.viewModel
 import androidx.navigation.NavController
 import com.ioannapergamali.mysmartroute.view.ui.components.TopBar
+import androidx.compose.ui.res.stringResource
+import com.ioannapergamali.mysmartroute.R
 import com.ioannapergamali.mysmartroute.view.ui.components.ScreenContainer
 import com.ioannapergamali.mysmartroute.viewmodel.DatabaseViewModel
 import com.ioannapergamali.mysmartroute.model.enumerations.UserRole
@@ -33,7 +35,7 @@ fun FirebaseDatabaseScreen(navController: NavController, openDrawer: () -> Unit)
     Scaffold(
         topBar = {
             TopBar(
-                title = "Firebase DB",
+                title = stringResource(R.string.firebase_db),
                 navController = navController,
                 showMenu = true,
                 onMenuClick = openDrawer

--- a/app/src/main/java/com/ioannapergamali/mysmartroute/view/ui/screens/FontPickerScreen.kt
+++ b/app/src/main/java/com/ioannapergamali/mysmartroute/view/ui/screens/FontPickerScreen.kt
@@ -32,6 +32,8 @@ import com.ioannapergamali.mysmartroute.viewmodel.SettingsViewModel
 import com.ioannapergamali.mysmartroute.utils.ThemePreferenceManager
 import com.ioannapergamali.mysmartroute.utils.FontPreferenceManager
 import com.ioannapergamali.mysmartroute.view.ui.components.TopBar
+import androidx.compose.ui.res.stringResource
+import com.ioannapergamali.mysmartroute.R
 import com.ioannapergamali.mysmartroute.view.ui.components.ScreenContainer
 import com.ioannapergamali.mysmartroute.model.interfaces.ThemeOption
 
@@ -52,7 +54,7 @@ fun FontPickerScreen(navController: NavController) {
     MysmartrouteTheme(theme = currentTheme, darkTheme = currentDark, font = selectedFont.fontFamily) {
         Scaffold(
             topBar = {
-                TopBar(title = "Fonts", navController = navController)
+                TopBar(title = stringResource(R.string.fonts), navController = navController)
             },
             containerColor = MaterialTheme.colorScheme.background
         ) { padding ->

--- a/app/src/main/java/com/ioannapergamali/mysmartroute/view/ui/screens/LocalDatabaseScreen.kt
+++ b/app/src/main/java/com/ioannapergamali/mysmartroute/view/ui/screens/LocalDatabaseScreen.kt
@@ -19,6 +19,8 @@ import androidx.compose.ui.unit.dp
 import androidx.lifecycle.viewmodel.compose.viewModel
 import androidx.navigation.NavController
 import com.ioannapergamali.mysmartroute.view.ui.components.TopBar
+import androidx.compose.ui.res.stringResource
+import com.ioannapergamali.mysmartroute.R
 import com.ioannapergamali.mysmartroute.view.ui.components.ScreenContainer
 import com.ioannapergamali.mysmartroute.viewmodel.DatabaseViewModel
 import com.ioannapergamali.mysmartroute.model.enumerations.UserRole
@@ -35,7 +37,7 @@ fun LocalDatabaseScreen(navController: NavController, openDrawer: () -> Unit) {
     Scaffold(
         topBar = {
             TopBar(
-                title = "Local DB",
+                title = stringResource(R.string.local_db),
                 navController = navController,
                 showMenu = true,
                 onMenuClick = openDrawer
@@ -115,6 +117,15 @@ fun LocalDatabaseScreen(navController: NavController, openDrawer: () -> Unit) {
                 } else {
                     items(data!!.menuOptions) { opt ->
                         Text("${opt.id} (${opt.menuId}) -> ${opt.titleResKey} -> ${opt.route}")
+                    }
+                }
+                item { Spacer(modifier = Modifier.padding(8.dp)) }
+                item { Text(stringResource(R.string.app_language), style = MaterialTheme.typography.titleMedium) }
+                if (data!!.languages.isEmpty()) {
+                    item { Text("Ο πίνακας είναι άδειος") }
+                } else {
+                    items(data!!.languages) { lang ->
+                        Text("${lang.id} -> ${lang.language}")
                     }
                 }
                 }

--- a/app/src/main/java/com/ioannapergamali/mysmartroute/view/ui/screens/PoIListScreen.kt
+++ b/app/src/main/java/com/ioannapergamali/mysmartroute/view/ui/screens/PoIListScreen.kt
@@ -16,6 +16,8 @@ import androidx.lifecycle.viewmodel.compose.viewModel
 import androidx.compose.ui.platform.LocalContext
 import androidx.navigation.NavController
 import com.ioannapergamali.mysmartroute.view.ui.components.TopBar
+import androidx.compose.ui.res.stringResource
+import com.ioannapergamali.mysmartroute.R
 import com.ioannapergamali.mysmartroute.view.ui.components.ScreenContainer
 import com.ioannapergamali.mysmartroute.viewmodel.PoIViewModel
 
@@ -28,7 +30,7 @@ fun PoIListScreen(navController: NavController, openDrawer: () -> Unit) {
 
     LaunchedEffect(Unit) { viewModel.loadPois(context) }
 
-    Scaffold(topBar = { TopBar(title = "PoIs", navController = navController, showMenu = true, onMenuClick = openDrawer) }) { padding ->
+    Scaffold(topBar = { TopBar(title = stringResource(R.string.view_pois), navController = navController, showMenu = true, onMenuClick = openDrawer) }) { padding ->
         ScreenContainer(modifier = Modifier.padding(padding), scrollable = false) {
             LazyColumn(modifier = Modifier.fillMaxSize()) {
                 items(pois) { poi ->

--- a/app/src/main/java/com/ioannapergamali/mysmartroute/view/ui/screens/SoundPickerScreen.kt
+++ b/app/src/main/java/com/ioannapergamali/mysmartroute/view/ui/screens/SoundPickerScreen.kt
@@ -31,6 +31,8 @@ import com.ioannapergamali.mysmartroute.view.ui.MysmartrouteTheme
 import com.ioannapergamali.mysmartroute.view.ui.AppTheme
 import com.ioannapergamali.mysmartroute.view.ui.AppFont
 import com.ioannapergamali.mysmartroute.view.ui.components.TopBar
+import androidx.compose.ui.res.stringResource
+import com.ioannapergamali.mysmartroute.R
 import com.ioannapergamali.mysmartroute.viewmodel.SettingsViewModel
 import androidx.compose.material3.Slider
 import com.ioannapergamali.mysmartroute.utils.SoundManager
@@ -55,7 +57,7 @@ fun SoundPickerScreen(navController: NavController) {
 
     MysmartrouteTheme(theme = currentTheme, darkTheme = currentDark, font = currentFont.fontFamily) {
         Scaffold(
-            topBar = { TopBar(title = "Sound", navController = navController) },
+            topBar = { TopBar(title = stringResource(R.string.sound), navController = navController) },
             containerColor = MaterialTheme.colorScheme.background
         ) { padding ->
             ScreenContainer(modifier = Modifier.padding(padding)) {

--- a/app/src/main/java/com/ioannapergamali/mysmartroute/view/ui/screens/ThemePickerScreen.kt
+++ b/app/src/main/java/com/ioannapergamali/mysmartroute/view/ui/screens/ThemePickerScreen.kt
@@ -35,6 +35,8 @@ import com.ioannapergamali.mysmartroute.viewmodel.SettingsViewModel
 import com.ioannapergamali.mysmartroute.utils.ThemePreferenceManager
 import com.ioannapergamali.mysmartroute.utils.FontPreferenceManager
 import com.ioannapergamali.mysmartroute.view.ui.components.TopBar
+import androidx.compose.ui.res.stringResource
+import com.ioannapergamali.mysmartroute.R
 import com.ioannapergamali.mysmartroute.view.ui.components.ScreenContainer
 
 @OptIn(ExperimentalMaterial3Api::class)
@@ -58,7 +60,7 @@ fun ThemePickerScreen(navController: NavController) {
     MysmartrouteTheme(theme = selectedTheme, darkTheme = dark, font = currentFont.fontFamily) {
         Scaffold(
             topBar = {
-                TopBar(title = "Themes", navController = navController)
+                TopBar(title = stringResource(R.string.theme), navController = navController)
             },
             containerColor = MaterialTheme.colorScheme.background
         ) { padding ->

--- a/app/src/main/java/com/ioannapergamali/mysmartroute/viewmodel/DatabaseViewModel.kt
+++ b/app/src/main/java/com/ioannapergamali/mysmartroute/viewmodel/DatabaseViewModel.kt
@@ -19,6 +19,7 @@ import com.ioannapergamali.mysmartroute.data.local.MenuEntity
 import com.ioannapergamali.mysmartroute.data.local.MenuOptionEntity
 import com.ioannapergamali.mysmartroute.data.local.UserEntity
 import com.ioannapergamali.mysmartroute.data.local.VehicleEntity
+import com.ioannapergamali.mysmartroute.data.local.LanguageSettingEntity
 import com.ioannapergamali.mysmartroute.utils.NetworkUtils
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
@@ -63,7 +64,8 @@ class DatabaseViewModel : ViewModel() {
                 db.settingsDao().getAllSettings(),
                 db.roleDao().getAllRoles(),
                 db.menuDao().getAllMenus(),
-                db.menuOptionDao().getAllMenuOptions()
+                db.menuOptionDao().getAllMenuOptions(),
+                db.languageSettingDao().getAll()
             ) { values ->
                 val users = values[0] as List<UserEntity>
                 val vehicles = values[1] as List<VehicleEntity>
@@ -72,7 +74,8 @@ class DatabaseViewModel : ViewModel() {
                 val roles = values[4] as List<RoleEntity>
                 val menus = values[5] as List<MenuEntity>
                 val options = values[6] as List<MenuOptionEntity>
-                DatabaseData(users, vehicles, pois, settings, roles, menus, options)
+                val languages = values[7] as List<LanguageSettingEntity>
+                DatabaseData(users, vehicles, pois, settings, roles, menus, options, languages)
             }.collect { data ->
                 Log.d(
                     TAG,
@@ -177,7 +180,7 @@ class DatabaseViewModel : ViewModel() {
             }
 
             Log.d(TAG, "Firebase data -> users:${users.size} vehicles:${vehicles.size} pois:${pois.size} settings:${settings.size} roles:${roles.size} menus:${menus.size} options:${menuOptions.size}")
-            _firebaseData.value = DatabaseData(users, vehicles, pois, settings, roles, menus, menuOptions)
+            _firebaseData.value = DatabaseData(users, vehicles, pois, settings, roles, menus, menuOptions, emptyList())
         }
     }
 
@@ -388,7 +391,8 @@ data class DatabaseData(
     val settings: List<SettingsEntity>,
     val roles: List<RoleEntity>,
     val menus: List<MenuEntity>,
-    val menuOptions: List<MenuOptionEntity>
+    val menuOptions: List<MenuOptionEntity>,
+    val languages: List<LanguageSettingEntity>
 )
 
 sealed class SyncState {

--- a/app/src/main/res/values-el/strings.xml
+++ b/app/src/main/res/values-el/strings.xml
@@ -88,4 +88,14 @@
     <string name="view_pois">Προβολή σημείων ενδιαφέροντος</string>
     <string name="view_users">Προβολή χρηστών</string>
     <string name="advance_date">Μεταφορά ημερομηνίας</string>
+    <string name="announce_transport">Δήλωση μεταφοράς</string>
+    <string name="from">Από</string>
+    <string name="to">Προς</string>
+    <string name="vehicle">Όχημα</string>
+    <string name="cost">Κόστος</string>
+    <string name="duration">Διάρκεια</string>
+    <string name="date">Ημερομηνία</string>
+    <string name="announce">Αποστολή</string>
+    <string name="duration_format">Διάρκεια: %1$d λεπτά</string>
+    <string name="app_language">Γλώσσα εφαρμογής</string>
 </resources>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -86,4 +86,14 @@
     <string name="view_pois">View PoIs</string>
     <string name="view_users">View Users</string>
     <string name="advance_date">Advance Date</string>
+    <string name="announce_transport">Announce Transport</string>
+    <string name="from">From</string>
+    <string name="to">To</string>
+    <string name="vehicle">Vehicle</string>
+    <string name="cost">Cost</string>
+    <string name="duration">Duration</string>
+    <string name="date">Date</string>
+    <string name="announce">Announce</string>
+    <string name="duration_format">Duration: %1$d min</string>
+    <string name="app_language">App Language</string>
 </resources>


### PR DESCRIPTION
## Summary
- store selected language to Firestore with toast messages
- show language table in local DB viewer
- use translated strings in database screens and pickers
- translate Announce Transport screen fields
- add new string resources for labels and duration

## Testing
- `./gradlew test -q` *(fails: domain `maven.pkg.jetbrains.space` blocked)*

------
https://chatgpt.com/codex/tasks/task_e_68601f248e1c832891e767fa7d21eeaf