### PR TITLE
Αφαίρεση λίστας διαθέσιμων οχημάτων

### DIFF
--- a/app/src/main/java/com/ioannapergamali/mysmartroute/view/ui/screens/RegisterVehicleScreen.kt
+++ b/app/src/main/java/com/ioannapergamali/mysmartroute/view/ui/screens/RegisterVehicleScreen.kt
@@ -59,14 +59,6 @@ fun RegisterVehicleScreen(navController: NavController, openDrawer: () -> Unit) 
         }
     ) { paddingValues ->
         ScreenContainer(modifier = Modifier.padding(paddingValues), scrollable = false) {
-            if (available.isNotEmpty()) {
-                LazyColumn(modifier = Modifier.fillMaxWidth().heightIn(max = 200.dp)) {
-                    items(available) { vehicle ->
-                        Text("${vehicle.name} - ${vehicle.address ?: ""}")
-                    }
-                }
-                Spacer(Modifier.height(8.dp))
-            }
             LazyVerticalGrid(
                 columns = GridCells.Fixed(3),
                 modifier = Modifier.fillMaxWidth(),


### PR DESCRIPTION
## Περιγραφή
Αφαιρέθηκε η προσωρινή προβολή των διαθέσιμων οχημάτων από την οθόνη «Καταχώρηση οχήματος» ώστε να μην εμφανίζονται πλέον τα κείμενα με τις τοποθεσίες πάνω από τα εικονίδια τύπων οχημάτων.

## Testing
- `./gradlew test` *(απέτυχε λόγω περιορισμών δικτύου)*

------
https://chatgpt.com/codex/tasks/task_e_6872c989297c83289ee823025872ebfd