### PR TITLE
Υποστήριξη διεύθυνσης για PoI

### DIFF
--- a/app/src/main/java/com/ioannapergamali/mysmartroute/data/local/MySmartRouteDatabase.kt
+++ b/app/src/main/java/com/ioannapergamali/mysmartroute/data/local/MySmartRouteDatabase.kt
@@ -30,7 +30,7 @@ import com.ioannapergamali.mysmartroute.data.local.MovingEntity
         MovingEntity::class,
         TransportAnnouncementEntity::class
     ],
-    version = 21
+    version = 22
 )
 abstract class MySmartRouteDatabase : RoomDatabase() {
     abstract fun userDao(): UserDao
@@ -321,6 +321,16 @@ abstract class MySmartRouteDatabase : RoomDatabase() {
             }
         }
 
+        private val MIGRATION_21_22 = object : Migration(21, 22) {
+            override fun migrate(database: SupportSQLiteDatabase) {
+                database.execSQL("ALTER TABLE `pois` ADD COLUMN `country` TEXT NOT NULL DEFAULT ''")
+                database.execSQL("ALTER TABLE `pois` ADD COLUMN `city` TEXT NOT NULL DEFAULT ''")
+                database.execSQL("ALTER TABLE `pois` ADD COLUMN `streetName` TEXT NOT NULL DEFAULT ''")
+                database.execSQL("ALTER TABLE `pois` ADD COLUMN `streetNum` INTEGER NOT NULL DEFAULT 0")
+                database.execSQL("ALTER TABLE `pois` ADD COLUMN `postalCode` INTEGER NOT NULL DEFAULT 0")
+            }
+        }
+
         private fun prepopulate(db: SupportSQLiteDatabase) {
             Log.d(TAG, "Prepopulating database")
             db.execSQL(
@@ -407,7 +417,8 @@ abstract class MySmartRouteDatabase : RoomDatabase() {
                     MIGRATION_17_18,
                     MIGRATION_18_19,
                     MIGRATION_19_20,
-                    MIGRATION_20_21
+                    MIGRATION_20_21,
+                    MIGRATION_21_22
                 )
                     .addCallback(object : RoomDatabase.Callback() {
                         override fun onCreate(db: SupportSQLiteDatabase) {

--- a/app/src/main/java/com/ioannapergamali/mysmartroute/data/local/PoIEntity.kt
+++ b/app/src/main/java/com/ioannapergamali/mysmartroute/data/local/PoIEntity.kt
@@ -7,7 +7,11 @@ import androidx.room.PrimaryKey
 data class PoIEntity(
     @PrimaryKey val id: String = "",
     val name: String = "",
-    val description: String = "",
+    val country: String = "",
+    val city: String = "",
+    val streetName: String = "",
+    val streetNum: Int = 0,
+    val postalCode: Int = 0,
     val type: String = "",
     val lat: Double = 0.0,
     val lng: Double = 0.0

--- a/app/src/main/java/com/ioannapergamali/mysmartroute/model/classes/poi/Poi.kt
+++ b/app/src/main/java/com/ioannapergamali/mysmartroute/model/classes/poi/Poi.kt
@@ -2,13 +2,14 @@ package com.ioannapergamali.mysmartroute.model.classes.poi
 
 import com.ioannapergamali.mysmartroute.model.enumerations.PoIType
 import com.ioannapergamali.mysmartroute.model.interfaces.PoI
+import com.ioannapergamali.mysmartroute.model.classes.poi.PoiAddress
 
 /**
  * Basic implementation of [PoI] used to represent a simple point of interest.
  */
 data class Poi(
     override val id: String,
-    override val description: String,
+    override val address: PoiAddress,
     override val type: PoIType
 ) : PoI
 

--- a/app/src/main/java/com/ioannapergamali/mysmartroute/model/classes/poi/PoiAddress.kt
+++ b/app/src/main/java/com/ioannapergamali/mysmartroute/model/classes/poi/PoiAddress.kt
@@ -1,0 +1,9 @@
+package com.ioannapergamali.mysmartroute.model.classes.poi
+
+data class PoiAddress(
+    var country: String = "",
+    var city: String = "",
+    var streetName: String = "",
+    var streetNum: Int = 0,
+    var postalCode: Int = 0
+)

--- a/app/src/main/java/com/ioannapergamali/mysmartroute/model/interfaces/PoI.kt
+++ b/app/src/main/java/com/ioannapergamali/mysmartroute/model/interfaces/PoI.kt
@@ -1,9 +1,10 @@
 package com.ioannapergamali.mysmartroute.model.interfaces
 
 import com.ioannapergamali.mysmartroute.model.enumerations.PoIType
+import com.ioannapergamali.mysmartroute.model.classes.poi.PoiAddress
 
 interface PoI {
     val id: String
-    val description: String
+    val address: PoiAddress
     val type: PoIType
 }

--- a/app/src/main/java/com/ioannapergamali/mysmartroute/utils/FirestoreMappers.kt
+++ b/app/src/main/java/com/ioannapergamali/mysmartroute/utils/FirestoreMappers.kt
@@ -4,6 +4,7 @@ import com.google.firebase.firestore.FirebaseFirestore
 import com.ioannapergamali.mysmartroute.data.local.SettingsEntity
 import com.ioannapergamali.mysmartroute.data.local.UserEntity
 import com.ioannapergamali.mysmartroute.data.local.VehicleEntity
+import com.ioannapergamali.mysmartroute.data.local.PoIEntity
 import com.ioannapergamali.mysmartroute.data.local.RoleEntity
 import com.ioannapergamali.mysmartroute.data.local.MenuEntity
 import com.ioannapergamali.mysmartroute.data.local.MenuOptionEntity
@@ -40,6 +41,19 @@ fun VehicleEntity.toFirestoreMap(): Map<String, Any> = mapOf(
         .document(userId),
     "type" to type,
     "seat" to seat
+)
+
+fun PoIEntity.toFirestoreMap(): Map<String, Any> = mapOf(
+    "id" to id,
+    "name" to name,
+    "country" to country,
+    "city" to city,
+    "streetName" to streetName,
+    "streetNum" to streetNum,
+    "postalCode" to postalCode,
+    "type" to type,
+    "lat" to lat,
+    "lng" to lng
 )
 
 /** Μετατροπή [SettingsEntity] σε Map. */

--- a/app/src/main/java/com/ioannapergamali/mysmartroute/view/ui/screens/AnnounceTransportScreen.kt
+++ b/app/src/main/java/com/ioannapergamali/mysmartroute/view/ui/screens/AnnounceTransportScreen.kt
@@ -398,7 +398,7 @@ fun AnnounceTransportScreen(navController: NavController, openDrawer: () -> Unit
                                     poiViewModel.addPoi(
                                         context,
                                         fromQuery,
-                                        fromQuery,
+                                        com.ioannapergamali.mysmartroute.model.classes.poi.PoiAddress(city = fromQuery),
                                         "HISTORICAL",
                                         startLatLng!!.latitude,
                                         startLatLng!!.longitude
@@ -520,7 +520,7 @@ fun AnnounceTransportScreen(navController: NavController, openDrawer: () -> Unit
                                     poiViewModel.addPoi(
                                         context,
                                         toQuery,
-                                        toQuery,
+                                        com.ioannapergamali.mysmartroute.model.classes.poi.PoiAddress(city = toQuery),
                                         "HISTORICAL",
                                         endLatLng!!.latitude,
                                         endLatLng!!.longitude

--- a/app/src/main/java/com/ioannapergamali/mysmartroute/view/ui/screens/DefinePoiScreen.kt
+++ b/app/src/main/java/com/ioannapergamali/mysmartroute/view/ui/screens/DefinePoiScreen.kt
@@ -20,6 +20,7 @@ import com.ioannapergamali.mysmartroute.utils.MapsUtils
 import com.ioannapergamali.mysmartroute.view.ui.components.ScreenContainer
 import com.ioannapergamali.mysmartroute.view.ui.components.TopBar
 import com.ioannapergamali.mysmartroute.viewmodel.PoIViewModel
+import com.ioannapergamali.mysmartroute.model.classes.poi.PoiAddress
 
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable
@@ -32,7 +33,11 @@ fun DefinePoiScreen(navController: NavController, openDrawer: () -> Unit) {
     var expanded by remember { mutableStateOf(false) }
     var selectedPoi by remember { mutableStateOf<PoIEntity?>(null) }
     var name by remember { mutableStateOf("") }
-    var description by remember { mutableStateOf("") }
+    var country by remember { mutableStateOf("") }
+    var city by remember { mutableStateOf("") }
+    var streetName by remember { mutableStateOf("") }
+    var streetNumInput by remember { mutableStateOf("") }
+    var postalCodeInput by remember { mutableStateOf("") }
     var selectedLatLng by remember { mutableStateOf<LatLng?>(null) }
     val markerState = rememberMarkerState()
 
@@ -53,7 +58,11 @@ fun DefinePoiScreen(navController: NavController, openDrawer: () -> Unit) {
             markerState.position = latLng
             cameraPositionState.position = CameraPosition.fromLatLngZoom(latLng, 13f)
             name = poi.name
-            description = poi.description
+            country = poi.country
+            city = poi.city
+            streetName = poi.streetName
+            streetNumInput = poi.streetNum.toString()
+            postalCodeInput = poi.postalCode.toString()
         }
     }
 
@@ -132,10 +141,60 @@ fun DefinePoiScreen(navController: NavController, openDrawer: () -> Unit) {
             )
             Spacer(Modifier.height(8.dp))
             OutlinedTextField(
-                value = description,
-                onValueChange = { description = it },
-                label = { Text(stringResource(R.string.poi_description)) },
+                value = country,
+                onValueChange = { country = it },
+                label = { Text("Country") },
                 modifier = Modifier.fillMaxWidth(),
+                shape = MaterialTheme.shapes.small,
+                colors = OutlinedTextFieldDefaults.colors(
+                    focusedBorderColor = MaterialTheme.colorScheme.primary,
+                    unfocusedBorderColor = MaterialTheme.colorScheme.primary
+                )
+            )
+            Spacer(Modifier.height(8.dp))
+            OutlinedTextField(
+                value = city,
+                onValueChange = { city = it },
+                label = { Text("City") },
+                modifier = Modifier.fillMaxWidth(),
+                shape = MaterialTheme.shapes.small,
+                colors = OutlinedTextFieldDefaults.colors(
+                    focusedBorderColor = MaterialTheme.colorScheme.primary,
+                    unfocusedBorderColor = MaterialTheme.colorScheme.primary
+                )
+            )
+            Spacer(Modifier.height(8.dp))
+            OutlinedTextField(
+                value = streetName,
+                onValueChange = { streetName = it },
+                label = { Text("Street Name") },
+                modifier = Modifier.fillMaxWidth(),
+                shape = MaterialTheme.shapes.small,
+                colors = OutlinedTextFieldDefaults.colors(
+                    focusedBorderColor = MaterialTheme.colorScheme.primary,
+                    unfocusedBorderColor = MaterialTheme.colorScheme.primary
+                )
+            )
+            Spacer(Modifier.height(8.dp))
+            OutlinedTextField(
+                value = streetNumInput,
+                onValueChange = { streetNumInput = it },
+                label = { Text("Street Number") },
+                modifier = Modifier.fillMaxWidth(),
+                keyboardOptions = KeyboardOptions(keyboardType = KeyboardType.Number),
+                shape = MaterialTheme.shapes.small,
+                colors = OutlinedTextFieldDefaults.colors(
+                    focusedBorderColor = MaterialTheme.colorScheme.primary,
+                    unfocusedBorderColor = MaterialTheme.colorScheme.primary
+                )
+            )
+            Spacer(Modifier.height(8.dp))
+            OutlinedTextField(
+                value = postalCodeInput,
+                onValueChange = { postalCodeInput = it },
+                label = { Text("Postal Code") },
+                modifier = Modifier.fillMaxWidth(),
+                keyboardOptions = KeyboardOptions(keyboardType = KeyboardType.Number),
                 shape = MaterialTheme.shapes.small,
                 colors = OutlinedTextFieldDefaults.colors(
                     focusedBorderColor = MaterialTheme.colorScheme.primary,
@@ -145,11 +204,13 @@ fun DefinePoiScreen(navController: NavController, openDrawer: () -> Unit) {
             Spacer(Modifier.height(16.dp))
             Button(onClick = {
                 val latLng = selectedLatLng
+                val streetNum = streetNumInput.toIntOrNull() ?: 0
+                val postalCode = postalCodeInput.toIntOrNull() ?: 0
                 if (name.isNotBlank() && latLng != null) {
                     viewModel.addPoi(
                         context,
                         name,
-                        description,
+                        PoiAddress(country, city, streetName, streetNum, postalCode),
                         "HISTORICAL",
                         latLng.latitude,
                         latLng.longitude

--- a/app/src/main/java/com/ioannapergamali/mysmartroute/view/ui/screens/FirebaseDatabaseScreen.kt
+++ b/app/src/main/java/com/ioannapergamali/mysmartroute/view/ui/screens/FirebaseDatabaseScreen.kt
@@ -61,7 +61,7 @@ fun FirebaseDatabaseScreen(navController: NavController, openDrawer: () -> Unit)
                 item { Spacer(modifier = Modifier.padding(8.dp)) }
                 item { Text("PoIs", style = MaterialTheme.typography.titleMedium) }
                 items(data!!.pois) { poi ->
-                    Text("${poi.name} (${poi.type}) - ${poi.description}")
+                    Text("${'$'}{poi.name} (${'$'}{poi.type}) - ${'$'}{poi.city}")
                 }
                 item { Spacer(modifier = Modifier.padding(8.dp)) }
                 item { Text("Settings", style = MaterialTheme.typography.titleMedium) }

--- a/app/src/main/java/com/ioannapergamali/mysmartroute/view/ui/screens/LocalDatabaseScreen.kt
+++ b/app/src/main/java/com/ioannapergamali/mysmartroute/view/ui/screens/LocalDatabaseScreen.kt
@@ -74,7 +74,7 @@ fun LocalDatabaseScreen(navController: NavController, openDrawer: () -> Unit) {
                     item { Text("Ο πίνακας είναι άδειος") }
                 } else {
                     items(data!!.pois) { poi ->
-                        Text("${poi.name} (${poi.type}) - ${poi.description}")
+                        Text("${'$'}{poi.name} (${'$'}{poi.type}) - ${'$'}{poi.city}")
                     }
                 }
                 item { Spacer(modifier = Modifier.padding(8.dp)) }

--- a/app/src/main/java/com/ioannapergamali/mysmartroute/viewmodel/PoIViewModel.kt
+++ b/app/src/main/java/com/ioannapergamali/mysmartroute/viewmodel/PoIViewModel.kt
@@ -6,6 +6,8 @@ import androidx.lifecycle.viewModelScope
 import com.google.firebase.firestore.FirebaseFirestore
 import com.ioannapergamali.mysmartroute.data.local.MySmartRouteDatabase
 import com.ioannapergamali.mysmartroute.data.local.PoIEntity
+import com.ioannapergamali.mysmartroute.utils.toFirestoreMap
+import com.ioannapergamali.mysmartroute.model.classes.poi.PoiAddress
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.first
@@ -42,7 +44,7 @@ class PoIViewModel : ViewModel() {
     fun addPoi(
         context: Context,
         name: String,
-        description: String,
+        address: PoiAddress,
         type: String,
         lat: Double,
         lng: Double
@@ -56,17 +58,22 @@ class PoIViewModel : ViewModel() {
             }
 
             val id = UUID.randomUUID().toString()
-            val poi = PoIEntity(id, name, description, type, lat, lng)
-            dao.insert(poi)
-            val data = hashMapOf(
-                "id" to id,
-                "name" to name,
-                "description" to description,
-                "type" to type,
-                "lat" to lat,
-                "lng" to lng
+            val poi = PoIEntity(
+                id = id,
+                name = name,
+                country = address.country,
+                city = address.city,
+                streetName = address.streetName,
+                streetNum = address.streetNum,
+                postalCode = address.postalCode,
+                type = type,
+                lat = lat,
+                lng = lng
             )
-            db.collection("pois").document(id).set(data)
+            dao.insert(poi)
+            db.collection("pois")
+                .document(id)
+                .set(poi.toFirestoreMap())
             _addState.value = AddPoiState.Success
         }
     }


### PR DESCRIPTION
## Περιγραφή
Προστέθηκε η data class `PoiAddress` και τροποποιήθηκαν οι κλάσεις ώστε οι πληροφορίες διεύθυνσης να αποθηκεύονται σε Room και Firestore. Η οθόνη «Ορισμός σημείου ενδιαφέροντος» ενημερώθηκε με νέα πεδία διεύθυνσης.

## Οδηγίες δοκιμών
- `./gradlew test` *(αποτυγχάνει λόγω έλλειψης Android SDK)*

------
https://chatgpt.com/codex/tasks/task_e_68637de462408328ad56828830f67773