### PR TITLE
Improve offline handling of role menu loading

### DIFF
--- a/app/src/main/java/com/ioannapergamali/mysmartroute/viewmodel/AuthenticationViewModel.kt
+++ b/app/src/main/java/com/ioannapergamali/mysmartroute/viewmodel/AuthenticationViewModel.kt
@@ -302,9 +302,17 @@ class AuthenticationViewModel : ViewModel() {
             val menusLocal = loadMenusWithInheritanceLocal(dbLocal, roleId)
             if (menusLocal.isNotEmpty()) {
                 _currentMenus.value = menusLocal
-            } else {
-                val menusRemote = loadMenusWithInheritanceRemote(roleId, dbLocal)
+            } else if (NetworkUtils.isInternetAvailable(context)) {
+                val menusRemote = try {
+                    loadMenusWithInheritanceRemote(roleId, dbLocal)
+                } catch (e: Exception) {
+                    Log.e(TAG, "Failed to load menus", e)
+                    emptyList()
+                }
                 _currentMenus.value = menusRemote
+            } else {
+                Log.w(TAG, "No internet connection and no local menus")
+                _currentMenus.value = emptyList()
             }
         }
     }


### PR DESCRIPTION
## Summary
- handle remote menu load failure in `AuthenticationViewModel`
- show warning when offline

## Testing
- `./gradlew test --no-daemon` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_68605bf492b883288ab618d2434666bb