### PR TITLE
Fix brace mismatch in AnnounceTransportScreen

### DIFF
--- a/app/src/main/java/com/ioannapergamali/mysmartroute/view/ui/screens/AnnounceTransportScreen.kt
+++ b/app/src/main/java/com/ioannapergamali/mysmartroute/view/ui/screens/AnnounceTransportScreen.kt
@@ -844,3 +844,4 @@ fun AnnounceTransportScreen(navController: NavController, openDrawer: () -> Unit
     }
 }
 }
+}


### PR DESCRIPTION
## Summary
- add missing closing brace to `AnnounceTransportScreen.kt`

## Testing
- `./gradlew test` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_686a178abed48328b2bcaf18e696a3cb