### PR TITLE
Custom color picker

### DIFF
--- a/app/src/main/java/com/ioannapergamali/mysmartroute/model/enumerations/VehicleColor.kt
+++ b/app/src/main/java/com/ioannapergamali/mysmartroute/model/enumerations/VehicleColor.kt
@@ -1,11 +1,13 @@
 package com.ioannapergamali.mysmartroute.model.enumerations
 
-/** Διαθέσιμα χρώματα οχημάτων. */
-enum class VehicleColor(val label: String) {
-    BLACK("Black"),
-    WHITE("White"),
-    RED("Red"),
-    BLUE("Blue"),
-    GREEN("Green"),
-    YELLOW("Yellow")
+import androidx.compose.ui.graphics.Color
+
+/** Διαθέσιμα χρώματα οχημάτων με αντίστοιχο χρώμα για προεπισκόπηση. */
+enum class VehicleColor(val label: String, val color: Color) {
+    BLACK("Black", Color.Black),
+    WHITE("White", Color.White),
+    RED("Red", Color.Red),
+    BLUE("Blue", Color.Blue),
+    GREEN("Green", Color(0xFF4CAF50)),
+    YELLOW("Yellow", Color(0xFFFFEB3B))
 }

--- a/app/src/main/java/com/ioannapergamali/mysmartroute/view/ui/screens/RegisterVehicleScreen.kt
+++ b/app/src/main/java/com/ioannapergamali/mysmartroute/view/ui/screens/RegisterVehicleScreen.kt
@@ -11,6 +11,7 @@ import androidx.compose.material.icons.filled.LocalTaxi
 import androidx.compose.material.icons.filled.TwoWheeler
 import androidx.compose.material.icons.filled.ArrowDropUp
 import androidx.compose.material.icons.filled.ArrowDropDown
+import androidx.compose.material.icons.filled.Add
 import androidx.compose.runtime.*
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.LocalContext
@@ -19,9 +20,13 @@ import androidx.compose.foundation.text.KeyboardOptions
 import androidx.compose.ui.text.input.KeyboardType
 import androidx.compose.ui.unit.dp
 import androidx.compose.foundation.layout.FlowRow
+import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.shape.CircleShape
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.draw.clip
+import androidx.compose.foundation.background
+import androidx.compose.foundation.border
+import androidx.compose.foundation.clickable
 import androidx.lifecycle.viewmodel.compose.viewModel
 import androidx.navigation.NavController
 import com.ioannapergamali.mysmartroute.model.enumerations.VehicleType
@@ -33,6 +38,7 @@ import com.ioannapergamali.mysmartroute.view.ui.components.ScreenContainer
 import com.ioannapergamali.mysmartroute.viewmodel.VehicleViewModel
 import androidx.compose.ui.res.stringResource
 import com.ioannapergamali.mysmartroute.R
+import androidx.compose.ui.graphics.Color
 
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable
@@ -53,6 +59,10 @@ fun RegisterVehicleScreen(navController: NavController, openDrawer: () -> Unit) 
     )
     var description by remember { mutableStateOf(descriptionOptions.first()) }
     var color by remember { mutableStateOf(VehicleColor.BLACK) }
+    var usingCustomColor by remember { mutableStateOf(false) }
+    var customColorName by remember { mutableStateOf("") }
+    var customColorValue by remember { mutableStateOf(Color.Black) }
+    var showCustomDialog by remember { mutableStateOf(false) }
     var seat by remember { mutableStateOf(0) }
     var type by remember { mutableStateOf(VehicleType.CAR) }
     var colorExpanded by remember { mutableStateOf(false) }
