### PR TITLE
Calculate duration via ViewModel

### DIFF
--- a/app/src/main/java/com/ioannapergamali/mysmartroute/view/ui/screens/AnnounceTransportScreen.kt
+++ b/app/src/main/java/com/ioannapergamali/mysmartroute/view/ui/screens/AnnounceTransportScreen.kt
@@ -20,7 +20,6 @@ import com.ioannapergamali.mysmartroute.model.enumerations.VehicleType
 import androidx.compose.ui.platform.LocalContext
 import com.ioannapergamali.mysmartroute.data.local.RouteEntity
 import com.google.android.libraries.places.api.model.Place
-import com.ioannapergamali.mysmartroute.utils.MapsUtils
 import kotlinx.coroutines.launch
 
 @OptIn(ExperimentalMaterial3Api::class)
@@ -65,13 +64,7 @@ fun AnnounceTransportScreen(navController: NavController, openDrawer: () -> Unit
         val vehicle = selectedVehicle
         if (rId != null && vehicle != null) {
             scope.launch {
-                val pois = routeViewModel.getRoutePois(context, rId)
-                if (pois.size >= 2) {
-                    val start = com.google.android.gms.maps.model.LatLng(pois.first().lat, pois.first().lng)
-                    val end = com.google.android.gms.maps.model.LatLng(pois.last().lat, pois.last().lng)
-                    val way = pois.drop(1).dropLast(1).map { com.google.android.gms.maps.model.LatLng(it.lat, it.lng) }
-                    duration = MapsUtils.fetchDuration(start, end, MapsUtils.getApiKey(context), vehicle, way)
-                }
+                duration = routeViewModel.getRouteDuration(context, rId, vehicle)
             }
         }
     }

--- a/app/src/main/java/com/ioannapergamali/mysmartroute/viewmodel/RouteViewModel.kt
+++ b/app/src/main/java/com/ioannapergamali/mysmartroute/viewmodel/RouteViewModel.kt
@@ -12,6 +12,9 @@ import com.ioannapergamali.mysmartroute.data.local.PoIEntity
 import com.ioannapergamali.mysmartroute.utils.NetworkUtils
 import com.ioannapergamali.mysmartroute.utils.toFirestoreMap
 import com.ioannapergamali.mysmartroute.utils.toRouteEntity
+import com.google.android.gms.maps.model.LatLng
+import com.ioannapergamali.mysmartroute.model.enumerations.VehicleType
+import com.ioannapergamali.mysmartroute.utils.MapsUtils
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.first
@@ -98,5 +101,23 @@ class RouteViewModel : ViewModel() {
         points.forEach { pointDao.insert(it) }
 
         return true
+    }
+
+    /**
+     * Υπολογίζει τη διάρκεια διαδρομής με βάση τα αποθηκευμένα σημεία και το επιλεγμένο όχημα.
+     * Χρησιμοποιεί το Google Maps Directions API για να επιστρέψει τη διάρκεια σε λεπτά.
+     */
+    suspend fun getRouteDuration(
+        context: Context,
+        routeId: String,
+        vehicleType: VehicleType
+    ): Int {
+        val pois = getRoutePois(context, routeId)
+        if (pois.size < 2) return 0
+        val origin = LatLng(pois.first().lat, pois.first().lng)
+        val destination = LatLng(pois.last().lat, pois.last().lng)
+        val waypoints = pois.drop(1).dropLast(1).map { LatLng(it.lat, it.lng) }
+        val apiKey = MapsUtils.getApiKey(context)
+        return MapsUtils.fetchDuration(origin, destination, apiKey, vehicleType, waypoints)
     }
 }


### PR DESCRIPTION
## Summary
- move route duration calculation to `RouteViewModel`
- simplify `AnnounceTransportScreen` to use the new method

## Testing
- `./gradlew test --no-daemon` *(fails: maven.pkg.jetbrains.space blocked)*

------
https://chatgpt.com/codex/tasks/task_e_68778f94f44883288731ebfb78631ceb