### PR TITLE
Εμφάνιση bubble πληκτρολογίου και αυτόματη κύλιση

### DIFF
--- a/app/src/main/java/com/ioannapergamali/mysmartroute/view/ui/components/KeyboardBubble.kt
+++ b/app/src/main/java/com/ioannapergamali/mysmartroute/view/ui/components/KeyboardBubble.kt
@@ -1,0 +1,40 @@
+package com.ioannapergamali.mysmartroute.view.ui.components
+
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.WindowInsets
+import androidx.compose.foundation.layout.asPaddingValues
+import androidx.compose.foundation.layout.calculateBottomPadding
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.unit.dp
+
+/**
+ * Εμφανίζει ένα ημιδιαφανές πλαίσιο πάνω από το πληκτρολόγιο
+ * με το κείμενο που πληκτρολογεί ο χρήστης.
+ */
+@Composable
+fun KeyboardBubble(text: String, visible: Boolean, modifier: Modifier = Modifier) {
+    if (visible) {
+        Box(
+            modifier = modifier
+                .fillMaxWidth()
+                .padding(bottom = WindowInsets.ime.asPaddingValues().calculateBottomPadding() + 16.dp),
+            contentAlignment = Alignment.BottomCenter
+        ) {
+            Box(
+                modifier = Modifier
+                    .background(Color(0xAA666666), RoundedCornerShape(8.dp))
+                    .padding(12.dp)
+            ) {
+                Text(text = text, color = Color.White)
+            }
+        }
+    }
+}

--- a/app/src/main/java/com/ioannapergamali/mysmartroute/view/ui/screens/SignUpScreen.kt
+++ b/app/src/main/java/com/ioannapergamali/mysmartroute/view/ui/screens/SignUpScreen.kt
@@ -12,6 +12,7 @@ import androidx.compose.ui.unit.dp
 import androidx.lifecycle.viewmodel.compose.viewModel
 import androidx.navigation.NavController
 import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.platform.LocalDensity
 import androidx.compose.ui.res.stringResource
 import android.app.Activity
 import android.widget.Toast
@@ -20,6 +21,10 @@ import com.ioannapergamali.mysmartroute.R
 import com.ioannapergamali.mysmartroute.model.enumerations.UserRole
 import com.ioannapergamali.mysmartroute.viewmodel.AuthenticationViewModel
 import com.ioannapergamali.mysmartroute.view.ui.components.ScreenContainer
