### PR TITLE
Fix menu option handling

### DIFF
--- a/app/src/main/java/com/ioannapergamali/mysmartroute/view/ui/screens/MenuScreen.kt
+++ b/app/src/main/java/com/ioannapergamali/mysmartroute/view/ui/screens/MenuScreen.kt
@@ -71,8 +71,16 @@ fun MenuScreen(navController: NavController, openDrawer: () -> Unit) {
                 CircularProgressIndicator()
             } else {
                 RoleMenu(role, menus) { route ->
-                    if (route.isNotEmpty()) navController.navigate(route)
-                    else Toast.makeText(context, "Η λειτουργία δεν είναι διαθέσιμη", Toast.LENGTH_SHORT).show()
+                    if (route.isNotEmpty() &&
+                        navController.graph.nodes.any { it.route == route }) {
+                        navController.navigate(route)
+                    } else {
+                        Toast.makeText(
+                            context,
+                            stringResource(R.string.not_implemented),
+                            Toast.LENGTH_SHORT
+                        ).show()
+                    }
                 }
             }
         }

--- a/app/src/main/res/values-el/strings.xml
+++ b/app/src/main/res/values-el/strings.xml
@@ -100,4 +100,5 @@
     <string name="announce">Αποστολή</string>
     <string name="duration_format">Διάρκεια: %1$d λεπτά</string>
     <string name="app_language">Γλώσσα εφαρμογής</string>
+    <string name="not_implemented">Η λειτουργία δεν είναι διαθέσιμη</string>
 </resources>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -98,4 +98,5 @@
     <string name="announce">Announce</string>
     <string name="duration_format">Duration: %1$d min</string>
     <string name="app_language">App Language</string>
+    <string name="not_implemented">Functionality not available</string>
 </resources>


### PR DESCRIPTION
## Summary
- add string resource for unimplemented features
- show toast when route is missing

## Testing
- `./gradlew test --no-daemon` *(fails: maven.pkg.jetbrains.space blocked)*

------
https://chatgpt.com/codex/tasks/task_e_6862dbb5d0f48328bfc4f0911e5b38df