### PR TITLE
Fix missing closing brace

### DIFF
--- a/app/src/main/java/com/ioannapergamali/mysmartroute/view/ui/screens/AnnounceTransportScreen.kt
+++ b/app/src/main/java/com/ioannapergamali/mysmartroute/view/ui/screens/AnnounceTransportScreen.kt
@@ -844,3 +844,4 @@ fun AnnounceTransportScreen(navController: NavController, openDrawer: () -> Unit
     }
 }
 }
+}


### PR DESCRIPTION
## Summary
- close the AnnounceTransportScreen composable with a missing brace

## Testing
- `./gradlew assembleDebug` *(fails: maven.pkg.jetbrains.space blocked)*

------
https://chatgpt.com/codex/tasks/task_e_686a4c58a5dc8328be30f0cf601d2d54