### PR TITLE
Fix loading logic on roles screen

### DIFF
--- a/app/src/main/java/com/ioannapergamali/mysmartroute/view/ui/screens/RolesScreen.kt
+++ b/app/src/main/java/com/ioannapergamali/mysmartroute/view/ui/screens/RolesScreen.kt
@@ -25,7 +25,6 @@ import com.ioannapergamali.mysmartroute.R
 import com.ioannapergamali.mysmartroute.model.enumerations.UserRole
 import com.ioannapergamali.mysmartroute.model.enumerations.localizedName
 import android.widget.Toast
-import kotlinx.coroutines.launch
 
 @Composable
 fun RolesScreen(navController: NavController, openDrawer: () -> Unit) {
@@ -46,10 +45,8 @@ fun RolesScreen(navController: NavController, openDrawer: () -> Unit) {
     }
 
     LaunchedEffect(Unit) {
+        dbViewModel.syncDatabasesSuspend(context)
         viewModel.loadRoles(context)
-        launch {
-            dbViewModel.syncDatabases(context)
-        }
     }
 
     Scaffold(


### PR DESCRIPTION
## Summary
- make database sync suspendable
- wait for sync before loading roles

## Testing
- `./gradlew test -q` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_6860a3019ba08328900e92ff0f8da846