### PR TITLE
Fix keyboard closing on dropdown open

### DIFF
--- a/app/src/main/java/com/ioannapergamali/mysmartroute/view/ui/screens/AnnounceTransportScreen.kt
+++ b/app/src/main/java/com/ioannapergamali/mysmartroute/view/ui/screens/AnnounceTransportScreen.kt
@@ -437,7 +437,8 @@ fun AnnounceTransportScreen(navController: NavController, openDrawer: () -> Unit
             DropdownMenu(
                 expanded = fromExpanded,
                 onDismissRequest = { fromExpanded = false },
-                modifier = Modifier.heightIn(max = 200.dp)
+                modifier = Modifier.heightIn(max = 200.dp),
+                properties = PopupProperties(focusable = false)
             ) {
                 fromSuggestions.forEach { address ->
                     DropdownMenuItem(
@@ -624,7 +625,8 @@ fun AnnounceTransportScreen(navController: NavController, openDrawer: () -> Unit
             DropdownMenu(
                 expanded = toExpanded,
                 onDismissRequest = { toExpanded = false },
-                modifier = Modifier.heightIn(max = 200.dp)
+                modifier = Modifier.heightIn(max = 200.dp),
+                properties = PopupProperties(focusable = false)
             ) {
                 toSuggestions.forEach { address ->
                     DropdownMenuItem(


### PR DESCRIPTION
## Summary
- keep the software keyboard visible when displaying suggestions in AnnounceTransportScreen

## Testing
- `./gradlew test` *(fails: some dependencies blocked)*

------
https://chatgpt.com/codex/tasks/task_e_68655f1f14e4832898ca6b13e571af7a