### PR TITLE
Προσθήκη ACRA για αναφορές σφαλμάτων

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -123,6 +123,9 @@ dependencies {
     // JSON parsing
     implementation("com.google.code.gson:gson:2.13.1")
 
+    // Crash reporting με ACRA
+    implementation("ch.acra:acra-mail:5.12.0")
+
     // Testing
     testImplementation("junit:junit:4.13.2")
     androidTestImplementation("androidx.test.ext:junit:1.1.5")

--- a/app/src/main/java/com/ioannapergamali/mysmartroute/MySmartRouteApplication.kt
+++ b/app/src/main/java/com/ioannapergamali/mysmartroute/MySmartRouteApplication.kt
@@ -1,7 +1,6 @@
 package com.ioannapergamali.mysmartroute
 
 import android.app.Application
-import android.util.Log
 import com.google.firebase.FirebaseApp
 import com.ioannapergamali.mysmartroute.BuildConfig
 import com.ioannapergamali.mysmartroute.utils.ShortcutUtils
@@ -10,11 +9,18 @@ import com.ioannapergamali.mysmartroute.viewmodel.AuthenticationViewModel
 import com.ioannapergamali.mysmartroute.utils.LanguagePreferenceManager
 import com.ioannapergamali.mysmartroute.utils.LocaleUtils
 import kotlinx.coroutines.runBlocking
+import org.acra.ACRA
+import org.acra.annotation.AcraCore
+import org.acra.annotation.AcraMail
+import org.acra.data.StringFormat
 
 
+@AcraCore(buildConfigClass = BuildConfig::class, reportFormat = StringFormat.JSON)
+@AcraMail(mailTo = "ioannapergamali@gmail.com", reportAsFile = false)
 class MySmartRouteApplication : Application() {
     override fun onCreate() {
         super.onCreate()
+        ACRA.init(this)
         val lang = runBlocking { LanguagePreferenceManager.getLanguage(this@MySmartRouteApplication) }
         LocaleUtils.updateLocale(this, lang)
         FirebaseApp.initializeApp(this)


### PR DESCRIPTION
## Περιγραφή
Προστέθηκε η βιβλιοθήκη **ACRA** ώστε τα σφάλματα της εφαρμογής να μπορούν να αποστέλλονται δωρεάν με email.

### Κύριες αλλαγές
- Προσθήκη εξάρτησης `ch.acra:acra-mail:5.12.0` στο `build.gradle.kts`.
- Ενημέρωση της `MySmartRouteApplication` με τα annotations και την κλήση `ACRA.init`.

## Testing
- `./gradlew test` *(απέτυχε λόγω περιορισμών δικτύου για maven.pkg.jetbrains.space)*

------
https://chatgpt.com/codex/tasks/task_e_68700c90e5dc8328a9f53ea3c4602a17