### PR TITLE
Add preview marker and remove option in announce screen

### DIFF
--- a/app/src/main/java/com/ioannapergamali/mysmartroute/view/ui/screens/AnnounceTransportScreen.kt
+++ b/app/src/main/java/com/ioannapergamali/mysmartroute/view/ui/screens/AnnounceTransportScreen.kt
@@ -12,6 +12,7 @@ import androidx.compose.material.icons.filled.Place
 import androidx.compose.material.icons.filled.Search
 import androidx.compose.material.icons.filled.MyLocation
 import androidx.compose.material.icons.filled.Save
+import androidx.compose.material.icons.filled.Close
 import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.Icon
 import androidx.compose.material3.IconButton
@@ -113,6 +114,7 @@ fun AnnounceTransportScreen(navController: NavController, openDrawer: () -> Unit
     var unsavedAddress by rememberSaveable { mutableStateOf<String?>(null) }
     val scope = rememberCoroutineScope()
     var pendingPoi by remember { mutableStateOf<Triple<String, Double, Double>?>(null) }
+    var removeIndex by remember { mutableStateOf<Int?>(null) }
     val fusedLocationClient = remember { LocationServices.getFusedLocationProviderClient(context) }
     val focusRequester = remember { FocusRequester() }
     val keyboardController = LocalSoftwareKeyboardController.current
@@ -222,7 +224,27 @@ fun AnnounceTransportScreen(navController: NavController, openDrawer: () -> Unit
                         Marker(
                             state = MarkerState(LatLng(poi.lat, poi.lng)),
                             title = poi.name,
-                            icon = BitmapDescriptorFactory.defaultMarker(hue)
+                            icon = BitmapDescriptorFactory.defaultMarker(hue),
+                            onClick = {
+                                removeIndex = index
+                                true
+                            }
+                        )
+                    }
+                    selectedPoi?.let { poi ->
+                        if (!routePois.contains(poi)) {
+                            Marker(
+                                state = MarkerState(LatLng(poi.lat, poi.lng)),
+                                title = poi.name,
+                                icon = BitmapDescriptorFactory.defaultMarker(BitmapDescriptorFactory.HUE_ORANGE)
+                            )
+                        }
+                    }
+                    unsavedPoint?.let { latLng ->
+                        Marker(
+                            state = MarkerState(latLng),
+                            title = unsavedAddress,
+                            icon = BitmapDescriptorFactory.defaultMarker(BitmapDescriptorFactory.HUE_ORANGE)
                         )
                     }
                     if (pathPoints.isNotEmpty()) {
@@ -348,6 +370,14 @@ fun AnnounceTransportScreen(navController: NavController, openDrawer: () -> Unit
                     enabled = selectedPoi != null || unsavedPoint != null
                 ) {
                     Icon(Icons.Default.Check, contentDescription = null)
+                }
+                if (removeIndex != null) {
+                    IconButton(onClick = {
+                        removeIndex?.let { routeViewModel.removePoiAt(it) }
+                        removeIndex = null
+                    }) {
+                        Icon(Icons.Default.Close, contentDescription = stringResource(R.string.remove_point))
+                    }
                 }
                 IconButton(onClick = {
                     selectedPoi?.let { navController.navigate("definePoi?lat=${it.lat}&lng=${it.lng}&source=announce&view=true") }

--- a/app/src/main/java/com/ioannapergamali/mysmartroute/viewmodel/RouteViewModel.kt
+++ b/app/src/main/java/com/ioannapergamali/mysmartroute/viewmodel/RouteViewModel.kt
@@ -34,6 +34,14 @@ class RouteViewModel : ViewModel() {
         _currentRoute.value = _currentRoute.value + poi
     }
 
+    fun removePoiAt(index: Int) {
+        val list = _currentRoute.value.toMutableList()
+        if (index in list.indices) {
+            list.removeAt(index)
+            _currentRoute.value = list
+        }
+    }
+
     fun clearCurrentRoute() {
         _currentRoute.value = emptyList()
     }

--- a/app/src/main/res/values-el/strings.xml
+++ b/app/src/main/res/values-el/strings.xml
@@ -115,6 +115,7 @@
     <string name="route_editor">Επεξεργασία διαδρομής</string>
     <string name="add_stop">Προσθήκη στάσης</string>
     <string name="add_point">Προσθήκη σημείου</string>
+    <string name="remove_point">Αφαίρεση σημείου</string>
     <string name="edit_route">Επεξεργασία διαδρομής</string>
     <string name="calculating_route">Υπολογισμός διαδρομής…</string>
     <!-- Περιγραφές ρόλων -->

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -114,6 +114,7 @@
     <string name="route_editor">Route Editor</string>
     <string name="add_stop">Add stop</string>
     <string name="add_point">Add point</string>
+    <string name="remove_point">Remove point</string>
     <string name="edit_route">Edit Route</string>
     <string name="calculating_route">Calculating route…</string>
     <!-- Role descriptions -->


### PR DESCRIPTION
## Summary
- show selected or unsaved point markers on map in AnnounceTransport screen
- enable deleting route markers via a close button
- add `removePoiAt` in `RouteViewModel`
- add new string resources for removing a point

## Testing
- `./gradlew test` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_6870a1be8f6c8328b6b60577fe821227