### PR TITLE
Open DefinePoiScreen from admin menu

### DIFF
--- a/app/src/main/java/com/ioannapergamali/mysmartroute/view/ui/screens/MenuScreen.kt
+++ b/app/src/main/java/com/ioannapergamali/mysmartroute/view/ui/screens/MenuScreen.kt
@@ -71,9 +71,10 @@ fun MenuScreen(navController: NavController, openDrawer: () -> Unit) {
                 CircularProgressIndicator()
             } else {
                 RoleMenu(role, menus) { route ->
-                    if (route.isNotEmpty() &&
-                        navController.graph.any { it.route == route }) {
-                        navController.navigate(route)
+                    val targetRoute = if (route == "definePoi") "definePoi?lat=&lng=" else route
+                    if (targetRoute.isNotEmpty() &&
+                        navController.graph.any { it.route == "definePoi?lat={lat}&lng={lng}" || it.route == targetRoute }) {
+                        navController.navigate(targetRoute)
                     } else {
                         Toast.makeText(
                             context,


### PR DESCRIPTION
## Summary
- fix navigation so the admin option "define_poi" opens `DefinePoiScreen`

## Testing
- `./gradlew test --no-daemon` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_68648847e2dc8328af87d59676c394c9