### PR TITLE
Improve dropdown focus on arrow tap

### DIFF
--- a/app/src/main/java/com/ioannapergamali/mysmartroute/view/ui/screens/AnnounceTransportScreen.kt
+++ b/app/src/main/java/com/ioannapergamali/mysmartroute/view/ui/screens/AnnounceTransportScreen.kt
@@ -390,6 +390,7 @@ fun AnnounceTransportScreen(navController: NavController, openDrawer: () -> Unit
             ExposedDropdownMenuBox(
                 expanded = fromExpanded,
                 onExpandedChange = {
+                    fromExpanded = false
                     fromFocusRequester.requestFocus()
                     keyboardController?.show()
                 },
@@ -576,6 +577,7 @@ fun AnnounceTransportScreen(navController: NavController, openDrawer: () -> Unit
             ExposedDropdownMenuBox(
                 expanded = toExpanded,
                 onExpandedChange = {
+                    toExpanded = false
                     toFocusRequester.requestFocus()
                     keyboardController?.show()
                 },


### PR DESCRIPTION
## Summary
- close dropdown and focus text field when arrow icon is pressed in "Από" and "Προς" fields

## Testing
- `./gradlew test --daemon` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_68656cc98c048328a1304f8d70cbe3df