### PR TITLE
Improve error visibility for roles loading

### DIFF
--- a/app/src/main/java/com/ioannapergamali/mysmartroute/view/ui/screens/RolesScreen.kt
+++ b/app/src/main/java/com/ioannapergamali/mysmartroute/view/ui/screens/RolesScreen.kt
@@ -24,6 +24,7 @@ import androidx.compose.ui.res.stringResource
 import com.ioannapergamali.mysmartroute.R
 import com.ioannapergamali.mysmartroute.model.enumerations.UserRole
 import com.ioannapergamali.mysmartroute.model.enumerations.localizedName
+import android.widget.Toast
 import kotlinx.coroutines.launch
 
 @Composable
@@ -33,6 +34,16 @@ fun RolesScreen(navController: NavController, openDrawer: () -> Unit) {
     val roles by viewModel.roles.collectAsState()
     val syncState by dbViewModel.syncState.collectAsState()
     val context = LocalContext.current
+
+    LaunchedEffect(syncState) {
+        if (syncState is SyncState.Error) {
+            val message = (syncState as SyncState.Error).message
+            Toast.makeText(context,
+                context.getString(R.string.roles_load_error, message),
+                Toast.LENGTH_LONG
+            ).show()
+        }
+    }
 
     LaunchedEffect(Unit) {
         viewModel.loadRoles(context)
@@ -52,18 +63,28 @@ fun RolesScreen(navController: NavController, openDrawer: () -> Unit) {
         }
     ) { padding ->
         ScreenContainer(modifier = Modifier.padding(padding), scrollable = false) {
-            if (roles.isEmpty() && syncState is SyncState.Loading) {
-                CircularProgressIndicator()
-            } else {
-                LazyColumn(modifier = Modifier.fillMaxSize()) {
-                    items(roles) { role ->
-                        val roleEnum = try {
-                            UserRole.valueOf(role.name)
-                        } catch (_: Exception) {
-                            null
+            when {
+                roles.isEmpty() && syncState is SyncState.Loading -> {
+                    CircularProgressIndicator()
+                }
+                roles.isEmpty() && syncState is SyncState.Error -> {
+                    val message = (syncState as SyncState.Error).message
+                    Text(stringResource(R.string.roles_load_error, message))
+                }
+                roles.isEmpty() -> {
+                    Text(stringResource(R.string.roles_empty))
+                }
+                else -> {
+                    LazyColumn(modifier = Modifier.fillMaxSize()) {
+                        items(roles) { role ->
+                            val roleEnum = try {
+                                UserRole.valueOf(role.name)
+                            } catch (_: Exception) {
+                                null
+                            }
+                            val displayName = roleEnum?.localizedName() ?: role.name
+                            Text("${'$'}{role.id} - ${'$'}displayName")
                         }
-                        val displayName = roleEnum?.localizedName() ?: role.name
-                        Text("${'$'}{role.id} - ${'$'}displayName")
                     }
                 }
             }

--- a/app/src/main/res/values-el/strings.xml
+++ b/app/src/main/res/values-el/strings.xml
@@ -33,6 +33,8 @@
     <string name="menu_title">Μενού</string>
     <string name="menu_role_prefix">Μενού για τον ρόλο: %1$s</string>
     <string name="roles_title">Ρόλοι</string>
+    <string name="roles_load_error">Αποτυχία φόρτωσης ρόλων: %1$s</string>
+    <string name="roles_empty">Δεν βρέθηκαν ρόλοι</string>
     <string name="about_title">Σχετικά</string>
     <string name="support_title">Υποστήριξη</string>
     <string name="databases_title">Βάσεις Δεδομένων</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -31,6 +31,8 @@
     <string name="menu_title">Menu</string>
     <string name="menu_role_prefix">Menu for role: %1$s</string>
     <string name="roles_title">Roles</string>
+    <string name="roles_load_error">Failed to load roles: %1$s</string>
+    <string name="roles_empty">No roles found</string>
     <string name="about_title">About</string>
     <string name="support_title">Support</string>
     <string name="databases_title">Databases</string>


### PR DESCRIPTION
## Summary
- show Toast when database sync fails on RolesScreen

## Testing
- `./gradlew --version`
- `./gradlew test --quiet` *(fails: blocked domain maven.pkg.jetbrains.space)*

------
https://chatgpt.com/codex/tasks/task_e_6860837f00f48328b26af16cb743f1f3