### PR TITLE
Add address search with Geocoder

### DIFF
--- a/app/src/main/res/values-el/strings.xml
+++ b/app/src/main/res/values-el/strings.xml
@@ -129,4 +129,5 @@
     <string name="role_driver_desc">Μπορείτε να δηλώνετε διαθέσιμες μεταφορές και να διαχειρίζεστε οχήματα.</string>
     <string name="role_admin_desc">Έχετε πρόσβαση σε λειτουργίες διαχείρισης και ορισμού σημείων ενδιαφέροντος.</string>
     <string name="poi_outside_heraklion">Επιλέξτε σημείο εντός Ηρακλείου</string>
+    <string name="search_address">Αναζήτηση διεύθυνσης</string>
 </resources>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -137,4 +137,5 @@
     <string name="role_driver_desc">You can announce transports and manage vehicles.</string>
     <string name="role_admin_desc">You have access to management functions and defining points of interest.</string>
     <string name="poi_outside_heraklion">Please select a point within Heraklion</string>
+    <string name="search_address">Search address</string>
 </resources>


### PR DESCRIPTION
## Summary
- let users search for addresses within Heraklion
- support a dropdown with geocoding suggestions
- add "search address" string resources

## Testing
- `./gradlew test` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_68759a6dc6f483289fff3392e14629e2