### PR TITLE
Extend Route with PoIs

### DIFF
--- a/app/src/main/java/com/ioannapergamali/mysmartroute/model/classes/routes/Route.kt
+++ b/app/src/main/java/com/ioannapergamali/mysmartroute/model/classes/routes/Route.kt
@@ -1,11 +1,14 @@
 package com.ioannapergamali.mysmartroute.model.classes.routes
 
+import com.ioannapergamali.mysmartroute.model.classes.poi.Poi
+
 /**
  * Represents a route between two points with an estimated cost.
  */
 data class Route(
-    val start: String,
-    val end: String,
+    val start: Poi,
+    val end: Poi,
+    val intermediatePois: List<Poi> = emptyList(),
     val cost: Double
 )
 

--- a/app/src/main/java/com/ioannapergamali/mysmartroute/view/ui/screens/AnnounceTransportScreen.kt
+++ b/app/src/main/java/com/ioannapergamali/mysmartroute/view/ui/screens/AnnounceTransportScreen.kt
@@ -41,6 +41,8 @@ import android.location.Geocoder
 import androidx.lifecycle.viewmodel.compose.viewModel
 import androidx.navigation.NavController
 import com.ioannapergamali.mysmartroute.model.classes.routes.Route
+import com.ioannapergamali.mysmartroute.model.classes.poi.Poi
+import com.ioannapergamali.mysmartroute.model.enumerations.PoIType
 import com.ioannapergamali.mysmartroute.model.enumerations.VehicleType
 import com.ioannapergamali.mysmartroute.utils.MapsUtils
 import com.ioannapergamali.mysmartroute.utils.NetworkUtils
@@ -642,7 +644,9 @@ fun AnnounceTransportScreen(navController: NavController, openDrawer: () -> Unit
                 val date = dateInput.toIntOrNull() ?: 0
                 val start = "${startLatLng!!.latitude},${startLatLng!!.longitude}"
                 val end = "${endLatLng!!.latitude},${endLatLng!!.longitude}"
-                val route = Route(start, end, cost)
+                val startPoi = Poi(id = "", description = start, type = PoIType.HISTORICAL)
+                val endPoi = Poi(id = "", description = end, type = PoIType.HISTORICAL)
+                val route = Route(startPoi, endPoi, cost = cost)
                 val type = selectedVehicleType ?: VehicleType.CAR
                 viewModel.announce(context, route, type, date, cost, durationMinutes)
             }

--- a/app/src/main/java/com/ioannapergamali/mysmartroute/viewmodel/TransportAnnouncementViewModel.kt
+++ b/app/src/main/java/com/ioannapergamali/mysmartroute/viewmodel/TransportAnnouncementViewModel.kt
@@ -56,8 +56,8 @@ class TransportAnnouncementViewModel : ViewModel() {
                 id = announcementId,
                 driverId = userId,
                 vehicleType = vehicleType.name,
-                start = route.start,
-                end = route.end,
+                start = route.start.description,
+                end = route.end.description,
                 date = date,
                 cost = cost,
                 durationMinutes = durationMinutes


### PR DESCRIPTION
## Summary
- extend `Route` model to hold PoI objects and optional intermediate points
- adapt announcement screen to create PoI objects
- update viewmodel when storing announcements

## Testing
- `./gradlew build` *(fails: maven.pkg.jetbrains.space blocked)*

------
https://chatgpt.com/codex/tasks/task_e_68635c3b83b8832890519b12263142a3