### PR TITLE
Προσθήκη εικονιδίου λεπτομερειών για POI

### DIFF
--- a/app/src/main/java/com/ioannapergamali/mysmartroute/view/ui/screens/AnnounceTransportScreen.kt
+++ b/app/src/main/java/com/ioannapergamali/mysmartroute/view/ui/screens/AnnounceTransportScreen.kt
@@ -31,6 +31,7 @@ import androidx.compose.material.icons.filled.Check
 import androidx.compose.material.icons.filled.Place
 import androidx.compose.material.icons.filled.Add
 import androidx.compose.material.icons.filled.Warning
+import androidx.compose.material.icons.filled.Info
 import com.google.maps.android.compose.GoogleMap
 import com.google.maps.android.compose.Marker
 import com.google.maps.android.compose.rememberCameraPositionState
@@ -125,6 +126,8 @@ fun AnnounceTransportScreen(navController: NavController, openDrawer: () -> Unit
 
     var startLatLng by remember { mutableStateOf<LatLng?>(null) }
     var endLatLng by remember { mutableStateOf<LatLng?>(null) }
+    var fromSelectedIsPoi by remember { mutableStateOf(false) }
+    var toSelectedIsPoi by remember { mutableStateOf(false) }
     val fromMarkerState = rememberMarkerState()
     val toMarkerState = rememberMarkerState()
     var costInput by remember { mutableStateOf("") }
@@ -145,10 +148,12 @@ fun AnnounceTransportScreen(navController: NavController, openDrawer: () -> Unit
                 startLatLng = latLng
                 fromQuery = resultPoiName!!
                 selectedFromDescription = resultPoiName
+                fromSelectedIsPoi = true
             } else {
                 endLatLng = latLng
                 toQuery = resultPoiName!!
                 selectedToDescription = resultPoiName
+                toSelectedIsPoi = true
             }
             savedHandle?.remove<String>("poiName")
             savedHandle?.remove<Double>("poiLat")
@@ -422,6 +427,17 @@ fun AnnounceTransportScreen(navController: NavController, openDrawer: () -> Unit
                                 tint = MaterialTheme.colorScheme.primary
                             )
                         }
+                        if (startLatLng != null && fromSelectedIsPoi) {
+                            IconButton(onClick = {
+                                navController.navigate("definePoi?lat=${startLatLng!!.latitude}&lng=${startLatLng!!.longitude}&source=from&view=true")
+                            }) {
+                                Icon(
+                                    Icons.Default.Info,
+                                    contentDescription = stringResource(R.string.poi_details),
+                                    tint = MaterialTheme.colorScheme.primary
+                                )
+                            }
+                        }
                         ExposedDropdownMenuDefaults.TrailingIcon(expanded = fromExpanded)
                     }
                 },
@@ -449,6 +465,7 @@ fun AnnounceTransportScreen(navController: NavController, openDrawer: () -> Unit
                             fromError = false
                             cameraPositionState.position = CameraPosition.fromLatLngZoom(startLatLng!!, 10f)
                             fromExpanded = false
+                            fromSelectedIsPoi = false
                             navController.navigate("definePoi?lat=${startLatLng!!.latitude}&lng=${startLatLng!!.longitude}&source=from&view=false")
                         }
                     )
@@ -465,7 +482,7 @@ fun AnnounceTransportScreen(navController: NavController, openDrawer: () -> Unit
                             fromError = false
                             cameraPositionState.position = CameraPosition.fromLatLngZoom(startLatLng!!, 10f)
                             fromExpanded = false
-                            navController.navigate("definePoi?lat=${startLatLng!!.latitude}&lng=${startLatLng!!.longitude}&source=from&view=true")
+                            fromSelectedIsPoi = true
                         }
                     )
                 }
@@ -528,6 +545,17 @@ fun AnnounceTransportScreen(navController: NavController, openDrawer: () -> Unit
                                 tint = MaterialTheme.colorScheme.primary
                             )
                         }
+                        if (endLatLng != null && toSelectedIsPoi) {
+                            IconButton(onClick = {
+                                navController.navigate("definePoi?lat=${endLatLng!!.latitude}&lng=${endLatLng!!.longitude}&source=to&view=true")
+                            }) {
+                                Icon(
+                                    Icons.Default.Info,
+                                    contentDescription = stringResource(R.string.poi_details),
+                                    tint = MaterialTheme.colorScheme.primary
+                                )
+                            }
+                        }
                         ExposedDropdownMenuDefaults.TrailingIcon(expanded = toExpanded)
                     }
                 },
@@ -555,6 +583,7 @@ fun AnnounceTransportScreen(navController: NavController, openDrawer: () -> Unit
                             toError = false
                             cameraPositionState.position = CameraPosition.fromLatLngZoom(endLatLng!!, 10f)
                             toExpanded = false
+                            toSelectedIsPoi = false
                             navController.navigate("definePoi?lat=${endLatLng!!.latitude}&lng=${endLatLng!!.longitude}&source=to&view=false")
                         }
                     )
@@ -571,7 +600,7 @@ fun AnnounceTransportScreen(navController: NavController, openDrawer: () -> Unit
                             toError = false
                             cameraPositionState.position = CameraPosition.fromLatLngZoom(endLatLng!!, 10f)
                             toExpanded = false
-                            navController.navigate("definePoi?lat=${endLatLng!!.latitude}&lng=${endLatLng!!.longitude}&source=to&view=true")
+                            toSelectedIsPoi = true
                         }
                     )
                 }

--- a/app/src/main/res/values-el/strings.xml
+++ b/app/src/main/res/values-el/strings.xml
@@ -107,6 +107,7 @@
     <string name="poi_saved">Το POI αποθηκεύτηκε</string>
     <string name="poi_exists">Το POI υπάρχει ήδη</string>
     <string name="poi_type">Τύπος POI</string>
+    <string name="poi_details">Λεπτομέρειες POI</string>
     <string name="not_implemented">Η λειτουργία δεν είναι διαθέσιμη</string>
     <!-- Περιγραφές ρόλων -->
     <string name="role_passenger_desc">Μπορείτε να δείτε διαδρομές και να κάνετε κρατήσεις.</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -105,6 +105,7 @@
     <string name="poi_saved">PoI saved</string>
     <string name="poi_exists">PoI already exists</string>
     <string name="poi_type">PoI Type</string>
+    <string name="poi_details">PoI details</string>
     <string name="not_implemented">Functionality not available</string>
     <!-- Role descriptions -->
     <string name="role_passenger_desc">You can view routes and make bookings.</string>


### PR DESCRIPTION
## Περιγραφή
Προστέθηκε δυνατότητα εμφάνισης εικονιδίου "λεπτομέρειες" στα πεδία "Από" και "Προς" όταν ο χρήστης επιλέγει αποθηκευμένο POI. Πατώντας το εικονίδιο ανοίγει η οθόνη προβολής του POI. Προστέθηκαν σχετικές μεταφράσεις στα αρχεία `strings.xml`.

## Έλεγχοι
- `./gradlew assembleDebug` (απέτυχε λόγω έλλειψης Android SDK)


------
https://chatgpt.com/codex/tasks/task_e_6864a32cb444832886537dbae6b19817