### PR TITLE
Fix admin menu role persistence

### DIFF
--- a/app/src/main/java/com/ioannapergamali/mysmartroute/viewmodel/AuthenticationViewModel.kt
+++ b/app/src/main/java/com/ioannapergamali/mysmartroute/viewmodel/AuthenticationViewModel.kt
@@ -239,9 +239,15 @@ class AuthenticationViewModel : ViewModel() {
                 .addOnSuccessListener { document ->
                     val roleName = document.getString("role")
                         ?: document.getString("roleId")
+                    val roleId = document.getString("roleId") ?: ""
                     Log.i(TAG, "Role from Firestore: $roleName")
                     _currentUserRole.value = roleName?.let {
                         runCatching { UserRole.valueOf(it) }.getOrNull()
+                    }
+                    viewModelScope.launch {
+                        val dao = MySmartRouteDatabase.getInstance(context).userDao()
+                        val current = dao.getUser(uid) ?: UserEntity(id = uid)
+                        dao.insert(current.copy(role = roleName ?: "", roleId = roleId))
                     }
                     if (loadMenus) loadCurrentUserMenus(context)
                 }


### PR DESCRIPTION
## Summary
- persist role and roleId in local DB when fetched from Firestore

## Testing
- `./gradlew test --console=plain --quiet` *(fails: domain maven.pkg.jetbrains.space blocked)*

------
https://chatgpt.com/codex/tasks/task_e_6863fd812bfc832888c91b009835e0f6