### PR TITLE
Fix DropdownMenu crash

### DIFF
--- a/app/src/main/java/com/ioannapergamali/mysmartroute/view/ui/screens/AnnounceTransportScreen.kt
+++ b/app/src/main/java/com/ioannapergamali/mysmartroute/view/ui/screens/AnnounceTransportScreen.kt
@@ -183,14 +183,15 @@ fun AnnounceTransportScreen(navController: NavController, openDrawer: () -> Unit
                         .fillMaxWidth()
                         .heightIn(max = 300.dp)
                 ) {
-                    LazyColumn {
-                        items(filtered) { poi ->
-                            DropdownMenuItem(text = { Text(poi.name) }, onClick = {
+                    filtered.forEach { poi ->
+                        DropdownMenuItem(
+                            text = { Text(poi.name) },
+                            onClick = {
                                 selectedPoi = poi
                                 query = poi.name
                                 menuExpanded = false
-                            })
-                        }
+                            }
+                        )
                     }
                 }
             }


### PR DESCRIPTION
## Summary
- replace `LazyColumn` in `DropdownMenu` with a simple `forEach` loop

## Testing
- `./gradlew test` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_686c95baac0083289e2a04bd8746c7ed