### PR TITLE
Εξάρτηση Jetpack Compose Foundation

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -87,6 +87,7 @@ dependencies {
     implementation("androidx.compose.ui:ui")
     implementation("androidx.compose.ui:ui-text")
     implementation("androidx.compose.ui:ui-tooling-preview")
+    implementation("androidx.compose.foundation:foundation")
     implementation("androidx.compose.runtime:runtime-livedata")
     implementation("androidx.navigation:navigation-compose:2.9.1")
     implementation("androidx.compose.material:material-icons-extended")


### PR DESCRIPTION
## Περιγραφή
Προστέθηκε το module `androidx.compose.foundation:foundation` στο `app/build.gradle.kts` ώστε να επιλυθούν τα σφάλματα `Unresolved reference` για τα `calculateBottomPadding()` και `WindowInsets.ime`.

## Έλεγχοι
- Επιχειρήθηκε εκτέλεση `./gradlew test`, αλλά απέτυχε λόγω αποκλεισμένης πρόσβασης στο `maven.pkg.jetbrains.space` κατά το κατέβασμα των εξαρτήσεων.


------
https://chatgpt.com/codex/tasks/task_e_687811d11d308328b5b9879554818872