### PR TITLE
Fix screen container scrolling

### DIFF
--- a/app/src/main/java/com/ioannapergamali/mysmartroute/view/ui/components/ScreenContainer.kt
+++ b/app/src/main/java/com/ioannapergamali/mysmartroute/view/ui/components/ScreenContainer.kt
@@ -36,8 +36,8 @@ fun ScreenContainer(
             ) {
                 Column(
                     modifier = Modifier
-                        .then(if (scrollable) Modifier.verticalScroll(scrollState) else Modifier)
-                        .fillMaxWidth(),
+                        .fillMaxSize()
+                        .then(if (scrollable) Modifier.verticalScroll(scrollState) else Modifier),
                     content = content
                 )
             }


### PR DESCRIPTION
## Summary
- ensure that `ScreenContainer` always fills available space before applying scrolling

## Testing
- `./gradlew lint` *(fails: domain maven.pkg.jetbrains.space blocked)*

------
https://chatgpt.com/codex/tasks/task_e_686a2bd392b083289c16f3a162a50cdc