### PR TITLE
Adjust spacing on transport screen

### DIFF
--- a/app/src/main/java/com/ioannapergamali/mysmartroute/view/ui/screens/AnnounceTransportScreen.kt
+++ b/app/src/main/java/com/ioannapergamali/mysmartroute/view/ui/screens/AnnounceTransportScreen.kt
@@ -371,7 +371,8 @@ fun AnnounceTransportScreen(navController: NavController, openDrawer: () -> Unit
             )
         }
 
-        Spacer(modifier = Modifier.height(8.dp))
+        // Παρέχουμε μεγαλύτερο κενό για να φαίνεται καθαρά το πεδίο εκκίνησης κάτω από τον χάρτη
+        Spacer(modifier = Modifier.height(16.dp))
 
         Row(verticalAlignment = Alignment.CenterVertically) {
             ExposedDropdownMenuBox(


### PR DESCRIPTION
## Summary
- increase the spacing below the map so the starting point field is clearly visible

## Testing
- `./gradlew test --no-daemon` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_6868ad178ab88328a68961daaaf12cc0