### PR TITLE
Προσθήκη populatePoiTypes και ενημέρωση Firebase BOM

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -95,7 +95,7 @@ dependencies {
 
     // Firebase
     // Χρήση της πιο πρόσφατης έκδοσης BOM
-    implementation(platform("com.google.firebase:firebase-bom:33.15.0"))
+    implementation(platform("com.google.firebase:firebase-bom:33.16.0"))
     implementation("com.google.firebase:firebase-auth-ktx")
     implementation("com.google.firebase:firebase-firestore-ktx")
 

--- a/app/src/main/java/com/ioannapergamali/mysmartroute/MySmartRouteApplication.kt
+++ b/app/src/main/java/com/ioannapergamali/mysmartroute/MySmartRouteApplication.kt
@@ -5,6 +5,7 @@ import android.util.Log
 import com.google.firebase.FirebaseApp
 import com.ioannapergamali.mysmartroute.BuildConfig
 import com.ioannapergamali.mysmartroute.utils.ShortcutUtils
+import com.ioannapergamali.mysmartroute.utils.populatePoiTypes
 import com.ioannapergamali.mysmartroute.viewmodel.AuthenticationViewModel
 import com.ioannapergamali.mysmartroute.utils.LanguagePreferenceManager
 import com.ioannapergamali.mysmartroute.utils.LocaleUtils
@@ -18,6 +19,7 @@ class MySmartRouteApplication : Application() {
         LocaleUtils.updateLocale(this, lang)
         FirebaseApp.initializeApp(this)
         AuthenticationViewModel().ensureMenusInitialized(this)
+        populatePoiTypes()
         // Η υπηρεσία Firebase App Check απενεργοποιήθηκε προσωρινά
         //val apiKey = BuildConfig.MAPS_API_KEY
 //        Log.d("MySmartRoute Maps API key ", "Maps API key loaded: ${apiKey.isNotBlank()}")

--- a/app/src/main/java/com/ioannapergamali/mysmartroute/utils/PoiTypeInitializer.kt
+++ b/app/src/main/java/com/ioannapergamali/mysmartroute/utils/PoiTypeInitializer.kt
@@ -1,0 +1,17 @@
+package com.ioannapergamali.mysmartroute.utils
+
+import com.google.firebase.firestore.FirebaseFirestore
+import com.ioannapergamali.mysmartroute.model.enumerations.PoIType
+
+/**
+ * Δημιουργεί τα έγγραφα της συλλογής `poi_types` στο Firestore αν δεν υπάρχουν.
+ */
+fun populatePoiTypes() {
+    val firestore = FirebaseFirestore.getInstance()
+    for (type in PoIType.values()) {
+        val data = mapOf("id" to type.name, "name" to type.name)
+        firestore.collection("poi_types")
+            .document(type.name)
+            .set(data)
+    }
+}


### PR DESCRIPTION
## Summary
- δημιουργήθηκε η συνάρτηση `populatePoiTypes` που γεμίζει τη συλλογή `poi_types`
- κλήση της συνάρτησης στο `MySmartRouteApplication`
- ενημέρωση Firebase BoM στην έκδοση 33.16.0

## Testing
- `./gradlew test` *(απέτυχε λόγω έλλειψης Android SDK)*

------
https://chatgpt.com/codex/tasks/task_e_6863bbe10d388328b13da2ddfc401504