### PR TITLE
Remove admin role description

### DIFF
--- a/app/src/main/java/com/ioannapergamali/mysmartroute/view/ui/screens/MenuScreen.kt
+++ b/app/src/main/java/com/ioannapergamali/mysmartroute/view/ui/screens/MenuScreen.kt
@@ -101,7 +101,7 @@ private fun RoleMenu(
         val descKey = when (role) {
             UserRole.PASSENGER -> "role_passenger_desc"
             UserRole.DRIVER -> "role_driver_desc"
-            UserRole.ADMIN -> "role_admin_desc"
+            UserRole.ADMIN -> null
             else -> null
         }
         descKey?.let { key ->


### PR DESCRIPTION
## Summary
- tweak admin role menu to not show any extra description

## Testing
- `./gradlew test` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_6864594c13d083289f57a0eba41aa6cc