### PR TITLE
Fix route-first vehicle filtering

### DIFF
--- a/app/src/main/java/com/ioannapergamali/mysmartroute/view/ui/screens/AnnounceTransportScreen.kt
+++ b/app/src/main/java/com/ioannapergamali/mysmartroute/view/ui/screens/AnnounceTransportScreen.kt
@@ -91,7 +91,7 @@ fun AnnounceTransportScreen(navController: NavController, openDrawer: () -> Unit
         displayRoutes = if (selectedVehicle == VehicleType.BIGBUS) {
             routes.filter { route ->
                 val pois = routeViewModel.getRoutePois(context, route.id)
-                pois.all { it.type == Place.Type.BUS_STATION }
+                pois.isNotEmpty() && pois.all { it.type == Place.Type.BUS_STATION }
             }
         } else {
             routes
@@ -99,7 +99,7 @@ fun AnnounceTransportScreen(navController: NavController, openDrawer: () -> Unit
 
         val isBusRoute = selectedRouteId?.let { id ->
             val poisSel = routeViewModel.getRoutePois(context, id)
-            poisSel.all { it.type == Place.Type.BUS_STATION }
+            poisSel.isNotEmpty() && poisSel.all { it.type == Place.Type.BUS_STATION }
         } ?: false
 
         filteredVehicles = if (isBusRoute) {


### PR DESCRIPTION
## Summary
- ensure route filtering logic only enables bus routes or vehicles when the associated points exist

## Testing
- `./gradlew test --continue` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_687aa82684508328a90a67cd1468015b