### PR TITLE
Enable text input search for POI selection

### DIFF
--- a/app/src/main/java/com/ioannapergamali/mysmartroute/view/ui/screens/AnnounceTransportScreen.kt
+++ b/app/src/main/java/com/ioannapergamali/mysmartroute/view/ui/screens/AnnounceTransportScreen.kt
@@ -390,14 +390,8 @@ fun AnnounceTransportScreen(navController: NavController, openDrawer: () -> Unit
             ExposedDropdownMenuBox(
                 expanded = fromExpanded,
                 onExpandedChange = {
-                    if (fromQuery.isNotBlank()) {
-                        val expand = !fromExpanded
-                        fromExpanded = expand
-                        if (expand) {
-                            fromFocusRequester.requestFocus()
-                            keyboardController?.show()
-                        }
-                    }
+                    fromFocusRequester.requestFocus()
+                    keyboardController?.show()
                 },
                 modifier = Modifier.weight(1f)
             ) {
@@ -582,14 +576,8 @@ fun AnnounceTransportScreen(navController: NavController, openDrawer: () -> Unit
             ExposedDropdownMenuBox(
                 expanded = toExpanded,
                 onExpandedChange = {
-                    if (toQuery.isNotBlank()) {
-                        val expand = !toExpanded
-                        toExpanded = expand
-                        if (expand) {
-                            toFocusRequester.requestFocus()
-                            keyboardController?.show()
-                        }
-                    }
+                    toFocusRequester.requestFocus()
+                    keyboardController?.show()
                 },
                 modifier = Modifier.weight(1f)
             ) {


### PR DESCRIPTION
## Summary
- tweak "Από" και "Προς" dropdowns να ανοίγουν το πληκτρολόγιο αντί για το μενού

## Testing
- `./gradlew test --no-daemon` *(απέτυχε: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_686567b4f1888328b1c23ca4d66f298f