### PR TITLE
Προσθήκη χάρτη και λίστας στάσεων στη δήλωση διαθεσιμότητας

### DIFF
--- a/app/src/main/java/com/ioannapergamali/mysmartroute/viewmodel/RouteViewModel.kt
+++ b/app/src/main/java/com/ioannapergamali/mysmartroute/viewmodel/RouteViewModel.kt
@@ -120,4 +120,22 @@ class RouteViewModel : ViewModel() {
         val apiKey = MapsUtils.getApiKey(context)
         return MapsUtils.fetchDuration(origin, destination, apiKey, vehicleType, waypoints)
     }
+
+    /**
+     * Επιστρέφει τη διάρκεια και τα σημεία της διαδρομής μέσω του Directions API.
+     */
+    suspend fun getRouteDirections(
+        context: Context,
+        routeId: String,
+        vehicleType: VehicleType
+    ): Pair<Int, List<LatLng>> {
+        val pois = getRoutePois(context, routeId)
+        if (pois.size < 2) return 0 to emptyList()
+        val origin = LatLng(pois.first().lat, pois.first().lng)
+        val destination = LatLng(pois.last().lat, pois.last().lng)
+        val waypoints = pois.drop(1).dropLast(1).map { LatLng(it.lat, it.lng) }
+        val apiKey = MapsUtils.getApiKey(context)
+        val data = MapsUtils.fetchDurationAndPath(origin, destination, apiKey, vehicleType, waypoints)
+        return data.duration to data.points
+    }
 }

--- a/app/src/main/res/values-el/strings.xml
+++ b/app/src/main/res/values-el/strings.xml
@@ -126,6 +126,7 @@
     <string name="calculating_route">Υπολογισμός διαδρομής…</string>
     <string name="save_route">Αποθήκευση διαδρομής</string>
     <string name="route_name">Όνομα διαδρομής</string>
+    <string name="stops_header">Στάσεις</string>
     <!-- Περιγραφές ρόλων -->
     <string name="role_passenger_desc">Μπορείτε να δείτε διαδρομές και να κάνετε κρατήσεις.</string>
     <string name="role_driver_desc">Μπορείτε να δηλώνετε διαθέσιμες μεταφορές και να διαχειρίζεστε οχήματα.</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -127,6 +127,7 @@
     <string name="calculating_route">Calculating route…</string>
     <string name="save_route">Save route</string>
     <string name="route_name">Route name</string>
+    <string name="stops_header">Stops</string>
     <!-- Legend texts -->
     <string name="legend_header">ΣΗΜΕΙΑ ΔΙΑΔΡΟΜΗΣ</string>
     <string name="legend_unsaved_point">Μη αποθηκευμένο εκτός διαδρομής</string>


### PR DESCRIPTION
## Περιγραφή
- προστέθηκε μέθοδος `getRouteDirections` στο `RouteViewModel`
- προβολή μόνο λεωφορείων στην οθόνη δήλωσης διαθεσιμότητας
- εμφάνιση χάρτη της επιλεγμένης διαδρομής μαζί με πολυγραμμή και markers
- προβολή λίστας στάσεων κάτω από τον χάρτη
- προστέθηκαν νέα strings για τις στάσεις σε ελληνικά και αγγλικά

## Testing
- `./gradlew test --no-daemon` *(αποτυχημένο: λείπει Android SDK)*

------
https://chatgpt.com/codex/tasks/task_e_687795d2bdf08328b289480ba7003e8a