### PR TITLE
Hide search on define from transport

### DIFF
--- a/app/src/main/java/com/ioannapergamali/mysmartroute/view/ui/screens/DefinePoiScreen.kt
+++ b/app/src/main/java/com/ioannapergamali/mysmartroute/view/ui/screens/DefinePoiScreen.kt
@@ -171,53 +171,58 @@ fun DefinePoiScreen(
 
 
 
-            Spacer(Modifier.height(8.dp))
-            ExposedDropdownMenuBox(expanded = addressMenuExpanded, onExpandedChange = { addressMenuExpanded = !addressMenuExpanded }) {
-                OutlinedTextField(
-                    value = addressQuery,
-                    onValueChange = { query ->
-                        addressQuery = query
-                        if (query.length >= 3) {
-                            coroutineScope.launch {
-                                addressResults = geocodeHeraklion(context, query)
-                                addressMenuExpanded = true
-                            }
-                        } else {
-                            addressResults = emptyList()
-                        }
-                    },
-                    label = { Text(stringResource(R.string.search_address)) },
-                    trailingIcon = { ExposedDropdownMenuDefaults.TrailingIcon(expanded = addressMenuExpanded) },
-                    modifier = Modifier.menuAnchor().fillMaxWidth(),
-                    shape = MaterialTheme.shapes.small,
-                    colors = OutlinedTextFieldDefaults.colors(
-                        focusedBorderColor = MaterialTheme.colorScheme.primary,
-                        unfocusedBorderColor = MaterialTheme.colorScheme.primary
-                    )
-                )
-                DropdownMenu(
+            if (source != "announce") {
+                Spacer(Modifier.height(8.dp))
+                ExposedDropdownMenuBox(
                     expanded = addressMenuExpanded,
-                    onDismissRequest = { addressMenuExpanded = false },
-                    modifier = Modifier
-                        .fillMaxWidth()
-                        .heightIn(max = 300.dp)
+                    onExpandedChange = { addressMenuExpanded = !addressMenuExpanded }
                 ) {
-                    addressResults.forEach { addr ->
-                        val line = addr.getAddressLine(0) ?: ""
-                        DropdownMenuItem(text = { Text(line) }, onClick = {
-                            addressQuery = line
-                            addressMenuExpanded = false
-                            streetName = addr.thoroughfare ?: ""
-                            streetNumInput = addr.subThoroughfare ?: ""
-                            city = addr.locality ?: ""
-                            postalCodeInput = addr.postalCode ?: ""
-                            country = addr.countryName ?: ""
-                            selectedLatLng = LatLng(addr.latitude, addr.longitude)
-                            selectedLatLng?.let {
-                                markerState.position = it
-                                cameraPositionState.position = CameraPosition.fromLatLngZoom(it, 13.79f)
+                    OutlinedTextField(
+                        value = addressQuery,
+                        onValueChange = { query ->
+                            addressQuery = query
+                            if (query.length >= 3) {
+                                coroutineScope.launch {
+                                    addressResults = geocodeHeraklion(context, query)
+                                    addressMenuExpanded = true
+                                }
+                            } else {
+                                addressResults = emptyList()
                             }
-                        })
+                        },
+                        label = { Text(stringResource(R.string.search_address)) },
+                        trailingIcon = { ExposedDropdownMenuDefaults.TrailingIcon(expanded = addressMenuExpanded) },
+                        modifier = Modifier.menuAnchor().fillMaxWidth(),
+                        shape = MaterialTheme.shapes.small,
+                        colors = OutlinedTextFieldDefaults.colors(
+                            focusedBorderColor = MaterialTheme.colorScheme.primary,
+                            unfocusedBorderColor = MaterialTheme.colorScheme.primary
+                        )
+                    )
+                    DropdownMenu(
+                        expanded = addressMenuExpanded,
+                        onDismissRequest = { addressMenuExpanded = false },
+                        modifier = Modifier
+                            .fillMaxWidth()
+                            .heightIn(max = 300.dp)
+                    ) {
+                        addressResults.forEach { addr ->
+                            val line = addr.getAddressLine(0) ?: ""
+                            DropdownMenuItem(text = { Text(line) }, onClick = {
+                                addressQuery = line
+                                addressMenuExpanded = false
+                                streetName = addr.thoroughfare ?: ""
+                                streetNumInput = addr.subThoroughfare ?: ""
+                                city = addr.locality ?: ""
+                                postalCodeInput = addr.postalCode ?: ""
+                                country = addr.countryName ?: ""
+                                selectedLatLng = LatLng(addr.latitude, addr.longitude)
+                                selectedLatLng?.let {
+                                    markerState.position = it
+                                    cameraPositionState.position = CameraPosition.fromLatLngZoom(it, 13.79f)
+                                }
+                            })
+                        }
                     }
                 }
             }


### PR DESCRIPTION
## Summary
- hide the address search field on `DefinePoiScreen` when opened from `AnnounceTransport`

## Testing
- `./gradlew test` *(fails: maven.pkg.jetbrains.space blocked)*

------
https://chatgpt.com/codex/tasks/task_e_6875a1b6126483289c80d73dde73d932