### PR TITLE
Add reflection fallback for bringIntoView

### DIFF
--- a/app/src/main/java/com/ioannapergamali/mysmartroute/view/ui/util/BringIntoViewCompat.kt
+++ b/app/src/main/java/com/ioannapergamali/mysmartroute/view/ui/util/BringIntoViewCompat.kt
@@ -1,0 +1,35 @@
+package com.ioannapergamali.mysmartroute.view.ui.util
+
+import androidx.compose.foundation.ExperimentalFoundationApi
+import androidx.compose.foundation.relocation.BringIntoViewRequester
+import kotlin.coroutines.resume
+import kotlin.coroutines.suspendCoroutine
+
+/**
+ * Συμβατική υλοποίηση της [bringIntoView] που επιχειρεί μέσω reflection
+ * να καλέσει την επίσημη συνάρτηση της βιβλιοθήκης Compose αν υπάρχει.
+ * Αν δεν υπάρχει, η κλήση απλώς αγνοείται.
+ */
+@OptIn(ExperimentalFoundationApi::class)
+@Suppress("FunctionName")
+suspend fun BringIntoViewRequester.bringIntoView() {
+    // Αναζητούμε την επίσημη μέθοδο μέσω reflection.
+    val method = try {
+        this::class.java.getMethod("bringIntoView", kotlin.coroutines.Continuation::class.java)
+    } catch (_: NoSuchMethodException) {
+        null
+    }
+
+    if (method != null) {
+        // Κλήση της suspend συνάρτησης χρησιμοποιώντας continuation
+        return suspendCoroutine { cont ->
+            try {
+                method.invoke(this, cont)
+            } catch (t: Throwable) {
+                cont.resume(Unit)
+            }
+        }
+    }
+    // Αν δεν βρεθεί μέθοδος, δεν κάνουμε τίποτα
+}
+

--- a/app/src/main/java/com/ioannapergamali/mysmartroute/view/ui/util/BringIntoViewOnFocus.kt
+++ b/app/src/main/java/com/ioannapergamali/mysmartroute/view/ui/util/BringIntoViewOnFocus.kt
@@ -2,9 +2,6 @@ package com.ioannapergamali.mysmartroute.view.ui.util
 
 import androidx.compose.foundation.relocation.BringIntoViewRequester
 import androidx.compose.foundation.relocation.bringIntoViewRequester
-// Η συνάρτηση bringIntoView είναι διαθέσιμη από Compose 1.3 και μετά
-// Φροντίζουμε να έχει γίνει import ώστε να μην εμφανίζεται σφάλμα "Unresolved reference"
-import androidx.compose.foundation.relocation.bringIntoView
 import androidx.compose.foundation.ExperimentalFoundationApi
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.composed


### PR DESCRIPTION
## Summary
- προσθήκη αρχείου `BringIntoViewCompat.kt` με υλοποίηση της `bringIntoView` μέσω reflection
- ενημέρωση `BringIntoViewOnFocus.kt` ώστε να χρησιμοποιεί την δικιά μας υλοποίηση

## Testing
- `./gradlew test --no-daemon` *(απέτυχε λόγω περιορισμών δικτύου)*

------
https://chatgpt.com/codex/tasks/task_e_687833b2d784832898d4fe38f538ed10