### PR TITLE
Fix POI dropdown focus

### DIFF
--- a/app/src/main/java/com/ioannapergamali/mysmartroute/view/ui/screens/AnnounceTransportScreen.kt
+++ b/app/src/main/java/com/ioannapergamali/mysmartroute/view/ui/screens/AnnounceTransportScreen.kt
@@ -233,7 +233,8 @@ fun AnnounceTransportScreen(navController: NavController, openDrawer: () -> Unit
                                 onClick = {
                                     selectedPoi = poi
                                     query = poi.name
-                                    menuExpanded = false
+                                    menuExpanded = true
+                                    focusRequester.requestFocus()
                                 }
                             )
                         }


### PR DESCRIPTION
## Summary
- keep text field focused after picking a POI
- leave dropdown menu expanded for easier additional typing

## Testing
- `./gradlew tasks --all` *(fails: SDK location not found)*
- `./gradlew build -x test` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_68702a2984c08328886f74f556e657d4