### PR TITLE
Fix menu init check for empty options

### DIFF
--- a/app/src/main/java/com/ioannapergamali/mysmartroute/viewmodel/AuthenticationViewModel.kt
+++ b/app/src/main/java/com/ioannapergamali/mysmartroute/viewmodel/AuthenticationViewModel.kt
@@ -341,7 +341,7 @@ class AuthenticationViewModel : ViewModel() {
 
             Log.i(TAG, "Using roleId: $roleId")
             var menusLocal = loadMenusWithInheritanceLocal(dbLocal, roleId)
-            var hasOptions = menusLocal.any { it.options.isNotEmpty() }
+            var hasOptions = menusLocal.all { it.options.isNotEmpty() }
             if (menusLocal.isEmpty() || !hasOptions) {
                 // Βεβαιωνόμαστε ότι η τοπική βάση περιέχει τα προεπιλεγμένα μενού
                 try {
@@ -350,7 +350,7 @@ class AuthenticationViewModel : ViewModel() {
                     Log.e(TAG, "Failed to initialize menus", e)
                 }
                 menusLocal = loadMenusWithInheritanceLocal(dbLocal, roleId)
-                hasOptions = menusLocal.any { it.options.isNotEmpty() }
+                hasOptions = menusLocal.all { it.options.isNotEmpty() }
             }
 
             if (menusLocal.isNotEmpty() && hasOptions) {
@@ -363,7 +363,7 @@ class AuthenticationViewModel : ViewModel() {
                     Log.e(TAG, "Failed to load menus", e)
                     emptyList()
                 }
-                val remoteHasOptions = menusRemote.any { it.options.isNotEmpty() }
+                val remoteHasOptions = menusRemote.all { it.options.isNotEmpty() }
                 if (menusRemote.isEmpty() || !remoteHasOptions) {
                     Log.i(TAG, "No menus found remotely, initializing defaults")
                     try {


### PR DESCRIPTION
## Summary
- ensure every menu has at least one option when loading user menus

## Testing
- `./gradlew test --no-daemon` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_68634a44236c8328a502abbde553793e