### PR TITLE
Προσθήκη προεπισκόπησης custom χρώματος

### DIFF
--- a/app/src/main/java/com/ioannapergamali/mysmartroute/view/ui/screens/RegisterVehicleScreen.kt
+++ b/app/src/main/java/com/ioannapergamali/mysmartroute/view/ui/screens/RegisterVehicleScreen.kt
@@ -249,7 +249,16 @@ fun RegisterVehicleScreen(navController: NavController, openDrawer: () -> Unit) 
                                 modifier = Modifier.size(220.dp)
                             )
                             Spacer(Modifier.height(8.dp))
-                            Text(text = tempColor.toHex())
+                            Row(verticalAlignment = Alignment.CenterVertically) {
+                                Box(
+                                    Modifier
+                                        .size(24.dp)
+                                        .background(tempColor, CircleShape)
+                                        .border(1.dp, MaterialTheme.colorScheme.onSurface, CircleShape)
+                                )
+                                Spacer(Modifier.width(8.dp))
+                                Text(text = tempColor.toHex())
+                            }
                             Spacer(Modifier.height(8.dp))
                             OutlinedTextField(
                                 value = customColorName,


### PR DESCRIPTION
## Πραγματοποιήθηκαν αλλαγές
- Προστέθηκε προεπισκόπηση του επιλεγμένου custom χρώματος με κυκλάκι και το HEX

## Οδηγίες ελέγχου
- `./gradlew test --no-daemon` *(αποτυγχάνει λόγω έλλειψης Android SDK)*

------
https://chatgpt.com/codex/tasks/task_e_6877fd4643a88328862c09d8ab21088a