### PR TITLE
Fix coroutine import in AnnounceTransportScreen

### DIFF
--- a/app/src/main/java/com/ioannapergamali/mysmartroute/view/ui/screens/AnnounceTransportScreen.kt
+++ b/app/src/main/java/com/ioannapergamali/mysmartroute/view/ui/screens/AnnounceTransportScreen.kt
@@ -44,6 +44,7 @@ import com.ioannapergamali.mysmartroute.viewmodel.PoIViewModel
 import com.ioannapergamali.mysmartroute.viewmodel.RouteViewModel
 import com.ioannapergamali.mysmartroute.data.local.PoIEntity
 import com.ioannapergamali.mysmartroute.model.enumerations.VehicleType
+import kotlinx.coroutines.launch
 
 private const val TAG = "AnnounceTransport"
 


### PR DESCRIPTION
## Summary
- προστέθηκε η εισαγωγή `kotlinx.coroutines.launch` στο `AnnounceTransportScreen.kt`

## Testing
- `./gradlew assembleDebug` *(απέτυχε λόγω περιορισμών πρόσβασης στο διαδίκτυο)*

------
https://chatgpt.com/codex/tasks/task_e_686c14d0970c8328a92d2dba758639e5