### PR TITLE
Fix LatLng saver generics

### DIFF
--- a/app/src/main/java/com/ioannapergamali/mysmartroute/utils/LatLngSaver.kt
+++ b/app/src/main/java/com/ioannapergamali/mysmartroute/utils/LatLngSaver.kt
@@ -7,7 +7,7 @@ import com.google.android.gms.maps.model.LatLng
 /**
  * A simple [Saver] for [LatLng] objects used with Compose's [rememberSaveable].
  */
-fun latLngSaver(): Saver<LatLng, List<Double>> = listSaver(
+fun latLngSaver(): Saver<LatLng, List<Double>> = Saver(
     save = { listOf(it.latitude, it.longitude) },
     restore = { LatLng(it[0], it[1]) }
 )

--- a/app/src/main/java/com/ioannapergamali/mysmartroute/view/ui/screens/AnnounceTransportScreen.kt
+++ b/app/src/main/java/com/ioannapergamali/mysmartroute/view/ui/screens/AnnounceTransportScreen.kt
@@ -104,7 +104,9 @@ fun AnnounceTransportScreen(navController: NavController, openDrawer: () -> Unit
     var selectedPoiId by rememberSaveable { mutableStateOf<String?>(null) }
     val selectedPoi = selectedPoiId?.let { id -> pois.find { it.id == id } }
     var selectingPoint by rememberSaveable { mutableStateOf(false) }
-    var unsavedPoint by rememberSaveable(stateSaver = nullableLatLngSaver()) { mutableStateOf<LatLng?>(null) }
+    var unsavedPoint: LatLng? by rememberSaveable(stateSaver = nullableLatLngSaver()) {
+        mutableStateOf<LatLng?>(null)
+    }
     var unsavedAddress by rememberSaveable { mutableStateOf<String?>(null) }
     val scope = rememberCoroutineScope()
     var pendingPoi by remember { mutableStateOf<Triple<String, Double, Double>?>(null) }


### PR DESCRIPTION
## Summary
- fix return type for `latLngSaver`
- ensure `unsavedPoint` is nullable

## Testing
- `./gradlew :app:compileDebugKotlin --quiet` *(fails: could not download dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_6870907fcf488328a4297d1c6088a094