### PR TITLE
Προσθήκη τύπου 'general' και αυτόματη αναγνώριση ονόματος POI

### DIFF
--- a/app/src/main/java/com/ioannapergamali/mysmartroute/model/enumerations/PoIType.kt
+++ b/app/src/main/java/com/ioannapergamali/mysmartroute/model/enumerations/PoIType.kt
@@ -5,5 +5,6 @@ enum class PoIType {
     BUS_STOP,
     RESTAURANT,
     PARKING,
-    SHOPPING
+    SHOPPING,
+    GENERAL
 }

--- a/app/src/main/java/com/ioannapergamali/mysmartroute/utils/MapsUtils.kt
+++ b/app/src/main/java/com/ioannapergamali/mysmartroute/utils/MapsUtils.kt
@@ -135,4 +135,21 @@ object MapsUtils {
             return@withContext parseDirections(body)
         }
     }
+
+    suspend fun fetchNearbyPlaceName(
+        location: LatLng,
+        apiKey: String
+    ): String? = withContext(Dispatchers.IO) {
+        val url =
+            "https://maps.googleapis.com/maps/api/place/nearbysearch/json?location=${'$'}{location.latitude},${'$'}{location.longitude}&radius=50&key=${'$'}apiKey"
+        val request = Request.Builder().url(url).build()
+        client.newCall(request).execute().use { response ->
+            if (!response.isSuccessful) return@withContext null
+            val body = response.body?.string() ?: return@withContext null
+            val jsonObj = JSONObject(body)
+            val results = jsonObj.optJSONArray("results") ?: return@withContext null
+            if (results.length() == 0) return@withContext null
+            return@withContext results.getJSONObject(0).optString("name")
+        }
+    }
 }


### PR DESCRIPTION
## Περίληψη
- Προστέθηκε νέα επιλογή `GENERAL` στο enum `PoIType`
- Αφαιρέθηκε το dropdown επιλογής ήδη καταχωρημένων POI από την οθόνη ορισμού
- Στο πάτημα του χάρτη αναζητείται κοντινό σημείο ενδιαφέροντος μέσω Google Places και συμπληρώνεται αυτόματα το όνομα
- Προστέθηκε βοηθητική συνάρτηση `fetchNearbyPlaceName` στο `MapsUtils`

## Έλεγχοι
- `./gradlew test` (απέτυχε λόγω περιορισμών δικτύου)

------
https://chatgpt.com/codex/tasks/task_e_6863a22b070883288bf544e4e293cba6