### PR TITLE
Fix Place Type default

### DIFF
--- a/app/src/main/java/com/ioannapergamali/mysmartroute/view/ui/screens/AnnounceTransportScreen.kt
+++ b/app/src/main/java/com/ioannapergamali/mysmartroute/view/ui/screens/AnnounceTransportScreen.kt
@@ -124,7 +124,8 @@ fun AnnounceTransportScreen(navController: NavController, openDrawer: () -> Unit
     var toError by remember { mutableStateOf(false) }
     var lastAddFrom by remember { mutableStateOf<Boolean?>(null) }
     var poiTypeExpanded by remember { mutableStateOf(false) }
-    var selectedPoiType by remember { mutableStateOf<Place.Type>(Place.Type.LANDMARK) }
+    // Χρησιμοποιούμε το ESTABLISHMENT ως προεπιλεγμένο είδος σημείου
+    var selectedPoiType by remember { mutableStateOf<Place.Type>(Place.Type.ESTABLISHMENT) }
 
     // Αρχικοποίηση του χάρτη στο Ηράκλειο με ζουμ όπως στο ζητούμενο URL
     val cameraPositionState = rememberCameraPositionState {


### PR DESCRIPTION
## Summary
- use ESTABLISHMENT as the default Place type in `AnnounceTransportScreen`

## Testing
- `./gradlew test` *(fails: domain not in allowlist)*

------
https://chatgpt.com/codex/tasks/task_e_6863d839d8cc8328b07d164003fc7691