### PR TITLE
Προσθήκη απλών οθονών εκτύπωσης

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -88,7 +88,7 @@ dependencies {
     implementation("androidx.compose.ui:ui-text")
     implementation("androidx.compose.ui:ui-tooling-preview")
     implementation("androidx.compose.runtime:runtime-livedata")
-    implementation("androidx.navigation:navigation-compose:2.7.1")
+    implementation("androidx.navigation:navigation-compose:2.9.1")
     implementation("androidx.compose.material:material-icons-extended")
 
     // DataStore για αποθήκευση ρυθμίσεων

--- a/app/src/main/java/com/ioannapergamali/mysmartroute/model/navigation/NavigationHost.kt
+++ b/app/src/main/java/com/ioannapergamali/mysmartroute/model/navigation/NavigationHost.kt
@@ -28,6 +28,9 @@ import com.ioannapergamali.mysmartroute.view.ui.screens.RolesScreen
 import com.ioannapergamali.mysmartroute.view.ui.screens.ProfileScreen
 import com.ioannapergamali.mysmartroute.view.ui.screens.RouteEditorScreen
 import com.ioannapergamali.mysmartroute.view.ui.screens.ManageFavoritesScreen
+import com.ioannapergamali.mysmartroute.view.ui.screens.PrintCompletedScreen
+import com.ioannapergamali.mysmartroute.view.ui.screens.PrintListScreen
+import com.ioannapergamali.mysmartroute.view.ui.screens.PrintScheduledScreen
 
 
 
@@ -140,6 +143,18 @@ fun NavigationHost(navController : NavHostController, openDrawer: () -> Unit) {
 
         composable("manageFavorites") {
             ManageFavoritesScreen(navController = navController, openDrawer = openDrawer)
+        }
+
+        composable("printList") {
+            PrintListScreen(navController = navController, openDrawer = openDrawer)
+        }
+
+        composable("printScheduled") {
+            PrintScheduledScreen(navController = navController, openDrawer = openDrawer)
+        }
+
+        composable("printCompleted") {
+            PrintCompletedScreen(navController = navController, openDrawer = openDrawer)
         }
 
         composable("soundPicker") {

--- a/app/src/main/java/com/ioannapergamali/mysmartroute/view/ui/screens/PrintCompletedScreen.kt
+++ b/app/src/main/java/com/ioannapergamali/mysmartroute/view/ui/screens/PrintCompletedScreen.kt
@@ -1,0 +1,30 @@
+package com.ioannapergamali.mysmartroute.view.ui.screens
+
+import androidx.compose.foundation.layout.padding
+import androidx.compose.material3.Scaffold
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.res.stringResource
+import androidx.navigation.NavController
+import com.ioannapergamali.mysmartroute.R
+import com.ioannapergamali.mysmartroute.view.ui.components.ScreenContainer
+import com.ioannapergamali.mysmartroute.view.ui.components.TopBar
+
+@Composable
+fun PrintCompletedScreen(navController: NavController, openDrawer: () -> Unit) {
+    Scaffold(
+        topBar = {
+            TopBar(
+                title = stringResource(R.string.print_completed),
+                navController = navController,
+                showMenu = true,
+                onMenuClick = openDrawer
+            )
+        }
+    ) { paddingValues ->
+        ScreenContainer(modifier = Modifier.padding(paddingValues)) {
+            Text(text = stringResource(R.string.not_implemented))
+        }
+    }
+}

--- a/app/src/main/java/com/ioannapergamali/mysmartroute/view/ui/screens/PrintListScreen.kt
+++ b/app/src/main/java/com/ioannapergamali/mysmartroute/view/ui/screens/PrintListScreen.kt
@@ -1,0 +1,30 @@
+package com.ioannapergamali.mysmartroute.view.ui.screens
+
+import androidx.compose.foundation.layout.padding
+import androidx.compose.material3.Scaffold
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.res.stringResource
+import androidx.navigation.NavController
+import com.ioannapergamali.mysmartroute.R
+import com.ioannapergamali.mysmartroute.view.ui.components.ScreenContainer
+import com.ioannapergamali.mysmartroute.view.ui.components.TopBar
+
+@Composable
+fun PrintListScreen(navController: NavController, openDrawer: () -> Unit) {
+    Scaffold(
+        topBar = {
+            TopBar(
+                title = stringResource(R.string.print_list),
+                navController = navController,
+                showMenu = true,
+                onMenuClick = openDrawer
+            )
+        }
+    ) { paddingValues ->
+        ScreenContainer(modifier = Modifier.padding(paddingValues)) {
+            Text(text = stringResource(R.string.not_implemented))
+        }
+    }
+}

--- a/app/src/main/java/com/ioannapergamali/mysmartroute/view/ui/screens/PrintScheduledScreen.kt
+++ b/app/src/main/java/com/ioannapergamali/mysmartroute/view/ui/screens/PrintScheduledScreen.kt
@@ -1,0 +1,30 @@
+package com.ioannapergamali.mysmartroute.view.ui.screens
+
+import androidx.compose.foundation.layout.padding
+import androidx.compose.material3.Scaffold
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.res.stringResource
+import androidx.navigation.NavController
+import com.ioannapergamali.mysmartroute.R
+import com.ioannapergamali.mysmartroute.view.ui.components.ScreenContainer
+import com.ioannapergamali.mysmartroute.view.ui.components.TopBar
+
+@Composable
+fun PrintScheduledScreen(navController: NavController, openDrawer: () -> Unit) {
+    Scaffold(
+        topBar = {
+            TopBar(
+                title = stringResource(R.string.print_scheduled),
+                navController = navController,
+                showMenu = true,
+                onMenuClick = openDrawer
+            )
+        }
+    ) { paddingValues ->
+        ScreenContainer(modifier = Modifier.padding(paddingValues)) {
+            Text(text = stringResource(R.string.not_implemented))
+        }
+    }
+}


### PR DESCRIPTION
## Περίληψη
- δημιουργήθηκαν οι οθόνες `PrintListScreen`, `PrintScheduledScreen` και `PrintCompletedScreen`
- προστέθηκαν οι νέες διαδρομές στο `NavigationHost`
- ενημερώθηκε η βιβλιοθήκη navigation στην έκδοση 2.9.1

## Έλεγχοι
- `./gradlew test` απέτυχε λόγω έλλειψης Android SDK

------
https://chatgpt.com/codex/tasks/task_e_6872a394f0848328b6e936de4d9045fd