### PR TITLE
Improve roles screen error handling

### DIFF
--- a/app/src/main/java/com/ioannapergamali/mysmartroute/view/ui/screens/RolesScreen.kt
+++ b/app/src/main/java/com/ioannapergamali/mysmartroute/view/ui/screens/RolesScreen.kt
@@ -52,18 +52,28 @@ fun RolesScreen(navController: NavController, openDrawer: () -> Unit) {
         }
     ) { padding ->
         ScreenContainer(modifier = Modifier.padding(padding), scrollable = false) {
-            if (roles.isEmpty() && syncState is SyncState.Loading) {
-                CircularProgressIndicator()
-            } else {
-                LazyColumn(modifier = Modifier.fillMaxSize()) {
-                    items(roles) { role ->
-                        val roleEnum = try {
-                            UserRole.valueOf(role.name)
-                        } catch (_: Exception) {
-                            null
+            when {
+                roles.isEmpty() && syncState is SyncState.Loading -> {
+                    CircularProgressIndicator()
+                }
+                roles.isEmpty() && syncState is SyncState.Error -> {
+                    val message = (syncState as SyncState.Error).message
+                    Text(stringResource(R.string.roles_load_error, message))
+                }
+                roles.isEmpty() -> {
+                    Text(stringResource(R.string.roles_empty))
+                }
+                else -> {
+                    LazyColumn(modifier = Modifier.fillMaxSize()) {
+                        items(roles) { role ->
+                            val roleEnum = try {
+                                UserRole.valueOf(role.name)
+                            } catch (_: Exception) {
+                                null
+                            }
+                            val displayName = roleEnum?.localizedName() ?: role.name
+                            Text("${'$'}{role.id} - ${'$'}displayName")
                         }
-                        val displayName = roleEnum?.localizedName() ?: role.name
-                        Text("${'$'}{role.id} - ${'$'}displayName")
                     }
                 }
             }

--- a/app/src/main/res/values-el/strings.xml
+++ b/app/src/main/res/values-el/strings.xml
@@ -33,6 +33,8 @@
     <string name="menu_title">Μενού</string>
     <string name="menu_role_prefix">Μενού για τον ρόλο: %1$s</string>
     <string name="roles_title">Ρόλοι</string>
+    <string name="roles_load_error">Αποτυχία φόρτωσης ρόλων: %1$s</string>
+    <string name="roles_empty">Δεν βρέθηκαν ρόλοι</string>
     <string name="about_title">Σχετικά</string>
     <string name="support_title">Υποστήριξη</string>
     <string name="databases_title">Βάσεις Δεδομένων</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -31,6 +31,8 @@
     <string name="menu_title">Menu</string>
     <string name="menu_role_prefix">Menu for role: %1$s</string>
     <string name="roles_title">Roles</string>
+    <string name="roles_load_error">Failed to load roles: %1$s</string>
+    <string name="roles_empty">No roles found</string>
     <string name="about_title">About</string>
     <string name="support_title">Support</string>
     <string name="databases_title">Databases</string>


### PR DESCRIPTION
## Summary
- show error or empty messages in RolesScreen
- add string resources for these new states

## Testing
- `./gradlew test --quiet` *(fails: blocked domain maven.pkg.jetbrains.space)*

------
https://chatgpt.com/codex/tasks/task_e_6860837f00f48328b26af16cb743f1f3