### PR TITLE
Προσθήκη διαγραφής POI

### DIFF
--- a/app/src/main/java/com/ioannapergamali/mysmartroute/data/local/PoIDao.kt
+++ b/app/src/main/java/com/ioannapergamali/mysmartroute/data/local/PoIDao.kt
@@ -21,4 +21,7 @@ interface PoIDao {
 
     @Query("SELECT * FROM pois WHERE name = :name LIMIT 1")
     suspend fun findByName(name: String): PoIEntity?
+
+    @Query("DELETE FROM pois WHERE id = :id")
+    suspend fun deleteById(id: String)
 }

--- a/app/src/main/java/com/ioannapergamali/mysmartroute/view/ui/screens/PoIListScreen.kt
+++ b/app/src/main/java/com/ioannapergamali/mysmartroute/view/ui/screens/PoIListScreen.kt
@@ -1,17 +1,21 @@
 package com.ioannapergamali.mysmartroute.view.ui.screens
 
-import androidx.compose.foundation.layout.fillMaxSize
-import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.*
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.items
 import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.Icon
+import androidx.compose.material3.IconButton
 import androidx.compose.material3.Scaffold
 import androidx.compose.material3.Text
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.Delete
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.unit.dp
 import androidx.lifecycle.viewmodel.compose.viewModel
 import androidx.compose.ui.platform.LocalContext
 import androidx.navigation.NavController
@@ -34,7 +38,17 @@ fun PoIListScreen(navController: NavController, openDrawer: () -> Unit) {
         ScreenContainer(modifier = Modifier.padding(padding), scrollable = false) {
             LazyColumn(modifier = Modifier.fillMaxSize()) {
                 items(pois) { poi ->
-                    Text(text = "${poi.name} (${poi.lat}, ${poi.lng})")
+                    Row(
+                        modifier = Modifier
+                            .fillMaxWidth()
+                            .padding(vertical = 4.dp),
+                        horizontalArrangement = Arrangement.SpaceBetween
+                    ) {
+                        Text(text = "${poi.name} (${poi.lat}, ${poi.lng})")
+                        IconButton(onClick = { viewModel.deletePoi(context, poi.id) }) {
+                            Icon(imageVector = Icons.Default.Delete, contentDescription = "Διαγραφή")
+                        }
+                    }
                 }
             }
         }

--- a/app/src/main/java/com/ioannapergamali/mysmartroute/viewmodel/PoIViewModel.kt
+++ b/app/src/main/java/com/ioannapergamali/mysmartroute/viewmodel/PoIViewModel.kt
@@ -88,4 +88,13 @@ class PoIViewModel : ViewModel() {
     fun resetAddState() {
         _addState.value = AddPoiState.Idle
     }
+
+    fun deletePoi(context: Context, id: String) {
+        viewModelScope.launch {
+            val dao = MySmartRouteDatabase.getInstance(context).poIDao()
+            dao.deleteById(id)
+            _pois.value = _pois.value.filterNot { it.id == id }
+            db.collection("pois").document(id).delete()
+        }
+    }
 }


### PR DESCRIPTION
## Περιγραφή
Προστέθηκε δυνατότητα διαγραφής σημείων ενδιαφέροντος (POI) μέσα από την οθόνη λίστας.

- Προστέθηκε μέθοδος `deleteById` στο `PoIDao`.
- Προστέθηκε η αντίστοιχη λογική στο `PoIViewModel`.
- Η `PoIListScreen` εμφανίζει κουμπί διαγραφής σε κάθε καταχώρηση.

## Έλεγχοι
- `./gradlew test` (απέτυχε λόγω έλλειψης Android SDK)


------
https://chatgpt.com/codex/tasks/task_e_6870a79b2bcc832888d0746229d67773