### PR TITLE
Fix vehicle query for logged user

### DIFF
--- a/app/src/main/java/com/ioannapergamali/mysmartroute/view/ui/screens/AnnounceTransportScreen.kt
+++ b/app/src/main/java/com/ioannapergamali/mysmartroute/view/ui/screens/AnnounceTransportScreen.kt
@@ -84,7 +84,7 @@ fun AnnounceTransportScreen(navController: NavController, openDrawer: () -> Unit
     var pathPoints by remember { mutableStateOf<List<LatLng>>(emptyList()) }
     val cameraPositionState = rememberCameraPositionState()
 
-    LaunchedEffect(routes, selectedVehicle, selectedRouteId) {
+    LaunchedEffect(routes, vehicles, selectedVehicle, selectedRouteId) {
         displayRoutes = if (selectedVehicle == VehicleType.BIGBUS) {
             routes.filter { route ->
                 val pois = routeViewModel.getRoutePois(context, route.id)

--- a/app/src/main/java/com/ioannapergamali/mysmartroute/viewmodel/VehicleViewModel.kt
+++ b/app/src/main/java/com/ioannapergamali/mysmartroute/viewmodel/VehicleViewModel.kt
@@ -113,7 +113,12 @@ class VehicleViewModel : ViewModel() {
             val userId = auth.currentUser?.uid
 
             val remote = if (NetworkUtils.isInternetAvailable(context)) {
-                runCatching { db.collection("vehicles").get().await() }.getOrNull()
+                val query = when {
+                    includeAll -> db.collection("vehicles")
+                    userId != null -> db.collection("vehicles").whereEqualTo("userId", userId)
+                    else -> null
+                }
+                query?.let { runCatching { it.get().await() }.getOrNull() }
                     ?.documents?.mapNotNull { it.toVehicleEntity() }
             } else null
 


### PR DESCRIPTION
## Summary
- filter Firestore vehicles by logged-in user when not admin

## Testing
- `./gradlew test` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_68788849571c83289d5a87fdb25a36a8