### PR TITLE
Ενημέρωση marker και υπομνήματος χάρτη

### DIFF
--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -119,6 +119,12 @@
     <string name="edit_route">Edit Route</string>
     <string name="calculating_route">Calculating route…</string>
     <string name="save_route">Save route</string>
+    <!-- Legend texts -->
+    <string name="legend_unsaved_point">Μη αποθηκευμένο εκτός διαδρομής</string>
+    <string name="legend_saved_poi">Αποθηκευμένο POI εκτός διαδρομής</string>
+    <string name="legend_route_point">Σημεία διαδρομής</string>
+    <string name="legend_unsaved_route">Μη αποθηκευμένη διαδρομή</string>
+    <string name="legend_saved_route">Αποθηκευμένη διαδρομή</string>
     <!-- Role descriptions -->
     <string name="role_passenger_desc">You can view routes and make bookings.</string>
     <string name="role_driver_desc">You can announce transports and manage vehicles.</string>


### PR DESCRIPTION
## Περιγραφή
Προστέθηκαν χρώματα markers και γραμμής στην οθόνη "Δήλωση μεταφοράς" καθώς και υπόμνημα με επεξήγηση κάτω από τον χάρτη.

### Κύριες αλλαγές
- Νέοι σταθεροί χρωματισμοί markers και μεταβλητή `routeSaved`.
- Ενημέρωση των markers και της polyline ανάλογα με την κατάσταση αποθήκευσης.
- Προσθήκη υπομνήματος με εικονίδια για τα markers και τις γραμμές.
- Νέα strings για το υπόμνημα.

## Έλεγχοι
- `./gradlew test` (απέτυχε λόγω περιορισμών δικτύου)


------
https://chatgpt.com/codex/tasks/task_e_6870c21ff8688328ab4f0445ed3e8b99