### PR TITLE
Add vehicle list from Google Places

### DIFF
--- a/app/src/main/java/com/ioannapergamali/mysmartroute/model/classes/vehicles/RemoteVehicle.kt
+++ b/app/src/main/java/com/ioannapergamali/mysmartroute/model/classes/vehicles/RemoteVehicle.kt
@@ -1,0 +1,9 @@
+package com.ioannapergamali.mysmartroute.model.classes.vehicles
+
+/**
+ * Απλό μοντέλο για όχημα που επιστρέφεται από το Google Places API.
+ */
+data class RemoteVehicle(
+    val name: String,
+    val address: String?
+)

--- a/app/src/main/java/com/ioannapergamali/mysmartroute/utils/VehiclePlacesUtils.kt
+++ b/app/src/main/java/com/ioannapergamali/mysmartroute/utils/VehiclePlacesUtils.kt
@@ -1,0 +1,44 @@
+package com.ioannapergamali.mysmartroute.utils
+
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.withContext
+import okhttp3.OkHttpClient
+import okhttp3.Request
+import org.json.JSONObject
+import com.ioannapergamali.mysmartroute.model.classes.vehicles.RemoteVehicle
+
+/**
+ * Βοηθητικό αντικείμενο για άντληση διαθέσιμων οχημάτων από το Google Places API
+ * για τον νομό Ηρακλείου.
+ */
+object VehiclePlacesUtils {
+    private val client = OkHttpClient()
+    private const val HERAKLION_LAT = 35.3387
+    private const val HERAKLION_LNG = 25.1442
+
+    suspend fun fetchVehicles(apiKey: String): List<RemoteVehicle> = withContext(Dispatchers.IO) {
+        val url = buildUrl(apiKey)
+        val request = Request.Builder().url(url).build()
+        client.newCall(request).execute().use { response ->
+            val body = response.body?.string() ?: return@withContext emptyList()
+            if (!response.isSuccessful) return@withContext emptyList()
+            val json = JSONObject(body)
+            if (json.optString("status") != "OK") return@withContext emptyList()
+            val results = json.optJSONArray("results") ?: return@withContext emptyList()
+            val list = mutableListOf<RemoteVehicle>()
+            for (i in 0 until results.length()) {
+                val item = results.getJSONObject(i)
+                val name = item.optString("name")
+                val address = item.optString("vicinity")
+                list.add(RemoteVehicle(name, address))
+            }
+            list
+        }
+    }
+
+    private fun buildUrl(apiKey: String): String {
+        return "https://maps.googleapis.com/maps/api/place/nearbysearch/json?" +
+            "location=$HERAKLION_LAT,$HERAKLION_LNG" +
+            "&radius=50000&type=car_rental&key=$apiKey"
+    }
+}

--- a/app/src/main/java/com/ioannapergamali/mysmartroute/view/ui/screens/RegisterVehicleScreen.kt
+++ b/app/src/main/java/com/ioannapergamali/mysmartroute/view/ui/screens/RegisterVehicleScreen.kt
@@ -12,7 +12,10 @@ import androidx.compose.ui.text.input.KeyboardType
 import androidx.compose.ui.unit.dp
 import androidx.lifecycle.viewmodel.compose.viewModel
 import androidx.navigation.NavController
+import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.lazy.items
 import com.ioannapergamali.mysmartroute.model.enumerations.VehicleType
+import com.ioannapergamali.mysmartroute.model.classes.vehicles.RemoteVehicle
 import com.ioannapergamali.mysmartroute.view.ui.components.TopBar
 import com.ioannapergamali.mysmartroute.view.ui.components.ScreenContainer
 import com.ioannapergamali.mysmartroute.viewmodel.VehicleViewModel
