### PR TITLE
Fix scroll in ScreenContainer

### DIFF
--- a/app/src/main/java/com/ioannapergamali/mysmartroute/view/ui/components/ScreenContainer.kt
+++ b/app/src/main/java/com/ioannapergamali/mysmartroute/view/ui/components/ScreenContainer.kt
@@ -35,8 +35,8 @@ fun ScreenContainer(
             ) {
                 Column(
                     modifier = Modifier
-                        .fillMaxSize()
-                        .then(if (scrollable) Modifier.verticalScroll(scrollState) else Modifier),
+                        .then(if (scrollable) Modifier.verticalScroll(scrollState) else Modifier)
+                        .fillMaxWidth(),
                     content = content
                 )
             }


### PR DESCRIPTION
## Summary
- ensure `ScreenContainer` column scrolls correctly by using `verticalScroll` before `fillMaxWidth`

## Testing
- `./gradlew test` *(fails: domain `maven.pkg.jetbrains.space` blocked)*

------
https://chatgpt.com/codex/tasks/task_e_686a1c2718848328babb2f531b2d6716