### PR TITLE
Fix nested scroll crash

### DIFF
--- a/app/src/main/java/com/ioannapergamali/mysmartroute/view/ui/screens/RegisterVehicleScreen.kt
+++ b/app/src/main/java/com/ioannapergamali/mysmartroute/view/ui/screens/RegisterVehicleScreen.kt
@@ -66,7 +66,8 @@ fun RegisterVehicleScreen(navController: NavController, openDrawer: () -> Unit) 
         }
     ) { paddingValues ->
         ScreenContainer(
-            modifier = Modifier.padding(paddingValues)
+            modifier = Modifier.padding(paddingValues),
+            scrollable = false
         ) {
             LazyVerticalGrid(
                 columns = GridCells.Fixed(3),


### PR DESCRIPTION
## Summary
- disable vertical scrolling in `RegisterVehicleScreen` to avoid nested lazy grid crash

## Testing
- `./gradlew test` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_68755c7400748328b3ce6d3efc9f6c41