### PR TITLE
Use Google Place types in dropdown

### DIFF
--- a/app/src/main/java/com/ioannapergamali/mysmartroute/utils/PlacesHelper.kt
+++ b/app/src/main/java/com/ioannapergamali/mysmartroute/utils/PlacesHelper.kt
@@ -10,6 +10,8 @@ import com.google.android.libraries.places.api.net.PlacesClient
 import com.ioannapergamali.mysmartroute.BuildConfig
 
 object PlacesHelper {
+    /** Επιστρέφει όλους τους διαθέσιμους τύπους από το Google Places SDK. */
+    fun allPlaceTypes(): List<Place.Type> = Place.Type.values().toList()
     /** Επιστρέφει μερικούς ενδεικτικούς τύπους σημείων ενδιαφέροντος. */
     fun samplePlaceTypes(): List<Place.Type> = listOf(
         Place.Type.RESTAURANT,

--- a/app/src/main/java/com/ioannapergamali/mysmartroute/view/ui/screens/DefinePoiScreen.kt
+++ b/app/src/main/java/com/ioannapergamali/mysmartroute/view/ui/screens/DefinePoiScreen.kt
@@ -23,6 +23,8 @@ import com.google.android.gms.maps.model.LatLngBounds
 import com.google.maps.android.compose.*
 import com.ioannapergamali.mysmartroute.R
 import com.ioannapergamali.mysmartroute.utils.MapsUtils
+import com.google.android.libraries.places.api.model.Place
+import com.ioannapergamali.mysmartroute.utils.PlacesHelper
 import com.ioannapergamali.mysmartroute.view.ui.components.ScreenContainer
 import com.ioannapergamali.mysmartroute.view.ui.components.TopBar
 import com.ioannapergamali.mysmartroute.viewmodel.PoIViewModel
@@ -39,7 +41,8 @@ fun DefinePoiScreen(navController: NavController, openDrawer: () -> Unit) {
 
     var name by remember { mutableStateOf("") }
     var typeMenuExpanded by remember { mutableStateOf(false) }
-    var selectedType by remember { mutableStateOf(PoIType.HISTORICAL) }
+    var selectedPlaceType by remember { mutableStateOf(Place.Type.RESTAURANT) }
+    val placeTypes = remember { PlacesHelper.allPlaceTypes().sortedBy { it.name } }
     var country by remember { mutableStateOf("") }
     var city by remember { mutableStateOf("") }
     var streetName by remember { mutableStateOf("") }
@@ -128,7 +131,7 @@ fun DefinePoiScreen(navController: NavController, openDrawer: () -> Unit) {
             Spacer(Modifier.height(8.dp))
             ExposedDropdownMenuBox(expanded = typeMenuExpanded, onExpandedChange = { typeMenuExpanded = !typeMenuExpanded }) {
                 OutlinedTextField(
-                    value = selectedType.name,
+                    value = selectedPlaceType.name,
                     onValueChange = {},
                     readOnly = true,
                     label = { Text(stringResource(R.string.poi_type)) },
@@ -141,9 +144,9 @@ fun DefinePoiScreen(navController: NavController, openDrawer: () -> Unit) {
                     )
                 )
                 DropdownMenu(expanded = typeMenuExpanded, onDismissRequest = { typeMenuExpanded = false }) {
-                    PoIType.values().forEach { t ->
+                    placeTypes.forEach { t ->
                         DropdownMenuItem(text = { Text(t.name) }, onClick = {
-                            selectedType = t
+                            selectedPlaceType = t
                             typeMenuExpanded = false
                         })
                     }
@@ -221,7 +224,7 @@ fun DefinePoiScreen(navController: NavController, openDrawer: () -> Unit) {
                         context,
                         name,
                         PoiAddress(country, city, streetName, streetNum, postalCode),
-                        selectedType,
+                        PoIType.values().firstOrNull { it.name == selectedPlaceType.name } ?: PoIType.GENERAL,
                         latLng.latitude,
                         latLng.longitude
                     )


### PR DESCRIPTION
## Summary
- add a utility to list all Google Place types
- populate POI type dropdown with those types
- map selected Place.Type back to our PoIType model when saving a POI

## Testing
- `./gradlew test --no-daemon` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_6863cf68d3cc8328a4bd0f737a1d8a6b