### PR TITLE
Fix missing ManageFavorites navigation

### DIFF
--- a/app/src/main/java/com/ioannapergamali/mysmartroute/model/navigation/NavigationHost.kt
+++ b/app/src/main/java/com/ioannapergamali/mysmartroute/model/navigation/NavigationHost.kt
@@ -27,6 +27,7 @@ import com.ioannapergamali.mysmartroute.view.ui.screens.DatabaseSyncScreen
 import com.ioannapergamali.mysmartroute.view.ui.screens.RolesScreen
 import com.ioannapergamali.mysmartroute.view.ui.screens.ProfileScreen
 import com.ioannapergamali.mysmartroute.view.ui.screens.RouteEditorScreen
+import com.ioannapergamali.mysmartroute.view.ui.screens.ManageFavoritesScreen
 
 
 
@@ -135,6 +136,10 @@ fun NavigationHost(navController : NavHostController, openDrawer: () -> Unit) {
 
         composable("profile") {
             ProfileScreen(navController = navController, openDrawer = openDrawer)
+        }
+
+        composable("manageFavorites") {
+            ManageFavoritesScreen(navController = navController, openDrawer = openDrawer)
         }
 
         composable("soundPicker") {

--- a/app/src/main/java/com/ioannapergamali/mysmartroute/view/ui/screens/ManageFavoritesScreen.kt
+++ b/app/src/main/java/com/ioannapergamali/mysmartroute/view/ui/screens/ManageFavoritesScreen.kt
@@ -1,0 +1,31 @@
+package com.ioannapergamali.mysmartroute.view.ui.screens
+
+import androidx.compose.foundation.layout.padding
+import androidx.compose.material3.Scaffold
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.res.stringResource
+import androidx.navigation.NavController
+import com.ioannapergamali.mysmartroute.R
+import com.ioannapergamali.mysmartroute.view.ui.components.ScreenContainer
+import com.ioannapergamali.mysmartroute.view.ui.components.TopBar
+
+@Composable
+fun ManageFavoritesScreen(navController: NavController, openDrawer: () -> Unit) {
+    Scaffold(
+        topBar = {
+            TopBar(
+                title = stringResource(R.string.manage_favorites),
+                navController = navController,
+                showMenu = true,
+                onMenuClick = openDrawer
+            )
+        }
+    ) { padding ->
+        ScreenContainer(modifier = Modifier.padding(padding)) {
+            Text(text = stringResource(R.string.manage_favorites))
+        }
+    }
+}
+


### PR DESCRIPTION
## Summary
- create `ManageFavoritesScreen` with a simple scaffold
- add new route `manageFavorites` to `NavigationHost`

## Testing
- `./gradlew test` *(failed: could not download dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_686f58e490a88328b2125ad95fa6a2c9