### PR TITLE
Fix driver name display in announcement screen

### DIFF
--- a/app/src/main/java/com/ioannapergamali/mysmartroute/view/ui/screens/AnnounceTransportScreen.kt
+++ b/app/src/main/java/com/ioannapergamali/mysmartroute/view/ui/screens/AnnounceTransportScreen.kt
@@ -181,9 +181,9 @@ fun AnnounceTransportScreen(navController: NavController, openDrawer: () -> Unit
                     )
                     ExposedDropdownMenu(expanded = expandedDriver, onDismissRequest = { expandedDriver = false }) {
                         drivers.forEach { driver ->
-                            DropdownMenuItem(text = { Text("${'$'}{driver.name} ${'$'}{driver.surname}") }, onClick = {
+                            DropdownMenuItem(text = { Text("${driver.name} ${driver.surname}") }, onClick = {
                                 selectedDriverId = driver.id
-                                selectedDriverName = "${'$'}{driver.name} ${'$'}{driver.surname}"
+                                selectedDriverName = "${driver.name} ${driver.surname}"
                                 expandedDriver = false
                                 selectedRouteId = null
                                 selectedVehicle = null


### PR DESCRIPTION
## Summary
- fix string interpolation in driver dropdown

## Testing
- `./gradlew test` *(fails: maven.pkg.jetbrains.space blocked)*

------
https://chatgpt.com/codex/tasks/task_e_687ab39ede748328a799c55e6ee8b57a