### PR TITLE
Fix dropdown menu scroll constraints

### DIFF
--- a/app/src/main/java/com/ioannapergamali/mysmartroute/view/ui/screens/AnnounceTransportScreen.kt
+++ b/app/src/main/java/com/ioannapergamali/mysmartroute/view/ui/screens/AnnounceTransportScreen.kt
@@ -211,14 +211,13 @@ fun AnnounceTransportScreen(navController: NavController, openDrawer: () -> Unit
                 DropdownMenu(
                     expanded = menuExpanded,
                     onDismissRequest = { menuExpanded = false },
-                    modifier = Modifier
-                        .fillMaxWidth()
-                        .heightIn(max = 300.dp)
+                    modifier = Modifier.fillMaxWidth()
                 ) {
                     val scrollState = rememberScrollState()
                     Column(
                         modifier = Modifier
                             .verticalScroll(scrollState)
+                            .heightIn(max = 300.dp)
                             .fillMaxWidth()
                     ) {
                         filtered.forEach { poi ->


### PR DESCRIPTION
## Summary
- ensure dropdown menu items container has a maximum height

## Testing
- `./gradlew test` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_686f5b507334832885c0398bc3501e62