### PR TITLE
Update POI selection workflow

### DIFF
--- a/app/src/main/java/com/ioannapergamali/mysmartroute/model/navigation/NavigationHost.kt
+++ b/app/src/main/java/com/ioannapergamali/mysmartroute/model/navigation/NavigationHost.kt
@@ -77,19 +77,25 @@ fun NavigationHost(navController : NavHostController, openDrawer: () -> Unit) {
             PoIListScreen(navController = navController, openDrawer = openDrawer)
         }
         composable(
-            route = "definePoi?lat={lat}&lng={lng}",
+            route = "definePoi?lat={lat}&lng={lng}&source={source}&view={view}",
             arguments = listOf(
                 navArgument("lat") { defaultValue = "" },
-                navArgument("lng") { defaultValue = "" }
+                navArgument("lng") { defaultValue = "" },
+                navArgument("source") { defaultValue = "" },
+                navArgument("view") { defaultValue = "false" }
             )
         ) { backStackEntry ->
             val lat = backStackEntry.arguments?.getString("lat")?.toDoubleOrNull()
             val lng = backStackEntry.arguments?.getString("lng")?.toDoubleOrNull()
+            val source = backStackEntry.arguments?.getString("source")
+            val viewOnly = backStackEntry.arguments?.getString("view")?.toBoolean() ?: false
             DefinePoiScreen(
                 navController = navController,
                 openDrawer = openDrawer,
                 initialLat = lat,
-                initialLng = lng
+                initialLng = lng,
+                source = source,
+                viewOnly = viewOnly
             )
         }
 

--- a/app/src/main/java/com/ioannapergamali/mysmartroute/view/ui/screens/MenuScreen.kt
+++ b/app/src/main/java/com/ioannapergamali/mysmartroute/view/ui/screens/MenuScreen.kt
@@ -71,9 +71,9 @@ fun MenuScreen(navController: NavController, openDrawer: () -> Unit) {
                 CircularProgressIndicator()
             } else {
                 RoleMenu(role, menus) { route ->
-                    val targetRoute = if (route == "definePoi") "definePoi?lat=&lng=" else route
+                    val targetRoute = if (route == "definePoi") "definePoi?lat=&lng=&source=&view=false" else route
                     if (targetRoute.isNotEmpty() &&
-                        navController.graph.any { it.route == "definePoi?lat={lat}&lng={lng}" || it.route == targetRoute }) {
+                        navController.graph.any { it.route == "definePoi?lat={lat}&lng={lng}&source={source}&view={view}" || it.route == targetRoute }) {
                         navController.navigate(targetRoute)
                     } else {
                         Toast.makeText(


### PR DESCRIPTION
## Summary
- add parameters to DefinePoiScreen to support view-only mode
- send new POI back to AnnounceTransportScreen via saved state
- auto-select saved POIs in transport declaration with check icons
- update navigation route and menu

## Testing
- `./gradlew assembleDebug` *(fails: maven.pkg.jetbrains.space blocked)*

------
https://chatgpt.com/codex/tasks/task_e_68648dffaea0832887271d3976f80f20