### PR TITLE
Adjust start point field spacing

### DIFF
--- a/app/src/main/java/com/ioannapergamali/mysmartroute/view/ui/screens/AnnounceTransportScreen.kt
+++ b/app/src/main/java/com/ioannapergamali/mysmartroute/view/ui/screens/AnnounceTransportScreen.kt
@@ -371,8 +371,8 @@ fun AnnounceTransportScreen(navController: NavController, openDrawer: () -> Unit
             )
         }
 
-        // Παρέχουμε μεγαλύτερο κενό για να φαίνεται καθαρά το πεδίο εκκίνησης κάτω από τον χάρτη
-        Spacer(modifier = Modifier.height(16.dp))
+        // Το πεδίο εκκίνησης ακολουθεί αμέσως μετά τον χάρτη
+        Spacer(modifier = Modifier.height(8.dp))
 
         Row(verticalAlignment = Alignment.CenterVertically) {
             ExposedDropdownMenuBox(


### PR DESCRIPTION
## Summary
- ensure the start point field appears right under the map on the transport announcement screen

## Testing
- `./gradlew test` *(fails: could not download dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_6868afe01910832888bdc607103727a4