### PR TITLE
Διόρθωση φιλτραρίσματος οχημάτων στην αναγγελία μεταφοράς

### DIFF
--- a/app/src/main/java/com/ioannapergamali/mysmartroute/view/ui/screens/AnnounceTransportScreen.kt
+++ b/app/src/main/java/com/ioannapergamali/mysmartroute/view/ui/screens/AnnounceTransportScreen.kt
@@ -76,9 +76,13 @@ fun AnnounceTransportScreen(navController: NavController, openDrawer: () -> Unit
         } ?: false
 
         filteredVehicles = if (isBusRoute) {
+            // Εάν η επιλεγμένη διαδρομή αποτελείται αποκλειστικά από στάσεις
+            // λεωφορείων, επιτρέπουμε μόνο την επιλογή μεγάλου λεωφορείου.
             vehicles.filter { VehicleType.valueOf(it.type) == VehicleType.BIGBUS }
         } else {
-            vehicles.filter { VehicleType.valueOf(it.type) != VehicleType.BIGBUS }
+            // Σε κάθε άλλη περίπτωση εμφανίζουμε όλα τα οχήματα ώστε ο χρήστης
+            // να μπορεί να επιλέξει ελεύθερα.
+            vehicles
         }
     }
 


### PR DESCRIPTION
## Summary
- Ενημερώθηκε το `AnnounceTransportScreen.kt` ώστε να εμφανίζει όλα τα οχήματα όταν η διαδρομή δεν αποτελείται αποκλειστικά από στάσεις λεωφορείων

## Testing
- `./gradlew test --no-daemon` *(απέτυχε λόγω περιορισμών πρόσβασης στο δίκτυο)*

------
https://chatgpt.com/codex/tasks/task_e_687848ba574083289adf2c775d076a31