### PR TITLE
Fix crash with DropdownMenu's LazyColumn

### DIFF
--- a/app/src/main/java/com/ioannapergamali/mysmartroute/view/ui/screens/AnnounceTransportScreen.kt
+++ b/app/src/main/java/com/ioannapergamali/mysmartroute/view/ui/screens/AnnounceTransportScreen.kt
@@ -207,17 +207,15 @@ fun AnnounceTransportScreen(navController: NavController, openDrawer: () -> Unit
                         .fillMaxWidth()
                         .heightIn(max = 300.dp)
                 ) {
-                    LazyColumn {
-                        items(filtered) { poi ->
-                            DropdownMenuItem(
-                                text = { Text(poi.name) },
-                                onClick = {
-                                    selectedPoi = poi
-                                    query = poi.name
-                                    menuExpanded = false
-                                }
-                            )
-                        }
+                    filtered.forEach { poi ->
+                        DropdownMenuItem(
+                            text = { Text(poi.name) },
+                            onClick = {
+                                selectedPoi = poi
+                                query = poi.name
+                                menuExpanded = false
+                            }
+                        )
                     }
                 }
             }


### PR DESCRIPTION
## Summary
- remove nested LazyColumn from `AnnounceTransportScreen` DropdownMenu to avoid SubcomposeLayout intrinsic size crash

## Testing
- `./gradlew test` *(fails: blocked maven.pkg.jetbrains.space)*

------
https://chatgpt.com/codex/tasks/task_e_686c9ed1c13c83288f7be77a110c9ade