### PR TITLE
Add Define PoI screen

### DIFF
--- a/app/src/main/java/com/ioannapergamali/mysmartroute/model/navigation/NavigationHost.kt
+++ b/app/src/main/java/com/ioannapergamali/mysmartroute/model/navigation/NavigationHost.kt
@@ -12,6 +12,7 @@ import com.ioannapergamali.mysmartroute.view.ui.screens.RegisterVehicleScreen
 import com.ioannapergamali.mysmartroute.view.ui.screens.AnnounceTransportScreen
 import com.ioannapergamali.mysmartroute.view.ui.screens.DirectionsMapScreen
 import com.ioannapergamali.mysmartroute.view.ui.screens.PoIListScreen
+import com.ioannapergamali.mysmartroute.view.ui.screens.DefinePoiScreen
 import com.ioannapergamali.mysmartroute.view.ui.screens.SettingsScreen
 import com.ioannapergamali.mysmartroute.view.ui.screens.AboutScreen
 import com.ioannapergamali.mysmartroute.view.ui.screens.SupportScreen
@@ -75,6 +76,10 @@ fun NavigationHost(navController : NavHostController, openDrawer: () -> Unit) {
         composable("poiList") {
             PoIListScreen(navController = navController, openDrawer = openDrawer)
         }
+        composable("definePoi") {
+            DefinePoiScreen(navController = navController, openDrawer = openDrawer)
+        }
+
 
         composable(
             route = "directionsMap/{start}/{end}",

--- a/app/src/main/res/values-el/strings.xml
+++ b/app/src/main/res/values-el/strings.xml
@@ -100,5 +100,11 @@
     <string name="announce">Αποστολή</string>
     <string name="duration_format">Διάρκεια: %1$d λεπτά</string>
     <string name="app_language">Γλώσσα εφαρμογής</string>
+    <string name="poi_name">Όνομα POI</string>
+    <string name="poi_description">Περιγραφή</string>
+    <string name="select_poi">Επιλογή POI</string>
+    <string name="save_poi">Αποθήκευση POI</string>
+    <string name="poi_saved">Το POI αποθηκεύτηκε</string>
+    <string name="poi_exists">Το POI υπάρχει ήδη</string>
     <string name="not_implemented">Η λειτουργία δεν είναι διαθέσιμη</string>
 </resources>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -98,5 +98,11 @@
     <string name="announce">Announce</string>
     <string name="duration_format">Duration: %1$d min</string>
     <string name="app_language">App Language</string>
+    <string name="poi_name">PoI Name</string>
+    <string name="poi_description">Description</string>
+    <string name="select_poi">Select PoI</string>
+    <string name="save_poi">Save PoI</string>
+    <string name="poi_saved">PoI saved</string>
+    <string name="poi_exists">PoI already exists</string>
     <string name="not_implemented">Functionality not available</string>
 </resources>


### PR DESCRIPTION
## Summary
- implement `DefinePoiScreen` with map and PoI dropdown
- register `definePoi` route in `NavigationHost`
- add string resources for PoI management in English and Greek

## Testing
- `./gradlew test` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_686374e0af78832899dc11b3261647c7