### PR TITLE
Custom color picker

### DIFF
--- a/app/src/main/java/com/ioannapergamali/mysmartroute/model/enumerations/VehicleColor.kt
+++ b/app/src/main/java/com/ioannapergamali/mysmartroute/model/enumerations/VehicleColor.kt
@@ -1,11 +1,13 @@
 package com.ioannapergamali.mysmartroute.model.enumerations
 
-/** Διαθέσιμα χρώματα οχημάτων. */
-enum class VehicleColor(val label: String) {
-    BLACK("Black"),
-    WHITE("White"),
-    RED("Red"),
-    BLUE("Blue"),
-    GREEN("Green"),
-    YELLOW("Yellow")
+import androidx.compose.ui.graphics.Color
+
+/** Διαθέσιμα χρώματα οχημάτων με αντίστοιχο χρώμα για προεπισκόπηση. */
+enum class VehicleColor(val label: String, val color: Color) {
+    BLACK("Black", Color.Black),
+    WHITE("White", Color.White),
+    RED("Red", Color.Red),
+    BLUE("Blue", Color.Blue),
+    GREEN("Green", Color(0xFF4CAF50)),
+    YELLOW("Yellow", Color(0xFFFFEB3B))
 }


### PR DESCRIPTION
## Summary
- προστέθηκαν χρώματα με κωδικό στο `VehicleColor`
- δυνατότητα επιλογής custom χρώματος στην οθόνη καταχώρησης οχήματος
- εμφάνιση κυκλικού εικονιδίου μπροστά από κάθε επιλογή χρώματος
- το πεδίο χρώματος ανοίγει πλέον διάλογο με παλέτα χρωμάτων

## Testing
- `./gradlew test --no-daemon` *(απέτυχε: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_6877b5c10dbc8328b89e035fbf242a19