+import com.ioannapergamali.mysmartroute.view.ui.components.KeyboardBubble
+import com.ioannapergamali.mysmartroute.view.ui.util.bringIntoViewOnFocus
+import com.ioannapergamali.mysmartroute.view.ui.util.observeBubble
+import com.ioannapergamali.mysmartroute.view.ui.util.rememberKeyboardBubbleState
 
 @Composable
 fun SignUpScreen(
@@ -47,6 +52,9 @@ fun SignUpScreen(
 
     var selectedRole by remember { mutableStateOf(UserRole.PASSENGER) }
 
+    val bubbleState = rememberKeyboardBubbleState()
+    val imeVisible = WindowInsets.ime.getBottom(LocalDensity.current) > 0
+
 
 
     Scaffold(
@@ -60,18 +68,25 @@ fun SignUpScreen(
         }
     ) { paddingValues ->
         ScreenContainer(modifier = Modifier.padding(paddingValues)) {
-            Column(
-                modifier = Modifier
-                    .fillMaxSize(),
+            Box(Modifier.fillMaxSize()) {
+                Column(
+                    modifier = Modifier
+                        .fillMaxSize(),
 
-                verticalArrangement = Arrangement.Top,
-                horizontalAlignment = Alignment.CenterHorizontally
-            ) {
+                    verticalArrangement = Arrangement.Top,
+                    horizontalAlignment = Alignment.CenterHorizontally
+                ) {
                 OutlinedTextField(
                     value = name,
-                    onValueChange = { name = it },
+                    onValueChange = { 
+                        name = it
+                        if (bubbleState.activeFieldId == 0) bubbleState.text = it
+                    },
                     label = { Text("Name") },
-                    modifier = Modifier.fillMaxWidth(),
+                    modifier = Modifier
+                        .fillMaxWidth()
+                        .bringIntoViewOnFocus()
+                        .observeBubble(bubbleState, 0) { name },
                     shape = MaterialTheme.shapes.small,
                     colors = OutlinedTextFieldDefaults.colors(
                         focusedBorderColor = MaterialTheme.colorScheme.primary,
@@ -81,9 +96,15 @@ fun SignUpScreen(
                 Spacer(Modifier.height(8.dp))
                 OutlinedTextField(
                     value = surname,
-                    onValueChange = { surname = it },
+                    onValueChange = {
+                        surname = it
+                        if (bubbleState.activeFieldId == 1) bubbleState.text = it
+                    },
                     label = { Text("Surname") },
-                    modifier = Modifier.fillMaxWidth(),
+                    modifier = Modifier
+                        .fillMaxWidth()
+                        .bringIntoViewOnFocus()
+                        .observeBubble(bubbleState, 1) { surname },
                     shape = MaterialTheme.shapes.small,
                     colors = OutlinedTextFieldDefaults.colors(
                         focusedBorderColor = MaterialTheme.colorScheme.primary,
@@ -93,9 +114,15 @@ fun SignUpScreen(
                 Spacer(Modifier.height(8.dp))
                 OutlinedTextField(
                     value = username,
-                    onValueChange = { username = it },
+                    onValueChange = {
+                        username = it
+                        if (bubbleState.activeFieldId == 2) bubbleState.text = it
+                    },
                     label = { Text("Username") },
-                    modifier = Modifier.fillMaxWidth(),
+                    modifier = Modifier
+                        .fillMaxWidth()
+                        .bringIntoViewOnFocus()
+                        .observeBubble(bubbleState, 2) { username },
                     shape = MaterialTheme.shapes.small,
                     colors = OutlinedTextFieldDefaults.colors(
                         focusedBorderColor = MaterialTheme.colorScheme.primary,
@@ -105,9 +132,15 @@ fun SignUpScreen(
                 Spacer(Modifier.height(8.dp))
                 OutlinedTextField(
                     value = email,
-                    onValueChange = { email = it },
+                    onValueChange = {
+                        email = it
+                        if (bubbleState.activeFieldId == 3) bubbleState.text = it
+                    },
                     label = { Text("Email") },
-                    modifier = Modifier.fillMaxWidth(),
+                    modifier = Modifier
+                        .fillMaxWidth()
+                        .bringIntoViewOnFocus()
+                        .observeBubble(bubbleState, 3) { email },
                     shape = MaterialTheme.shapes.small,
                     colors = OutlinedTextFieldDefaults.colors(
                         focusedBorderColor = MaterialTheme.colorScheme.primary,
@@ -117,9 +150,15 @@ fun SignUpScreen(
                 Spacer(Modifier.height(8.dp))
                 OutlinedTextField(
                     value = phoneNum,
-                    onValueChange = { phoneNum = it },
+                    onValueChange = {
+                        phoneNum = it
+                        if (bubbleState.activeFieldId == 4) bubbleState.text = it
+                    },
                     label = { Text("Phone Number") },
-                    modifier = Modifier.fillMaxWidth(),
+                    modifier = Modifier
+                        .fillMaxWidth()
+                        .bringIntoViewOnFocus()
+                        .observeBubble(bubbleState, 4) { phoneNum },
                     keyboardOptions = KeyboardOptions(keyboardType = KeyboardType.Phone),
                     shape = MaterialTheme.shapes.small,
                     colors = OutlinedTextFieldDefaults.colors(
@@ -130,9 +169,15 @@ fun SignUpScreen(
                 Spacer(Modifier.height(8.dp))
                 OutlinedTextField(
                     value = password,
-                    onValueChange = { password = it },
+                    onValueChange = {
+                        password = it
+                        if (bubbleState.activeFieldId == 5) bubbleState.text = it
+                    },
                     label = { Text("Password") },
-                    modifier = Modifier.fillMaxWidth(),
+                    modifier = Modifier
+                        .fillMaxWidth()
+                        .bringIntoViewOnFocus()
+                        .observeBubble(bubbleState, 5) { password },
                     visualTransformation = PasswordVisualTransformation(),
                     shape = MaterialTheme.shapes.small,
                     colors = OutlinedTextFieldDefaults.colors(
@@ -145,9 +190,15 @@ fun SignUpScreen(
                 Text("Address", style = MaterialTheme.typography.titleMedium)
                 OutlinedTextField(
                     value = city,
-                    onValueChange = { city = it },
+                    onValueChange = {
+                        city = it
+                        if (bubbleState.activeFieldId == 6) bubbleState.text = it
+                    },
                     label = { Text("City") },
-                    modifier = Modifier.fillMaxWidth(),
+                    modifier = Modifier
+                        .fillMaxWidth()
+                        .bringIntoViewOnFocus()
+                        .observeBubble(bubbleState, 6) { city },
                     shape = MaterialTheme.shapes.small,
                     colors = OutlinedTextFieldDefaults.colors(
                         focusedBorderColor = MaterialTheme.colorScheme.primary,
@@ -157,9 +208,15 @@ fun SignUpScreen(
                 Spacer(Modifier.height(8.dp))
                 OutlinedTextField(
                     value = streetName,
-                    onValueChange = { streetName = it },
+                    onValueChange = {
+                        streetName = it
+                        if (bubbleState.activeFieldId == 7) bubbleState.text = it
+                    },
                     label = { Text("Street Name") },
-                    modifier = Modifier.fillMaxWidth(),
+                    modifier = Modifier
+                        .fillMaxWidth()
+                        .bringIntoViewOnFocus()
+                        .observeBubble(bubbleState, 7) { streetName },
                     shape = MaterialTheme.shapes.small,
                     colors = OutlinedTextFieldDefaults.colors(
                         focusedBorderColor = MaterialTheme.colorScheme.primary,
@@ -169,9 +226,15 @@ fun SignUpScreen(
                 Spacer(Modifier.height(8.dp))
                 OutlinedTextField(
                     value = streetNumInput,
-                    onValueChange = { streetNumInput = it },
+                    onValueChange = {
+                        streetNumInput = it
+                        if (bubbleState.activeFieldId == 8) bubbleState.text = it
+                    },
                     label = { Text("Street Number") },
-                    modifier = Modifier.fillMaxWidth(),
+                    modifier = Modifier
+                        .fillMaxWidth()
+                        .bringIntoViewOnFocus()
+                        .observeBubble(bubbleState, 8) { streetNumInput },
                     keyboardOptions = KeyboardOptions(keyboardType = KeyboardType.Number),
                     shape = MaterialTheme.shapes.small,
                     colors = OutlinedTextFieldDefaults.colors(
@@ -182,9 +245,15 @@ fun SignUpScreen(
                 Spacer(Modifier.height(8.dp))
                 OutlinedTextField(
                     value = postalCodeInput,
-                    onValueChange = { postalCodeInput = it },
+                    onValueChange = {
+                        postalCodeInput = it
+                        if (bubbleState.activeFieldId == 9) bubbleState.text = it
+                    },
                     label = { Text("Postal Code") },
-                    modifier = Modifier.fillMaxWidth(),
+                    modifier = Modifier
+                        .fillMaxWidth()
+                        .bringIntoViewOnFocus()
+                        .observeBubble(bubbleState, 9) { postalCodeInput },
                     keyboardOptions = KeyboardOptions(keyboardType = KeyboardType.Number),
                     shape = MaterialTheme.shapes.small,
                     colors = OutlinedTextFieldDefaults.colors(
@@ -241,6 +310,12 @@ fun SignUpScreen(
                     Text("Sign Up")
                 }
 
+                }
+
+                KeyboardBubble(
+                    text = bubbleState.text,
+                    visible = imeVisible && bubbleState.activeFieldId != null
+                )
             }
         }
 

--- a/app/src/main/java/com/ioannapergamali/mysmartroute/view/ui/util/BringIntoViewOnFocus.kt
+++ b/app/src/main/java/com/ioannapergamali/mysmartroute/view/ui/util/BringIntoViewOnFocus.kt
@@ -1,0 +1,26 @@
+package com.ioannapergamali.mysmartroute.view.ui.util
+
+import androidx.compose.foundation.layout.BringIntoViewRequester
+import androidx.compose.foundation.layout.bringIntoViewRequester
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.composed
+import androidx.compose.ui.focus.onFocusEvent
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.rememberCoroutineScope
+import kotlinx.coroutines.launch
+
+/**
+ * Modifier που μετακινεί αυτόματα το στοιχείο εντός ορατής περιοχής
+ * όταν λαμβάνει το focus.
+ */
+fun Modifier.bringIntoViewOnFocus(): Modifier = composed {
+    val bringIntoViewRequester = remember { BringIntoViewRequester() }
+    val scope = rememberCoroutineScope()
+    this
+        .bringIntoViewRequester(bringIntoViewRequester)
+        .onFocusEvent { state ->
+            if (state.isFocused) {
+                scope.launch { bringIntoViewRequester.bringIntoView() }
+            }
+        }
+}

--- a/app/src/main/java/com/ioannapergamali/mysmartroute/view/ui/util/BubbleObservers.kt
+++ b/app/src/main/java/com/ioannapergamali/mysmartroute/view/ui/util/BubbleObservers.kt
@@ -1,0 +1,20 @@
+package com.ioannapergamali.mysmartroute.view.ui.util
+
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.composed
+import androidx.compose.ui.focus.onFocusChanged
+
+/**
+ * Συνδέει ένα TextField με την κατάσταση του bubble ώστε να
+ * εμφανίζεται το κείμενό του όταν έχει focus.
+ */
+fun Modifier.observeBubble(state: KeyboardBubbleState, fieldId: Int, currentValue: () -> String): Modifier = composed {
+    this.onFocusChanged { focusState ->
+        if (focusState.isFocused) {
+            state.activeFieldId = fieldId
+            state.text = currentValue()
+        } else if (state.activeFieldId == fieldId) {
+            state.activeFieldId = null
+        }
+    }
+}

--- a/app/src/main/java/com/ioannapergamali/mysmartroute/view/ui/util/KeyboardBubbleState.kt
+++ b/app/src/main/java/com/ioannapergamali/mysmartroute/view/ui/util/KeyboardBubbleState.kt
@@ -1,0 +1,18 @@
+package com.ioannapergamali.mysmartroute.view.ui.util
+
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.runtime.Composable
+
+/**
+ * Κράτημα κατάστασης του κειμένου που εμφανίζεται στο bubble.
+ */
+class KeyboardBubbleState {
+    var text by mutableStateOf("")
+    var activeFieldId by mutableStateOf<Int?>(null)
+}
+
+@Composable
+fun rememberKeyboardBubbleState() = remember { KeyboardBubbleState() }


### PR DESCRIPTION
## Συνοπτικά
- Προστέθηκαν βοηθητικά utilities για bubble πληκτρολογίου και bringIntoView
- Ενημερώθηκε η οθόνη εγγραφής ώστε να εμφανίζει bubble πάνω από το πληκτρολόγιο
- Κάθε πεδίο μετακινείται αυτόματα όταν παίρνει focus

## Έλεγχοι
- `./gradlew :app:assembleDebug -x lint --no-daemon` *(αποτυχία λόγω περιορισμών δικτύου)*

------
https://chatgpt.com/codex/tasks/task_e_68780c16d6a483288ceeb7e86694a441