### PR TITLE
Μετονομασία DeclareTransport σε Route

### DIFF
--- a/app/src/main/assets/menus.json
+++ b/app/src/main/assets/menus.json
@@ -28,7 +28,7 @@
         "titleKey": "driver_menu_title",
         "options": [
           {"titleKey": "register_vehicle", "route": "registerVehicle"},
-          {"titleKey": "announce_transport", "route": "declareTransport"},
+          {"titleKey": "declare_route", "route": "declareRoute"},
           {"titleKey": "announce_availability", "route": "announceAvailability"},
           {"titleKey": "find_passengers", "route": "findPassengers"},
           {"titleKey": "print_list", "route": "printList"},

--- a/app/src/main/java/com/ioannapergamali/mysmartroute/data/local/MySmartRouteDatabase.kt
+++ b/app/src/main/java/com/ioannapergamali/mysmartroute/data/local/MySmartRouteDatabase.kt
@@ -236,7 +236,7 @@ abstract class MySmartRouteDatabase : RoomDatabase() {
                 val driverMenuId = "menu_driver_main"
                 insertMenu(driverMenuId, "role_driver", "driver_menu_title")
                 insertOption("opt_driver_1", driverMenuId, "register_vehicle", "registerVehicle")
-                insertOption("opt_driver_2", driverMenuId, "announce_transport", "declareTransport")
+                insertOption("opt_driver_2", driverMenuId, "declare_route", "declareRoute")
                 insertOption("opt_driver_3", driverMenuId, "announce_availability", "announceAvailability")
                 insertOption("opt_driver_4", driverMenuId, "find_passengers", "findPassengers")
                 insertOption("opt_driver_5", driverMenuId, "print_list", "printList")
@@ -493,7 +493,7 @@ abstract class MySmartRouteDatabase : RoomDatabase() {
             val driverMenuId = "menu_driver_main"
             insertMenu(driverMenuId, "role_driver", "driver_menu_title")
             insertOption("opt_driver_1", driverMenuId, "register_vehicle", "registerVehicle")
-            insertOption("opt_driver_2", driverMenuId, "announce_transport", "declareTransport")
+            insertOption("opt_driver_2", driverMenuId, "declare_route", "declareRoute")
             insertOption("opt_driver_3", driverMenuId, "announce_availability", "announceAvailability")
             insertOption("opt_driver_4", driverMenuId, "find_passengers", "findPassengers")
             insertOption("opt_driver_5", driverMenuId, "print_list", "printList")

--- a/app/src/main/java/com/ioannapergamali/mysmartroute/model/navigation/NavigationHost.kt
+++ b/app/src/main/java/com/ioannapergamali/mysmartroute/model/navigation/NavigationHost.kt
@@ -10,7 +10,7 @@ import com.ioannapergamali.mysmartroute.view.ui.screens.SignUpScreen
 import com.ioannapergamali.mysmartroute.view.ui.screens.MenuScreen
 import com.ioannapergamali.mysmartroute.view.ui.screens.RegisterVehicleScreen
 import com.ioannapergamali.mysmartroute.view.ui.screens.AnnounceTransportScreen
-import com.ioannapergamali.mysmartroute.view.ui.screens.DeclareTransportScreen
+import com.ioannapergamali.mysmartroute.view.ui.screens.DeclareRouteScreen
 import com.ioannapergamali.mysmartroute.view.ui.screens.DirectionsMapScreen
 import com.ioannapergamali.mysmartroute.view.ui.screens.PoIListScreen
 import com.ioannapergamali.mysmartroute.view.ui.screens.DefinePoiScreen
@@ -71,8 +71,8 @@ fun NavigationHost(navController : NavHostController, openDrawer: () -> Unit) {
             RegisterVehicleScreen(navController = navController, openDrawer = openDrawer)
         }
 
-        composable("declareTransport") {
-            DeclareTransportScreen(navController = navController, openDrawer = openDrawer)
+        composable("declareRoute") {
+            DeclareRouteScreen(navController = navController, openDrawer = openDrawer)
         }
 
         composable("announceAvailability") {

--- a/app/src/main/java/com/ioannapergamali/mysmartroute/view/ui/screens/DeclareRouteScreen.kt
+++ b/app/src/main/java/com/ioannapergamali/mysmartroute/view/ui/screens/DeclareRouteScreen.kt
@@ -21,7 +21,7 @@ import kotlinx.coroutines.launch
 
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable
-fun DeclareTransportScreen(navController: NavController, openDrawer: () -> Unit) {
+fun DeclareRouteScreen(navController: NavController, openDrawer: () -> Unit) {
     val context = LocalContext.current
     val scope = rememberCoroutineScope()
     val routeViewModel: RouteViewModel = viewModel()
@@ -39,7 +39,7 @@ fun DeclareTransportScreen(navController: NavController, openDrawer: () -> Unit)
 
     Scaffold(topBar = {
         TopBar(
-            title = stringResource(R.string.announce_transport),
+            title = stringResource(R.string.declare_route),
             navController = navController,
             showMenu = true,
             onMenuClick = openDrawer


### PR DESCRIPTION
## Ποιες αλλαγές έγιναν
- Μετονομασία του αρχείου και της συνάρτησης `DeclareTransportScreen` σε `DeclareRouteScreen`
- Ενημέρωση του NavigationHost για τη νέα οθόνη και διαδρομή `declareRoute`
- Αντικατάσταση της επιλογής στο `menus.json` και στην αρχικοποίηση βάσης
- Προσαρμογή του τίτλου της οθόνης σε "Δήλωση διαδρομής"

## Οδηγίες ελέγχου
- Το έργο δεν χτίστηκε πλήρως λόγω περιορισμών δικτύου κατά τη λήψη εξαρτήσεων.

------
https://chatgpt.com/codex/tasks/task_e_6875bcf762e48328b6431417afdb4358