### PR TITLE
Εμφάνιση οθόνης DefinePoi κατά την επιλογή διεύθυνσης

### DIFF
--- a/app/src/main/java/com/ioannapergamali/mysmartroute/view/ui/screens/AnnounceTransportScreen.kt
+++ b/app/src/main/java/com/ioannapergamali/mysmartroute/view/ui/screens/AnnounceTransportScreen.kt
@@ -397,6 +397,7 @@ fun AnnounceTransportScreen(navController: NavController, openDrawer: () -> Unit
                             fromError = false
                             cameraPositionState.position = CameraPosition.fromLatLngZoom(startLatLng!!, 10f)
                             fromExpanded = false
+                            navController.navigate("definePoi?lat=${startLatLng!!.latitude}&lng=${startLatLng!!.longitude}")
                         }
                     )
                 }
@@ -412,6 +413,7 @@ fun AnnounceTransportScreen(navController: NavController, openDrawer: () -> Unit
                             fromError = false
                             cameraPositionState.position = CameraPosition.fromLatLngZoom(startLatLng!!, 10f)
                             fromExpanded = false
+                            navController.navigate("definePoi?lat=${startLatLng!!.latitude}&lng=${startLatLng!!.longitude}")
                         }
                     )
                 }


### PR DESCRIPTION
## Περιγραφή
Ενημερώθηκε η `AnnounceTransportScreen` ώστε όταν ο χρήστης επιλέγει προτεινόμενη διεύθυνση ή POI στο πεδίο "Από" να ανοίγει αυτόματα η οθόνη ορισμού σημείου ενδιαφέροντος (`DefinePoiScreen`).

## Αποτελέσματα ελέγχων
- `./gradlew test` απέτυχε λόγω έλλειψης Android SDK.


------
https://chatgpt.com/codex/tasks/task_e_68647ce26520832886a8495f530f6637