### PR TITLE
Fix flow type for language settings

### DIFF
--- a/app/src/main/java/com/ioannapergamali/mysmartroute/data/local/LanguageSettingDao.kt
+++ b/app/src/main/java/com/ioannapergamali/mysmartroute/data/local/LanguageSettingDao.kt
@@ -4,6 +4,7 @@ import androidx.room.Dao
 import androidx.room.Insert
 import androidx.room.OnConflictStrategy
 import androidx.room.Query
+import kotlinx.coroutines.flow.Flow
 
 @Dao
 interface LanguageSettingDao {
@@ -14,5 +15,5 @@ interface LanguageSettingDao {
     suspend fun get(): LanguageSettingEntity?
 
     @Query("SELECT * FROM app_language")
-    suspend fun getAll(): List<LanguageSettingEntity>
+    fun getAll(): Flow<List<LanguageSettingEntity>>
 }


### PR DESCRIPTION
## Summary
- επισκευή `LanguageSettingDao` ώστε η μέθοδος `getAll()` να επιστρέφει `Flow<List<LanguageSettingEntity>>`

## Testing
- `./gradlew assembleDebug` *(απέτυχε: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_68602db5fc708328a567b6a7e93fea08