### PR TITLE
Ενοποίηση αντικειμένου PoI

### DIFF
--- a/app/src/main/java/com/ioannapergamali/mysmartroute/data/local/Converters.kt
+++ b/app/src/main/java/com/ioannapergamali/mysmartroute/data/local/Converters.kt
@@ -1,0 +1,24 @@
+package com.ioannapergamali.mysmartroute.data.local
+
+import androidx.room.TypeConverter
+import com.google.gson.Gson
+import com.ioannapergamali.mysmartroute.model.classes.poi.PoiAddress
+import com.ioannapergamali.mysmartroute.model.enumerations.PoIType
+
+/** Μετατροπές για αποθήκευση σύνθετων τύπων στη Room. */
+object Converters {
+    private val gson = Gson()
+
+    @TypeConverter
+    fun fromPoiType(type: PoIType): String = type.name
+
+    @TypeConverter
+    fun toPoiType(value: String): PoIType = PoIType.valueOf(value)
+
+    @TypeConverter
+    fun fromAddress(address: PoiAddress): String = gson.toJson(address)
+
+    @TypeConverter
+    fun toAddress(json: String): PoiAddress =
+        gson.fromJson(json, PoiAddress::class.java)
+}

--- a/app/src/main/java/com/ioannapergamali/mysmartroute/data/local/MySmartRouteDatabase.kt
+++ b/app/src/main/java/com/ioannapergamali/mysmartroute/data/local/MySmartRouteDatabase.kt
@@ -15,6 +15,8 @@ import com.ioannapergamali.mysmartroute.data.local.LanguageSettingEntity
 import com.ioannapergamali.mysmartroute.data.local.LanguageSettingDao
 import com.ioannapergamali.mysmartroute.data.local.RouteEntity
 import com.ioannapergamali.mysmartroute.data.local.MovingEntity
+import androidx.room.TypeConverters
+import com.ioannapergamali.mysmartroute.data.local.Converters
 
 @Database(
     entities = [
@@ -30,8 +32,9 @@ import com.ioannapergamali.mysmartroute.data.local.MovingEntity
         MovingEntity::class,
         TransportAnnouncementEntity::class
     ],
-    version = 22
+    version = 23
 )
