### PR TITLE
Fix settings weight import error

### DIFF
--- a/app/src/main/java/com/ioannapergamali/mysmartroute/view/ui/screens/SettingsScreen.kt
+++ b/app/src/main/java/com/ioannapergamali/mysmartroute/view/ui/screens/SettingsScreen.kt
@@ -3,7 +3,6 @@ package com.ioannapergamali.mysmartroute.view.ui.screens
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.fillMaxWidth
-import androidx.compose.foundation.layout.weight
 import androidx.compose.material3.Button
 import androidx.compose.material3.Divider
 import androidx.compose.material3.DropdownMenu


### PR DESCRIPTION
## Summary
- remove an invalid weight import to fix compilation issue

## Testing
- `./gradlew tasks --no-daemon`
- `./gradlew assembleDebug --no-daemon` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_686c6913a45883288911a6f19b795047