### PR TITLE
Implement Firestore routes

### DIFF
--- a/app/src/main/java/com/ioannapergamali/mysmartroute/model/classes/routes/RouteFirestore.kt
+++ b/app/src/main/java/com/ioannapergamali/mysmartroute/model/classes/routes/RouteFirestore.kt
@@ -1,0 +1,13 @@
+package com.ioannapergamali.mysmartroute.model.classes.routes
+
+import com.google.firebase.firestore.DocumentReference
+
+/**
+ * Μοντέλο διαδρομής που αποθηκεύεται στο Firestore με αναφορές σε PoIs.
+ */
+data class RouteFirestore(
+    val id: String = "",
+    val start: DocumentReference? = null,
+    val end: DocumentReference? = null,
+    val cost: Double = 0.0
+)

--- a/app/src/main/java/com/ioannapergamali/mysmartroute/utils/FirestoreMappers.kt
+++ b/app/src/main/java/com/ioannapergamali/mysmartroute/utils/FirestoreMappers.kt
@@ -8,6 +8,8 @@ import com.ioannapergamali.mysmartroute.data.local.RoleEntity
 import com.ioannapergamali.mysmartroute.data.local.MenuEntity
 import com.ioannapergamali.mysmartroute.data.local.MenuOptionEntity
 import com.ioannapergamali.mysmartroute.data.local.TransportAnnouncementEntity
+import com.ioannapergamali.mysmartroute.data.local.RouteEntity
+import com.google.firebase.firestore.DocumentReference
 
 /** Βοηθητικά extensions για μετατροπή οντοτήτων σε δομές κατάλληλες για το Firestore. */
 /** Μετατροπή ενός [UserEntity] σε Map. */
@@ -108,6 +110,29 @@ fun TransportAnnouncementEntity.toFirestoreMap(): Map<String, Any> = mapOf(
     "cost" to cost,
     "durationMinutes" to durationMinutes
 )
+
+fun RouteEntity.toFirestoreMap(): Map<String, Any> = mapOf(
+    "id" to id,
+    "start" to FirebaseFirestore.getInstance().collection("pois").document(startPoiId),
+    "end" to FirebaseFirestore.getInstance().collection("pois").document(endPoiId),
+    "cost" to cost
+)
+
+fun DocumentSnapshot.toRouteEntity(): RouteEntity? {
+    val routeId = getString("id") ?: id
+    val start = when (val raw = get("start")) {
+        is DocumentReference -> raw.id
+        is String -> raw
+        else -> getString("start")
+    } ?: return null
+    val end = when (val raw = get("end")) {
+        is DocumentReference -> raw.id
+        is String -> raw
+        else -> getString("end")
+    } ?: return null
+    val costVal = getDouble("cost") ?: 0.0
+    return RouteEntity(routeId, start, end, costVal)
+}
 
 fun DocumentSnapshot.toTransportAnnouncementEntity(): TransportAnnouncementEntity? {
     val announcementId = getString("id") ?: id

--- a/app/src/main/java/com/ioannapergamali/mysmartroute/viewmodel/RouteViewModel.kt
+++ b/app/src/main/java/com/ioannapergamali/mysmartroute/viewmodel/RouteViewModel.kt
@@ -1,0 +1,53 @@
+package com.ioannapergamali.mysmartroute.viewmodel
+
+import android.content.Context
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.viewModelScope
+import com.google.firebase.firestore.FirebaseFirestore
+import com.ioannapergamali.mysmartroute.data.local.MySmartRouteDatabase
+import com.ioannapergamali.mysmartroute.data.local.RouteEntity
+import com.ioannapergamali.mysmartroute.utils.NetworkUtils
+import com.ioannapergamali.mysmartroute.utils.toFirestoreMap
+import com.ioannapergamali.mysmartroute.utils.toRouteEntity
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.first
+import kotlinx.coroutines.launch
+import java.util.UUID
+
+/**
+ * ViewModel για διαχείριση διαδρομών στο Firestore και στη Room DB.
+ */
+class RouteViewModel : ViewModel() {
+    private val firestore = FirebaseFirestore.getInstance()
+
+    private val _routes = MutableStateFlow<List<RouteEntity>>(emptyList())
+    val routes: StateFlow<List<RouteEntity>> = _routes
+
+    fun loadRoutes(context: Context) {
+        viewModelScope.launch {
+            val dao = MySmartRouteDatabase.getInstance(context).routeDao()
+            _routes.value = dao.getAll().first()
+            firestore.collection("routes").get()
+                .addOnSuccessListener { snapshot ->
+                    val list = snapshot.documents.mapNotNull { it.toRouteEntity() }
+                    _routes.value = list
+                    viewModelScope.launch { list.forEach { dao.insert(it) } }
+                }
+        }
+    }
+
+    fun addRoute(context: Context, startPoiId: String, endPoiId: String, cost: Double) {
+        viewModelScope.launch {
+            val dao = MySmartRouteDatabase.getInstance(context).routeDao()
+            val id = UUID.randomUUID().toString()
+            val entity = RouteEntity(id, startPoiId, endPoiId, cost)
+            if (NetworkUtils.isInternetAvailable(context)) {
+                firestore.collection("routes").document(id).set(entity.toFirestoreMap())
+                    .addOnSuccessListener { viewModelScope.launch { dao.insert(entity) } }
+            } else {
+                dao.insert(entity)
+            }
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- create `RouteFirestore` data model for routes with PoI references
- map `RouteEntity` to and from Firestore
- add `RouteViewModel` for loading and saving routes

## Testing
- `./gradlew build` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_686361661be8832887af8ee80565c409