+@TypeConverters(Converters::class)
 abstract class MySmartRouteDatabase : RoomDatabase() {
     abstract fun userDao(): UserDao
     abstract fun vehicleDao(): VehicleDao

--- a/app/src/main/java/com/ioannapergamali/mysmartroute/data/local/PoIEntity.kt
+++ b/app/src/main/java/com/ioannapergamali/mysmartroute/data/local/PoIEntity.kt
@@ -2,17 +2,16 @@ package com.ioannapergamali.mysmartroute.data.local
 
 import androidx.room.Entity
 import androidx.room.PrimaryKey
+import androidx.room.Embedded
+import com.ioannapergamali.mysmartroute.model.classes.poi.PoiAddress
+import com.ioannapergamali.mysmartroute.model.enumerations.PoIType
 
 @Entity(tableName = "pois")
 data class PoIEntity(
     @PrimaryKey val id: String = "",
     val name: String = "",
-    val country: String = "",
-    val city: String = "",
-    val streetName: String = "",
-    val streetNum: Int = 0,
-    val postalCode: Int = 0,
-    val type: String = "",
+    @Embedded val address: PoiAddress = PoiAddress(),
+    val type: PoIType = PoIType.HISTORICAL,
     val lat: Double = 0.0,
     val lng: Double = 0.0
 )

--- a/app/src/main/java/com/ioannapergamali/mysmartroute/view/ui/screens/AnnounceTransportScreen.kt
+++ b/app/src/main/java/com/ioannapergamali/mysmartroute/view/ui/screens/AnnounceTransportScreen.kt
@@ -50,6 +50,7 @@ import com.ioannapergamali.mysmartroute.R
 import com.ioannapergamali.mysmartroute.viewmodel.TransportAnnouncementViewModel
 import com.ioannapergamali.mysmartroute.viewmodel.VehicleViewModel
 import com.ioannapergamali.mysmartroute.viewmodel.PoIViewModel
+import com.ioannapergamali.mysmartroute.model.enumerations.PoIType
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.withContext
@@ -399,7 +400,7 @@ fun AnnounceTransportScreen(navController: NavController, openDrawer: () -> Unit
                                         context,
                                         fromQuery,
                                         com.ioannapergamali.mysmartroute.model.classes.poi.PoiAddress(city = fromQuery),
-                                        "HISTORICAL",
+                                        PoIType.HISTORICAL,
                                         startLatLng!!.latitude,
                                         startLatLng!!.longitude
                                     )
@@ -521,7 +522,7 @@ fun AnnounceTransportScreen(navController: NavController, openDrawer: () -> Unit
                                         context,
                                         toQuery,
                                         com.ioannapergamali.mysmartroute.model.classes.poi.PoiAddress(city = toQuery),
-                                        "HISTORICAL",
+                                        PoIType.HISTORICAL,
                                         endLatLng!!.latitude,
                                         endLatLng!!.longitude
                                     )

--- a/app/src/main/java/com/ioannapergamali/mysmartroute/view/ui/screens/DefinePoiScreen.kt
+++ b/app/src/main/java/com/ioannapergamali/mysmartroute/view/ui/screens/DefinePoiScreen.kt
@@ -28,6 +28,7 @@ import com.ioannapergamali.mysmartroute.view.ui.components.ScreenContainer
 import com.ioannapergamali.mysmartroute.view.ui.components.TopBar
 import com.ioannapergamali.mysmartroute.viewmodel.PoIViewModel
 import com.ioannapergamali.mysmartroute.model.classes.poi.PoiAddress
+import com.ioannapergamali.mysmartroute.model.enumerations.PoIType
 
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable
@@ -228,7 +229,7 @@ fun DefinePoiScreen(navController: NavController, openDrawer: () -> Unit) {
                         context,
                         name,
                         PoiAddress(country, city, streetName, streetNum, postalCode),
-                        "HISTORICAL",
+                        PoIType.HISTORICAL,
                         latLng.latitude,
                         latLng.longitude
                     )

--- a/app/src/main/java/com/ioannapergamali/mysmartroute/viewmodel/DatabaseViewModel.kt
+++ b/app/src/main/java/com/ioannapergamali/mysmartroute/viewmodel/DatabaseViewModel.kt
@@ -18,6 +18,7 @@ import com.ioannapergamali.mysmartroute.data.local.RoleEntity
 import com.ioannapergamali.mysmartroute.data.local.MenuEntity
 import com.ioannapergamali.mysmartroute.data.local.MenuOptionEntity
 import com.ioannapergamali.mysmartroute.data.local.UserEntity
+import com.ioannapergamali.mysmartroute.utils.toPoIEntity
 import com.ioannapergamali.mysmartroute.data.local.VehicleEntity
 import com.ioannapergamali.mysmartroute.data.local.LanguageSettingEntity
 import com.ioannapergamali.mysmartroute.utils.NetworkUtils
@@ -114,7 +115,7 @@ class DatabaseViewModel : ViewModel() {
                 }
             Log.d(TAG, "Fetched ${'$'}{vehicles.size} vehicles from Firebase")
             val pois = firestore.collection("pois").get().await()
-                .documents.mapNotNull { it.toObject(PoIEntity::class.java) }
+                .documents.mapNotNull { it.toPoIEntity() }
             Log.d(TAG, "Fetched ${'$'}{pois.size} pois from Firebase")
             val settings = firestore.collection("user_settings").get().await()
                 .documents.mapNotNull { doc ->
@@ -243,7 +244,7 @@ class DatabaseViewModel : ViewModel() {
                         }
                     Log.d(TAG, "Fetching PoIs from Firestore")
                     val pois = firestore.collection("pois").get().await()
-                        .documents.mapNotNull { it.toObject(PoIEntity::class.java) }
+                        .documents.mapNotNull { it.toPoIEntity() }
                     Log.d(TAG, "Fetched ${pois.size} pois")
                     Log.d(TAG, "Fetching settings from Firestore")
                     val settings = firestore.collection("user_settings").get().await()

--- a/app/src/main/java/com/ioannapergamali/mysmartroute/viewmodel/PoIViewModel.kt
+++ b/app/src/main/java/com/ioannapergamali/mysmartroute/viewmodel/PoIViewModel.kt
@@ -8,6 +8,8 @@ import com.ioannapergamali.mysmartroute.data.local.MySmartRouteDatabase
 import com.ioannapergamali.mysmartroute.data.local.PoIEntity
 import com.ioannapergamali.mysmartroute.utils.toFirestoreMap
 import com.ioannapergamali.mysmartroute.model.classes.poi.PoiAddress
+import com.ioannapergamali.mysmartroute.model.enumerations.PoIType
+import com.ioannapergamali.mysmartroute.utils.toPoIEntity
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.first
@@ -33,7 +35,7 @@ class PoIViewModel : ViewModel() {
             db.collection("pois").get()
                 .addOnSuccessListener { snapshot ->
                     val list = snapshot.documents.mapNotNull { doc ->
-                        doc.toObject(PoIEntity::class.java)
+                        doc.toPoIEntity()
                     }
                     _pois.value = list
                     viewModelScope.launch { dao.insertAll(list) }
@@ -45,7 +47,7 @@ class PoIViewModel : ViewModel() {
         context: Context,
         name: String,
         address: PoiAddress,
-        type: String,
+        type: PoIType,
         lat: Double,
         lng: Double
     ) {
@@ -61,11 +63,7 @@ class PoIViewModel : ViewModel() {
             val poi = PoIEntity(
                 id = id,
                 name = name,
-                country = address.country,
-                city = address.city,
-                streetName = address.streetName,
-                streetNum = address.streetNum,
-                postalCode = address.postalCode,
+                address = address,
                 type = type,
                 lat = lat,
                 lng = lng


### PR DESCRIPTION
## Περιγραφή
Μετατράπηκε η οντότητα `PoIEntity` ώστε να αποθηκεύει διεύθυνση και τύπο ως υπο-αντικείμενα (`PoiAddress`, `PoIType`). Προστέθηκαν `TypeConverters` και ενημερώθηκαν οι ViewModel και οθόνες για χρήση των νέων τύπων. Η τοπική βάση αυξήθηκε σε έκδοση 23.

## Έλεγχοι
- `./gradlew test` αποτυγχάνει λόγω έλλειψης Android SDK.


------
https://chatgpt.com/codex/tasks/task_e_68638e26e7148328be22c9120dc2bb7a