### PR TITLE
Επιδιόρθωση του BringIntoViewCompat

### DIFF
--- a/app/src/main/java/com/ioannapergamali/mysmartroute/view/ui/util/BringIntoViewCompat.kt
+++ b/app/src/main/java/com/ioannapergamali/mysmartroute/view/ui/util/BringIntoViewCompat.kt
@@ -12,7 +12,7 @@ import kotlin.coroutines.suspendCoroutine
  */
 @OptIn(ExperimentalFoundationApi::class)
 @Suppress("FunctionName")
-
+suspend fun BringIntoViewRequester.safeBringIntoView() {
     // Αναζητούμε την επίσημη μέθοδο μέσω reflection.
     val method = try {
         this::class.java.getMethod("bringIntoView", kotlin.coroutines.Continuation::class.java)


### PR DESCRIPTION
## Summary
Επαναφέρεται η χαμένη δήλωση της συνάρτησης `safeBringIntoView` στο `BringIntoViewCompat.kt` ώστε να αποφεύγονται σφάλματα μεταγλώττισης.

## Testing
- `./gradlew tasks --all` *(απέτυχε λόγω περιορισμών πρόσβασης στο διαδίκτυο)*

------
https://chatgpt.com/codex/tasks/task_e_68783dea50208328b664fcd405453a32