### PR TITLE
Προσθήκη ετικετών στα Ελληνικά για VehicleColor

### DIFF
--- a/app/src/main/java/com/ioannapergamali/mysmartroute/model/enumerations/VehicleColor.kt
+++ b/app/src/main/java/com/ioannapergamali/mysmartroute/model/enumerations/VehicleColor.kt
@@ -4,10 +4,16 @@ import androidx.compose.ui.graphics.Color
 
 /** Διαθέσιμα χρώματα οχημάτων με αντίστοιχο χρώμα για προεπισκόπηση. */
 enum class VehicleColor(val label: String, val color: Color) {
-    BLACK("Black", Color.Black),
-    WHITE("White", Color.White),
-    RED("Red", Color.Red),
-    BLUE("Blue", Color.Blue),
-    GREEN("Green", Color(0xFF4CAF50)),
-    YELLOW("Yellow", Color(0xFFFFEB3B))
+    /** Μαύρο */
+    BLACK("Μαύρο", Color.Black),
+    /** Άσπρο */
+    WHITE("Άσπρο", Color.White),
+    /** Κόκκινο */
+    RED("Κόκκινο", Color.Red),
+    /** Μπλε */
+    BLUE("Μπλε", Color.Blue),
+    /** Πράσινο */
+    GREEN("Πράσινο", Color(0xFF4CAF50)),
+    /** Κίτρινο */
+    YELLOW("Κίτρινο", Color(0xFFFFEB3B))
 }


### PR DESCRIPTION
## Περιγραφή
Ενημερώθηκε το enum `VehicleColor` ώστε οι ετικέτες των χρωμάτων να εμφανίζονται στα ελληνικά. Οι τιμές `Color` παραμένουν, επιτρέποντας σωστή προεπισκόπηση στο picker χρωμάτων.

## Δοκιμές
- `./gradlew assembleDebug` *(αποτυχημένο: λείπει Android SDK)*

------
https://chatgpt.com/codex/tasks/task_e_6877bb8475808328b2b1d8517405d7b1