### PR TITLE
Improve roles loading error display

### DIFF
--- a/app/src/main/res/values-el/strings.xml
+++ b/app/src/main/res/values-el/strings.xml
@@ -33,6 +33,8 @@
     <string name="menu_title">Μενού</string>
     <string name="menu_role_prefix">Μενού για τον ρόλο: %1$s</string>
     <string name="roles_title">Ρόλοι</string>
+    <string name="roles_load_error">Αποτυχία φόρτωσης ρόλων: %1$s</string>
+    <string name="roles_empty">Δεν βρέθηκαν ρόλοι</string>
     <string name="about_title">Σχετικά</string>
     <string name="support_title">Υποστήριξη</string>
     <string name="databases_title">Βάσεις Δεδομένων</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -31,6 +31,8 @@
     <string name="menu_title">Menu</string>
     <string name="menu_role_prefix">Menu for role: %1$s</string>
     <string name="roles_title">Roles</string>
+    <string name="roles_load_error">Failed to load roles: %1$s</string>
+    <string name="roles_empty">No roles found</string>
     <string name="about_title">About</string>
     <string name="support_title">Support</string>
     <string name="databases_title">Databases</string>


### PR DESCRIPTION
## Summary
- adjust RolesScreen to keep showing progress only while sync is running

## Testing
- `./gradlew --version`
- `./gradlew test --quiet` *(fails: blocked domain maven.pkg.jetbrains.space)*

------
https://chatgpt.com/codex/tasks/task_e_6860837f00f48328b26af16cb743f1f3