### PR TITLE
Ενημέρωση υπομνημάτων χάρτη

### DIFF
--- a/app/src/main/java/com/ioannapergamali/mysmartroute/view/ui/screens/AnnounceTransportScreen.kt
+++ b/app/src/main/java/com/ioannapergamali/mysmartroute/view/ui/screens/AnnounceTransportScreen.kt
@@ -278,27 +278,11 @@ fun AnnounceTransportScreen(navController: NavController, openDrawer: () -> Unit
                 )
             }
 
-            Row(
+            LegendTable(
                 modifier = Modifier
                     .fillMaxWidth()
-                    .padding(top = 8.dp),
-                horizontalArrangement = Arrangement.SpaceEvenly,
-                verticalAlignment = Alignment.CenterVertically
-            ) {
-                MarkerLegendItem(Color.Red, stringResource(R.string.legend_unsaved_point))
-                MarkerLegendItem(Color.Green, stringResource(R.string.legend_saved_poi))
-                MarkerLegendItem(Color.Blue, stringResource(R.string.legend_route_point))
-            }
-            Row(
-                modifier = Modifier
-                    .fillMaxWidth()
-                    .padding(bottom = 8.dp),
-                horizontalArrangement = Arrangement.SpaceEvenly,
-                verticalAlignment = Alignment.CenterVertically
-            ) {
-                LineLegendItem(Color.Red, stringResource(R.string.legend_unsaved_route))
-                LineLegendItem(Color.Green, stringResource(R.string.legend_saved_route))
-            }
+                    .padding(vertical = 8.dp)
+            )
 
             Spacer(Modifier.height(16.dp))
 
@@ -516,8 +500,10 @@ fun AnnounceTransportScreen(navController: NavController, openDrawer: () -> Unit
 @Composable
 private fun MarkerLegendItem(color: Color, text: String) {
     Row(verticalAlignment = Alignment.CenterVertically) {
-        Icon(Icons.Default.Place, contentDescription = null, tint = color)
-        Spacer(Modifier.width(4.dp))
+        Canvas(Modifier.size(12.dp)) {
+            drawCircle(color = color)
+        }
+        Spacer(Modifier.width(8.dp))
         Text(text, style = MaterialTheme.typography.bodySmall)
     }
 }
@@ -525,11 +511,27 @@ private fun MarkerLegendItem(color: Color, text: String) {
 @Composable
 private fun LineLegendItem(color: Color, text: String) {
     Row(verticalAlignment = Alignment.CenterVertically) {
-        Canvas(Modifier.size(width = 24.dp, height = 4.dp)) {
+        Canvas(Modifier.size(width = 24.dp, height = 2.dp)) {
             drawRect(color = color)
         }
-        Spacer(Modifier.width(4.dp))
+        Spacer(Modifier.width(8.dp))
         Text(text, style = MaterialTheme.typography.bodySmall)
+    }
+}
+
+@Composable
+private fun LegendTable(modifier: Modifier = Modifier) {
+    Column(modifier) {
+        Text(
+            text = stringResource(R.string.legend_header),
+            style = MaterialTheme.typography.titleSmall
+        )
+        Spacer(Modifier.height(4.dp))
+        MarkerLegendItem(Color.Red, stringResource(R.string.legend_unsaved_point))
+        MarkerLegendItem(Color.Green, stringResource(R.string.legend_saved_poi))
+        MarkerLegendItem(Color.Blue, stringResource(R.string.legend_route_point))
+        LineLegendItem(Color.Red, stringResource(R.string.legend_unsaved_route))
+        LineLegendItem(Color.Green, stringResource(R.string.legend_saved_route))
     }
 }
 

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -120,6 +120,7 @@
     <string name="calculating_route">Calculating route…</string>
     <string name="save_route">Save route</string>
     <!-- Legend texts -->
+    <string name="legend_header">ΣΗΜΕΙΑ ΔΙΑΔΡΟΜΗΣ</string>
     <string name="legend_unsaved_point">Μη αποθηκευμένο εκτός διαδρομής</string>
     <string name="legend_saved_poi">Αποθηκευμένο POI εκτός διαδρομής</string>
     <string name="legend_route_point">Σημεία διαδρομής</string>


### PR DESCRIPTION
## Summary
- δημιουργήθηκε `LegendTable` για εμφάνιση σε στήλη
- τα εικονίδια υπομνήματος έγιναν κυκλάκια/γραμμές
- προστέθηκε συμβολοσειρά `legend_header`

## Testing
- `./gradlew test --quiet` *(απέτυχε: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_6870d2592dc88328a9e01a0687d34d02