### PR TITLE
Add hex color input and validation for vehicle registration

### DIFF
--- a/app/src/main/java/com/ioannapergamali/mysmartroute/view/ui/components/ColorWheelPicker.kt
+++ b/app/src/main/java/com/ioannapergamali/mysmartroute/view/ui/components/ColorWheelPicker.kt
@@ -99,3 +99,10 @@ fun Color.toRgb(): String {
     val b = (blue * 255).roundToInt()
     return "rgb($r,$g,$b)"
 }
+
+/** Μετατρέπει μια συμβολοσειρά HEX σε [Color] αν είναι έγκυρη */
+fun String.toColorOrNull(): Color? = try {
+    Color(AndroidColor.parseColor(this))
+} catch (_: Exception) {
+    null
+}

--- a/app/src/main/java/com/ioannapergamali/mysmartroute/view/ui/screens/RegisterVehicleScreen.kt
+++ b/app/src/main/java/com/ioannapergamali/mysmartroute/view/ui/screens/RegisterVehicleScreen.kt
@@ -37,6 +37,7 @@ import com.ioannapergamali.mysmartroute.view.ui.components.TopBar
 import com.ioannapergamali.mysmartroute.view.ui.components.ScreenContainer
 import com.ioannapergamali.mysmartroute.view.ui.components.ColorWheelPicker
 import com.ioannapergamali.mysmartroute.view.ui.components.toHex
+import com.ioannapergamali.mysmartroute.view.ui.components.toColorOrNull
 import com.ioannapergamali.mysmartroute.viewmodel.VehicleViewModel
 import androidx.compose.ui.res.stringResource
 import com.ioannapergamali.mysmartroute.R
@@ -230,6 +231,7 @@ fun RegisterVehicleScreen(navController: NavController, openDrawer: () -> Unit) 
             }
             if (showCustomDialog) {
                 var tempColor by remember { mutableStateOf(customColorValue) }
+                var tempHex by remember { mutableStateOf(tempColor.toHex()) }
                 AlertDialog(
                     onDismissRequest = { showCustomDialog = false },
                     confirmButton = {
@@ -245,7 +247,10 @@ fun RegisterVehicleScreen(navController: NavController, openDrawer: () -> Unit) 
                         Column(horizontalAlignment = Alignment.CenterHorizontally) {
                             ColorWheelPicker(
                                 selectedColor = tempColor,
-                                onColorSelected = { tempColor = it },
+                                onColorSelected = {
+                                    tempColor = it
+                                    tempHex = it.toHex()
+                                },
                                 modifier = Modifier.size(220.dp)
                             )
                             Spacer(Modifier.height(8.dp))
@@ -257,7 +262,16 @@ fun RegisterVehicleScreen(navController: NavController, openDrawer: () -> Unit) 
                                         .border(1.dp, MaterialTheme.colorScheme.onSurface, CircleShape)
                                 )
                                 Spacer(Modifier.width(8.dp))
-                                Text(text = tempColor.toHex())
+                                OutlinedTextField(
+                                    value = tempHex,
+                                    onValueChange = {
+                                        tempHex = it
+                                        it.toColorOrNull()?.let { c -> tempColor = c }
+                                    },
+                                    label = { Text("HEX") },
+                                    singleLine = true,
+                                    modifier = Modifier.width(120.dp)
+                                )
                             }
                             Spacer(Modifier.height(8.dp))
                             OutlinedTextField(

--- a/app/src/main/java/com/ioannapergamali/mysmartroute/viewmodel/VehicleViewModel.kt
+++ b/app/src/main/java/com/ioannapergamali/mysmartroute/viewmodel/VehicleViewModel.kt
@@ -55,6 +55,21 @@ class VehicleViewModel : ViewModel() {
                 return@launch
             }
 
+            if (plate.isBlank()) {
+                _registerState.value = RegisterState.Error("License plate required")
+                return@launch
+            }
+
+            if (seat <= 0) {
+                _registerState.value = RegisterState.Error("Seats must be greater than 0")
+                return@launch
+            }
+
+            if (color.isBlank()) {
+                _registerState.value = RegisterState.Error("Color required")
+                return@launch
+            }
+
             val vehicleId = UUID.randomUUID().toString()
             val entity = VehicleEntity(vehicleId, description, userId, type.name, seat, color, plate)
             val vehicleData = entity.toFirestoreMap()


### PR DESCRIPTION
## Summary
- allow hex code input for custom vehicle colors
- validate all fields when registering a vehicle

## Testing
- `./gradlew test` *(fails: could not download dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_6877ff1c0f088328b91c359cebccb04f