### PR TITLE
Προσθήκη ColorPicker

### DIFF
--- a/app/src/main/java/com/ioannapergamali/mysmartroute/view/ui/components/ColorPicker.kt
+++ b/app/src/main/java/com/ioannapergamali/mysmartroute/view/ui/components/ColorPicker.kt
@@ -1,0 +1,58 @@
+package com.ioannapergamali.mysmartroute.view.ui.components
+
+import androidx.compose.foundation.background
+import androidx.compose.foundation.border
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.layout.*
+import androidx.compose.foundation.shape.CircleShape
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.graphics.Shape
+import androidx.compose.foundation.layout.FlowRow
+
+/**
+ * Απλός picker χρωμάτων με πλέγμα από κουμπιά.
+ * @param colors Λίστα διαθέσιμων χρωμάτων
+ * @param selectedColor Το επιλεγμένο χρώμα
+ * @param onColorSelected Callback όταν επιλεχθεί χρώμα
+ */
+@Composable
+fun ColorPicker(
+    colors: List<Color>,
+    selectedColor: Color,
+    onColorSelected: (Color) -> Unit,
+    modifier: Modifier = Modifier,
+    shape: Shape = CircleShape
+) {
+    Column(modifier, horizontalAlignment = Alignment.CenterHorizontally) {
+        FlowRow(
+            horizontalArrangement = Arrangement.spacedBy(8.dp),
+            verticalArrangement = Arrangement.spacedBy(8.dp)
+        ) {
+            colors.forEach { color ->
+                Box(
+                    Modifier
+                        .size(36.dp)
+                        .background(color, shape)
+                        .border(
+                            width = if (color == selectedColor) 2.dp else 1.dp,
+                            color = if (color == selectedColor) MaterialTheme.colorScheme.primary else MaterialTheme.colorScheme.onSurface,
+                            shape = shape
+                        )
+                        .clickable { onColorSelected(color) }
+                )
+            }
+        }
+        Spacer(Modifier.height(8.dp))
+        Box(
+            Modifier
+                .size(40.dp)
+                .background(selectedColor, shape)
+                .border(1.dp, MaterialTheme.colorScheme.onSurface, shape)
+        )
+    }
+}

--- a/app/src/main/java/com/ioannapergamali/mysmartroute/view/ui/screens/RegisterVehicleScreen.kt
+++ b/app/src/main/java/com/ioannapergamali/mysmartroute/view/ui/screens/RegisterVehicleScreen.kt
@@ -35,6 +35,7 @@ import androidx.compose.material3.menuAnchor
 import com.ioannapergamali.mysmartroute.model.classes.vehicles.RemoteVehicle
 import com.ioannapergamali.mysmartroute.view.ui.components.TopBar
 import com.ioannapergamali.mysmartroute.view.ui.components.ScreenContainer
+import com.ioannapergamali.mysmartroute.view.ui.components.ColorPicker
 import com.ioannapergamali.mysmartroute.viewmodel.VehicleViewModel
 import androidx.compose.ui.res.stringResource
 import com.ioannapergamali.mysmartroute.R
@@ -245,23 +246,11 @@ fun RegisterVehicleScreen(navController: NavController, openDrawer: () -> Unit) 
                                 Color.Red, Color.Green, Color.Blue, Color.Yellow,
                                 Color.Magenta, Color.Cyan, Color.Black, Color.White
                             )
-                            FlowRow(
-                                horizontalArrangement = Arrangement.spacedBy(8.dp)
-                            ) {
-                                palette.forEach { c ->
-                                    Box(
-                                        Modifier
-                                            .size(36.dp)
-                                            .background(c, CircleShape)
-                                            .border(
-                                                if (tempColor == c) 2.dp else 1.dp,
-                                                MaterialTheme.colorScheme.primary,
-                                                CircleShape
-                                            )
-                                            .clickable { tempColor = c }
-                                    )
-                                }
-                            }
+                            ColorPicker(
+                                colors = palette,
+                                selectedColor = tempColor,
+                                onColorSelected = { tempColor = it }
+                            )
                             Spacer(Modifier.height(8.dp))
                             OutlinedTextField(
                                 value = customColorName,


### PR DESCRIPTION
## Περιγραφή
Προστέθηκε νέο composable `ColorPicker` για επιλογή χρώματος με πλέγμα κουμπιών.
Ενημερώθηκε η οθόνη `RegisterVehicleScreen` ώστε να χρησιμοποιεί το νέο picker στο διάλογο του custom χρώματος.

## Έλεγχοι
- `./gradlew test` *(απέτυχε λόγω έλλειψης Android SDK)*

------
https://chatgpt.com/codex/tasks/task_e_6877d2e6e6108328b1318370ee2ea42e