### PR TITLE
Εμφάνιση διάρκειας με format string

### DIFF
--- a/app/src/main/java/com/ioannapergamali/mysmartroute/view/ui/screens/AnnounceTransportScreen.kt
+++ b/app/src/main/java/com/ioannapergamali/mysmartroute/view/ui/screens/AnnounceTransportScreen.kt
@@ -144,7 +144,7 @@ fun AnnounceTransportScreen(navController: NavController, openDrawer: () -> Unit
 
             Spacer(Modifier.height(16.dp))
 
-            Text(stringResource(R.string.duration) + ": $duration")
+            Text(stringResource(R.string.duration_format, duration))
 
             Spacer(Modifier.height(16.dp))
 


### PR DESCRIPTION
## Summary
- use `duration_format` string in `AnnounceTransportScreen`

## Testing
- `./gradlew test --no-daemon` *(fails: domain maven.pkg.jetbrains.space blocked)*

------
https://chatgpt.com/codex/tasks/task_e_687785ee12288328ae170d80b7cfff46