### PR TITLE
Fix Compose scroll crash

### DIFF
--- a/app/src/main/java/com/ioannapergamali/mysmartroute/view/ui/screens/RegisterVehicleScreen.kt
+++ b/app/src/main/java/com/ioannapergamali/mysmartroute/view/ui/screens/RegisterVehicleScreen.kt
@@ -56,7 +56,7 @@ fun RegisterVehicleScreen(navController: NavController, openDrawer: () -> Unit) 
             )
         }
     ) { paddingValues ->
-        ScreenContainer(modifier = Modifier.padding(paddingValues)) {
+        ScreenContainer(modifier = Modifier.padding(paddingValues), scrollable = false) {
             if (available.isNotEmpty()) {
                 Text("Google Vehicles for Heraklion:", style = MaterialTheme.typography.titleMedium)
                 LazyColumn(modifier = Modifier.fillMaxWidth().heightIn(max = 200.dp)) {


### PR DESCRIPTION
## Summary
- avoid nested scroll by disabling parent scroll in RegisterVehicleScreen

## Testing
- `./gradlew test` *(fails: domain is not in allowlist)*

------
https://chatgpt.com/codex/tasks/task_e_6872bc00721c8328a1990f1bc6e1a293