### PR TITLE
Fix LatLng saver and nullable state

### DIFF
--- a/app/src/main/java/com/ioannapergamali/mysmartroute/utils/LatLngSaver.kt
+++ b/app/src/main/java/com/ioannapergamali/mysmartroute/utils/LatLngSaver.kt
@@ -11,3 +11,11 @@ fun latLngSaver(): Saver<LatLng, List<Double>> = listSaver(
     save = { listOf(it.latitude, it.longitude) },
     restore = { LatLng(it[0], it[1]) }
 )
+
+/**
+ * A [Saver] that also supports `null` values for [LatLng].
+ */
+fun nullableLatLngSaver(): Saver<LatLng?, List<Double>?> = Saver(
+    save = { it?.let { listOf(it.latitude, it.longitude) } },
+    restore = { it?.let { LatLng(it[0], it[1]) } }
+)

--- a/app/src/main/java/com/ioannapergamali/mysmartroute/view/ui/screens/AnnounceTransportScreen.kt
+++ b/app/src/main/java/com/ioannapergamali/mysmartroute/view/ui/screens/AnnounceTransportScreen.kt
@@ -33,7 +33,7 @@ import com.google.maps.android.compose.GoogleMap
 import com.google.maps.android.compose.MapProperties
 import com.google.maps.android.compose.rememberCameraPositionState
 import com.google.maps.android.compose.Polyline
-import com.ioannapergamali.mysmartroute.utils.latLngSaver
+import com.ioannapergamali.mysmartroute.utils.nullableLatLngSaver
 import com.ioannapergamali.mysmartroute.R
 import com.ioannapergamali.mysmartroute.utils.MapsUtils
 import com.ioannapergamali.mysmartroute.view.ui.components.ScreenContainer
@@ -104,7 +104,7 @@ fun AnnounceTransportScreen(navController: NavController, openDrawer: () -> Unit
     var selectedPoiId by rememberSaveable { mutableStateOf<String?>(null) }
     val selectedPoi = selectedPoiId?.let { id -> pois.find { it.id == id } }
     var selectingPoint by rememberSaveable { mutableStateOf(false) }
-    var unsavedPoint by rememberSaveable(stateSaver = latLngSaver()) { mutableStateOf<LatLng?>(null) }
+    var unsavedPoint by rememberSaveable(stateSaver = nullableLatLngSaver()) { mutableStateOf<LatLng?>(null) }
     var unsavedAddress by rememberSaveable { mutableStateOf<String?>(null) }
     val scope = rememberCoroutineScope()
     var pendingPoi by remember { mutableStateOf<Triple<String, Double, Double>?>(null) }


### PR DESCRIPTION
## Summary
- handle nullable LatLng with a dedicated saver
- update AnnounceTransportScreen to use the new saver

## Testing
- `./gradlew assembleDebug` *(fails: Could not download dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_68708f0d704083289f4eae3eb636b7c0