### PR TITLE
Υποστήριξη αποθήκευσης ανακοινώσεων

### DIFF
--- a/app/src/main/java/com/ioannapergamali/mysmartroute/data/local/MySmartRouteDatabase.kt
+++ b/app/src/main/java/com/ioannapergamali/mysmartroute/data/local/MySmartRouteDatabase.kt
@@ -27,9 +27,10 @@ import com.ioannapergamali.mysmartroute.data.local.MovingEntity
         MenuOptionEntity::class,
         LanguageSettingEntity::class,
         RouteEntity::class,
-        MovingEntity::class
+        MovingEntity::class,
+        TransportAnnouncementEntity::class
     ],
-    version = 20
+    version = 21
 )
 abstract class MySmartRouteDatabase : RoomDatabase() {
     abstract fun userDao(): UserDao
@@ -42,6 +43,7 @@ abstract class MySmartRouteDatabase : RoomDatabase() {
     abstract fun languageSettingDao(): LanguageSettingDao
     abstract fun routeDao(): RouteDao
     abstract fun movingDao(): MovingDao
+    abstract fun transportAnnouncementDao(): TransportAnnouncementDao
 
     companion object {
         @Volatile
@@ -301,6 +303,24 @@ abstract class MySmartRouteDatabase : RoomDatabase() {
             }
         }
 
+        private val MIGRATION_20_21 = object : Migration(20, 21) {
+            override fun migrate(database: SupportSQLiteDatabase) {
+                database.execSQL(
+                    "CREATE TABLE IF NOT EXISTS `transport_announcements` (" +
+                        "`id` TEXT NOT NULL, " +
+                        "`driverId` TEXT NOT NULL, " +
+                        "`vehicleType` TEXT NOT NULL, " +
+                        "`start` TEXT NOT NULL, " +
+                        "`end` TEXT NOT NULL, " +
+                        "`date` INTEGER NOT NULL, " +
+                        "`cost` REAL NOT NULL, " +
+                        "`durationMinutes` INTEGER NOT NULL, " +
+                        "PRIMARY KEY(`id`)" +
+                        ")"
+                )
+            }
+        }
+
         private fun prepopulate(db: SupportSQLiteDatabase) {
             Log.d(TAG, "Prepopulating database")
             db.execSQL(
@@ -386,7 +406,8 @@ abstract class MySmartRouteDatabase : RoomDatabase() {
                     MIGRATION_16_17,
                     MIGRATION_17_18,
                     MIGRATION_18_19,
-                    MIGRATION_19_20
+                    MIGRATION_19_20,
+                    MIGRATION_20_21
                 )
                     .addCallback(object : RoomDatabase.Callback() {
                         override fun onCreate(db: SupportSQLiteDatabase) {

--- a/app/src/main/java/com/ioannapergamali/mysmartroute/data/local/TransportAnnouncementDao.kt
+++ b/app/src/main/java/com/ioannapergamali/mysmartroute/data/local/TransportAnnouncementDao.kt
@@ -1,0 +1,16 @@
+package com.ioannapergamali.mysmartroute.data.local
+
+import androidx.room.Dao
+import androidx.room.Insert
+import androidx.room.OnConflictStrategy
+import androidx.room.Query
+import kotlinx.coroutines.flow.Flow
+
+@Dao
+interface TransportAnnouncementDao {
+    @Insert(onConflict = OnConflictStrategy.REPLACE)
+    suspend fun insert(announcement: TransportAnnouncementEntity)
+
+    @Query("SELECT * FROM transport_announcements WHERE driverId = :driverId")
+    fun getAnnouncementsForDriver(driverId: String): Flow<List<TransportAnnouncementEntity>>
+}

--- a/app/src/main/java/com/ioannapergamali/mysmartroute/data/local/TransportAnnouncementEntity.kt
+++ b/app/src/main/java/com/ioannapergamali/mysmartroute/data/local/TransportAnnouncementEntity.kt
@@ -1,0 +1,16 @@
+package com.ioannapergamali.mysmartroute.data.local
+
+import androidx.room.Entity
+import androidx.room.PrimaryKey
+
+@Entity(tableName = "transport_announcements")
+data class TransportAnnouncementEntity(
+    @PrimaryKey val id: String = "",
+    val driverId: String = "",
+    val vehicleType: String = "",
+    val start: String = "",
+    val end: String = "",
+    val date: Int = 0,
+    val cost: Double = 0.0,
+    val durationMinutes: Int = 0
+)

--- a/app/src/main/java/com/ioannapergamali/mysmartroute/utils/FirestoreMappers.kt
+++ b/app/src/main/java/com/ioannapergamali/mysmartroute/utils/FirestoreMappers.kt
@@ -7,6 +7,7 @@ import com.ioannapergamali.mysmartroute.data.local.VehicleEntity
 import com.ioannapergamali.mysmartroute.data.local.RoleEntity
 import com.ioannapergamali.mysmartroute.data.local.MenuEntity
 import com.ioannapergamali.mysmartroute.data.local.MenuOptionEntity
+import com.ioannapergamali.mysmartroute.data.local.TransportAnnouncementEntity
 
 /** Βοηθητικά extensions για μετατροπή οντοτήτων σε δομές κατάλληλες για το Firestore. */
 /** Μετατροπή ενός [UserEntity] σε Map. */
@@ -96,3 +97,36 @@ fun MenuOptionEntity.toFirestoreMap(): Map<String, Any> = mapOf(
     "titleKey" to titleResKey,
     "route" to route
 )
+
+fun TransportAnnouncementEntity.toFirestoreMap(): Map<String, Any> = mapOf(
+    "id" to id,
+    "driverId" to FirebaseFirestore.getInstance().collection("users").document(driverId),
+    "vehicleType" to vehicleType,
+    "start" to start,
+    "end" to end,
+    "date" to date,
+    "cost" to cost,
+    "durationMinutes" to durationMinutes
+)
+
+fun DocumentSnapshot.toTransportAnnouncementEntity(): TransportAnnouncementEntity? {
+    val announcementId = getString("id") ?: id
+    val driver = when (val raw = get("driverId")) {
+        is String -> raw
+        is com.google.firebase.firestore.DocumentReference -> raw.id
+        else -> null
+    } ?: return null
+    val routeStart = getString("start") ?: return null
+    val routeEnd = getString("end") ?: return null
+    val routeId = "" // not stored separately
+    return TransportAnnouncementEntity(
+        id = announcementId,
+        driverId = driver,
+        vehicleType = getString("vehicleType") ?: "",
+        start = routeStart,
+        end = routeEnd,
+        date = (getLong("date") ?: 0L).toInt(),
+        cost = getDouble("cost") ?: 0.0,
+        durationMinutes = (getLong("durationMinutes") ?: 0L).toInt()
+    )
+}

--- a/app/src/main/java/com/ioannapergamali/mysmartroute/view/ui/screens/AnnounceTransportScreen.kt
+++ b/app/src/main/java/com/ioannapergamali/mysmartroute/view/ui/screens/AnnounceTransportScreen.kt
@@ -644,7 +644,7 @@ fun AnnounceTransportScreen(navController: NavController, openDrawer: () -> Unit
                 val end = "${endLatLng!!.latitude},${endLatLng!!.longitude}"
                 val route = Route(start, end, cost)
                 val type = selectedVehicleType ?: VehicleType.CAR
-                viewModel.announce(route, type, date, cost, durationMinutes)
+                viewModel.announce(context, route, type, date, cost, durationMinutes)
             }
         }) {
             Text(stringResource(R.string.announce))

--- a/app/src/main/java/com/ioannapergamali/mysmartroute/viewmodel/TransportAnnouncementViewModel.kt
+++ b/app/src/main/java/com/ioannapergamali/mysmartroute/viewmodel/TransportAnnouncementViewModel.kt
@@ -1,11 +1,17 @@
 package com.ioannapergamali.mysmartroute.viewmodel
 
+import android.content.Context
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import com.google.firebase.auth.FirebaseAuth
+import com.google.firebase.firestore.FirebaseFirestore
 import com.ioannapergamali.mysmartroute.model.classes.routes.Route
 import com.ioannapergamali.mysmartroute.model.classes.transports.TransportAnnouncement
 import com.ioannapergamali.mysmartroute.model.enumerations.VehicleType
+import com.ioannapergamali.mysmartroute.data.local.MySmartRouteDatabase
+import com.ioannapergamali.mysmartroute.data.local.TransportAnnouncementEntity
+import com.ioannapergamali.mysmartroute.utils.NetworkUtils
+import com.ioannapergamali.mysmartroute.utils.toFirestoreMap
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.launch
@@ -16,6 +22,7 @@ import java.util.UUID
  */
 class TransportAnnouncementViewModel : ViewModel() {
     private val auth = FirebaseAuth.getInstance()
+    private val firestore = FirebaseFirestore.getInstance()
 
     private val _state = MutableStateFlow<AnnouncementState>(AnnouncementState.Idle)
     val state: StateFlow<AnnouncementState> = _state
@@ -23,8 +30,16 @@ class TransportAnnouncementViewModel : ViewModel() {
     private val _announcements = MutableStateFlow<List<TransportAnnouncement>>(emptyList())
     val announcements: StateFlow<List<TransportAnnouncement>> = _announcements
 
-    fun announce(route: Route, vehicleType: VehicleType, date: Int, cost: Double, durationMinutes: Int) {
+    fun announce(
+        context: Context,
+        route: Route,
+        vehicleType: VehicleType,
+        date: Int,
+        cost: Double,
+        durationMinutes: Int
+    ) {
         viewModelScope.launch {
+            _state.value = AnnouncementState.Loading
             val userId = auth.currentUser?.uid
             if (userId == null) {
                 _state.value = AnnouncementState.Error("User not logged in")
@@ -36,23 +51,59 @@ class TransportAnnouncementViewModel : ViewModel() {
                 return@launch
             }
 
-            val announcement = TransportAnnouncement(
-                id = UUID.randomUUID().toString(),
+            val announcementId = UUID.randomUUID().toString()
+            val entity = TransportAnnouncementEntity(
+                id = announcementId,
                 driverId = userId,
-                vehicleType = vehicleType,
-                route = route,
+                vehicleType = vehicleType.name,
+                start = route.start,
+                end = route.end,
                 date = date,
                 cost = cost,
                 durationMinutes = durationMinutes
             )
 
-            _announcements.value = _announcements.value + announcement
-            _state.value = AnnouncementState.Success
+            val dao = MySmartRouteDatabase.getInstance(context).transportAnnouncementDao()
+
+            if (NetworkUtils.isInternetAvailable(context)) {
+                firestore.collection("transport_announcements")
+                    .document(announcementId)
+                    .set(entity.toFirestoreMap())
+                    .addOnSuccessListener {
+                        viewModelScope.launch { dao.insert(entity) }
+                        _announcements.value = _announcements.value + TransportAnnouncement(
+                            announcementId,
+                            userId,
+                            vehicleType,
+                            route,
+                            date,
+                            cost,
+                            durationMinutes
+                        )
+                        _state.value = AnnouncementState.Success
+                    }
+                    .addOnFailureListener { e ->
+                        _state.value = AnnouncementState.Error(e.localizedMessage ?: "Failed")
+                    }
+            } else {
+                dao.insert(entity)
+                _announcements.value = _announcements.value + TransportAnnouncement(
+                    announcementId,
+                    userId,
+                    vehicleType,
+                    route,
+                    date,
+                    cost,
+                    durationMinutes
+                )
+                _state.value = AnnouncementState.Success
+            }
         }
     }
 
     sealed class AnnouncementState {
         object Idle : AnnouncementState()
+        object Loading : AnnouncementState()
         object Success : AnnouncementState()
         data class Error(val message: String) : AnnouncementState()
     }


### PR DESCRIPTION
## Πραγματοποιήθηκαν αλλαγές
- Προστέθηκαν `TransportAnnouncementEntity` και `TransportAnnouncementDao`
- Ενημερώθηκε η βάση `MySmartRouteDatabase` σε έκδοση 21 με νέα οντότητα και migration
- Προστέθηκαν map helpers στο `FirestoreMappers`
- Εμπλουτίστηκε το `TransportAnnouncementViewModel` ώστε να αποθηκεύει το announcement σε Room και Firestore
- Ανανεώθηκε η οθόνη `AnnounceTransportScreen` για χρήση του νέου API

## Οδηγίες ελέγχου
Η εντολή `./gradlew test` δεν εκτελέστηκε επιτυχώς λόγω περιορισμών δικτύου κατά τη λήψη των εξαρτήσεων.

------
https://chatgpt.com/codex/tasks/task_e_6863547b280c8328baacf8b5a93fec19