### PR TITLE
Fix unresolved reference in MenuScreen

### DIFF
--- a/app/src/main/java/com/ioannapergamali/mysmartroute/view/ui/screens/MenuScreen.kt
+++ b/app/src/main/java/com/ioannapergamali/mysmartroute/view/ui/screens/MenuScreen.kt
@@ -72,7 +72,7 @@ fun MenuScreen(navController: NavController, openDrawer: () -> Unit) {
             } else {
                 RoleMenu(role, menus) { route ->
                     if (route.isNotEmpty() &&
-                        navController.graph.nodes.any { it.route == route }) {
+                        navController.graph.any { it.route == route }) {
                         navController.navigate(route)
                     } else {
                         Toast.makeText(


### PR DESCRIPTION
## Summary
- use NavGraph Iterable instead of `nodes` to check routes

## Testing
- `./gradlew lintVitalRelease --no-daemon` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_6862ef1e36b48328bd686066f41ae586