### PR TITLE
Fix compose compiler version

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -43,7 +43,8 @@ android {
     }
 
     composeOptions {
-        kotlinCompilerExtensionVersion = "1.5.15"
+        // Χρησιμοποιούμε την πιο πρόσφατη έκδοση του compiler
+        kotlinCompilerExtensionVersion = "1.6.10"
     }
 
     compileOptions {


### PR DESCRIPTION
## Summary
- update `kotlinCompilerExtensionVersion` to 1.6.10 so that modifier `menuAnchor` is recognised

## Testing
- `./gradlew test --no-daemon` *(fails: Could not resolve dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_686c702997d88328a2f35a4e0bf9216c