### PR TITLE
Ελεγχόμενη λίστα PoI

### DIFF
--- a/app/src/main/java/com/ioannapergamali/mysmartroute/view/ui/screens/AnnounceTransportScreen.kt
+++ b/app/src/main/java/com/ioannapergamali/mysmartroute/view/ui/screens/AnnounceTransportScreen.kt
@@ -39,6 +39,8 @@ import androidx.compose.material3.DropdownMenuItem
 import androidx.compose.material3.ExposedDropdownMenuBox
 import androidx.compose.material3.ExposedDropdownMenuDefaults
 import androidx.lifecycle.viewmodel.compose.viewModel
+import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.lazy.items
 import com.google.maps.android.compose.Marker
 import com.google.maps.android.compose.MarkerState
 import com.ioannapergamali.mysmartroute.viewmodel.PoIViewModel
@@ -152,28 +154,40 @@ fun AnnounceTransportScreen(navController: NavController, openDrawer: () -> Unit
                     value = query,
                     onValueChange = {
                         query = it
-                        menuExpanded = it.isNotBlank()
+                        selectedPoi = selectedPoi?.copy(name = it)
                     },
                     label = { Text(stringResource(R.string.add_point)) },
                     trailingIcon = {
                         Icon(
                             imageVector = Icons.Default.ArrowDropDown,
                             contentDescription = null,
-                            modifier = Modifier.clickable { menuExpanded = !menuExpanded }
+                            modifier = Modifier.clickable {
+                                if (query.isNotBlank()) {
+                                    menuExpanded = !menuExpanded
+                                }
+                            }
                         )
                     },
                     modifier = Modifier
                         .menuAnchor()
                         .fillMaxWidth()
                 )
-                val filtered = pois.filter { it.name.contains(query, true) }.sortedBy { it.name }
-                DropdownMenu(expanded = menuExpanded, onDismissRequest = { menuExpanded = false }) {
-                    filtered.take(4).forEach { poi ->
-                        DropdownMenuItem(text = { Text(poi.name) }, onClick = {
-                            selectedPoi = poi
-                            query = poi.name
-                            menuExpanded = false
-                        })
+                val filtered = if (query.isNotBlank()) {
+                    pois.filter { it.name.contains(query, true) }.sortedBy { it.name }
+                } else emptyList()
+                DropdownMenu(
+                    expanded = menuExpanded,
+                    onDismissRequest = { menuExpanded = false },
+                    modifier = Modifier.heightIn(max = 200.dp)
+                ) {
+                    LazyColumn {
+                        items(filtered) { poi ->
+                            DropdownMenuItem(text = { Text(poi.name) }, onClick = {
+                                selectedPoi = poi
+                                query = poi.name
+                                menuExpanded = false
+                            })
+                        }
                     }
                 }
             }


### PR DESCRIPTION
## Περιγραφή
- δεν ανοίγει αυτόματα η λίστα PoI όταν πληκτρολογούμε
- η λίστα εμφανίζει στοιχεία μόνο αν έχει γραφτεί κείμενο
- δυνατότητα κύλισης στη λίστα επιλογών
- αν ο χρήστης επιστρέφει από ορισμό νέου σημείου, το όνομα παραμένει στο πεδίο και μπορεί να τροποποιηθεί

## Testing
- `./gradlew --version`
- `tail -n 20 /tmp/gradle.log`

Codex couldn't run certain commands due to environment limitations. Consider configuring a setup script or internet access in your Codex environment to install dependencies.

------
https://chatgpt.com/codex/tasks/task_e_686c327a16988328829d86472b7067c7