### PR TITLE
Fix brace in DatabaseViewModel

### DIFF
--- a/app/src/main/java/com/ioannapergamali/mysmartroute/viewmodel/DatabaseViewModel.kt
+++ b/app/src/main/java/com/ioannapergamali/mysmartroute/viewmodel/DatabaseViewModel.kt
@@ -378,6 +378,7 @@ class DatabaseViewModel : ViewModel() {
                     prefs.edit().putLong("last_sync", newTs).apply()
                     _lastSyncTime.value = newTs
                 }
+                }
                 _syncState.value = SyncState.Success
             } catch (e: TimeoutCancellationException) {
                 Log.e(TAG, "Sync timeout", e)


### PR DESCRIPTION
## Summary
- fix missing closing brace for `withTimeout` in `DatabaseViewModel`

## Testing
- `kotlinc app/src/main/java/com/ioannapergamali/mysmartroute/viewmodel/DatabaseViewModel.kt -d /tmp/out.jar` *(fails to resolve Android references)*


------
https://chatgpt.com/codex/tasks/task_e_68607b0b28748328b39a586d58ae6cbd