### PR TITLE
Add comment on menu loading fallback

### DIFF
--- a/app/src/main/java/com/ioannapergamali/mysmartroute/viewmodel/AuthenticationViewModel.kt
+++ b/app/src/main/java/com/ioannapergamali/mysmartroute/viewmodel/AuthenticationViewModel.kt
@@ -290,6 +290,12 @@ class AuthenticationViewModel : ViewModel() {
         return menus.distinctBy { it.menu.id }
     }
 
+    /**
+     * Φορτώνει τα μενού του τρέχοντος χρήστη από την τοπική βάση.
+     * Αν δεν υπάρχουν και υπάρχει σύνδεση στο διαδίκτυο,
+     * τα ανακτά από το Firestore. Σε περίπτωση που και εκεί
+     * δεν βρεθούν, γίνεται αρχικοποίηση από το τοπικό menus.json.
+     */
     fun loadCurrentUserMenus(context: Context) {
         viewModelScope.launch {
             val uid = auth.currentUser?.uid ?: run {


### PR DESCRIPTION
## Summary
- add Greek comment explaining how user menus are loaded with a local fallback

## Testing
- `./gradlew test --console=plain` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_68608f025ab48328a81bd7dbac21fb7c