### PR TITLE
Fix Poi name override

### DIFF
--- a/app/src/main/java/com/ioannapergamali/mysmartroute/model/classes/poi/Poi.kt
+++ b/app/src/main/java/com/ioannapergamali/mysmartroute/model/classes/poi/Poi.kt
@@ -9,7 +9,7 @@ import com.ioannapergamali.mysmartroute.model.classes.poi.PoiAddress
  */
 data class Poi(
     override val id: String,
-    val name: String,
+    override val name: String,
     override val address: PoiAddress,
     override val type: PoIType
 ) : PoI


### PR DESCRIPTION
## Summary
- fix override for `name` property in `Poi`

## Testing
- `./gradlew test --no-daemon` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_686394947bc88328b0d88ad184f05637