### PR TITLE
Βελτίωση οθόνης δήλωσης διαθεσιμότητας

### DIFF
--- a/app/src/main/java/com/ioannapergamali/mysmartroute/data/local/MySmartRouteDatabase.kt
+++ b/app/src/main/java/com/ioannapergamali/mysmartroute/data/local/MySmartRouteDatabase.kt
@@ -38,7 +38,7 @@ import com.ioannapergamali.mysmartroute.data.local.Converters
         RoutePointEntity::class,
         TransportDeclarationEntity::class
     ],
-    version = 29
+    version = 30
 )
 @TypeConverters(Converters::class)
 abstract class MySmartRouteDatabase : RoomDatabase() {
@@ -442,6 +442,12 @@ abstract class MySmartRouteDatabase : RoomDatabase() {
             }
         }
 
+        private val MIGRATION_29_30 = object : Migration(29, 30) {
+            override fun migrate(database: SupportSQLiteDatabase) {
+                database.execSQL("ALTER TABLE `routes` ADD COLUMN `userId` TEXT NOT NULL DEFAULT ''")
+            }
+        }
+
         private fun prepopulate(db: SupportSQLiteDatabase) {
             Log.d(TAG, "Prepopulating database")
             db.execSQL(
@@ -545,7 +551,8 @@ abstract class MySmartRouteDatabase : RoomDatabase() {
                     MIGRATION_25_26,
                     MIGRATION_26_27,
                     MIGRATION_27_28,
-                    MIGRATION_28_29
+                    MIGRATION_28_29,
+                    MIGRATION_29_30
                 )
                     .addCallback(object : RoomDatabase.Callback() {
                         override fun onCreate(db: SupportSQLiteDatabase) {

--- a/app/src/main/java/com/ioannapergamali/mysmartroute/data/local/RouteDao.kt
+++ b/app/src/main/java/com/ioannapergamali/mysmartroute/data/local/RouteDao.kt
@@ -13,6 +13,9 @@ interface RouteDao {
     @Query("SELECT * FROM routes")
     fun getAll(): kotlinx.coroutines.flow.Flow<List<RouteEntity>>
 
+    @Query("SELECT * FROM routes WHERE userId = :userId")
+    fun getRoutesForUser(userId: String): kotlinx.coroutines.flow.Flow<List<RouteEntity>>
+
     @Query("SELECT * FROM routes WHERE name = :name LIMIT 1")
     suspend fun findByName(name: String): RouteEntity?
 }

--- a/app/src/main/java/com/ioannapergamali/mysmartroute/data/local/RouteEntity.kt
+++ b/app/src/main/java/com/ioannapergamali/mysmartroute/data/local/RouteEntity.kt
@@ -6,6 +6,7 @@ import androidx.room.PrimaryKey
 @Entity(tableName = "routes")
 data class RouteEntity(
     @PrimaryKey val id: String = "",
+    val userId: String = "",
     val name: String = "",
     val startPoiId: String = "",
     val endPoiId: String = ""

--- a/app/src/main/java/com/ioannapergamali/mysmartroute/utils/FirestoreMappers.kt
+++ b/app/src/main/java/com/ioannapergamali/mysmartroute/utils/FirestoreMappers.kt
@@ -150,6 +150,7 @@ fun MenuOptionEntity.toFirestoreMap(): Map<String, Any> = mapOf(
 
 fun RouteEntity.toFirestoreMap(points: List<RoutePointEntity> = emptyList()): Map<String, Any> = mapOf(
     "id" to id,
+    "userId" to userId,
     "name" to name,
     "start" to FirebaseFirestore.getInstance().collection("pois").document(startPoiId),
     "end" to FirebaseFirestore.getInstance().collection("pois").document(endPoiId),
@@ -160,6 +161,7 @@ fun RouteEntity.toFirestoreMap(points: List<RoutePointEntity> = emptyList()): Ma
 
 fun DocumentSnapshot.toRouteEntity(): RouteEntity? {
     val routeId = getString("id") ?: id
+    val userId = getString("userId") ?: ""
     val routeName = getString("name") ?: ""
     val start = when (val raw = get("start")) {
         is DocumentReference -> raw.id
@@ -171,7 +173,7 @@ fun DocumentSnapshot.toRouteEntity(): RouteEntity? {
         is String -> raw
         else -> getString("end")
     } ?: return null
-    return RouteEntity(routeId, routeName, start, end)
+    return RouteEntity(routeId, userId, routeName, start, end)
 }
 
 fun DocumentSnapshot.toRouteWithPoints(): Pair<RouteEntity, List<RoutePointEntity>>? {


### PR DESCRIPTION
## Περιγραφή
- Προστέθηκε πεδίο `userId` στο `RouteEntity` και αποθήκευση του στην βάση και στο Firestore.
- Νέο migration 29→30 και ενημέρωση έκδοσης βάσης.
- Προστέθηκε μέθοδος `getRoutesForUser` στο `RouteDao`.
- Το `RouteViewModel` φορτώνει και αποθηκεύει διαδρομές μόνο για τον συνδεδεμένο χρήστη.
- Στην οθόνη δήλωσης διαθεσιμότητας εμφανίζονται μόνο οι κατάλληλες διαδρομές.
  Για λεωφορεία φιλτράρονται διαδρομές με στάσεις τύπου BUS_STOP.

## Δοκιμές
- `./gradlew test` *(απέτυχε λόγω περιορισμένων δικτύων)*

------
https://chatgpt.com/codex/tasks/task_e_68776dadcd44832883c10ab13a236f40