### PR TITLE
Ενημέρωση εντοπισμού τύπου POI

### DIFF
--- a/app/src/main/java/com/ioannapergamali/mysmartroute/utils/MapsUtils.kt
+++ b/app/src/main/java/com/ioannapergamali/mysmartroute/utils/MapsUtils.kt
@@ -159,7 +159,7 @@ object MapsUtils {
         apiKey: String
     ): Place.Type? = withContext(Dispatchers.IO) {
         val url =
-            "https://maps.googleapis.com/maps/api/place/nearbysearch/json?location=${'$'}{location.latitude},${'$'}{location.longitude}&radius=50&key=${'$'}apiKey"
+            "https://maps.googleapis.com/maps/api/place/nearbysearch/json?location=${'$'}{location.latitude},${'$'}{location.longitude}&radius=100&key=${'$'}apiKey"
         val request = Request.Builder().url(url).build()
         client.newCall(request).execute().use { response ->
             if (!response.isSuccessful) return@withContext null
@@ -168,8 +168,10 @@ object MapsUtils {
             val results = jsonObj.optJSONArray("results") ?: return@withContext null
             if (results.length() == 0) return@withContext null
             val types = results.getJSONObject(0).optJSONArray("types") ?: return@withContext null
+            val exclude = setOf("POINT_OF_INTEREST", "ESTABLISHMENT")
             for (i in 0 until types.length()) {
                 val typeStr = types.getString(i).uppercase().replace('-', '_')
+                if (typeStr in exclude) continue
                 val type = runCatching { enumValueOf<Place.Type>(typeStr) }.getOrNull()
                 if (type != null) return@withContext type
             }


### PR DESCRIPTION
## Περιγραφή
Βελτιώθηκε η συνάρτηση `fetchNearbyPlaceType` ώστε να αγνοεί γενικούς τύπους (π.χ. `POINT_OF_INTEREST`, `ESTABLISHMENT`) και να αυξάνει την ακτίνα αναζήτησης. Έτσι ο τύπος του σημείου ενημερώνεται σωστότερα όταν ο χρήστης επιλέγει θέση στον χάρτη.

## Έλεγχοι
- `./gradlew test` αποτυγχάνει λόγω έλλειψης Android SDK.

------
https://chatgpt.com/codex/tasks/task_e_6863e37e05a083288a2b79b84387fc26