### PR TITLE
Fix keyboard overlap in vehicle registration screen

### DIFF
--- a/app/src/main/java/com/ioannapergamali/mysmartroute/view/ui/screens/RegisterVehicleScreen.kt
+++ b/app/src/main/java/com/ioannapergamali/mysmartroute/view/ui/screens/RegisterVehicleScreen.kt
@@ -66,14 +66,12 @@ fun RegisterVehicleScreen(navController: NavController, openDrawer: () -> Unit) 
         }
     ) { paddingValues ->
         ScreenContainer(
-            modifier = Modifier.padding(paddingValues),
-            scrollable = false
+            modifier = Modifier.padding(paddingValues)
         ) {
             LazyVerticalGrid(
                 columns = GridCells.Fixed(3),
                 modifier = Modifier
-                    .fillMaxWidth()
-                    .imePadding(),
+                    .fillMaxWidth(),
                 horizontalArrangement = Arrangement.spacedBy(8.dp),
                 verticalArrangement = Arrangement.spacedBy(8.dp)
             ) {


### PR DESCRIPTION
## Summary
- ensure `RegisterVehicleScreen` scrolls when the keyboard appears
- remove unneeded `imePadding` on the grid

## Testing
- `./gradlew test` *(fails: maven.pkg.jetbrains.space blocked)*

------
https://chatgpt.com/codex/tasks/task_e_68756633399c8328b148b5f6ef19fe9f