### PR TITLE
Fix role menu loading

### DIFF
--- a/app/src/main/java/com/ioannapergamali/mysmartroute/view/ui/screens/RolesScreen.kt
+++ b/app/src/main/java/com/ioannapergamali/mysmartroute/view/ui/screens/RolesScreen.kt
@@ -24,6 +24,7 @@ import androidx.compose.ui.res.stringResource
 import com.ioannapergamali.mysmartroute.R
 import com.ioannapergamali.mysmartroute.model.enumerations.UserRole
 import com.ioannapergamali.mysmartroute.model.enumerations.localizedName
+import kotlinx.coroutines.launch
 
 @Composable
 fun RolesScreen(navController: NavController, openDrawer: () -> Unit) {
@@ -34,8 +35,10 @@ fun RolesScreen(navController: NavController, openDrawer: () -> Unit) {
     val context = LocalContext.current
 
     LaunchedEffect(Unit) {
-        dbViewModel.syncDatabases(context)
         viewModel.loadRoles(context)
+        launch {
+            dbViewModel.syncDatabases(context)
+        }
     }
 
     Scaffold(


### PR DESCRIPTION
## Summary
- load roles before syncing DB
- perform DB sync asynchronously

## Testing
- `./gradlew assembleDebug` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_686081f44d5c83288c217b208d2c1bec