### PR TITLE
Fix unmatched braces in AdminSignUpScreen

### DIFF
--- a/app/src/main/java/com/ioannapergamali/mysmartroute/view/ui/screens/AdminSignUpScreen.kt
+++ b/app/src/main/java/com/ioannapergamali/mysmartroute/view/ui/screens/AdminSignUpScreen.kt
@@ -266,5 +266,6 @@ fun AdminSignUpScreen(
                 else -> {}
             }
         }
+        }
     )
 }


### PR DESCRIPTION
## Summary
- close the Scaffold lambda in `AdminSignUpScreen.kt`

## Testing
- `./gradlew test` *(fails: blocked network access)*

------
https://chatgpt.com/codex/tasks/task_e_687aa184a9f483288d33e9429bee7961