### PR TITLE
Διόρθωση ColorWheelPicker

### DIFF
--- a/app/src/main/java/com/ioannapergamali/mysmartroute/view/ui/components/ColorWheelPicker.kt
+++ b/app/src/main/java/com/ioannapergamali/mysmartroute/view/ui/components/ColorWheelPicker.kt
@@ -17,7 +17,6 @@ import androidx.compose.ui.input.pointer.pointerInput
 import androidx.compose.ui.platform.LocalDensity
 import androidx.compose.ui.unit.Density
 import androidx.compose.ui.unit.dp
-import androidx.compose.ui.unit.toPx
 import kotlin.math.*
 
 /**
@@ -56,8 +55,8 @@ fun ColorWheelPicker(
             colors.forEachIndexed { index, color ->
                 val angle = 2 * PI * index / colors.size
                 val radius = circleRadiusPx - itemRadiusPx - 4.dp.toPx()
-                val x = center.x + cos(angle) * radius
-                val y = center.y + sin(angle) * radius
+                val x = center.x + cos(angle).toFloat() * radius
+                val y = center.y + sin(angle).toFloat() * radius
                 drawCircle(
                     color = color,
                     radius = itemRadiusPx,


### PR DESCRIPTION
## Συνοπτικά
- αφαίρεση ανύπαρκτου import `toPx`
- μετατροπή των αποτελεσμάτων από `cos`/`sin` σε `Float`

## Testing
- `./gradlew :app:help` *(απέτυχε λόγω περιορισμών δικτύου)*

------
https://chatgpt.com/codex/tasks/task_e_6877fab115dc83289f7fcbdabd1c03b3