### PR TITLE
Add imePadding to vehicle grid

### DIFF
--- a/app/src/main/java/com/ioannapergamali/mysmartroute/view/ui/screens/RegisterVehicleScreen.kt
+++ b/app/src/main/java/com/ioannapergamali/mysmartroute/view/ui/screens/RegisterVehicleScreen.kt
@@ -71,7 +71,9 @@ fun RegisterVehicleScreen(navController: NavController, openDrawer: () -> Unit) 
         ) {
             LazyVerticalGrid(
                 columns = GridCells.Fixed(3),
-                modifier = Modifier.fillMaxWidth(),
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .imePadding(),
                 horizontalArrangement = Arrangement.spacedBy(8.dp),
                 verticalArrangement = Arrangement.spacedBy(8.dp)
             ) {


### PR DESCRIPTION
## Summary
- prevent keyboard overlap in `RegisterVehicleScreen` by adding `imePadding()` to `LazyVerticalGrid`

## Testing
- `./gradlew test` *(fails: could not download dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_687560edc7dc83288373b07a165dafa3