### PR TITLE
Προσθήκη φίλτρου για αναζήτηση POI

### DIFF
--- a/app/src/main/java/com/ioannapergamali/mysmartroute/view/ui/screens/AnnounceTransportScreen.kt
+++ b/app/src/main/java/com/ioannapergamali/mysmartroute/view/ui/screens/AnnounceTransportScreen.kt
@@ -118,7 +118,7 @@ fun AnnounceTransportScreen(navController: NavController, openDrawer: () -> Unit
     val keyboardController = LocalSoftwareKeyboardController.current
     val fromPoiSuggestions = remember(fromQuery, pois) {
         if (fromQuery.isBlank()) emptyList() else
-        pois.filter { it.name.contains(fromQuery, ignoreCase = true) }
+        pois.filter { it.name.startsWith(fromQuery, ignoreCase = true) }
             .sortedBy { it.name }
     }
 
@@ -129,7 +129,7 @@ fun AnnounceTransportScreen(navController: NavController, openDrawer: () -> Unit
     val toFocusRequester = remember { FocusRequester() }
     val toPoiSuggestions = remember(toQuery, pois) {
         if (toQuery.isBlank()) emptyList() else
-        pois.filter { it.name.contains(toQuery, ignoreCase = true) }
+        pois.filter { it.name.startsWith(toQuery, ignoreCase = true) }
             .sortedBy { it.name }
     }
 

--- a/app/src/main/res/values-el/strings.xml
+++ b/app/src/main/res/values-el/strings.xml
@@ -92,7 +92,7 @@
     <string name="advance_date">Μεταφορά ημερομηνίας</string>
     <string name="announce_transport">Δήλωση μεταφοράς</string>
     <string name="from">Από</string>
-    <string name="start_point">Σημείο έναρξης διαδρομής</string>
+    <string name="start_point">Σημείο Εκκίνησης</string>
     <string name="to">Προς</string>
     <string name="vehicle">Όχημα</string>
     <string name="cost">Κόστος</string>


### PR DESCRIPTION
## Τι άλλαξε
- Το πεδίο "Σημείο Εκκίνησης" στη δήλωση μεταφοράς προτείνει μόνο POI που αρχίζουν από τα γράμματα που πληκτρολογεί ο χρήστης
- Ενημερώθηκε η ελληνική μετάφραση του label σε "Σημείο Εκκίνησης"

## Οδηγίες ελέγχου
- `./gradlew test` (απαιτεί Android SDK για να ολοκληρωθεί)


------
https://chatgpt.com/codex/tasks/task_e_68659a53b3888328a1302dfb631ec7ed