### PR TITLE
Ενημέρωση AnnounceTransportScreen

### DIFF
--- a/app/src/main/java/com/ioannapergamali/mysmartroute/view/ui/screens/AnnounceTransportScreen.kt
+++ b/app/src/main/java/com/ioannapergamali/mysmartroute/view/ui/screens/AnnounceTransportScreen.kt
@@ -376,60 +376,6 @@ fun AnnounceTransportScreen(navController: NavController, openDrawer: () -> Unit
             )
         }
 
-        if (startLatLng != null && endLatLng != null) {
-            Spacer(modifier = Modifier.height(8.dp))
-            Button(onClick = {
-                fetchRoute()
-            }) {
-                Text(stringResource(R.string.directions))
-            }
-        }
-
-        Spacer(modifier = Modifier.height(8.dp))
-        Box {
-            Button(onClick = { stopMenuExpanded = true }) {
-                Icon(Icons.Default.Add, contentDescription = null)
-                Spacer(Modifier.width(8.dp))
-                Text(stringResource(R.string.add_stop))
-            }
-            DropdownMenu(expanded = stopMenuExpanded, onDismissRequest = { stopMenuExpanded = false }) {
-                pois.forEach { poi ->
-                    DropdownMenuItem(
-                        text = { Text(poi.name) },
-                        onClick = {
-                            routePois.add(poi)
-                            stopMenuExpanded = false
-                        }
-                    )
-                }
-            }
-        }
-        routePois.forEachIndexed { index, poi ->
-            Text(text = "${index + 1}. ${poi.name}")
-        }
-
-        Spacer(modifier = Modifier.height(8.dp))
-        Button(onClick = {
-            if (CoordinateUtils.isValid(startLatLng) && CoordinateUtils.isValid(endLatLng)) {
-                Toast.makeText(context, context.getString(R.string.coordinates_valid), Toast.LENGTH_SHORT).show()
-            } else {
-                Toast.makeText(context, context.getString(R.string.coordinates_missing), Toast.LENGTH_SHORT).show()
-            }
-        }) {
-            Text(stringResource(R.string.check_coordinates))
-        }
-
-        Spacer(modifier = Modifier.height(8.dp))
-        Button(onClick = {
-            if (NetworkUtils.isInternetAvailable(context)) {
-                Toast.makeText(context, context.getString(R.string.internet_available), Toast.LENGTH_SHORT).show()
-            } else {
-                Toast.makeText(context, context.getString(R.string.no_internet), Toast.LENGTH_SHORT).show()
-            }
-        }) {
-            Text(stringResource(R.string.check_internet))
-        }
-
         Spacer(modifier = Modifier.height(8.dp))
 
         Row(verticalAlignment = Alignment.CenterVertically) {
@@ -454,7 +400,7 @@ fun AnnounceTransportScreen(navController: NavController, openDrawer: () -> Unit
                         showRoute = false
                     }
                 },
-                label = { Text(stringResource(R.string.from)) },
+                label = { Text(stringResource(R.string.start_point)) },
                 isError = fromError,
                 trailingIcon = {
                     Row {
@@ -555,9 +501,63 @@ fun AnnounceTransportScreen(navController: NavController, openDrawer: () -> Unit
                 tint = MaterialTheme.colorScheme.primary
             )
         }
-    }
 
         Spacer(modifier = Modifier.height(8.dp))
+
+        if (startLatLng != null && endLatLng != null) {
+            Spacer(modifier = Modifier.height(8.dp))
+            Button(onClick = {
+                fetchRoute()
+            }) {
+                Text(stringResource(R.string.directions))
+            }
+        }
+
+        Spacer(modifier = Modifier.height(8.dp))
+        Box {
+            Button(onClick = { stopMenuExpanded = true }) {
+                Icon(Icons.Default.Add, contentDescription = null)
+                Spacer(Modifier.width(8.dp))
+                Text(stringResource(R.string.add_stop))
+            }
+            DropdownMenu(expanded = stopMenuExpanded, onDismissRequest = { stopMenuExpanded = false }) {
+                pois.forEach { poi ->
+                    DropdownMenuItem(
+                        text = { Text(poi.name) },
+                        onClick = {
+                            routePois.add(poi)
+                            stopMenuExpanded = false
+                        }
+                    )
+                }
+            }
+        }
+        routePois.forEachIndexed { index, poi ->
+            Text(text = "${index + 1}. ${poi.name}")
+        }
+
+        Spacer(modifier = Modifier.height(8.dp))
+        Button(onClick = {
+            if (CoordinateUtils.isValid(startLatLng) && CoordinateUtils.isValid(endLatLng)) {
+                Toast.makeText(context, context.getString(R.string.coordinates_valid), Toast.LENGTH_SHORT).show()
+            } else {
+                Toast.makeText(context, context.getString(R.string.coordinates_missing), Toast.LENGTH_SHORT).show()
+            }
+        }) {
+            Text(stringResource(R.string.check_coordinates))
+        }
+
+        Spacer(modifier = Modifier.height(8.dp))
+        Button(onClick = {
+            if (NetworkUtils.isInternetAvailable(context)) {
+                Toast.makeText(context, context.getString(R.string.internet_available), Toast.LENGTH_SHORT).show()
+            } else {
+                Toast.makeText(context, context.getString(R.string.no_internet), Toast.LENGTH_SHORT).show()
+            }
+        }) {
+            Text(stringResource(R.string.check_internet))
+        }
+
 
         Row(verticalAlignment = Alignment.CenterVertically) {
             ExposedDropdownMenuBox(

--- a/app/src/main/res/values-el/strings.xml
+++ b/app/src/main/res/values-el/strings.xml
@@ -92,6 +92,7 @@
     <string name="advance_date">Μεταφορά ημερομηνίας</string>
     <string name="announce_transport">Δήλωση μεταφοράς</string>
     <string name="from">Από</string>
+    <string name="start_point">Σημείο έναρξης διαδρομής</string>
     <string name="to">Προς</string>
     <string name="vehicle">Όχημα</string>
     <string name="cost">Κόστος</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -90,6 +90,7 @@
     <string name="advance_date">Advance Date</string>
     <string name="announce_transport">Announce Transport</string>
     <string name="from">From</string>
+    <string name="start_point">Starting point</string>
     <string name="to">To</string>
     <string name="vehicle">Vehicle</string>
     <string name="cost">Cost</string>


### PR DESCRIPTION
## Περιγραφή
- μετακινήθηκε το πεδίο επιλογής "Από" αμέσως μετά τον χάρτη
- προστέθηκε νέο κλειδί `start_point` στα strings και χρησιμοποιείται στο label του πεδίου

## Testing
- `./gradlew test` *(απέτυχε λόγω έλλειψης πρόσβασης στο maven.pkg.jetbrains.space)*

------
https://chatgpt.com/codex/tasks/task_e_686533d93f8c8328a23e20f694605bbd