### PR TITLE
Fix combine call for LanguageSettingEntity

### DIFF
--- a/app/src/main/java/com/ioannapergamali/mysmartroute/viewmodel/DatabaseViewModel.kt
+++ b/app/src/main/java/com/ioannapergamali/mysmartroute/viewmodel/DatabaseViewModel.kt
@@ -66,15 +66,7 @@ class DatabaseViewModel : ViewModel() {
                 db.menuDao().getAllMenus(),
                 db.menuOptionDao().getAllMenuOptions(),
                 db.languageSettingDao().getAll()
-            ) { values ->
-                val users = values[0] as List<UserEntity>
-                val vehicles = values[1] as List<VehicleEntity>
-                val pois = values[2] as List<PoIEntity>
-                val settings = values[3] as List<SettingsEntity>
-                val roles = values[4] as List<RoleEntity>
-                val menus = values[5] as List<MenuEntity>
-                val options = values[6] as List<MenuOptionEntity>
-                val languages = values[7] as List<LanguageSettingEntity>
+            ) { users, vehicles, pois, settings, roles, menus, options, languages ->
                 DatabaseData(users, vehicles, pois, settings, roles, menus, options, languages)
             }.collect { data ->
                 Log.d(


### PR DESCRIPTION
## Summary
- fix combine call to use typed parameters for the language settings list

## Testing
- `./gradlew test --no-daemon` *(fails: Could not download from maven.pkg.jetbrains.space)*

------
https://chatgpt.com/codex/tasks/task_e_68603a5aaa848328be5094ab4e707341