### PR TITLE
Fix vertical scroll crash

### DIFF
--- a/app/src/main/java/com/ioannapergamali/mysmartroute/view/ui/screens/AnnounceTransportScreen.kt
+++ b/app/src/main/java/com/ioannapergamali/mysmartroute/view/ui/screens/AnnounceTransportScreen.kt
@@ -217,8 +217,8 @@ fun AnnounceTransportScreen(navController: NavController, openDrawer: () -> Unit
                     val scrollState = rememberScrollState()
                     Column(
                         modifier = Modifier
-                            .verticalScroll(scrollState)
                             .heightIn(max = 300.dp)
+                            .verticalScroll(scrollState)
                             .fillMaxWidth()
                     ) {
                         filtered.forEach { poi ->


### PR DESCRIPTION
## Summary
- fix Compose vertical scroll crash by constraining the dropdown menu before applying `verticalScroll`

## Testing
- `./gradlew test` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_686ff9a844308328917d4efcfd6c0922