### PR TITLE
Fix AnnounceTransportScreen scrolling

### DIFF
--- a/app/src/main/java/com/ioannapergamali/mysmartroute/view/ui/screens/AnnounceTransportScreen.kt
+++ b/app/src/main/java/com/ioannapergamali/mysmartroute/view/ui/screens/AnnounceTransportScreen.kt
@@ -314,9 +314,8 @@ fun AnnounceTransportScreen(navController: NavController, openDrawer: () -> Unit
         endLatLng?.let { toMarkerState.position = it }
     }
 
-    ScreenContainer(modifier = Modifier.padding(0.dp), scrollable = false) {
-        LazyColumn {
-            item {
+    ScreenContainer(modifier = Modifier.padding(0.dp)) {
+        Column {
                 TopBar(
                     title = stringResource(R.string.announce_transport),
                     navController = navController,
@@ -843,7 +842,5 @@ fun AnnounceTransportScreen(navController: NavController, openDrawer: () -> Unit
         }
     }
     }
-}
-}
 }
 }


### PR DESCRIPTION
## Summary
- remove LazyColumn wrapper from AnnounceTransportScreen
- rely on ScreenContainer's default scrolling

## Testing
- `./gradlew test` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_6869fa5e8090832887ee6f2e812d629a