### PR TITLE
Fix Composable usage in MenuScreen

### DIFF
--- a/app/src/main/java/com/ioannapergamali/mysmartroute/view/ui/screens/MenuScreen.kt
+++ b/app/src/main/java/com/ioannapergamali/mysmartroute/view/ui/screens/MenuScreen.kt
@@ -77,7 +77,7 @@ fun MenuScreen(navController: NavController, openDrawer: () -> Unit) {
                     } else {
                         Toast.makeText(
                             context,
-                            stringResource(R.string.not_implemented),
+                            context.getString(R.string.not_implemented),
                             Toast.LENGTH_SHORT
                         ).show()
                     }


### PR DESCRIPTION
## Summary
- avoid calling stringResource outside Compose

## Testing
- `./gradlew test` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_6862f1a67d3c8328a24181e9a2d67d43