### PR TITLE
Fix missing brace in AnnounceTransportScreen

### DIFF
--- a/app/src/main/java/com/ioannapergamali/mysmartroute/view/ui/screens/AnnounceTransportScreen.kt
+++ b/app/src/main/java/com/ioannapergamali/mysmartroute/view/ui/screens/AnnounceTransportScreen.kt
@@ -845,3 +845,5 @@ fun AnnounceTransportScreen(navController: NavController, openDrawer: () -> Unit
     }
 }
 }
+}
+}


### PR DESCRIPTION
## Summary
- close missing brace in AnnounceTransportScreen

## Testing
- `./gradlew test` *(fails: maven.pkg.jetbrains.space blocked)*

------
https://chatgpt.com/codex/tasks/task_e_68690c761fc883289040fdd0b1d4f0c5