### PR TITLE
Προσθήκη επιλογής POI στη Δήλωση μεταφοράς

### DIFF
--- a/app/src/main/java/com/ioannapergamali/mysmartroute/data/local/MySmartRouteDatabase.kt
+++ b/app/src/main/java/com/ioannapergamali/mysmartroute/data/local/MySmartRouteDatabase.kt
@@ -15,6 +15,8 @@ import com.ioannapergamali.mysmartroute.data.local.LanguageSettingEntity
 import com.ioannapergamali.mysmartroute.data.local.LanguageSettingDao
 import com.ioannapergamali.mysmartroute.data.local.RouteEntity
 import com.ioannapergamali.mysmartroute.data.local.MovingEntity
+import com.ioannapergamali.mysmartroute.data.local.RoutePointEntity
+import com.ioannapergamali.mysmartroute.data.local.RoutePointDao
 import androidx.room.TypeConverters
 import com.ioannapergamali.mysmartroute.data.local.Converters
 
@@ -30,9 +32,10 @@ import com.ioannapergamali.mysmartroute.data.local.Converters
         MenuOptionEntity::class,
         LanguageSettingEntity::class,
         RouteEntity::class,
-        MovingEntity::class
+        MovingEntity::class,
+        RoutePointEntity::class
     ],
-    version = 24
+    version = 25
 )
 @TypeConverters(Converters::class)
 abstract class MySmartRouteDatabase : RoomDatabase() {
@@ -47,6 +50,7 @@ abstract class MySmartRouteDatabase : RoomDatabase() {
     abstract fun languageSettingDao(): LanguageSettingDao
     abstract fun routeDao(): RouteDao
     abstract fun movingDao(): MovingDao
+    abstract fun routePointDao(): RoutePointDao
 
     companion object {
         @Volatile
@@ -359,6 +363,19 @@ abstract class MySmartRouteDatabase : RoomDatabase() {
             }
         }
 
+        private val MIGRATION_24_25 = object : Migration(24, 25) {
+            override fun migrate(database: SupportSQLiteDatabase) {
+                database.execSQL(
+                    "CREATE TABLE IF NOT EXISTS `route_points` (" +
+                        "`routeId` TEXT NOT NULL, " +
+                        "`position` INTEGER NOT NULL, " +
+                        "`poiId` TEXT NOT NULL, " +
+                        "PRIMARY KEY(`routeId`, `position`)" +
+                        ")"
+                )
+            }
+        }
+
         private fun prepopulate(db: SupportSQLiteDatabase) {
             Log.d(TAG, "Prepopulating database")
             db.execSQL(
@@ -456,7 +473,8 @@ abstract class MySmartRouteDatabase : RoomDatabase() {
                     MIGRATION_18_19,
                     MIGRATION_19_20,
                     MIGRATION_21_22,
-                    MIGRATION_23_24
+                    MIGRATION_23_24,
+                    MIGRATION_24_25
                 )
                     .addCallback(object : RoomDatabase.Callback() {
                         override fun onCreate(db: SupportSQLiteDatabase) {

--- a/app/src/main/java/com/ioannapergamali/mysmartroute/data/local/RoutePointDao.kt
+++ b/app/src/main/java/com/ioannapergamali/mysmartroute/data/local/RoutePointDao.kt
@@ -1,0 +1,15 @@
+package com.ioannapergamali.mysmartroute.data.local
+
+import androidx.room.Dao
+import androidx.room.Insert
+import androidx.room.OnConflictStrategy
+import androidx.room.Query
+
+@Dao
+interface RoutePointDao {
+    @Insert(onConflict = OnConflictStrategy.REPLACE)
+    suspend fun insert(point: RoutePointEntity)
+
+    @Query("SELECT * FROM route_points WHERE routeId = :routeId ORDER BY position")
+    fun getPointsForRoute(routeId: String): kotlinx.coroutines.flow.Flow<List<RoutePointEntity>>
+}

--- a/app/src/main/java/com/ioannapergamali/mysmartroute/data/local/RoutePointEntity.kt
+++ b/app/src/main/java/com/ioannapergamali/mysmartroute/data/local/RoutePointEntity.kt
@@ -1,0 +1,10 @@
+package com.ioannapergamali.mysmartroute.data.local
+
+import androidx.room.Entity
+
+@Entity(tableName = "route_points", primaryKeys = ["routeId", "position"])
+data class RoutePointEntity(
+    val routeId: String,
+    val position: Int,
+    val poiId: String
+)

--- a/app/src/main/res/values-el/strings.xml
+++ b/app/src/main/res/values-el/strings.xml
@@ -112,6 +112,7 @@
     <string name="not_implemented">Η λειτουργία δεν είναι διαθέσιμη</string>
     <string name="route_editor">Επεξεργασία διαδρομής</string>
     <string name="add_stop">Προσθήκη στάσης</string>
+    <string name="add_point">Προσθήκη σημείου</string>
     <string name="edit_route">Επεξεργασία διαδρομής</string>
     <!-- Περιγραφές ρόλων -->
     <string name="role_passenger_desc">Μπορείτε να δείτε διαδρομές και να κάνετε κρατήσεις.</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -111,6 +111,7 @@
     <string name="not_implemented">Functionality not available</string>
     <string name="route_editor">Route Editor</string>
     <string name="add_stop">Add stop</string>
+    <string name="add_point">Add point</string>
     <string name="edit_route">Edit Route</string>
     <!-- Role descriptions -->
     <string name="role_passenger_desc">You can view routes and make bookings.</string>


### PR DESCRIPTION
## Summary
- δημιουργία νέων οντοτήτων RoutePoint και DAO
- επέκταση της βάσης δεδομένων με νέο πίνακα `route_points`
- map extensions για αποθήκευση διαδρομών με πολλά σημεία
- ενημέρωση RouteViewModel για χρήση πολλαπλών POI
- προσθήκη dropdown και εικονιδίων στη Δήλωση μεταφοράς
- νέοι πόροι κειμένου για "Προσθήκη σημείου"

## Testing
- `./gradlew assembleDebug` *(αποτυχημένο: πρόσβαση στο maven.pkg.jetbrains.space μπλοκαρίστηκε)*

------
https://chatgpt.com/codex/tasks/task_e_686c015d4d9c832894952e510cf6cf23