@@ -165,11 +175,20 @@ fun RegisterVehicleScreen(navController: NavController, openDrawer: () -> Unit) 
             }
             Spacer(Modifier.height(8.dp))
             ExposedDropdownMenuBox(expanded = colorExpanded, onExpandedChange = { colorExpanded = !colorExpanded }) {
+                val currentLabel = if (usingCustomColor) customColorName else color.label
+                val previewColor = if (usingCustomColor) customColorValue else color.color
                 OutlinedTextField(
-                    value = color.label,
+                    value = currentLabel,
                     onValueChange = {},
                     readOnly = true,
                     label = { Text(stringResource(R.string.vehicle_color)) },
+                    leadingIcon = {
+                        Box(
+                            Modifier
+                                .size(24.dp)
+                                .background(previewColor, CircleShape)
+                        )
+                    },
                     trailingIcon = { ExposedDropdownMenuDefaults.TrailingIcon(expanded = colorExpanded) },
                     modifier = Modifier.menuAnchor().fillMaxWidth(),
                     colors = OutlinedTextFieldDefaults.colors(
@@ -179,12 +198,80 @@ fun RegisterVehicleScreen(navController: NavController, openDrawer: () -> Unit) 
                 )
                 ExposedDropdownMenu(expanded = colorExpanded, onDismissRequest = { colorExpanded = false }) {
                     VehicleColor.values().forEach { option ->
-                        DropdownMenuItem(text = { Text(option.label) }, onClick = {
-                            color = option
-                            colorExpanded = false
-                        })
+                        DropdownMenuItem(
+                            text = { Text(option.label) },
+                            leadingIcon = {
+                                Box(
+                                    Modifier
+                                        .size(24.dp)
+                                        .background(option.color, CircleShape)
+                                )
+                            },
+                            onClick = {
+                                usingCustomColor = false
+                                color = option
+                                colorExpanded = false
+                            }
+                        )
                     }
+                    DropdownMenuItem(
+                        text = { Text("Custom") },
+                        leadingIcon = {
+                            Icon(Icons.Default.Add, contentDescription = null)
+                        },
+                        onClick = {
+                            showCustomDialog = true
+                            colorExpanded = false
+                        }
+                    )
                 }
+            }
+            if (showCustomDialog) {
+                var tempColor by remember { mutableStateOf(customColorValue) }
+                AlertDialog(
+                    onDismissRequest = { showCustomDialog = false },
+                    confirmButton = {
+                        TextButton(onClick = {
+                            customColorValue = tempColor
+                            usingCustomColor = true
+                            if (customColorName.isBlank()) customColorName = "Custom"
+                            showCustomDialog = false
+                        }) { Text("OK") }
+                    },
+                    title = { Text("Επιλογή χρώματος") },
+                    text = {
+                        Column {
+                            val palette = listOf(
+                                Color.Red, Color.Green, Color.Blue, Color.Yellow,
+                                Color.Magenta, Color.Cyan, Color.Black, Color.White
+                            )
+                            FlowRow(
+                                horizontalArrangement = Arrangement.spacedBy(8.dp)
+                            ) {
+                                palette.forEach { c ->
+                                    Box(
+                                        Modifier
+                                            .size(36.dp)
+                                            .background(c, CircleShape)
+                                            .border(
+                                                if (tempColor == c) 2.dp else 1.dp,
+                                                MaterialTheme.colorScheme.primary,
+                                                CircleShape
+                                            )
+                                            .clickable { tempColor = c }
+                                    )
+                                }
+                            }
+                            Spacer(Modifier.height(8.dp))
+                            OutlinedTextField(
+                                value = customColorName,
+                                onValueChange = { customColorName = it },
+                                label = { Text("Όνομα χρώματος") },
+                                singleLine = true
+                            )
+                        }
+                    }
+                )
             }
             Spacer(Modifier.height(8.dp))
             OutlinedTextField(
@@ -227,7 +314,8 @@ fun RegisterVehicleScreen(navController: NavController, openDrawer: () -> Unit) 
 
             Spacer(Modifier.height(16.dp))
             Button(onClick = {
-                viewModel.registerVehicle(context, description, type, seat, color.name, plate)
+                val colorParam = if (usingCustomColor) customColorName else color.name
+                viewModel.registerVehicle(context, description, type, seat, colorParam, plate)
             }) {
                 Text("Register")
             }


### PR DESCRIPTION
## Summary
- προστέθηκαν χρώματα με κωδικό στο `VehicleColor`
- δυνατότητα επιλογής custom χρώματος στην οθόνη καταχώρησης οχήματος
- εμφάνιση κυκλικού εικονιδίου μπροστά από κάθε επιλογή χρώματος

## Testing
- `./gradlew test --no-daemon` *(απέτυχε: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_6877b5c10dbc8328b89e035fbf242a19