### PR TITLE
Δυνατότητα αναζήτησης οδών/σπιτιών

### DIFF
--- a/app/src/main/java/com/ioannapergamali/mysmartroute/utils/MapsUtils.kt
+++ b/app/src/main/java/com/ioannapergamali/mysmartroute/utils/MapsUtils.kt
@@ -10,6 +10,7 @@ import kotlinx.coroutines.withContext
 import okhttp3.OkHttpClient
 import okhttp3.Request
 import org.json.JSONObject
+import org.json.JSONArray
 import com.ioannapergamali.mysmartroute.model.enumerations.VehicleType
 
 object MapsUtils {
@@ -153,29 +154,48 @@ object MapsUtils {
         location: LatLng,
         apiKey: String
     ): String? = withContext(Dispatchers.IO) {
-        val url =
+        val nearbyUrl =
             "https://maps.googleapis.com/maps/api/place/nearbysearch/json?" +
                 "location=${location.latitude},${location.longitude}" +
                 "&rankby=distance&type=establishment&key=$apiKey"
-        val request = Request.Builder().url(url).build()
+        val request = Request.Builder().url(nearbyUrl).build()
         client.newCall(request).execute().use { response ->
             val body = response.body?.string()
-            if (!response.isSuccessful) {
-                Log.e(TAG, "fetchNearbyPlaceName failed: ${response.code} - ${response.message}")
-                if (body != null) Log.e(TAG, body)
-                return@withContext null
+            if (response.isSuccessful) {
+                val actualBody = body ?: return@withContext null
+                val jsonObj = JSONObject(actualBody)
+                val status = jsonObj.optString("status")
+                if (status == "OK") {
+                    val results = jsonObj.optJSONArray("results") ?: return@withContext null
+                    if (results.length() > 0) {
+                        return@withContext results.getJSONObject(0).optString("name")
+                    }
+                }
             }
-            val actualBody = body ?: return@withContext null
-            val jsonObj = JSONObject(actualBody)
-            val status = jsonObj.optString("status")
-            if (status != "OK") {
-                Log.e(TAG, "Nearby place name request failed: $status")
-                jsonObj.optString("error_message")?.let { Log.e(TAG, it) }
-                return@withContext null
+
+            // Αν δεν βρέθηκε κάποιο κοντινό "establishment", χρησιμοποιούμε geocoding
+            val geocodeUrl =
+                "https://maps.googleapis.com/maps/api/geocode/json?" +
+                    "latlng=${location.latitude},${location.longitude}&key=$apiKey"
+            val geocodeRequest = Request.Builder().url(geocodeUrl).build()
+            client.newCall(geocodeRequest).execute().use { geoResp ->
+                val geoBody = geoResp.body?.string()
+                if (!geoResp.isSuccessful) {
+                    Log.e(TAG, "geocode name failed: ${geoResp.code} - ${geoResp.message}")
+                    if (geoBody != null) Log.e(TAG, geoBody)
+                    return@withContext null
+                }
+                val geocodeObj = JSONObject(geoBody ?: return@withContext null)
+                val geoStatus = geocodeObj.optString("status")
+                if (geoStatus != "OK") {
+                    Log.e(TAG, "Geocode name request failed: $geoStatus")
+                    geocodeObj.optString("error_message")?.let { Log.e(TAG, it) }
+                    return@withContext null
+                }
+                val geoResults = geocodeObj.optJSONArray("results") ?: return@withContext null
+                if (geoResults.length() == 0) return@withContext null
+                return@withContext geoResults.getJSONObject(0).optString("formatted_address")
             }
-            val results = jsonObj.optJSONArray("results") ?: return@withContext null
-            if (results.length() == 0) return@withContext null
-            return@withContext results.getJSONObject(0).optString("name")
         }
     }
 
@@ -183,38 +203,60 @@ object MapsUtils {
         location: LatLng,
         apiKey: String
     ): Place.Type? = withContext(Dispatchers.IO) {
-        val url =
+        val nearbyUrl =
             "https://maps.googleapis.com/maps/api/place/nearbysearch/json?" +
                 "location=${location.latitude},${location.longitude}" +
                 "&rankby=distance&type=establishment&key=$apiKey"
-        val request = Request.Builder().url(url).build()
+        val request = Request.Builder().url(nearbyUrl).build()
         client.newCall(request).execute().use { response ->
             val body = response.body?.string()
-            if (!response.isSuccessful) {
-                Log.e(TAG, "fetchNearbyPlaceType failed: ${response.code} - ${response.message}")
-                if (body != null) Log.e(TAG, body)
-                return@withContext null
+            var typesArray: org.json.JSONArray? = null
+
+            if (response.isSuccessful) {
+                val jsonObj = JSONObject(body ?: return@withContext null)
+                if (jsonObj.optString("status") == "OK") {
+                    val results = jsonObj.optJSONArray("results")
+                    if (results != null && results.length() > 0) {
+                        typesArray = results.getJSONObject(0).optJSONArray("types")
+                    }
+                }
             }
-            val actualBody = body ?: return@withContext null
-            val jsonObj = JSONObject(actualBody)
-            val status = jsonObj.optString("status")
-            if (status != "OK") {
-                Log.e(TAG, "Nearby place type request failed: $status")
-                jsonObj.optString("error_message")?.let { Log.e(TAG, it) }
-                return@withContext null
+
+            if (typesArray == null || typesArray!!.length() == 0) {
+                // Χρήση geocoding αν δεν υπάρχουν αποτελέσματα establishment
+                val geocodeUrl =
+                    "https://maps.googleapis.com/maps/api/geocode/json?" +
+                        "latlng=${location.latitude},${location.longitude}&key=$apiKey"
+                val geocodeRequest = Request.Builder().url(geocodeUrl).build()
+                client.newCall(geocodeRequest).execute().use { geoResp ->
+                    val geoBody = geoResp.body?.string()
+                    if (!geoResp.isSuccessful) {
+                        Log.e(TAG, "geocode type failed: ${geoResp.code} - ${geoResp.message}")
+                        if (geoBody != null) Log.e(TAG, geoBody)
+                        return@withContext null
+                    }
+                    val geoObj = JSONObject(geoBody ?: return@withContext null)
+                    if (geoObj.optString("status") != "OK") {
+                        Log.e(TAG, "Geocode type request failed: ${geoObj.optString("status")}")
+                        geoObj.optString("error_message")?.let { Log.e(TAG, it) }
+                        return@withContext null
+                    }
+                    val geoResults = geoObj.optJSONArray("results") ?: return@withContext null
+                    if (geoResults.length() == 0) return@withContext null
+                    typesArray = geoResults.getJSONObject(0).optJSONArray("types")
+                }
             }
-            val results = jsonObj.optJSONArray("results") ?: return@withContext null
-            if (results.length() == 0) return@withContext null
+
             val exclude = setOf("POINT_OF_INTEREST", "ESTABLISHMENT", "LOCALITY", "POLITICAL")
-            for (r in 0 until results.length()) {
-                val types = results.getJSONObject(r).optJSONArray("types") ?: continue
-                for (i in 0 until types.length()) {
-                    val typeStr = types.getString(i).uppercase().replace('-', '_')
+            if (typesArray != null) {
+                for (i in 0 until typesArray!!.length()) {
+                    val typeStr = typesArray!!.getString(i).uppercase().replace('-', '_')
                     if (typeStr in exclude) continue
                     val type = runCatching { enumValueOf<Place.Type>(typeStr) }.getOrNull()
                     if (type != null) return@withContext type
                 }
             }
+
             return@withContext null
         }
     }


### PR DESCRIPTION
## Πυρήνας αλλαγών
- fallback σε Google Geocoding API όταν δεν βρίσκουμε κοντινό `establishment`
- εισαγωγή `org.json.JSONArray` και χρήση των αποτελεσμάτων geocode για όνομα και τύπο

## Οδηγίες δοκιμών
- `./gradlew test` *(αποτυγχάνει λόγω περιορισμών δικτύου)*

------
https://chatgpt.com/codex/tasks/task_e_687051beaa688328945f1e007841fd31