### PR TITLE
Fix missing fields on AnnounceTransportScreen

### DIFF
--- a/app/src/main/java/com/ioannapergamali/mysmartroute/view/ui/screens/AnnounceTransportScreen.kt
+++ b/app/src/main/java/com/ioannapergamali/mysmartroute/view/ui/screens/AnnounceTransportScreen.kt
@@ -315,8 +315,9 @@ fun AnnounceTransportScreen(navController: NavController, openDrawer: () -> Unit
         endLatLng?.let { toMarkerState.position = it }
     }
 
-    ScreenContainer(modifier = Modifier.padding(0.dp)) {
-        Column {
+    ScreenContainer(modifier = Modifier.padding(0.dp), scrollable = false) {
+        LazyColumn {
+            item {
                 TopBar(
                     title = stringResource(R.string.announce_transport),
                     navController = navController,
@@ -843,6 +844,7 @@ fun AnnounceTransportScreen(navController: NavController, openDrawer: () -> Unit
         }
     }
     }
+}
 }
 }
 }


### PR DESCRIPTION
## Summary
- restore `LazyColumn` layout for AnnounceTransportScreen to ensure all fields show

## Testing
- `./gradlew test` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_686a0b2e083083288db491bfc11ad460