### PR TITLE
Fix type inference for POI selection

### DIFF
--- a/app/src/main/java/com/ioannapergamali/mysmartroute/view/ui/screens/AnnounceTransportScreen.kt
+++ b/app/src/main/java/com/ioannapergamali/mysmartroute/view/ui/screens/AnnounceTransportScreen.kt
@@ -124,7 +124,7 @@ fun AnnounceTransportScreen(navController: NavController, openDrawer: () -> Unit
     var toError by remember { mutableStateOf(false) }
     var lastAddFrom by remember { mutableStateOf<Boolean?>(null) }
     var poiTypeExpanded by remember { mutableStateOf(false) }
-    var selectedPoiType by remember { mutableStateOf(Place.Type.LANDMARK) }
+    var selectedPoiType by remember { mutableStateOf<Place.Type>(Place.Type.LANDMARK) }
 
     // Αρχικοποίηση του χάρτη στο Ηράκλειο με ζουμ όπως στο ζητούμενο URL
     val cameraPositionState = rememberCameraPositionState {


### PR DESCRIPTION
## Summary
- explicitly specify type for `selectedPoiType` state in `AnnounceTransportScreen`

## Testing
- `./gradlew test --no-daemon` *(fails: unable to download dependencies in offline mode)*

------
https://chatgpt.com/codex/tasks/task_e_6863d679a9e88328b07376bcaf79405f