### PR TITLE
Fix search field focus on dropdown

### DIFF
--- a/app/src/main/java/com/ioannapergamali/mysmartroute/view/ui/screens/AnnounceTransportScreen.kt
+++ b/app/src/main/java/com/ioannapergamali/mysmartroute/view/ui/screens/AnnounceTransportScreen.kt
@@ -196,6 +196,7 @@ fun AnnounceTransportScreen(navController: NavController, openDrawer: () -> Unit
                             modifier = Modifier.clickable {
                                 if (query.isNotBlank()) {
                                     menuExpanded = !menuExpanded
+                                    focusRequester.requestFocus()
                                 }
                             }
                         )


### PR DESCRIPTION
## Summary
- keep text field focused when opening the dropdown on AnnounceTransportScreen

## Testing
- `./gradlew test` *(fails: maven.pkg.jetbrains.space blocked)*

------
https://chatgpt.com/codex/tasks/task_e_686f62f18d3883289f6fd91864aeacf4