### PR TITLE
Rename start field label

### DIFF
--- a/app/src/main/res/values-el/strings.xml
+++ b/app/src/main/res/values-el/strings.xml
@@ -92,7 +92,7 @@
     <string name="advance_date">Μεταφορά ημερομηνίας</string>
     <string name="announce_transport">Δήλωση μεταφοράς</string>
     <string name="from">Από</string>
-    <string name="start_point">Σημείο Εκκίνησης</string>
+    <string name="start_point">Σημείο εκκίνησης</string>
     <string name="destination">Προορισμός</string>
     <string name="vehicle">Όχημα</string>
     <string name="cost">Κόστος</string>


### PR DESCRIPTION
## Summary
- update Greek text for `start_point` to "Σημείο εκκίνησης"

## Testing
- `./gradlew test` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_6868bff1ee148328a67ad30cb09760bb