### PR TITLE
Βελτίωση προσθήκης σημείων στη δήλωση μεταφοράς

### DIFF
--- a/app/src/main/res/values-el/strings.xml
+++ b/app/src/main/res/values-el/strings.xml
@@ -116,6 +116,7 @@
     <string name="add_stop">Προσθήκη στάσης</string>
     <string name="add_point">Προσθήκη σημείου</string>
     <string name="remove_point">Αφαίρεση σημείου</string>
+    <string name="reset_field">Καθαρισμός πεδίου</string>
     <string name="edit_route">Επεξεργασία διαδρομής</string>
     <string name="calculating_route">Υπολογισμός διαδρομής…</string>
     <string name="save_route">Αποθήκευση διαδρομής</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -115,6 +115,7 @@
     <string name="add_stop">Add stop</string>
     <string name="add_point">Add point</string>
     <string name="remove_point">Remove point</string>
+    <string name="reset_field">Clear field</string>
     <string name="edit_route">Edit Route</string>
     <string name="calculating_route">Calculating route…</string>
     <string name="save_route">Save route</string>


### PR DESCRIPTION
## Περιγραφή
- προστέθηκε κουμπί καθαρισμού πεδίου δίπλα στο εικονίδιο "Current location"
- καθαρισμός προσωρινών τιμών όταν αποθηκεύεται νέο PoI
- αναζήτηση υπάρχοντος σημείου με ανοχή συντεταγμένων
- προστέθηκαν αντίστοιχες συμβολοσειρές σε EN/EL

## Έλεγχοι
- `./gradlew test` *(αποτυχία λόγω έλλειψης Android SDK)*

------
https://chatgpt.com/codex/tasks/task_e_6870b04dc3008328bd77ff6929e38ef2