### PR TITLE
Fix PoI duplication logic and keep selection state

### DIFF
--- a/app/src/main/java/com/ioannapergamali/mysmartroute/viewmodel/PoIViewModel.kt
+++ b/app/src/main/java/com/ioannapergamali/mysmartroute/viewmodel/PoIViewModel.kt
@@ -53,7 +53,8 @@ class PoIViewModel : ViewModel() {
     ) {
         viewModelScope.launch {
             val dao = MySmartRouteDatabase.getInstance(context).poIDao()
-            val exists = dao.findByLocation(lat, lng) != null || dao.findByName(name) != null
+            // Επιτρέπουμε αποθήκευση ίδιου σημείου αν έχει διαφορετικό όνομα.
+            val exists = dao.findByName(name) != null
             if (exists) {
                 _addState.value = AddPoiState.Exists
                 return@launch


### PR DESCRIPTION
## Summary
- allow saving multiple PoIs at the same location if they use different names
- persist selected point on `AnnounceTransportScreen`
- show message when attempting to add an unsaved point to the route

## Testing
- `./gradlew test --no-daemon` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_687080a12ef48328a7af07980cf38fe8