### PR TITLE
Fix latLngSaver reference

### DIFF
--- a/app/src/main/java/com/ioannapergamali/mysmartroute/utils/LatLngSaver.kt
+++ b/app/src/main/java/com/ioannapergamali/mysmartroute/utils/LatLngSaver.kt
@@ -1,0 +1,13 @@
+package com.ioannapergamali.mysmartroute.utils
+
+import androidx.compose.runtime.saveable.Saver
+import androidx.compose.runtime.saveable.listSaver
+import com.google.android.gms.maps.model.LatLng
+
+/**
+ * A simple [Saver] for [LatLng] objects used with Compose's [rememberSaveable].
+ */
+fun latLngSaver(): Saver<LatLng, List<Double>> = listSaver(
+    save = { listOf(it.latitude, it.longitude) },
+    restore = { LatLng(it[0], it[1]) }
+)

--- a/app/src/main/java/com/ioannapergamali/mysmartroute/view/ui/screens/AnnounceTransportScreen.kt
+++ b/app/src/main/java/com/ioannapergamali/mysmartroute/view/ui/screens/AnnounceTransportScreen.kt
@@ -33,7 +33,7 @@ import com.google.maps.android.compose.GoogleMap
 import com.google.maps.android.compose.MapProperties
 import com.google.maps.android.compose.rememberCameraPositionState
 import com.google.maps.android.compose.Polyline
-import com.google.maps.android.compose.latLngSaver
+import com.ioannapergamali.mysmartroute.utils.latLngSaver
 import com.ioannapergamali.mysmartroute.R
 import com.ioannapergamali.mysmartroute.utils.MapsUtils
 import com.ioannapergamali.mysmartroute.view.ui.components.ScreenContainer
@@ -104,7 +104,7 @@ fun AnnounceTransportScreen(navController: NavController, openDrawer: () -> Unit
     var selectedPoiId by rememberSaveable { mutableStateOf<String?>(null) }
     val selectedPoi = selectedPoiId?.let { id -> pois.find { it.id == id } }
     var selectingPoint by rememberSaveable { mutableStateOf(false) }
-    var unsavedPoint by rememberSaveable(stateSaver = com.google.maps.android.compose.latLngSaver()) { mutableStateOf<LatLng?>(null) }
+    var unsavedPoint by rememberSaveable(stateSaver = latLngSaver()) { mutableStateOf<LatLng?>(null) }
     var unsavedAddress by rememberSaveable { mutableStateOf<String?>(null) }
     val scope = rememberCoroutineScope()
     var pendingPoi by remember { mutableStateOf<Triple<String, Double, Double>?>(null) }


### PR DESCRIPTION
## Summary
- add our own `latLngSaver` implementation
- update `AnnounceTransportScreen` to use new saver

## Testing
- `./gradlew assembleDebug` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_6870862e67b08328b306a095a16597df