### PR TITLE
Fix formatting in catch block

### DIFF
--- a/app/src/main/java/com/ioannapergamali/mysmartroute/viewmodel/DatabaseViewModel.kt
+++ b/app/src/main/java/com/ioannapergamali/mysmartroute/viewmodel/DatabaseViewModel.kt
@@ -384,7 +384,9 @@ class DatabaseViewModel : ViewModel() {
                 _syncState.value = SyncState.Error("Sync timeout")
             } catch (e: Exception) {
                 Log.e(TAG, "Sync error", e)
-                _syncState.value = SyncState.Error(e.localizedMessage ?: "Sync failed")
+                _syncState.value = SyncState.Error(
+                    e.localizedMessage ?: "Sync failed"
+                )
             }
         }
     }


### PR DESCRIPTION
## Summary
- tidy catch block formatting in `DatabaseViewModel`

## Testing
- `kotlinc app/src/main/java/com/ioannapergamali/mysmartroute/viewmodel/DatabaseViewModel.kt -d /tmp/dummy.jar` *(fails: expecting ')' at line 382)*

------
https://chatgpt.com/codex/tasks/task_e_686068a7bd708328871c1c7359a5441d