### PR TITLE
Fix ACRA initialization

### DIFF
--- a/app/src/main/java/com/ioannapergamali/mysmartroute/MySmartRouteApplication.kt
+++ b/app/src/main/java/com/ioannapergamali/mysmartroute/MySmartRouteApplication.kt
@@ -9,26 +9,22 @@ import com.ioannapergamali.mysmartroute.viewmodel.AuthenticationViewModel
 import com.ioannapergamali.mysmartroute.utils.LanguagePreferenceManager
 import com.ioannapergamali.mysmartroute.utils.LocaleUtils
 import kotlinx.coroutines.runBlocking
-import org.acra.ACRA
 import org.acra.data.StringFormat
-import org.acra.config.CoreConfigurationBuilder
-import org.acra.config.MailSenderConfigurationBuilder
+import org.acra.ktx.initAcra
+import org.acra.config.mailSender
 
 
 class MySmartRouteApplication : Application() {
     override fun onCreate() {
         super.onCreate()
-        val config = CoreConfigurationBuilder().apply {
-            setBuildConfigClass(BuildConfig::class.java)
-            setReportFormat(StringFormat.JSON)
-            withPluginConfigurations(
-                MailSenderConfigurationBuilder().apply {
-                    setMailTo("ioannapergamali@gmail.com")
-                    setReportAsFile(false)
-                }.build()
-            )
-        }.build()
-        ACRA.init(this, config)
+        initAcra {
+            buildConfigClass = BuildConfig::class.java
+            reportFormat = StringFormat.JSON
+            mailSender {
+                mailTo = "ioannapergamali@gmail.com"
+                reportAsFile = false
+            }
+        }
         val lang = runBlocking { LanguagePreferenceManager.getLanguage(this@MySmartRouteApplication) }
         LocaleUtils.updateLocale(this, lang)
         FirebaseApp.initializeApp(this)


### PR DESCRIPTION
## Summary
- use `initAcra` DSL instead of obsolete builder calls

## Testing
- `./gradlew test` *(fails: maven.pkg.jetbrains.space blocked)*

------
https://chatgpt.com/codex/tasks/task_e_68701cade0508328ac2efe88f57c110f