### PR TITLE
Add dropdown example activity

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -30,6 +30,9 @@
                 <category android:name="android.intent.category.LAUNCHER" />
             </intent-filter>
         </activity>
+        <activity
+            android:name=".DropdownActivity"
+            android:exported="false" />
     </application>
 
 </manifest>

--- a/app/src/main/java/com/ioannapergamali/mysmartroute/DropdownActivity.kt
+++ b/app/src/main/java/com/ioannapergamali/mysmartroute/DropdownActivity.kt
@@ -1,0 +1,22 @@
+package com.ioannapergamali.mysmartroute
+
+import android.os.Bundle
+import android.widget.ArrayAdapter
+import android.widget.AutoCompleteTextView
+import androidx.appcompat.app.AppCompatActivity
+
+class DropdownActivity : AppCompatActivity() {
+    override fun onCreate(savedInstanceState: Bundle?) {
+        super.onCreate(savedInstanceState)
+        setContentView(R.layout.activity_dropdown)
+
+        val locations = listOf("Σημείο 1", "Σημείο 2", "Σημείο 3")
+
+        val fromAuto = findViewById<AutoCompleteTextView>(R.id.fromAuto)
+        val toAuto = findViewById<AutoCompleteTextView>(R.id.toAuto)
+
+        val adapter = ArrayAdapter(this, android.R.layout.simple_list_item_1, locations)
+        fromAuto.setAdapter(adapter)
+        toAuto.setAdapter(adapter)
+    }
+}

--- a/app/src/main/res/drawable/ic_arrow_drop_down.xml
+++ b/app/src/main/res/drawable/ic_arrow_drop_down.xml
@@ -1,0 +1,9 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="24dp"
+    android:height="24dp"
+    android:viewportWidth="24"
+    android:viewportHeight="24">
+    <path
+        android:fillColor="#FF000000"
+        android:pathData="M7,10l5,5 5,-5"/>
+</vector>

--- a/app/src/main/res/layout/activity_dropdown.xml
+++ b/app/src/main/res/layout/activity_dropdown.xml
@@ -1,0 +1,64 @@
+<?xml version="1.0" encoding="utf-8"?>
+<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    android:orientation="vertical"
+    android:layout_width="match_parent"
+    android:layout_height="wrap_content"
+    android:padding="16dp">
+
+    <!-- Γραμμή "Από" -->
+    <LinearLayout
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:orientation="horizontal">
+
+        <com.google.android.material.textfield.TextInputLayout
+            android:layout_width="0dp"
+            android:layout_height="wrap_content"
+            android:layout_weight="1"
+            app:endIconMode="none">
+
+            <AutoCompleteTextView
+                android:id="@+id/fromAuto"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:hint="Από" />
+        </com.google.android.material.textfield.TextInputLayout>
+
+        <ImageView
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:layout_gravity="center_vertical"
+            android:src="@drawable/ic_arrow_drop_down"
+            android:clickable="false"
+            android:focusable="false" />
+    </LinearLayout>
+
+    <!-- Γραμμή "Προς" -->
+    <LinearLayout
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:layout_marginTop="8dp"
+        android:orientation="horizontal">
+
+        <com.google.android.material.textfield.TextInputLayout
+            android:layout_width="0dp"
+            android:layout_height="wrap_content"
+            android:layout_weight="1"
+            app:endIconMode="none">
+
+            <AutoCompleteTextView
+                android:id="@+id/toAuto"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:hint="Προς" />
+        </com.google.android.material.textfield.TextInputLayout>
+
+        <ImageView
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:layout_gravity="center_vertical"
+            android:src="@drawable/ic_arrow_drop_down"
+            android:clickable="false"
+            android:focusable="false" />
+    </LinearLayout>
+</LinearLayout>


### PR DESCRIPTION
## Summary
- add a simple layout with `AutoCompleteTextView` and a non-clickable arrow icon to the side
- implement `DropdownActivity` using that layout
- register the new activity in the manifest

## Testing
- `./gradlew assembleDebug` *(fails: maven.pkg.jetbrains.space blocked)*

------
https://chatgpt.com/codex/tasks/task_e_686491a520688328b114fc631ccbac40