### PR TITLE
Προσθήκη ColorWheelPicker

### DIFF
--- a/app/src/main/java/com/ioannapergamali/mysmartroute/view/ui/components/ColorWheelPicker.kt
+++ b/app/src/main/java/com/ioannapergamali/mysmartroute/view/ui/components/ColorWheelPicker.kt
@@ -1,0 +1,99 @@
+package com.ioannapergamali.mysmartroute.view.ui.components
+
+import android.graphics.Color as AndroidColor
+import androidx.compose.foundation.Canvas
+import androidx.compose.foundation.background
+import androidx.compose.foundation.border
+import androidx.compose.foundation.gestures.detectTapGestures
+import androidx.compose.foundation.layout.*
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.runtime.*
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.geometry.Offset
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.drawscope.drawIntoCanvas
+import androidx.compose.ui.graphics.drawscope.withTransform
+import androidx.compose.ui.input.pointer.pointerInput
+import androidx.compose.ui.unit.Density
+import androidx.compose.ui.unit.dp
+import kotlin.math.*
+
+/**
+ * Color picker με κυκλική διάταξη που καλύπτει όλο το φάσμα αποχρώσεων.
+ * @param selectedColor Το επιλεγμένο χρώμα
+ * @param onColorSelected Callback όταν γίνει επιλογή
+ * @param modifier Modifier διάταξης
+ * @param shades Πλήθος αποχρώσεων που θα εμφανιστούν
+ */
+@Composable
+fun ColorWheelPicker(
+    selectedColor: Color,
+    onColorSelected: (Color) -> Unit,
+    modifier: Modifier = Modifier,
+    shades: Int = 60
+) {
+    val colors = remember(shades) { generateColorPalette(shades) }
+    BoxWithConstraints(modifier) {
+        val size = min(maxWidth, maxHeight)
+        val circleRadiusPx = with(LocalDensity.current) { (size / 2).toPx() }
+        val itemRadiusPx = with(LocalDensity.current) { 12.dp.toPx() }
+        Canvas(
+            modifier = Modifier
+                .size(size)
+                .pointerInput(colors) {
+                    detectTapGestures { offset ->
+                        val center = Offset(circleRadiusPx, circleRadiusPx)
+                        val angle = ((atan2(offset.y - center.y, offset.x - center.x) + 2 * PI) % (2 * PI))
+                        val index = ((angle / (2 * PI)) * colors.size).roundToInt() % colors.size
+                        onColorSelected(colors[index])
+                    }
+                }
+        ) {
+            val center = Offset(circleRadiusPx, circleRadiusPx)
+            colors.forEachIndexed { index, color ->
+                val angle = 2 * PI * index / colors.size
+                val radius = circleRadiusPx - itemRadiusPx - 4.dp.toPx()
+                val x = center.x + cos(angle) * radius
+                val y = center.y + sin(angle) * radius
+                drawCircle(
+                    color = color,
+                    radius = itemRadiusPx,
+                    center = Offset(x, y)
+                )
+                if (color == selectedColor) {
+                    drawCircle(
+                        color = MaterialTheme.colorScheme.onSurface,
+                        radius = itemRadiusPx + 4.dp.toPx(),
+                        center = Offset(x, y),
+                        style = androidx.compose.ui.graphics.drawscope.Stroke(width = 3.dp.toPx())
+                    )
+                }
+            }
+        }
+    }
+}
+
+/** Δημιουργεί παλέτα χρωμάτων καλύπτοντας όλο το φάσμα αποχρώσεων */
+fun generateColorPalette(shades: Int): List<Color> {
+    return List(shades) { index ->
+        val hue = index * 360f / shades
+        val hsv = floatArrayOf(hue, 1f, 1f)
+        Color(AndroidColor.HSVToColor(hsv))
+    }
+}
+
+/** Επιστρέφει την HEX μορφή ενός χρώματος */
+fun Color.toHex(): String {
+    val r = (red * 255).roundToInt()
+    val g = (green * 255).roundToInt()
+    val b = (blue * 255).roundToInt()
+    return "#%02X%02X%02X".format(r, g, b)
+}
+
+/** Επιστρέφει την RGB μορφή ενός χρώματος */
+fun Color.toRgb(): String {
+    val r = (red * 255).roundToInt()
+    val g = (green * 255).roundToInt()
+    val b = (blue * 255).roundToInt()
+    return "rgb($r,$g,$b)"
+}

--- a/app/src/main/java/com/ioannapergamali/mysmartroute/view/ui/screens/RegisterVehicleScreen.kt
+++ b/app/src/main/java/com/ioannapergamali/mysmartroute/view/ui/screens/RegisterVehicleScreen.kt
@@ -35,7 +35,8 @@ import androidx.compose.material3.menuAnchor
 import com.ioannapergamali.mysmartroute.model.classes.vehicles.RemoteVehicle
 import com.ioannapergamali.mysmartroute.view.ui.components.TopBar
 import com.ioannapergamali.mysmartroute.view.ui.components.ScreenContainer
-import com.ioannapergamali.mysmartroute.view.ui.components.ColorPicker
+import com.ioannapergamali.mysmartroute.view.ui.components.ColorWheelPicker
+import com.ioannapergamali.mysmartroute.view.ui.components.toHex
 import com.ioannapergamali.mysmartroute.viewmodel.VehicleViewModel
 import androidx.compose.ui.res.stringResource
 import com.ioannapergamali.mysmartroute.R
@@ -241,16 +242,14 @@ fun RegisterVehicleScreen(navController: NavController, openDrawer: () -> Unit) 
                     },
                     title = { Text("Επιλογή χρώματος") },
                     text = {
-                        Column {
-                            val palette = listOf(
-                                Color.Red, Color.Green, Color.Blue, Color.Yellow,
-                                Color.Magenta, Color.Cyan, Color.Black, Color.White
-                            )
-                            ColorPicker(
-                                colors = palette,
+                        Column(horizontalAlignment = Alignment.CenterHorizontally) {
+                            ColorWheelPicker(
                                 selectedColor = tempColor,
-                                onColorSelected = { tempColor = it }
+                                onColorSelected = { tempColor = it },
+                                modifier = Modifier.size(220.dp)
                             )
+                            Spacer(Modifier.height(8.dp))
+                            Text(text = tempColor.toHex())
                             Spacer(Modifier.height(8.dp))
                             OutlinedTextField(
                                 value = customColorName,


### PR DESCRIPTION
## Σύνοψη
- δημιουργία νέου composable `ColorWheelPicker` με κυκλική παλέτα χρωμάτων
- επέκταση `RegisterVehicleScreen` ώστε να χρησιμοποιεί τον νέο picker για προσαρμοσμένο χρώμα και εμφάνιση HEX τιμής

## Έλεγχοι
- `./gradlew assembleDebug` *(απέτυχε λόγω περιορισμένων δικτυακών προσβάσεων)*

------
https://chatgpt.com/codex/tasks/task_e_6877e87d47748328873529136ef51627