### PR TITLE
Δυναμικά Place Types στη βάση

### DIFF
--- a/app/src/main/java/com/ioannapergamali/mysmartroute/MySmartRouteApplication.kt
+++ b/app/src/main/java/com/ioannapergamali/mysmartroute/MySmartRouteApplication.kt
@@ -19,7 +19,7 @@ class MySmartRouteApplication : Application() {
         LocaleUtils.updateLocale(this, lang)
         FirebaseApp.initializeApp(this)
         AuthenticationViewModel().ensureMenusInitialized(this)
-        populatePoiTypes()
+        populatePoiTypes(this)
         // Η υπηρεσία Firebase App Check απενεργοποιήθηκε προσωρινά
         //val apiKey = BuildConfig.MAPS_API_KEY
 //        Log.d("MySmartRoute Maps API key ", "Maps API key loaded: ${apiKey.isNotBlank()}")

--- a/app/src/main/java/com/ioannapergamali/mysmartroute/data/local/Converters.kt
+++ b/app/src/main/java/com/ioannapergamali/mysmartroute/data/local/Converters.kt
@@ -3,17 +3,17 @@ package com.ioannapergamali.mysmartroute.data.local
 import androidx.room.TypeConverter
 import com.google.gson.Gson
 import com.ioannapergamali.mysmartroute.model.classes.poi.PoiAddress
-import com.ioannapergamali.mysmartroute.model.enumerations.PoIType
+import com.google.android.libraries.places.api.model.Place
 
 /** Μετατροπές για αποθήκευση σύνθετων τύπων στη Room. */
 object Converters {
     private val gson = Gson()
 
     @TypeConverter
-    fun fromPoiType(type: PoIType): String = type.name
+    fun fromPoiType(type: Place.Type): String = type.name
 
     @TypeConverter
-    fun toPoiType(value: String): PoIType = PoIType.valueOf(value)
+    fun toPoiType(value: String): Place.Type = enumValueOf(value)
 
     @TypeConverter
     fun fromAddress(address: PoiAddress): String = gson.toJson(address)

--- a/app/src/main/java/com/ioannapergamali/mysmartroute/data/local/PoIEntity.kt
+++ b/app/src/main/java/com/ioannapergamali/mysmartroute/data/local/PoIEntity.kt
@@ -7,7 +7,7 @@ import androidx.room.Index
 import androidx.room.PrimaryKey
 import androidx.room.Embedded
 import com.ioannapergamali.mysmartroute.model.classes.poi.PoiAddress
-import com.ioannapergamali.mysmartroute.model.enumerations.PoIType
+import com.google.android.libraries.places.api.model.Place
 
 @Entity(
     tableName = "pois",
@@ -25,7 +25,7 @@ data class PoIEntity(
     @PrimaryKey val id: String = "",
     val name: String = "",
     @Embedded val address: PoiAddress = PoiAddress(),
-    @ColumnInfo(name = "typeId") val type: PoIType = PoIType.HISTORICAL,
+    @ColumnInfo(name = "typeId") val type: Place.Type = Place.Type.ESTABLISHMENT,
     val lat: Double = 0.0,
     val lng: Double = 0.0
 )

--- a/app/src/main/java/com/ioannapergamali/mysmartroute/model/enumerations/PoIType.kt
+++ b/app/src/main/java/com/ioannapergamali/mysmartroute/model/enumerations/PoIType.kt
@@ -1,10 +1,8 @@
 package com.ioannapergamali.mysmartroute.model.enumerations
 
-enum class PoIType {
-    HISTORICAL,
-    BUS_STOP,
-    RESTAURANT,
-    PARKING,
-    SHOPPING,
-    GENERAL
-}
+import com.google.android.libraries.places.api.model.Place
+
+/**
+ * Χρησιμοποιούμε απευθείας τους τύπους του Google Places SDK.
+ */
+typealias PoIType = Place.Type

--- a/app/src/main/java/com/ioannapergamali/mysmartroute/utils/FirestoreMappers.kt
+++ b/app/src/main/java/com/ioannapergamali/mysmartroute/utils/FirestoreMappers.kt
@@ -177,12 +177,10 @@ fun DocumentSnapshot.toPoIEntity(): PoIEntity? {
         is String -> rawType
         is DocumentReference -> rawType.id
         else -> getString("type")
-    } ?: com.ioannapergamali.mysmartroute.model.enumerations.PoIType.HISTORICAL.name
-    val type = try {
-        com.ioannapergamali.mysmartroute.model.enumerations.PoIType.valueOf(typeStr)
-    } catch (e: Exception) {
-        com.ioannapergamali.mysmartroute.model.enumerations.PoIType.HISTORICAL
-    }
+    } ?: com.google.android.libraries.places.api.model.Place.Type.ESTABLISHMENT.name
+    val type = runCatching {
+        enumValueOf<com.google.android.libraries.places.api.model.Place.Type>(typeStr)
+    }.getOrElse { com.google.android.libraries.places.api.model.Place.Type.ESTABLISHMENT }
     val latVal = getDouble("lat") ?: 0.0
     val lngVal = getDouble("lng") ?: 0.0
     return PoIEntity(poiId, poiName, address, type, latVal, lngVal)

--- a/app/src/main/java/com/ioannapergamali/mysmartroute/utils/PoiTypeInitializer.kt
+++ b/app/src/main/java/com/ioannapergamali/mysmartroute/utils/PoiTypeInitializer.kt
@@ -1,14 +1,23 @@
 package com.ioannapergamali.mysmartroute.utils
 
+import android.content.Context
+import com.google.android.libraries.places.api.model.Place
 import com.google.firebase.firestore.FirebaseFirestore
-import com.ioannapergamali.mysmartroute.model.enumerations.PoIType
+import com.ioannapergamali.mysmartroute.data.local.MySmartRouteDatabase
+import com.ioannapergamali.mysmartroute.data.local.PoiTypeEntity
+import kotlinx.coroutines.runBlocking
 
 /**
  * Δημιουργεί τα έγγραφα της συλλογής `poi_types` στο Firestore αν δεν υπάρχουν.
  */
-fun populatePoiTypes() {
+fun populatePoiTypes(context: Context) {
     val firestore = FirebaseFirestore.getInstance()
-    for (type in PoIType.values()) {
+    val types = Place.Type.values()
+    runBlocking {
+        MySmartRouteDatabase.getInstance(context).poiTypeDao()
+            .insertAll(types.map { PoiTypeEntity(it.name, it.name) })
+    }
+    for (type in types) {
         val data = mapOf("id" to type.name, "name" to type.name)
         firestore.collection("poi_types")
             .document(type.name)

--- a/app/src/main/java/com/ioannapergamali/mysmartroute/view/ui/screens/AnnounceTransportScreen.kt
+++ b/app/src/main/java/com/ioannapergamali/mysmartroute/view/ui/screens/AnnounceTransportScreen.kt
@@ -50,7 +50,7 @@ import com.ioannapergamali.mysmartroute.R
 import com.ioannapergamali.mysmartroute.viewmodel.TransportAnnouncementViewModel
 import com.ioannapergamali.mysmartroute.viewmodel.VehicleViewModel
 import com.ioannapergamali.mysmartroute.viewmodel.PoIViewModel
-import com.ioannapergamali.mysmartroute.model.enumerations.PoIType
+import com.google.android.libraries.places.api.model.Place
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.withContext
@@ -124,7 +124,7 @@ fun AnnounceTransportScreen(navController: NavController, openDrawer: () -> Unit
     var toError by remember { mutableStateOf(false) }
     var lastAddFrom by remember { mutableStateOf<Boolean?>(null) }
     var poiTypeExpanded by remember { mutableStateOf(false) }
-    var selectedPoiType by remember { mutableStateOf(PoIType.HISTORICAL) }
+    var selectedPoiType by remember { mutableStateOf(Place.Type.LANDMARK) }
 
     // Αρχικοποίηση του χάρτη στο Ηράκλειο με ζουμ όπως στο ζητούμενο URL
     val cameraPositionState = rememberCameraPositionState {
@@ -594,7 +594,7 @@ fun AnnounceTransportScreen(navController: NavController, openDrawer: () -> Unit
                 )
             )
             DropdownMenu(expanded = poiTypeExpanded, onDismissRequest = { poiTypeExpanded = false }) {
-                PoIType.values().forEach { t ->
+                Place.Type.values().forEach { t ->
                     DropdownMenuItem(text = { Text(t.name) }, onClick = {
                         selectedPoiType = t
                         poiTypeExpanded = false

--- a/app/src/main/java/com/ioannapergamali/mysmartroute/view/ui/screens/DefinePoiScreen.kt
+++ b/app/src/main/java/com/ioannapergamali/mysmartroute/view/ui/screens/DefinePoiScreen.kt
@@ -29,7 +29,6 @@ import com.ioannapergamali.mysmartroute.view.ui.components.ScreenContainer
 import com.ioannapergamali.mysmartroute.view.ui.components.TopBar
 import com.ioannapergamali.mysmartroute.viewmodel.PoIViewModel
 import com.ioannapergamali.mysmartroute.model.classes.poi.PoiAddress
-import com.ioannapergamali.mysmartroute.model.enumerations.PoIType
 
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable
@@ -224,7 +223,7 @@ fun DefinePoiScreen(navController: NavController, openDrawer: () -> Unit) {
                         context,
                         name,
                         PoiAddress(country, city, streetName, streetNum, postalCode),
-                        PoIType.values().firstOrNull { it.name == selectedPlaceType.name } ?: PoIType.GENERAL,
+                        Place.Type.values().firstOrNull { it.name == selectedPlaceType.name } ?: Place.Type.ESTABLISHMENT,
                         latLng.latitude,
                         latLng.longitude
                     )

--- a/app/src/main/java/com/ioannapergamali/mysmartroute/viewmodel/PoIViewModel.kt
+++ b/app/src/main/java/com/ioannapergamali/mysmartroute/viewmodel/PoIViewModel.kt
@@ -8,7 +8,7 @@ import com.ioannapergamali.mysmartroute.data.local.MySmartRouteDatabase
 import com.ioannapergamali.mysmartroute.data.local.PoIEntity
 import com.ioannapergamali.mysmartroute.utils.toFirestoreMap
 import com.ioannapergamali.mysmartroute.model.classes.poi.PoiAddress
-import com.ioannapergamali.mysmartroute.model.enumerations.PoIType
+import com.google.android.libraries.places.api.model.Place
 import com.ioannapergamali.mysmartroute.utils.toPoIEntity
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
@@ -47,7 +47,7 @@ class PoIViewModel : ViewModel() {
         context: Context,
         name: String,
         address: PoiAddress,
-        type: PoIType,
+        type: Place.Type,
         lat: Double,
         lng: Double
     ) {


### PR DESCRIPTION
## Summary
- χρησιμοποιείται πλέον το `Place.Type` του Google Places SDK αντί για δικό μας enum
- αποθήκευση όλων των διαθέσιμων place types στη Room και στο Firestore
- ενημέρωση κώδικα ώστε να χρησιμοποιεί τις νέες δομές

## Testing
- `./gradlew test --no-daemon` *(απέτυχε: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_6863d3130404832895e0af3ed6ed1441