### PR TITLE
Fix XML namespace for TextInputLayout

### DIFF
--- a/app/src/main/res/layout/activity_dropdown.xml
+++ b/app/src/main/res/layout/activity_dropdown.xml
@@ -1,5 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
     android:orientation="vertical"
     android:layout_width="match_parent"
     android:layout_height="wrap_content"


### PR DESCRIPTION
## Summary
- fix missing `xmlns:app` namespace in `activity_dropdown.xml`

## Testing
- `./gradlew tasks --no-daemon` *(fails: maven.pkg.jetbrains.space blocked)*

------
https://chatgpt.com/codex/tasks/task_e_686494388e848328942836460cf7671d