### PR TITLE
Αποφυγή αποθήκευσης διαδρομής με κενά πεδία

### DIFF
--- a/app/src/main/java/com/ioannapergamali/mysmartroute/view/ui/screens/DeclareRouteScreen.kt
+++ b/app/src/main/java/com/ioannapergamali/mysmartroute/view/ui/screens/DeclareRouteScreen.kt
@@ -560,7 +560,7 @@ fun DeclareRouteScreen(navController: NavController, openDrawer: () -> Unit) {
                 onClick = {
                     val ids = routePois.map { it.id }
                     scope.launch {
-                        if (ids.size >= 2) {
+                        if (ids.size >= 2 && routeName.isNotBlank()) {
                             val inserted = routeViewModel.addRoute(context, ids, routeName)
                             if (inserted) {
                                 routeSaved = true
@@ -571,10 +571,12 @@ fun DeclareRouteScreen(navController: NavController, openDrawer: () -> Unit) {
                             } else {
                                 Toast.makeText(context, context.getString(R.string.route_exists), Toast.LENGTH_SHORT).show()
                             }
+                        } else {
+                            Toast.makeText(context, context.getString(R.string.fill_all_fields), Toast.LENGTH_SHORT).show()
                         }
                     }
                 },
-                enabled = routePois.size >= 2
+                enabled = routePois.size >= 2 && routeName.isNotBlank()
             ) {
                 Text(stringResource(R.string.save_route))
             }

--- a/app/src/main/java/com/ioannapergamali/mysmartroute/viewmodel/RouteViewModel.kt
+++ b/app/src/main/java/com/ioannapergamali/mysmartroute/viewmodel/RouteViewModel.kt
@@ -90,7 +90,7 @@ class RouteViewModel : ViewModel() {
     }
 
     suspend fun addRoute(context: Context, poiIds: List<String>, name: String): Boolean {
-        if (poiIds.size < 2) return false
+        if (poiIds.size < 2 || name.isBlank()) return false
         val db = MySmartRouteDatabase.getInstance(context)
         val routeDao = db.routeDao()
         val pointDao = db.routePointDao()

--- a/app/src/main/res/values-el/strings.xml
+++ b/app/src/main/res/values-el/strings.xml
@@ -133,4 +133,5 @@
     <string name="role_admin_desc">Έχετε πρόσβαση σε λειτουργίες διαχείρισης και ορισμού σημείων ενδιαφέροντος.</string>
     <string name="poi_outside_heraklion">Επιλέξτε σημείο εντός Ηρακλείου</string>
     <string name="search_address">Αναζήτηση διεύθυνσης</string>
+    <string name="fill_all_fields">Συμπλήρωσε όλα τα πεδία</string>
 </resources>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -141,4 +141,5 @@
     <string name="role_admin_desc">You have access to management functions and defining points of interest.</string>
     <string name="poi_outside_heraklion">Please select a point within Heraklion</string>
     <string name="search_address">Search address</string>
+    <string name="fill_all_fields">Please fill in all fields</string>
 </resources>


### PR DESCRIPTION
## Περιγραφή
- Προστέθηκε έλεγχος στο κουμπί αποθήκευσης ώστε να απαιτείται συμπλήρωση του ονόματος διαδρομής και τουλάχιστον δύο σημεία
- Ενημερώθηκε η `RouteViewModel.addRoute` να απορρίπτει κενό όνομα
- Προστέθηκαν μηνύματα "Συμπλήρωσε όλα τα πεδία" στα strings (EN/GR)

## Οδηγίες δοκιμών
- `./gradlew test` *(αποτυγχάνει λόγω περιορισμών δικτύου)*

------
https://chatgpt.com/codex/tasks/task_e_6877ac12214483289e29d10a3e83cc86