### PR TITLE
Fix keyboard overlap on register vehicle screen

### DIFF
--- a/app/src/main/java/com/ioannapergamali/mysmartroute/view/ui/screens/RegisterVehicleScreen.kt
+++ b/app/src/main/java/com/ioannapergamali/mysmartroute/view/ui/screens/RegisterVehicleScreen.kt
@@ -66,8 +66,7 @@ fun RegisterVehicleScreen(navController: NavController, openDrawer: () -> Unit) 
         }
     ) { paddingValues ->
         ScreenContainer(
-            modifier = Modifier.padding(paddingValues),
-            scrollable = false
+            modifier = Modifier.padding(paddingValues)
         ) {
             LazyVerticalGrid(
                 columns = GridCells.Fixed(3),


### PR DESCRIPTION
## Summary
- enable default scrolling behaviour on RegisterVehicleScreen so content adjusts when the keyboard appears

## Testing
- `./gradlew test --no-daemon` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_68755a9d64b083288f25db3505367866