### PR TITLE
Επίλυση διπλοεγγραφών μενού

### DIFF
--- a/app/src/main/java/com/ioannapergamali/mysmartroute/viewmodel/AuthenticationViewModel.kt
+++ b/app/src/main/java/com/ioannapergamali/mysmartroute/viewmodel/AuthenticationViewModel.kt
@@ -148,11 +148,11 @@ class AuthenticationViewModel : ViewModel() {
                     val snapshot = roleMenusRef.get().await()
                     if (snapshot.isEmpty) {
                         defaultMenus(context, role).forEach { (menuTitle, options) ->
-                            val menuId = UUID.randomUUID().toString()
+                            val menuId = "${roleId}_${menuTitle}"
                             val menuDoc = roleMenusRef.document(menuId)
                             batch.set(menuDoc, mapOf("id" to menuId, "titleKey" to menuTitle))
                             options.forEach { (optTitle, route) ->
-                                val optId = UUID.randomUUID().toString()
+                                val optId = "${menuId}_${optTitle}"
                                 batch.set(
                                     menuDoc.collection("options").document(optId),
                                     mapOf("id" to optId, "titleKey" to optTitle, "route" to route)
@@ -353,13 +353,13 @@ class AuthenticationViewModel : ViewModel() {
             val menusSnap = roleRef.collection("menus").get().await()
             if (menusSnap.isEmpty) {
                 cfg.menus.forEach { menu ->
-                    val menuId = UUID.randomUUID().toString()
+                    val menuId = "${roleId}_${menu.titleKey}"
                     val menuDoc = roleRef.collection("menus").document(menuId)
                     batch.set(menuDoc, mapOf("id" to menuId, "titleKey" to menu.titleKey))
                     commitNeeded = true
                     menuDao.insert(MenuEntity(menuId, roleId, menu.titleKey))
                     menu.options.forEach { opt ->
-                        val optId = UUID.randomUUID().toString()
+                        val optId = "${menuId}_${opt.titleKey}"
                         batch.set(
                             menuDoc.collection("options").document(optId),
                             mapOf("id" to optId, "titleKey" to opt.titleKey, "route" to opt.route),


### PR DESCRIPTION
## Περιγραφή
Διορθώθηκε η δημιουργία διπλών μενού κατά την αρχικοποίηση. Τα `id` των μενού και των επιλογών παράγονται πλέον με βάση το `roleId` και το `titleKey`, ώστε οι επαναλαμβανόμενες κλήσεις να μη δημιουργούν νέα στοιχεία.

## Testing
- `./gradlew test` *(απέτυχε λόγω περιορισμών δικτύου)*

------
https://chatgpt.com/codex/tasks/task_e_6860351f46748328856b59b9f64d0ae4