### PR TITLE
Add global keyboard bubble

### DIFF
--- a/app/src/main/java/com/ioannapergamali/mysmartroute/view/ui/components/ScreenContainer.kt
+++ b/app/src/main/java/com/ioannapergamali/mysmartroute/view/ui/components/ScreenContainer.kt
@@ -5,9 +5,10 @@ import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.ColumnScope
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.fillMaxSize
-import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.imePadding
+import androidx.compose.foundation.layout.WindowInsets
+import androidx.compose.ui.platform.LocalDensity
 import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.verticalScroll
 import androidx.compose.foundation.text.selection.SelectionContainer
@@ -15,10 +16,14 @@ import androidx.compose.material3.LocalContentColor
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.CompositionLocalProvider
+import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.res.dimensionResource
 import androidx.compose.ui.unit.dp
 import com.ioannapergamali.mysmartroute.R
+import com.ioannapergamali.mysmartroute.view.ui.components.KeyboardBubble
+import com.ioannapergamali.mysmartroute.view.ui.util.LocalKeyboardBubbleState
+import com.ioannapergamali.mysmartroute.view.ui.util.rememberKeyboardBubbleState
 
 @Composable
 fun ScreenContainer(
@@ -27,7 +32,12 @@ fun ScreenContainer(
     content: @Composable ColumnScope.() -> Unit
 ) {
     val scrollState = rememberScrollState()
-    CompositionLocalProvider(LocalContentColor provides MaterialTheme.colorScheme.primary) {
+    val bubbleState = rememberKeyboardBubbleState()
+    val imeVisible = WindowInsets.ime.getBottom(LocalDensity.current) > 0
+    CompositionLocalProvider(
+        LocalContentColor provides MaterialTheme.colorScheme.primary,
+        LocalKeyboardBubbleState provides bubbleState
+    ) {
         SelectionContainer {
             Box(
                 modifier = modifier
@@ -41,6 +51,11 @@ fun ScreenContainer(
                         .then(if (scrollable) Modifier.verticalScroll(scrollState) else Modifier)
                         .imePadding(),
                     content = content
+                )
+                KeyboardBubble(
+                    text = bubbleState.text,
+                    visible = imeVisible && bubbleState.activeFieldId != null,
+                    modifier = Modifier.align(Alignment.BottomCenter)
                 )
             }
         }

--- a/app/src/main/java/com/ioannapergamali/mysmartroute/view/ui/screens/AdminSignUpScreen.kt
+++ b/app/src/main/java/com/ioannapergamali/mysmartroute/view/ui/screens/AdminSignUpScreen.kt
@@ -19,6 +19,8 @@ import com.ioannapergamali.mysmartroute.R
 import com.ioannapergamali.mysmartroute.model.enumerations.UserRole
 import com.ioannapergamali.mysmartroute.viewmodel.AuthenticationViewModel
 import com.ioannapergamali.mysmartroute.view.ui.components.ScreenContainer
+import com.ioannapergamali.mysmartroute.view.ui.util.observeBubble
+import com.ioannapergamali.mysmartroute.view.ui.util.LocalKeyboardBubbleState
 
 @Composable
 fun AdminSignUpScreen(
@@ -45,6 +47,8 @@ fun AdminSignUpScreen(
     var streetNumInput by remember { mutableStateOf("") }
     var postalCodeInput by remember { mutableStateOf("") }
 
+    val bubbleState = LocalKeyboardBubbleState.current!!
+
 
 
     Scaffold(
@@ -68,7 +72,9 @@ fun AdminSignUpScreen(
                     value = name,
                     onValueChange = { name = it },
                     label = { Text("Name") },
-                    modifier = Modifier.fillMaxWidth(),
+                    modifier = Modifier
+                        .fillMaxWidth()
+                        .observeBubble(bubbleState, 0) { name },
                     shape = MaterialTheme.shapes.small,
                     colors = OutlinedTextFieldDefaults.colors(
                         focusedBorderColor = MaterialTheme.colorScheme.primary,
@@ -80,7 +86,9 @@ fun AdminSignUpScreen(
                     value = surname,
                     onValueChange = { surname = it },
                     label = { Text("Surname") },
-                    modifier = Modifier.fillMaxWidth(),
+                    modifier = Modifier
+                        .fillMaxWidth()
+                        .observeBubble(bubbleState, 1) { surname },
                     shape = MaterialTheme.shapes.small,
                     colors = OutlinedTextFieldDefaults.colors(
                         focusedBorderColor = MaterialTheme.colorScheme.primary,
@@ -92,7 +100,9 @@ fun AdminSignUpScreen(
                     value = username,
                     onValueChange = { username = it },
                     label = { Text("Username") },
-                    modifier = Modifier.fillMaxWidth(),
+                    modifier = Modifier
+                        .fillMaxWidth()
+                        .observeBubble(bubbleState, 2) { username },
                     shape = MaterialTheme.shapes.small,
                     colors = OutlinedTextFieldDefaults.colors(
                         focusedBorderColor = MaterialTheme.colorScheme.primary,
@@ -104,7 +114,9 @@ fun AdminSignUpScreen(
                     value = email,
                     onValueChange = { email = it },
                     label = { Text("Email") },
-                    modifier = Modifier.fillMaxWidth(),
+                    modifier = Modifier
+                        .fillMaxWidth()
+                        .observeBubble(bubbleState, 3) { email },
                     shape = MaterialTheme.shapes.small,
                     colors = OutlinedTextFieldDefaults.colors(
                         focusedBorderColor = MaterialTheme.colorScheme.primary,
@@ -116,7 +128,9 @@ fun AdminSignUpScreen(
                     value = phoneNum,
                     onValueChange = { phoneNum = it },
                     label = { Text("Phone Number") },
-                    modifier = Modifier.fillMaxWidth(),
+                    modifier = Modifier
+                        .fillMaxWidth()
+                        .observeBubble(bubbleState, 4) { phoneNum },
                     keyboardOptions = KeyboardOptions(keyboardType = KeyboardType.Phone),
                     shape = MaterialTheme.shapes.small,
                     colors = OutlinedTextFieldDefaults.colors(
@@ -129,7 +143,9 @@ fun AdminSignUpScreen(
                     value = password,
                     onValueChange = { password = it },
                     label = { Text("Password") },
-                    modifier = Modifier.fillMaxWidth(),
+                    modifier = Modifier
+                        .fillMaxWidth()
+                        .observeBubble(bubbleState, 5) { password },
                     visualTransformation = PasswordVisualTransformation(),
                     shape = MaterialTheme.shapes.small,
                     colors = OutlinedTextFieldDefaults.colors(
@@ -144,7 +160,9 @@ fun AdminSignUpScreen(
                     value = city,
                     onValueChange = { city = it },
                     label = { Text("City") },
-                    modifier = Modifier.fillMaxWidth(),
+                    modifier = Modifier
+                        .fillMaxWidth()
+                        .observeBubble(bubbleState, 6) { city },
                     shape = MaterialTheme.shapes.small,
                     colors = OutlinedTextFieldDefaults.colors(
                         focusedBorderColor = MaterialTheme.colorScheme.primary,
@@ -156,7 +174,9 @@ fun AdminSignUpScreen(
                     value = streetName,
                     onValueChange = { streetName = it },
                     label = { Text("Street Name") },
-                    modifier = Modifier.fillMaxWidth(),
+                    modifier = Modifier
+                        .fillMaxWidth()
+                        .observeBubble(bubbleState, 7) { streetName },
                     shape = MaterialTheme.shapes.small,
                     colors = OutlinedTextFieldDefaults.colors(
                         focusedBorderColor = MaterialTheme.colorScheme.primary,
@@ -168,7 +188,9 @@ fun AdminSignUpScreen(
                     value = streetNumInput,
                     onValueChange = { streetNumInput = it },
                     label = { Text("Street Number") },
-                    modifier = Modifier.fillMaxWidth(),
+                    modifier = Modifier
+                        .fillMaxWidth()
+                        .observeBubble(bubbleState, 8) { streetNumInput },
                     keyboardOptions = KeyboardOptions(keyboardType = KeyboardType.Number),
                     shape = MaterialTheme.shapes.small,
                     colors = OutlinedTextFieldDefaults.colors(
@@ -181,7 +203,9 @@ fun AdminSignUpScreen(
                     value = postalCodeInput,
                     onValueChange = { postalCodeInput = it },
                     label = { Text("Postal Code") },
-                    modifier = Modifier.fillMaxWidth(),
+                    modifier = Modifier
+                        .fillMaxWidth()
+                        .observeBubble(bubbleState, 9) { postalCodeInput },
                     keyboardOptions = KeyboardOptions(keyboardType = KeyboardType.Number),
                     shape = MaterialTheme.shapes.small,
                     colors = OutlinedTextFieldDefaults.colors(

--- a/app/src/main/java/com/ioannapergamali/mysmartroute/view/ui/screens/AnnounceTransportScreen.kt
+++ b/app/src/main/java/com/ioannapergamali/mysmartroute/view/ui/screens/AnnounceTransportScreen.kt
@@ -38,6 +38,8 @@ import com.ioannapergamali.mysmartroute.data.local.RouteEntity
 import com.ioannapergamali.mysmartroute.data.local.VehicleEntity
 import com.google.android.libraries.places.api.model.Place
 import com.ioannapergamali.mysmartroute.data.local.PoIEntity
+import com.ioannapergamali.mysmartroute.view.ui.util.observeBubble
+import com.ioannapergamali.mysmartroute.view.ui.util.LocalKeyboardBubbleState
 import kotlinx.coroutines.launch
 import com.ioannapergamali.mysmartroute.model.classes.poi.PoiAddress
 
@@ -84,6 +86,7 @@ fun AnnounceTransportScreen(navController: NavController, openDrawer: () -> Unit
     var pois by remember { mutableStateOf<List<PoIEntity>>(emptyList()) }
     var pathPoints by remember { mutableStateOf<List<LatLng>>(emptyList()) }
     val cameraPositionState = rememberCameraPositionState()
+    val bubbleState = LocalKeyboardBubbleState.current!!
 
     LaunchedEffect(routes, vehicles, selectedVehicle, selectedRouteId) {
         displayRoutes = if (selectedVehicle == VehicleType.BIGBUS) {
@@ -264,7 +267,9 @@ fun AnnounceTransportScreen(navController: NavController, openDrawer: () -> Unit
                 value = costText,
                 onValueChange = { costText = it },
                 label = { Text(stringResource(R.string.cost)) },
-                modifier = Modifier.fillMaxWidth(),
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .observeBubble(bubbleState, 0) { costText },
                 keyboardOptions = androidx.compose.foundation.text.KeyboardOptions(keyboardType = androidx.compose.ui.text.input.KeyboardType.Number)
             )
 

--- a/app/src/main/java/com/ioannapergamali/mysmartroute/view/ui/screens/DeclareRouteScreen.kt
+++ b/app/src/main/java/com/ioannapergamali/mysmartroute/view/ui/screens/DeclareRouteScreen.kt
@@ -78,6 +78,8 @@ import com.ioannapergamali.mysmartroute.viewmodel.RouteViewModel
 import com.ioannapergamali.mysmartroute.data.local.PoIEntity
 import com.ioannapergamali.mysmartroute.model.enumerations.VehicleType
 import kotlinx.coroutines.launch
+import com.ioannapergamali.mysmartroute.view.ui.util.observeBubble
+import com.ioannapergamali.mysmartroute.view.ui.util.LocalKeyboardBubbleState
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.withContext
 import kotlin.math.abs
@@ -138,6 +140,7 @@ fun DeclareRouteScreen(navController: NavController, openDrawer: () -> Unit) {
     val fusedLocationClient = remember { LocationServices.getFusedLocationProviderClient(context) }
     val focusRequester = remember { FocusRequester() }
     val keyboardController = LocalSoftwareKeyboardController.current
+    val bubbleState = LocalKeyboardBubbleState.current!!
 
     fun goToCurrentLocation() {
         if (ActivityCompat.checkSelfPermission(
@@ -325,7 +328,10 @@ fun DeclareRouteScreen(navController: NavController, openDrawer: () -> Unit) {
                     },
                     label = { Text(stringResource(R.string.search_address)) },
                     trailingIcon = { ExposedDropdownMenuDefaults.TrailingIcon(expanded = addressMenuExpanded) },
-                    modifier = Modifier.menuAnchor().fillMaxWidth(),
+                    modifier = Modifier
+                        .menuAnchor()
+                        .fillMaxWidth()
+                        .observeBubble(bubbleState, 0) { addressQuery },
                     shape = MaterialTheme.shapes.small,
                     colors = OutlinedTextFieldDefaults.colors(
                         focusedBorderColor = MaterialTheme.colorScheme.primary,
@@ -413,6 +419,7 @@ fun DeclareRouteScreen(navController: NavController, openDrawer: () -> Unit) {
                         .menuAnchor()
                         .fillMaxWidth()
                         .focusRequester(focusRequester)
+                        .observeBubble(bubbleState, 1) { query }
                 )
 
                 val filtered = if (query.isNotBlank()) {
@@ -549,7 +556,9 @@ fun DeclareRouteScreen(navController: NavController, openDrawer: () -> Unit) {
                 onValueChange = { routeName = it },
                 label = { Text(stringResource(R.string.route_name)) },
                 singleLine = true,
-                modifier = Modifier.fillMaxWidth(),
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .observeBubble(bubbleState, 2) { routeName },
                 colors = OutlinedTextFieldDefaults.colors(
                     focusedBorderColor = MaterialTheme.colorScheme.primary,
                     unfocusedBorderColor = MaterialTheme.colorScheme.primary

--- a/app/src/main/java/com/ioannapergamali/mysmartroute/view/ui/screens/DefinePoiScreen.kt
+++ b/app/src/main/java/com/ioannapergamali/mysmartroute/view/ui/screens/DefinePoiScreen.kt
@@ -32,6 +32,8 @@ import com.ioannapergamali.mysmartroute.view.ui.components.TopBar
 import com.ioannapergamali.mysmartroute.viewmodel.PoIViewModel
 import com.ioannapergamali.mysmartroute.model.classes.poi.PoiAddress
 import androidx.compose.material3.menuAnchor
+import com.ioannapergamali.mysmartroute.view.ui.util.observeBubble
+import com.ioannapergamali.mysmartroute.view.ui.util.LocalKeyboardBubbleState
 
 private const val TAG = "DefinePoiScreen"
 
@@ -63,6 +65,7 @@ fun DefinePoiScreen(
     var addressQuery by remember { mutableStateOf("") }
     var addressResults by remember { mutableStateOf<List<String>>(emptyList()) }
     var addressMenuExpanded by remember { mutableStateOf(false) }
+    val bubbleState = LocalKeyboardBubbleState.current!!
     val initialLatLng = remember(initialLat, initialLng) {
         if (initialLat != null && initialLng != null) LatLng(initialLat, initialLng) else null
     }
@@ -193,7 +196,10 @@ fun DefinePoiScreen(
                         },
                         label = { Text(stringResource(R.string.search_address)) },
                         trailingIcon = { ExposedDropdownMenuDefaults.TrailingIcon(expanded = addressMenuExpanded) },
-                        modifier = Modifier.menuAnchor().fillMaxWidth(),
+                        modifier = Modifier
+                            .menuAnchor()
+                            .fillMaxWidth()
+                            .observeBubble(bubbleState, 0) { addressQuery },
                         shape = MaterialTheme.shapes.small,
                         colors = OutlinedTextFieldDefaults.colors(
                             focusedBorderColor = MaterialTheme.colorScheme.primary,
@@ -237,7 +243,9 @@ fun DefinePoiScreen(
                 value = name,
                 onValueChange = { name = it },
                 label = { Text(stringResource(R.string.poi_name)) },
-                modifier = Modifier.fillMaxWidth(),
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .observeBubble(bubbleState, 1) { name },
                 shape = MaterialTheme.shapes.small,
                 colors = OutlinedTextFieldDefaults.colors(
                     focusedBorderColor = MaterialTheme.colorScheme.primary,
@@ -280,7 +288,9 @@ fun DefinePoiScreen(
                 value = country,
                 onValueChange = { country = it },
                 label = { Text("Country") },
-                modifier = Modifier.fillMaxWidth(),
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .observeBubble(bubbleState, 2) { country },
                 shape = MaterialTheme.shapes.small,
                 colors = OutlinedTextFieldDefaults.colors(
                     focusedBorderColor = MaterialTheme.colorScheme.primary,
@@ -292,7 +302,9 @@ fun DefinePoiScreen(
                 value = city,
                 onValueChange = { city = it },
                 label = { Text("City") },
-                modifier = Modifier.fillMaxWidth(),
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .observeBubble(bubbleState, 3) { city },
                 shape = MaterialTheme.shapes.small,
                 colors = OutlinedTextFieldDefaults.colors(
                     focusedBorderColor = MaterialTheme.colorScheme.primary,
@@ -304,7 +316,9 @@ fun DefinePoiScreen(
                 value = streetName,
                 onValueChange = { streetName = it },
                 label = { Text("Street Name") },
-                modifier = Modifier.fillMaxWidth(),
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .observeBubble(bubbleState, 4) { streetName },
                 shape = MaterialTheme.shapes.small,
                 colors = OutlinedTextFieldDefaults.colors(
                     focusedBorderColor = MaterialTheme.colorScheme.primary,
@@ -316,7 +330,9 @@ fun DefinePoiScreen(
                 value = streetNumInput,
                 onValueChange = { streetNumInput = it },
                 label = { Text("Street Number") },
-                modifier = Modifier.fillMaxWidth(),
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .observeBubble(bubbleState, 5) { streetNumInput },
                 keyboardOptions = KeyboardOptions(keyboardType = KeyboardType.Number),
                 shape = MaterialTheme.shapes.small,
                 colors = OutlinedTextFieldDefaults.colors(
@@ -329,7 +345,9 @@ fun DefinePoiScreen(
                 value = postalCodeInput,
                 onValueChange = { postalCodeInput = it },
                 label = { Text("Postal Code") },
-                modifier = Modifier.fillMaxWidth(),
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .observeBubble(bubbleState, 6) { postalCodeInput },
                 keyboardOptions = KeyboardOptions(keyboardType = KeyboardType.Number),
                 shape = MaterialTheme.shapes.small,
                 colors = OutlinedTextFieldDefaults.colors(

--- a/app/src/main/java/com/ioannapergamali/mysmartroute/view/ui/screens/HomeScreen.kt
+++ b/app/src/main/java/com/ioannapergamali/mysmartroute/view/ui/screens/HomeScreen.kt
@@ -27,6 +27,8 @@ import com.ioannapergamali.mysmartroute.viewmodel.AuthenticationViewModel
 import androidx.compose.ui.text.input.PasswordVisualTransformation
 import com.ioannapergamali.mysmartroute.view.ui.components.ScreenContainer
 import com.google.firebase.auth.FirebaseAuth
+import com.ioannapergamali.mysmartroute.view.ui.util.observeBubble
+import com.ioannapergamali.mysmartroute.view.ui.util.LocalKeyboardBubbleState
 
 @Composable
 fun HomeScreen(
@@ -57,6 +59,7 @@ fun HomeScreen(
         val context = LocalContext.current
         var email by remember { mutableStateOf("") }
         var password by remember { mutableStateOf("") }
+        val bubbleState = LocalKeyboardBubbleState.current!!
 
         ScreenContainer(modifier = Modifier.padding(paddingValues)) {
             val isLarge = windowInfo.width > 600.dp && windowInfo.orientation == WindowOrientation.Landscape
@@ -176,7 +179,9 @@ private fun HomeContent(
                 value = email,
                 onValueChange = onEmailChange,
                 label = { Text(stringResource(R.string.email)) },
-                modifier = Modifier.fillMaxWidth(),
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .observeBubble(bubbleState, 0) { email },
                 shape = MaterialTheme.shapes.small,
                 colors = OutlinedTextFieldDefaults.colors(
                     focusedBorderColor = MaterialTheme.colorScheme.primary,
@@ -191,7 +196,9 @@ private fun HomeContent(
                 onValueChange = onPasswordChange,
                 label = { Text(stringResource(R.string.password)) },
                 visualTransformation = PasswordVisualTransformation(),
-                modifier = Modifier.fillMaxWidth(),
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .observeBubble(bubbleState, 1) { password },
                 shape = MaterialTheme.shapes.small,
                 colors = OutlinedTextFieldDefaults.colors(
                     focusedBorderColor = MaterialTheme.colorScheme.primary,

--- a/app/src/main/java/com/ioannapergamali/mysmartroute/view/ui/screens/RegisterVehicleScreen.kt
+++ b/app/src/main/java/com/ioannapergamali/mysmartroute/view/ui/screens/RegisterVehicleScreen.kt
@@ -43,6 +43,8 @@ import com.ioannapergamali.mysmartroute.viewmodel.VehicleViewModel
 import androidx.compose.ui.res.stringResource
 import com.ioannapergamali.mysmartroute.R
 import androidx.compose.ui.graphics.Color
+import com.ioannapergamali.mysmartroute.view.ui.util.observeBubble
+import com.ioannapergamali.mysmartroute.view.ui.util.LocalKeyboardBubbleState
 
 @OptIn(ExperimentalMaterial3Api::class, ExperimentalLayoutApi::class)
 @Composable
@@ -72,6 +74,7 @@ fun RegisterVehicleScreen(navController: NavController, openDrawer: () -> Unit) 
     var type by remember { mutableStateOf(VehicleType.CAR) }
     var colorExpanded by remember { mutableStateOf(false) }
     var descExpanded by remember { mutableStateOf(false) }
+    val bubbleState = LocalKeyboardBubbleState.current!!
 
     LaunchedEffect(Unit) { viewModel.loadAvailableVehicles(context) }
 
@@ -146,7 +149,9 @@ fun RegisterVehicleScreen(navController: NavController, openDrawer: () -> Unit) 
                 value = name,
                 onValueChange = { name = it },
                 label = { Text(stringResource(R.string.vehicle_name)) },
-                modifier = Modifier.fillMaxWidth(),
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .observeBubble(bubbleState, 0) { name },
                 shape = MaterialTheme.shapes.small,
                 colors = OutlinedTextFieldDefaults.colors(
                     focusedBorderColor = MaterialTheme.colorScheme.primary,
@@ -158,7 +163,9 @@ fun RegisterVehicleScreen(navController: NavController, openDrawer: () -> Unit) 
                 value = plate,
                 onValueChange = { plate = it },
                 label = { Text(stringResource(R.string.license_plate)) },
-                modifier = Modifier.fillMaxWidth(),
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .observeBubble(bubbleState, 1) { plate },
                 shape = MaterialTheme.shapes.small,
                 colors = OutlinedTextFieldDefaults.colors(
                     focusedBorderColor = MaterialTheme.colorScheme.primary,
@@ -284,7 +291,9 @@ fun RegisterVehicleScreen(navController: NavController, openDrawer: () -> Unit) 
                                     },
                                     label = { Text("HEX") },
                                     singleLine = true,
-                                    modifier = Modifier.width(120.dp)
+                                    modifier = Modifier
+                                        .width(120.dp)
+                                        .observeBubble(bubbleState, 2) { tempHex }
                                 )
                             }
                             Spacer(Modifier.height(8.dp))
@@ -292,7 +301,8 @@ fun RegisterVehicleScreen(navController: NavController, openDrawer: () -> Unit) 
                                 value = customColorName,
                                 onValueChange = { customColorName = it },
                                 label = { Text("Όνομα χρώματος") },
-                                singleLine = true
+                                singleLine = true,
+                                modifier = Modifier.observeBubble(bubbleState, 3) { customColorName }
                             )
                         }
                     }
@@ -305,6 +315,7 @@ fun RegisterVehicleScreen(navController: NavController, openDrawer: () -> Unit) 
                 label = { Text(stringResource(R.string.seats_label)) },
                 keyboardOptions = KeyboardOptions(keyboardType = KeyboardType.Number),
                 singleLine = true,
+                modifier = Modifier.observeBubble(bubbleState, 4) { seat.toString() },
                 trailingIcon = {
                     Row {
                         IconButton(onClick = { if (seat > 0) seat-- }) {

--- a/app/src/main/java/com/ioannapergamali/mysmartroute/view/ui/screens/SignUpScreen.kt
+++ b/app/src/main/java/com/ioannapergamali/mysmartroute/view/ui/screens/SignUpScreen.kt
@@ -12,7 +12,6 @@ import androidx.compose.ui.unit.dp
 import androidx.lifecycle.viewmodel.compose.viewModel
 import androidx.navigation.NavController
 import androidx.compose.ui.platform.LocalContext
-import androidx.compose.ui.platform.LocalDensity
 import androidx.compose.ui.res.stringResource
 import android.app.Activity
 import android.widget.Toast
@@ -21,10 +20,9 @@ import com.ioannapergamali.mysmartroute.R
 import com.ioannapergamali.mysmartroute.model.enumerations.UserRole
 import com.ioannapergamali.mysmartroute.viewmodel.AuthenticationViewModel
 import com.ioannapergamali.mysmartroute.view.ui.components.ScreenContainer
-import com.ioannapergamali.mysmartroute.view.ui.components.KeyboardBubble
 import com.ioannapergamali.mysmartroute.view.ui.util.bringIntoViewOnFocus
 import com.ioannapergamali.mysmartroute.view.ui.util.observeBubble
-import com.ioannapergamali.mysmartroute.view.ui.util.rememberKeyboardBubbleState
+import com.ioannapergamali.mysmartroute.view.ui.util.LocalKeyboardBubbleState
 
 @Composable
 fun SignUpScreen(
@@ -52,8 +50,7 @@ fun SignUpScreen(
 
     var selectedRole by remember { mutableStateOf(UserRole.PASSENGER) }
 
-    val bubbleState = rememberKeyboardBubbleState()
-    val imeVisible = WindowInsets.ime.getBottom(LocalDensity.current) > 0
+    val bubbleState = LocalKeyboardBubbleState.current!!
 
 
 
@@ -78,9 +75,8 @@ fun SignUpScreen(
                 ) {
                 OutlinedTextField(
                     value = name,
-                    onValueChange = { 
+                    onValueChange = {
                         name = it
-                        if (bubbleState.activeFieldId == 0) bubbleState.text = it
                     },
                     label = { Text("Name") },
                     modifier = Modifier
@@ -98,7 +94,6 @@ fun SignUpScreen(
                     value = surname,
                     onValueChange = {
                         surname = it
-                        if (bubbleState.activeFieldId == 1) bubbleState.text = it
                     },
                     label = { Text("Surname") },
                     modifier = Modifier
@@ -116,7 +111,6 @@ fun SignUpScreen(
                     value = username,
                     onValueChange = {
                         username = it
-                        if (bubbleState.activeFieldId == 2) bubbleState.text = it
                     },
                     label = { Text("Username") },
                     modifier = Modifier
@@ -134,7 +128,6 @@ fun SignUpScreen(
                     value = email,
                     onValueChange = {
                         email = it
-                        if (bubbleState.activeFieldId == 3) bubbleState.text = it
                     },
                     label = { Text("Email") },
                     modifier = Modifier
@@ -152,7 +145,6 @@ fun SignUpScreen(
                     value = phoneNum,
                     onValueChange = {
                         phoneNum = it
-                        if (bubbleState.activeFieldId == 4) bubbleState.text = it
                     },
                     label = { Text("Phone Number") },
                     modifier = Modifier
@@ -171,7 +163,6 @@ fun SignUpScreen(
                     value = password,
                     onValueChange = {
                         password = it
-                        if (bubbleState.activeFieldId == 5) bubbleState.text = it
                     },
                     label = { Text("Password") },
                     modifier = Modifier
@@ -192,7 +183,6 @@ fun SignUpScreen(
                     value = city,
                     onValueChange = {
                         city = it
-                        if (bubbleState.activeFieldId == 6) bubbleState.text = it
                     },
                     label = { Text("City") },
                     modifier = Modifier
@@ -210,7 +200,6 @@ fun SignUpScreen(
                     value = streetName,
                     onValueChange = {
                         streetName = it
-                        if (bubbleState.activeFieldId == 7) bubbleState.text = it
                     },
                     label = { Text("Street Name") },
                     modifier = Modifier
@@ -228,7 +217,6 @@ fun SignUpScreen(
                     value = streetNumInput,
                     onValueChange = {
                         streetNumInput = it
-                        if (bubbleState.activeFieldId == 8) bubbleState.text = it
                     },
                     label = { Text("Street Number") },
                     modifier = Modifier
@@ -247,7 +235,6 @@ fun SignUpScreen(
                     value = postalCodeInput,
                     onValueChange = {
                         postalCodeInput = it
-                        if (bubbleState.activeFieldId == 9) bubbleState.text = it
                     },
                     label = { Text("Postal Code") },
                     modifier = Modifier
@@ -312,10 +299,6 @@ fun SignUpScreen(
 
                 }
 
-                KeyboardBubble(
-                    text = bubbleState.text,
-                    visible = imeVisible && bubbleState.activeFieldId != null
-                )
             }
         }
 

--- a/app/src/main/java/com/ioannapergamali/mysmartroute/view/ui/util/BubbleObservers.kt
+++ b/app/src/main/java/com/ioannapergamali/mysmartroute/view/ui/util/BubbleObservers.kt
@@ -3,12 +3,19 @@ package com.ioannapergamali.mysmartroute.view.ui.util
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.composed
 import androidx.compose.ui.focus.onFocusChanged
+import androidx.compose.runtime.LaunchedEffect
 
 /**
  * Συνδέει ένα TextField με την κατάσταση του bubble ώστε να
  * εμφανίζεται το κείμενό του όταν έχει focus.
  */
 fun Modifier.observeBubble(state: KeyboardBubbleState, fieldId: Int, currentValue: () -> String): Modifier = composed {
+    val value = currentValue()
+    LaunchedEffect(value, state.activeFieldId) {
+        if (state.activeFieldId == fieldId) {
+            state.text = value
+        }
+    }
     this.onFocusChanged { focusState ->
         if (focusState.isFocused) {
             state.activeFieldId = fieldId

--- a/app/src/main/java/com/ioannapergamali/mysmartroute/view/ui/util/KeyboardBubbleState.kt
+++ b/app/src/main/java/com/ioannapergamali/mysmartroute/view/ui/util/KeyboardBubbleState.kt
@@ -5,6 +5,7 @@ import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.compositionLocalOf
 
 /**
  * Κράτημα κατάστασης του κειμένου που εμφανίζεται στο bubble.
@@ -16,3 +17,5 @@ class KeyboardBubbleState {
 
 @Composable
 fun rememberKeyboardBubbleState() = remember { KeyboardBubbleState() }
+
+val LocalKeyboardBubbleState = compositionLocalOf<KeyboardBubbleState?> { null }


### PR DESCRIPTION
## Summary
- integrate keyboard bubble in `ScreenContainer` for all screens
- observe field focus and text changes via `observeBubble`
- expose bubble state with composition local
- apply bubble support across screens

## Testing
- `./gradlew test` *(fails: domain maven.pkg.jetbrains.space blocked)*

------
https://chatgpt.com/codex/tasks/task_e_687a7c770338832881f03afbf092a025