### PR TITLE
Trigger Define POI on map tap

### DIFF
--- a/app/src/main/java/com/ioannapergamali/mysmartroute/model/navigation/NavigationHost.kt
+++ b/app/src/main/java/com/ioannapergamali/mysmartroute/model/navigation/NavigationHost.kt
@@ -76,8 +76,21 @@ fun NavigationHost(navController : NavHostController, openDrawer: () -> Unit) {
         composable("poiList") {
             PoIListScreen(navController = navController, openDrawer = openDrawer)
         }
-        composable("definePoi") {
-            DefinePoiScreen(navController = navController, openDrawer = openDrawer)
+        composable(
+            route = "definePoi?lat={lat}&lng={lng}",
+            arguments = listOf(
+                navArgument("lat") { defaultValue = "" },
+                navArgument("lng") { defaultValue = "" }
+            )
+        ) { backStackEntry ->
+            val lat = backStackEntry.arguments?.getString("lat")?.toDoubleOrNull()
+            val lng = backStackEntry.arguments?.getString("lng")?.toDoubleOrNull()
+            DefinePoiScreen(
+                navController = navController,
+                openDrawer = openDrawer,
+                initialLat = lat,
+                initialLng = lng
+            )
         }
 
 

--- a/app/src/main/java/com/ioannapergamali/mysmartroute/view/ui/screens/AnnounceTransportScreen.kt
+++ b/app/src/main/java/com/ioannapergamali/mysmartroute/view/ui/screens/AnnounceTransportScreen.kt
@@ -227,6 +227,7 @@ fun AnnounceTransportScreen(navController: NavController, openDrawer: () -> Unit
                             }
                             fromError = false
                             mapSelectionMode = null
+                            navController.navigate("definePoi?lat=${latLng.latitude}&lng=${latLng.longitude}")
                         }
                         MapSelectionMode.TO -> {
                             endLatLng = latLng
@@ -237,6 +238,7 @@ fun AnnounceTransportScreen(navController: NavController, openDrawer: () -> Unit
                             }
                             toError = false
                             mapSelectionMode = null
+                            navController.navigate("definePoi?lat=${latLng.latitude}&lng=${latLng.longitude}")
                         }
                         null -> {}
                     }

--- a/app/src/main/java/com/ioannapergamali/mysmartroute/view/ui/screens/DefinePoiScreen.kt
+++ b/app/src/main/java/com/ioannapergamali/mysmartroute/view/ui/screens/DefinePoiScreen.kt
@@ -35,7 +35,12 @@ private const val TAG = "DefinePoiScreen"
 
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable
-fun DefinePoiScreen(navController: NavController, openDrawer: () -> Unit) {
+fun DefinePoiScreen(
+    navController: NavController,
+    openDrawer: () -> Unit,
+    initialLat: Double? = null,
+    initialLng: Double? = null
+) {
     val viewModel: PoIViewModel = viewModel()
     val addState by viewModel.addState.collectAsState()
     val context = LocalContext.current
@@ -50,11 +55,17 @@ fun DefinePoiScreen(navController: NavController, openDrawer: () -> Unit) {
     var streetName by remember { mutableStateOf("") }
     var streetNumInput by remember { mutableStateOf("") }
     var postalCodeInput by remember { mutableStateOf("") }
-    var selectedLatLng by remember { mutableStateOf<LatLng?>(null) }
-    val markerState = rememberMarkerState()
+    val initialLatLng = remember(initialLat, initialLng) {
+        if (initialLat != null && initialLng != null) LatLng(initialLat, initialLng) else null
+    }
+    var selectedLatLng by remember { mutableStateOf<LatLng?>(initialLatLng) }
+    val markerState = rememberMarkerState(position = selectedLatLng ?: LatLng(0.0, 0.0))
 
     val cameraPositionState = rememberCameraPositionState {
-        position = CameraPosition.fromLatLngZoom(LatLng(35.3325932, 25.073835), 13.79f)
+        position = CameraPosition.fromLatLngZoom(
+            selectedLatLng ?: LatLng(35.3325932, 25.073835),
+            13.79f
+        )
     }
     val heraklionBounds = remember {
         LatLngBounds(LatLng(34.9, 24.8), LatLng(35.5, 25.9))
@@ -99,6 +110,7 @@ fun DefinePoiScreen(navController: NavController, openDrawer: () -> Unit) {
                 }
                 LaunchedEffect(selectedLatLng) {
                     selectedLatLng?.let { latLng ->
+                        cameraPositionState.position = CameraPosition.fromLatLngZoom(latLng, 13.79f)
                         val place = MapsUtils.fetchNearbyPlaceName(
                             latLng,
                             MapsUtils.getApiKey(context)


### PR DESCRIPTION
## Summary
- open DefinePoi screen with coordinates
- pass lat/lng to DefinePoiScreen and center marker
- trigger navigation when tapping map on AnnounceTransportScreen

## Testing
- `./gradlew test` *(fails: maven.pkg.jetbrains.space blocked)*

------
https://chatgpt.com/codex/tasks/task_e_6864734051b48328ab614c6d2bbe7d72