### PR TITLE
Fix scroll on AnnounceTransport screen

### DIFF
--- a/app/src/main/java/com/ioannapergamali/mysmartroute/view/ui/screens/AnnounceTransportScreen.kt
+++ b/app/src/main/java/com/ioannapergamali/mysmartroute/view/ui/screens/AnnounceTransportScreen.kt
@@ -313,14 +313,16 @@ fun AnnounceTransportScreen(navController: NavController, openDrawer: () -> Unit
         endLatLng?.let { toMarkerState.position = it }
     }
 
-    ScreenContainer(modifier = Modifier.padding(0.dp)) {
-        TopBar(
-            title = stringResource(R.string.announce_transport),
-            navController = navController,
-            showMenu = true,
-            onMenuClick = openDrawer
-        )
-        Spacer(modifier = Modifier.height(16.dp))
+    ScreenContainer(modifier = Modifier.padding(0.dp), scrollable = false) {
+        LazyColumn {
+            item {
+                TopBar(
+                    title = stringResource(R.string.announce_transport),
+                    navController = navController,
+                    showMenu = true,
+                    onMenuClick = openDrawer
+                )
+                Spacer(modifier = Modifier.height(16.dp))
 
         if (!isKeyMissing) {
             GoogleMap(


### PR DESCRIPTION
## Summary
- wrap AnnounceTransport screen contents in `LazyColumn`
- disable internal scrolling in `ScreenContainer`

## Testing
- `./gradlew test --console=plain` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_68690019629883289f47ad7c03470116