### PR TITLE
Fix unresolved reference to PlaceLikelihoodBufferResponse

### DIFF
--- a/app/src/main/java/com/ioannapergamali/mysmartroute/utils/PlacesHelper.kt
+++ b/app/src/main/java/com/ioannapergamali/mysmartroute/utils/PlacesHelper.kt
@@ -5,7 +5,6 @@ import android.util.Log
 import com.google.android.libraries.places.api.Places
 import com.google.android.libraries.places.api.model.Place
 import com.google.android.libraries.places.api.model.PlaceLikelihood
-import com.google.android.libraries.places.api.model.PlaceLikelihoodBufferResponse
 import com.google.android.libraries.places.api.net.FindCurrentPlaceRequest
 import com.google.android.libraries.places.api.net.PlacesClient
 import com.ioannapergamali.mysmartroute.BuildConfig


### PR DESCRIPTION
## Summary
Αφαιρέθηκε το παρωχημένο import `PlaceLikelihoodBufferResponse` από το `PlacesHelper.kt`. Ο κώδικας χρησιμοποιεί ήδη την σύγχρονη κλάση `FindCurrentPlaceResponse` και η ύπαρξη του import προκαλούσε σφάλμα μεταγλώττισης.

## Testing
- `./gradlew test --stacktrace` *(απέτυχε: `SDK location not found`)*

------
https://chatgpt.com/codex/tasks/task_e_6863cc1d20c083289db7e49e813ebcab