### PR TITLE
Fix dropdown expansion on AnnounceTransportScreen

### DIFF
--- a/app/src/main/java/com/ioannapergamali/mysmartroute/view/ui/screens/AnnounceTransportScreen.kt
+++ b/app/src/main/java/com/ioannapergamali/mysmartroute/view/ui/screens/AnnounceTransportScreen.kt
@@ -146,12 +146,15 @@ fun AnnounceTransportScreen(navController: NavController, openDrawer: () -> Unit
 
             ExposedDropdownMenuBox(
                 expanded = menuExpanded,
-                onExpandedChange = {},
+                onExpandedChange = { menuExpanded = !menuExpanded },
                 modifier = Modifier.fillMaxWidth()
             ) {
                 OutlinedTextField(
                     value = query,
-                    onValueChange = { query = it; menuExpanded = true },
+                    onValueChange = {
+                        query = it
+                        menuExpanded = it.isNotBlank()
+                    },
                     label = { Text(stringResource(R.string.add_point)) },
                     trailingIcon = {
                         Icon(


### PR DESCRIPTION
## Summary
- toggle the dropdown menu correctly in `AnnounceTransportScreen`
- only keep dropdown expanded when there is text input

## Testing
- `./gradlew test` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_686c0cbf2ee48328a31834079ef40e15