### PR TITLE
Fix Subcompose intrinsic size crash

### DIFF
--- a/app/src/main/java/com/ioannapergamali/mysmartroute/view/ui/screens/AnnounceTransportScreen.kt
+++ b/app/src/main/java/com/ioannapergamali/mysmartroute/view/ui/screens/AnnounceTransportScreen.kt
@@ -178,7 +178,7 @@ fun AnnounceTransportScreen(navController: NavController, openDrawer: () -> Unit
                 DropdownMenu(
                     expanded = menuExpanded,
                     onDismissRequest = { menuExpanded = false },
-                    modifier = Modifier.heightIn(max = 200.dp)
+                    modifier = Modifier.height(200.dp)
                 ) {
                     LazyColumn {
                         items(filtered) { poi ->


### PR DESCRIPTION
## Summary
- fix DropdownMenu height to avoid intrinsic measurement crash

## Testing
- `./gradlew test --quiet` *(fails: maven.pkg.jetbrains.space blocked)*

------
https://chatgpt.com/codex/tasks/task_e_686c415d0410832895e823f3c5ca33b5