### PR TITLE
Διόρθωση φόρτωσης οχημάτων και εμφάνισης χάρτη

### DIFF
--- a/app/src/main/java/com/ioannapergamali/mysmartroute/view/ui/screens/AnnounceTransportScreen.kt
+++ b/app/src/main/java/com/ioannapergamali/mysmartroute/view/ui/screens/AnnounceTransportScreen.kt
@@ -166,14 +166,16 @@ fun AnnounceTransportScreen(navController: NavController, openDrawer: () -> Unit
 
             Spacer(Modifier.height(16.dp))
 
-            if (pathPoints.isNotEmpty()) {
+            if (pathPoints.isNotEmpty() || pois.isNotEmpty()) {
                 GoogleMap(
                     modifier = Modifier
                         .fillMaxWidth()
                         .height(200.dp),
                     cameraPositionState = cameraPositionState
                 ) {
-                    Polyline(points = pathPoints)
+                    if (pathPoints.isNotEmpty()) {
+                        Polyline(points = pathPoints)
+                    }
                     pois.forEach { poi ->
                         Marker(
                             state = MarkerState(position = LatLng(poi.lat, poi.lng)),

--- a/app/src/main/java/com/ioannapergamali/mysmartroute/viewmodel/VehicleViewModel.kt
+++ b/app/src/main/java/com/ioannapergamali/mysmartroute/viewmodel/VehicleViewModel.kt
@@ -106,29 +106,25 @@ class VehicleViewModel : ViewModel() {
 
             val userId = auth.currentUser?.uid
 
-            val snapshot = if (NetworkUtils.isInternetAvailable(context)) {
-                runCatching {
-                    if (includeAll) {
-                        db.collection("vehicles").get().await()
-                    } else if (userId != null) {
-                        db.collection("vehicles")
-                            .whereEqualTo("userId", db.collection("users").document(userId))
-                            .get().await()
-                    } else null
-                }.getOrNull()
+            val remote = if (NetworkUtils.isInternetAvailable(context)) {
+                runCatching { db.collection("vehicles").get().await() }.getOrNull()
+                    ?.documents?.mapNotNull { it.toVehicleEntity() }
             } else null
 
-            if (snapshot != null) {
-                val list = snapshot.documents.mapNotNull { it.toVehicleEntity() }
-                _vehicles.value = list
-                list.forEach { insertVehicleSafely(vehicleDao, userDao, it) }
+            val local = if (includeAll) {
+                vehicleDao.getAllVehicles().first()
             } else {
-                _vehicles.value = if (includeAll) {
-                    vehicleDao.getAllVehicles().first()
-                } else {
-                    userId?.let { vehicleDao.getVehiclesForUser(it) } ?: emptyList()
-                }
+                userId?.let { vehicleDao.getVehiclesForUser(it) } ?: emptyList()
             }
+
+            var list = (remote ?: emptyList()) + local
+            list = list.distinctBy { it.id }
+            if (!includeAll && userId != null) {
+                list = list.filter { it.userId == userId }
+            }
+
+            _vehicles.value = list
+            list.forEach { insertVehicleSafely(vehicleDao, userDao, it) }
         }
     }
 


### PR DESCRIPTION
## Περιγραφή
- Βελτιώθηκε η μέθοδος `loadRegisteredVehicles` ώστε να συγχωνεύει δεδομένα από το Firestore και την τοπική βάση, αφαιρώντας διπλότυπα.
- Η οθόνη δήλωσης διαθεσιμότητας εμφανίζει πλέον χάρτη ακόμη κι όταν δεν έχει υπολογιστεί η διαδρομή, προβάλλοντας τουλάχιστον τις στάσεις.

## Έλεγχοι
- `./gradlew test --no-daemon` *(απέτυχε: αδυναμία λήψης εξαρτήσεων λόγω περιορισμών δικτύου)*

------
https://chatgpt.com/codex/tasks/task_e_68785d7afec08328a9e7ecc7a41d2228