### PR TITLE
Fix missing brace in AnnounceTransportScreen

### DIFF
--- a/app/src/main/java/com/ioannapergamali/mysmartroute/view/ui/screens/AnnounceTransportScreen.kt
+++ b/app/src/main/java/com/ioannapergamali/mysmartroute/view/ui/screens/AnnounceTransportScreen.kt
@@ -814,3 +814,4 @@ fun AnnounceTransportScreen(navController: NavController, openDrawer: () -> Unit
     }
     }
 }
+}


### PR DESCRIPTION
## Summary
- add a closing curly bracket at the end of `AnnounceTransportScreen.kt`

## Testing
- `./gradlew tasks --all` *(fails: domain not allowed)*

------
https://chatgpt.com/codex/tasks/task_e_686538046a8c832899d38ccb6a2fb7e0