### PR TITLE
Fix crash when inserting poi types

### DIFF
--- a/app/src/main/java/com/ioannapergamali/mysmartroute/data/local/PoiTypeDao.kt
+++ b/app/src/main/java/com/ioannapergamali/mysmartroute/data/local/PoiTypeDao.kt
@@ -9,7 +9,7 @@ import kotlinx.coroutines.flow.Flow
 /** Προσπέλαση τύπων σημείων ενδιαφέροντος. */
 @Dao
 interface PoiTypeDao {
-    @Insert(onConflict = OnConflictStrategy.REPLACE)
+    @Insert(onConflict = OnConflictStrategy.IGNORE)
     suspend fun insertAll(types: List<PoiTypeEntity>)
 
     @Query("SELECT * FROM poi_types")


### PR DESCRIPTION
## Summary
- avoid using REPLACE when inserting POI type entities

## Testing
- `./gradlew test` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_6871108d33b4832889c52639c078c4f4