### PR TITLE
Fix import for heightIn modifier

### DIFF
--- a/app/src/main/java/com/ioannapergamali/mysmartroute/view/ui/screens/AnnounceTransportScreen.kt
+++ b/app/src/main/java/com/ioannapergamali/mysmartroute/view/ui/screens/AnnounceTransportScreen.kt
@@ -3,6 +3,7 @@ package com.ioannapergamali.mysmartroute.view.ui.screens
 import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.heightIn
 import androidx.compose.foundation.layout.padding
 import androidx.compose.material3.*
 import android.util.Log


### PR DESCRIPTION
## Summary
- add missing import for `heightIn` in AnnounceTransportScreen

## Testing
- `./gradlew test --stacktrace` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_68649f500e448328829cde7274763bcb