### PR TITLE
Fix syntax error in AnnounceTransportScreen

### DIFF
--- a/app/src/main/java/com/ioannapergamali/mysmartroute/view/ui/screens/AnnounceTransportScreen.kt
+++ b/app/src/main/java/com/ioannapergamali/mysmartroute/view/ui/screens/AnnounceTransportScreen.kt
@@ -845,3 +845,4 @@ fun AnnounceTransportScreen(navController: NavController, openDrawer: () -> Unit
     }
 }
 }
+}


### PR DESCRIPTION
## Summary
- close the `AnnounceTransportScreen` composable with a missing closing brace

## Testing
- `./gradlew test` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_6869ff2708f083289f5905bcd55cb111