### PR TITLE
Prevent duplicate routes

### DIFF
--- a/app/src/main/java/com/ioannapergamali/mysmartroute/data/local/RouteDao.kt
+++ b/app/src/main/java/com/ioannapergamali/mysmartroute/data/local/RouteDao.kt
@@ -12,4 +12,7 @@ interface RouteDao {
 
     @Query("SELECT * FROM routes")
     fun getAll(): kotlinx.coroutines.flow.Flow<List<RouteEntity>>
+
+    @Query("SELECT * FROM routes WHERE name = :name LIMIT 1")
+    suspend fun findByName(name: String): RouteEntity?
 }

--- a/app/src/main/java/com/ioannapergamali/mysmartroute/view/ui/screens/AnnounceTransportScreen.kt
+++ b/app/src/main/java/com/ioannapergamali/mysmartroute/view/ui/screens/AnnounceTransportScreen.kt
@@ -486,12 +486,19 @@ fun AnnounceTransportScreen(navController: NavController, openDrawer: () -> Unit
             Button(
                 onClick = {
                     val ids = routePois.map { it.id }
-                    if (ids.size >= 2) {
-                        routeViewModel.addRoute(context, ids, routeName)
-                        routeSaved = true
-                        selectedPoiId = null
-                        unsavedPoint = null
-                        unsavedAddress = null
+                    scope.launch {
+                        if (ids.size >= 2) {
+                            val inserted = routeViewModel.addRoute(context, ids, routeName)
+                            if (inserted) {
+                                routeSaved = true
+                                selectedPoiId = null
+                                unsavedPoint = null
+                                unsavedAddress = null
+                                Toast.makeText(context, context.getString(R.string.route_saved_success), Toast.LENGTH_SHORT).show()
+                            } else {
+                                Toast.makeText(context, context.getString(R.string.route_exists), Toast.LENGTH_SHORT).show()
+                            }
+                        }
                     }
                 },
                 enabled = routePois.size >= 2

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -110,6 +110,8 @@
     <string name="poi_details">PoI details</string>
     <string name="save_point">Save point</string>
     <string name="point_not_saved_toast">Please save the point before adding it</string>
+    <string name="route_saved_success">Η διαδρομή αποθηκεύτηκε με επιτυχία</string>
+    <string name="route_exists">Υπάρχει ήδη διαδρομή με αυτό το όνομα</string>
     <string name="not_implemented">Functionality not available</string>
     <string name="route_editor">Route Editor</string>
     <string name="add_stop">Add stop</string>


### PR DESCRIPTION
## Summary
- prevent saving multiple routes with the same name
- show toast messages for success or duplicate
- expose DB query to find route by name

## Testing
- `./gradlew assembleDebug` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_6871141cd58c832884c1ddc8c9f73181