### PR TITLE
Βελτίωση διαχείρισης POI και χρωματισμού δρομολογίου

### DIFF
--- a/app/src/main/java/com/ioannapergamali/mysmartroute/view/ui/components/ScreenContainer.kt
+++ b/app/src/main/java/com/ioannapergamali/mysmartroute/view/ui/components/ScreenContainer.kt
@@ -7,6 +7,7 @@ import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.imePadding
 import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.verticalScroll
 import androidx.compose.foundation.text.selection.SelectionContainer
@@ -37,7 +38,8 @@ fun ScreenContainer(
                 Column(
                     modifier = Modifier
                         .fillMaxSize()
-                        .then(if (scrollable) Modifier.verticalScroll(scrollState) else Modifier),
+                        .then(if (scrollable) Modifier.verticalScroll(scrollState) else Modifier)
+                        .imePadding(),
                     content = content
                 )
             }

--- a/app/src/main/java/com/ioannapergamali/mysmartroute/view/ui/screens/AnnounceTransportScreen.kt
+++ b/app/src/main/java/com/ioannapergamali/mysmartroute/view/ui/screens/AnnounceTransportScreen.kt
@@ -23,6 +23,7 @@ import androidx.compose.foundation.clickable
 import com.google.android.gms.maps.model.CameraPosition
 import com.google.android.gms.maps.model.LatLng
 import com.google.android.gms.maps.model.LatLngBounds
+import com.google.android.gms.maps.model.BitmapDescriptorFactory
 import com.google.maps.android.compose.GoogleMap
 import com.google.maps.android.compose.MapProperties
 import com.google.maps.android.compose.rememberCameraPositionState
@@ -117,8 +118,17 @@ fun AnnounceTransportScreen(navController: NavController, openDrawer: () -> Unit
                         }
                     }
                 ) {
-                    routePois.forEach { poi ->
-                        Marker(state = MarkerState(LatLng(poi.lat, poi.lng)), title = poi.name)
+                    routePois.forEachIndexed { index, poi ->
+                        val hue = when (index) {
+                            0 -> BitmapDescriptorFactory.HUE_GREEN
+                            routePois.lastIndex -> BitmapDescriptorFactory.HUE_RED
+                            else -> BitmapDescriptorFactory.HUE_AZURE
+                        }
+                        Marker(
+                            state = MarkerState(LatLng(poi.lat, poi.lng)),
+                            title = poi.name,
+                            icon = BitmapDescriptorFactory.defaultMarker(hue)
+                        )
                     }
                     if (pathPoints.isNotEmpty()) {
                         Polyline(points = pathPoints)

--- a/app/src/main/java/com/ioannapergamali/mysmartroute/viewmodel/PoIViewModel.kt
+++ b/app/src/main/java/com/ioannapergamali/mysmartroute/viewmodel/PoIViewModel.kt
@@ -69,6 +69,7 @@ class PoIViewModel : ViewModel() {
                 lng = lng
             )
             dao.insert(poi)
+            _pois.value = _pois.value + poi
             db.collection("pois")
                 .document(id)
                 .set(poi.toFirestoreMap())


### PR DESCRIPTION
## Περιγραφή
- Προστέθηκε ενημέρωση της λίστας `pois` μετά την αποθήκευση ενός νέου σημείου ενδιαφέροντος
- Τα markers στο χάρτη πλέον αλλάζουν χρώμα (πράσινο για εκκίνηση, μπλε για ενδιάμεσα και κόκκινο για τερματισμό)
- Προστέθηκε `imePadding` ώστε το πληκτρολόγιο να εμφανίζεται πάνω από τις λίστες

## Οδηγίες ελέγχου
- `./gradlew test` (απέτυχε λόγω περιορισμών δικτύου κατά το κατέβασμα βιβλιοθηκών)


------
https://chatgpt.com/codex/tasks/task_e_686c1a5e96648328a8bd91eff171ed9b