### PR TITLE
Fix bubble state reference in HomeContent

### DIFF
--- a/app/src/main/java/com/ioannapergamali/mysmartroute/view/ui/screens/HomeScreen.kt
+++ b/app/src/main/java/com/ioannapergamali/mysmartroute/view/ui/screens/HomeScreen.kt
@@ -148,6 +148,7 @@ private fun HomeContent(
     onLogout: () -> Unit = {},
     modifier: Modifier = Modifier
 ) {
+    val bubbleState = LocalKeyboardBubbleState.current!!
     Column(
         modifier = modifier,
         horizontalAlignment = Alignment.CenterHorizontally


### PR DESCRIPTION
## Summary
- define `bubbleState` inside `HomeContent` to resolve build error

## Testing
- `./gradlew test --quiet` *(fails: maven.pkg.jetbrains.space blocked)*

------
https://chatgpt.com/codex/tasks/task_e_687a956648388328a7f90304467dbabb