### PR TITLE
Replace clear icon with refresh

### DIFF
--- a/app/src/main/java/com/ioannapergamali/mysmartroute/view/ui/screens/AnnounceTransportScreen.kt
+++ b/app/src/main/java/com/ioannapergamali/mysmartroute/view/ui/screens/AnnounceTransportScreen.kt
@@ -11,7 +11,7 @@ import androidx.compose.material.icons.filled.Directions
 import androidx.compose.material.icons.filled.Place
 import androidx.compose.material.icons.filled.Search
 import androidx.compose.material.icons.filled.MyLocation
-import androidx.compose.material.icons.filled.Clear
+import androidx.compose.material.icons.filled.Refresh
 import androidx.compose.material.icons.filled.Save
 import androidx.compose.material.icons.filled.Close
 import androidx.compose.material3.ExperimentalMaterial3Api
@@ -297,7 +297,7 @@ fun AnnounceTransportScreen(navController: NavController, openDrawer: () -> Unit
                     trailingIcon = {
                         Row {
                             Icon(
-                                imageVector = Icons.Default.Clear,
+                                imageVector = Icons.Default.Refresh,
                                 contentDescription = stringResource(R.string.reset_field),
                                 modifier = Modifier.clickable {
                                     query = ""


### PR DESCRIPTION
## Summary
- swap the `Clear` icon for `Refresh` in `AnnounceTransportScreen`

## Testing
- `./gradlew tasks --all`
- `./gradlew test` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_6870bc0517f483289e7dd9d3ee467a12