### PR TITLE
Fix dropdown focus

### DIFF
--- a/app/src/main/java/com/ioannapergamali/mysmartroute/view/ui/screens/AnnounceTransportScreen.kt
+++ b/app/src/main/java/com/ioannapergamali/mysmartroute/view/ui/screens/AnnounceTransportScreen.kt
@@ -173,12 +173,18 @@ fun AnnounceTransportScreen(navController: NavController, openDrawer: () -> Unit
 
             Spacer(Modifier.height(16.dp))
 
+            val focusRequester = remember { FocusRequester() }
             ExposedDropdownMenuBox(
                 expanded = menuExpanded,
-                onExpandedChange = { menuExpanded = !menuExpanded },
+                onExpandedChange = {
+                    if (query.isNotBlank()) {
+                        menuExpanded = !menuExpanded
+                    } else {
+                        focusRequester.requestFocus()
+                    }
+                },
                 modifier = Modifier.fillMaxWidth()
             ) {
-                val focusRequester = remember { FocusRequester() }
                 LaunchedEffect(Unit) { focusRequester.requestFocus() }
                 OutlinedTextField(
                     value = query,


### PR DESCRIPTION
## Summary
- prevent empty dropdown in AnnounceTransportScreen

## Testing
- `./gradlew test` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_6870228e1f208328bd7d833362d2ec87