### PR TITLE
Fix imports for Compose features

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -43,8 +43,8 @@ android {
     }
 
     composeOptions {
-        // Χρησιμοποιούμε την πιο πρόσφατη έκδοση του compiler
-        kotlinCompilerExtensionVersion = "1.6.10"
+        // Χρήση της επίσημης έκδοσης του compiler
+        kotlinCompilerExtensionVersion = "1.6.1"
     }
 
     compileOptions {
@@ -80,8 +80,8 @@ dependencies {
     implementation("androidx.constraintlayout:constraintlayout:2.1.4")
 
     // Jetpack Compose
-    implementation(platform("androidx.compose:compose-bom:2025.06.01"))
-    androidTestImplementation(platform("androidx.compose:compose-bom:2025.06.01"))
+    implementation(platform("androidx.compose:compose-bom:2024.06.01"))
+    androidTestImplementation(platform("androidx.compose:compose-bom:2024.06.01"))
 
     implementation("androidx.compose.material3:material3")
     implementation("androidx.compose.ui:ui")

--- a/app/src/main/java/com/ioannapergamali/mysmartroute/view/ui/components/KeyboardBubble.kt
+++ b/app/src/main/java/com/ioannapergamali/mysmartroute/view/ui/components/KeyboardBubble.kt
@@ -7,6 +7,7 @@ import androidx.compose.foundation.layout.asPaddingValues
 import androidx.compose.foundation.layout.calculateBottomPadding
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.ime
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable

--- a/app/src/main/java/com/ioannapergamali/mysmartroute/view/ui/util/BringIntoViewOnFocus.kt
+++ b/app/src/main/java/com/ioannapergamali/mysmartroute/view/ui/util/BringIntoViewOnFocus.kt
@@ -1,9 +1,11 @@
 package com.ioannapergamali.mysmartroute.view.ui.util
 
-import androidx.compose.foundation.layout.BringIntoViewRequester
-import androidx.compose.foundation.layout.bringIntoViewRequester
+import androidx.compose.foundation.relocation.BringIntoViewRequester
+import androidx.compose.foundation.relocation.bringIntoViewRequester
+import androidx.compose.foundation.relocation.bringIntoView
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.composed
+import androidx.compose.ui.focus.FocusState
 import androidx.compose.ui.focus.onFocusEvent
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.rememberCoroutineScope
@@ -18,7 +20,7 @@ fun Modifier.bringIntoViewOnFocus(): Modifier = composed {
     val scope = rememberCoroutineScope()
     this
         .bringIntoViewRequester(bringIntoViewRequester)
-        .onFocusEvent { state ->
+        .onFocusEvent { state: FocusState ->
             if (state.isFocused) {
                 scope.launch { bringIntoViewRequester.bringIntoView() }
             }


### PR DESCRIPTION
## Summary
- import `ime` so keyboard insets resolve
- use relocation package for `BringIntoViewRequester`
- pin Compose compiler version to 1.6.1 and update BOM

## Testing
- `./gradlew test` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_687814fdd82883289a8b40e1c1e73fc2