@@ -22,12 +25,15 @@ import com.ioannapergamali.mysmartroute.viewmodel.VehicleViewModel
 fun RegisterVehicleScreen(navController: NavController, openDrawer: () -> Unit) {
     val viewModel: VehicleViewModel = viewModel()
     val state by viewModel.registerState.collectAsState()
+    val available by viewModel.availableVehicles.collectAsState()
     val context = LocalContext.current
 
     var description by remember { mutableStateOf("") }
     var seatInput by remember { mutableStateOf("") }
     var expanded by remember { mutableStateOf(false) }
     var type by remember { mutableStateOf(VehicleType.CAR) }
+
+    LaunchedEffect(Unit) { viewModel.loadAvailableVehicles(context) }
 
     Scaffold(
         topBar = {
@@ -40,6 +46,15 @@ fun RegisterVehicleScreen(navController: NavController, openDrawer: () -> Unit) 
         }
     ) { paddingValues ->
         ScreenContainer(modifier = Modifier.padding(paddingValues)) {
+            if (available.isNotEmpty()) {
+                Text("Google Vehicles for Heraklion:", style = MaterialTheme.typography.titleMedium)
+                LazyColumn(modifier = Modifier.fillMaxWidth().heightIn(max = 200.dp)) {
+                    items(available) { vehicle ->
+                        Text("${vehicle.name} - ${vehicle.address ?: ""}")
+                    }
+                }
+                Spacer(Modifier.height(8.dp))
+            }
             ExposedDropdownMenuBox(expanded = expanded, onExpandedChange = { expanded = !expanded }) {
                 OutlinedTextField(
                     value = type.name,

--- a/app/src/main/java/com/ioannapergamali/mysmartroute/viewmodel/VehicleViewModel.kt
+++ b/app/src/main/java/com/ioannapergamali/mysmartroute/viewmodel/VehicleViewModel.kt
@@ -11,6 +11,9 @@ import com.ioannapergamali.mysmartroute.data.local.VehicleEntity
 import com.ioannapergamali.mysmartroute.data.local.insertVehicleSafely
 import com.ioannapergamali.mysmartroute.model.enumerations.VehicleType
 import com.ioannapergamali.mysmartroute.utils.NetworkUtils
+import com.ioannapergamali.mysmartroute.utils.MapsUtils
+import com.ioannapergamali.mysmartroute.utils.VehiclePlacesUtils
+import com.ioannapergamali.mysmartroute.model.classes.vehicles.RemoteVehicle
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.launch
@@ -22,6 +25,9 @@ class VehicleViewModel : ViewModel() {
 
     private val _vehicles = MutableStateFlow<List<VehicleEntity>>(emptyList())
     val vehicles: StateFlow<List<VehicleEntity>> = _vehicles
+
+    private val _availableVehicles = MutableStateFlow<List<RemoteVehicle>>(emptyList())
+    val availableVehicles: StateFlow<List<RemoteVehicle>> = _availableVehicles
 
     private val _registerState = MutableStateFlow<RegisterState>(RegisterState.Idle)
     val registerState: StateFlow<RegisterState> = _registerState
@@ -77,6 +83,13 @@ class VehicleViewModel : ViewModel() {
             val userId = auth.currentUser?.uid ?: return@launch
             val dao = MySmartRouteDatabase.getInstance(context).vehicleDao()
             _vehicles.value = dao.getVehiclesForUser(userId)
+        }
+    }
+
+    fun loadAvailableVehicles(context: Context) {
+        viewModelScope.launch {
+            val apiKey = MapsUtils.getApiKey(context)
+            _availableVehicles.value = VehiclePlacesUtils.fetchVehicles(apiKey)
         }
     }
 


### PR DESCRIPTION
## Summary
- add `VehiclePlacesUtils` for Google Places API queries
- model remote vehicles with `RemoteVehicle`
- expose available vehicles in `VehicleViewModel`
- show fetched vehicles in `RegisterVehicleScreen`

## Testing
- `./gradlew tasks --no-daemon` *(fails: blocked maven access)*

------
https://chatgpt.com/codex/tasks/task_e_68729ca000188328bd450fa1a982923a