### PR TITLE
Ενημέρωση δήλωσης διαθεσιμότητας

### DIFF
--- a/app/src/main/java/com/ioannapergamali/mysmartroute/view/ui/screens/AnnounceTransportScreen.kt
+++ b/app/src/main/java/com/ioannapergamali/mysmartroute/view/ui/screens/AnnounceTransportScreen.kt
@@ -198,7 +198,7 @@ fun AnnounceTransportScreen(navController: NavController, openDrawer: () -> Unit
                         contentDescription = null
                     )
                     Spacer(Modifier.width(8.dp))
-                    Text(routeName, style = MaterialTheme.typography.titleMedium)
+                    Text("$selectedVehicleDesc - $routeName", style = MaterialTheme.typography.titleMedium)
                 }
 
                 Spacer(Modifier.height(16.dp))
@@ -235,7 +235,7 @@ fun AnnounceTransportScreen(navController: NavController, openDrawer: () -> Unit
                             style = MaterialTheme.typography.labelMedium
                         )
                         Text(
-                            stringResource(R.string.poi_description),
+                            stringResource(R.string.poi_type),
                             modifier = Modifier.weight(1f),
                             style = MaterialTheme.typography.labelMedium
                         )
@@ -248,7 +248,7 @@ fun AnnounceTransportScreen(navController: NavController, openDrawer: () -> Unit
                                 modifier = Modifier.weight(1f)
                             )
                             Text(
-                                formatAddress(poi.address),
+                                poi.type.name,
                                 modifier = Modifier.weight(1f)
                             )
                         }


### PR DESCRIPTION
## Περιγραφή
- προσθήκη εμφάνισης περιγραφής οχήματος δίπλα από το εικονίδιο
- προβολή τύπου POI αντί για διεύθυνση στον πίνακα στάσεων

## Οδηγίες ελέγχου
- `./gradlew test` *(αποτυγχάνει λόγω έλλειψης Android SDK)*

------
https://chatgpt.com/codex/tasks/task_e_68787e2354088328addedbf43ee6ac45