### PR TITLE
Fix Scaffold invocation in AdminSignUpScreen

### DIFF
--- a/app/src/main/java/com/ioannapergamali/mysmartroute/view/ui/screens/AdminSignUpScreen.kt
+++ b/app/src/main/java/com/ioannapergamali/mysmartroute/view/ui/screens/AdminSignUpScreen.kt
@@ -59,8 +59,9 @@ fun AdminSignUpScreen(
                 onMenuClick = openDrawer
             )
         }
+    ) { paddingValues ->
         ScreenContainer(modifier = Modifier.padding(paddingValues)) {
-        val bubbleState = LocalKeyboardBubbleState.current!!
+            val bubbleState = LocalKeyboardBubbleState.current!!
             Column(
                 modifier = Modifier
                     .fillMaxSize(),


### PR DESCRIPTION
## Summary
- fix `Scaffold` setup in `AdminSignUpScreen`

## Testing
- `./gradlew test` *(fails: maven.pkg.jetbrains.space blocked)*

------
https://chatgpt.com/codex/tasks/task_e_687a9fb6bddc83288711d93c4cd8f5ea