### PR TITLE
Update Compose BOM

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -80,8 +80,8 @@ dependencies {
     implementation("androidx.constraintlayout:constraintlayout:2.1.4")
 
     // Jetpack Compose
-    implementation(platform("androidx.compose:compose-bom:2024.06.00"))
-    androidTestImplementation(platform("androidx.compose:compose-bom:2024.06.00"))
+    implementation(platform("androidx.compose:compose-bom:2025.06.01"))
+    androidTestImplementation(platform("androidx.compose:compose-bom:2025.06.01"))
 
     implementation("androidx.compose.material3:material3")
     implementation("androidx.compose.ui:ui")


### PR DESCRIPTION
## Summary
- update Compose BOM to `2025.06.01` so menuAnchor is available

## Testing
- `./gradlew test --dry-run` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_686c7302f4148328835b82cd3a154397