### PR TITLE
Fix scroll area in ScreenContainer

### DIFF
--- a/app/src/main/java/com/ioannapergamali/mysmartroute/view/ui/components/ScreenContainer.kt
+++ b/app/src/main/java/com/ioannapergamali/mysmartroute/view/ui/components/ScreenContainer.kt
@@ -5,7 +5,6 @@ import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.ColumnScope
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.fillMaxSize
-import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.verticalScroll
@@ -34,10 +33,15 @@ fun ScreenContainer(
                     .border(2.dp, MaterialTheme.colorScheme.primary)
                     .padding(dimensionResource(id = R.dimen.padding_screen))
             ) {
+                val columnModifier = if (scrollable) {
+                    Modifier
+                        .fillMaxSize()
+                        .verticalScroll(scrollState)
+                } else {
+                    Modifier.fillMaxSize()
+                }
                 Column(
-                    modifier = Modifier
-                        .then(if (scrollable) Modifier.verticalScroll(scrollState) else Modifier)
-                        .fillMaxWidth(),
+                    modifier = columnModifier,
                     content = content
                 )
             }


### PR DESCRIPTION
## Summary
- adjust the ScreenContainer to always fill the available space
- apply vertical scrolling when enabled

## Testing
- `./gradlew test --console=plain` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_686a252709548328ae7e92053d4f5422