### PR TITLE
Fix closing parenthesis in AdminSignUpScreen

### DIFF
--- a/app/src/main/java/com/ioannapergamali/mysmartroute/view/ui/screens/AdminSignUpScreen.kt
+++ b/app/src/main/java/com/ioannapergamali/mysmartroute/view/ui/screens/AdminSignUpScreen.kt
@@ -267,5 +267,4 @@ fun AdminSignUpScreen(
             }
         }
         }
-    )
 }


### PR DESCRIPTION
## Summary
- remove stray parenthesis at the end of `AdminSignUpScreen`

## Testing
- `./gradlew test --no-daemon` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_687aa3da33cc832880bb9b95a6c27f07