### PR TITLE
Fix route refresh in transport screen

### DIFF
--- a/app/src/main/java/com/ioannapergamali/mysmartroute/view/ui/screens/AnnounceTransportScreen.kt
+++ b/app/src/main/java/com/ioannapergamali/mysmartroute/view/ui/screens/AnnounceTransportScreen.kt
@@ -119,6 +119,10 @@ fun AnnounceTransportScreen(navController: NavController, openDrawer: () -> Unit
         } else {
             list
         }
+
+        if (selectedRouteId != null && selectedVehicle != null) {
+            refreshRoute()
+        }
     }
 
     LaunchedEffect(Unit) {


### PR DESCRIPTION
## Summary
- trigger refreshRoute in AnnounceTransportScreen whenever state changes

## Testing
- `./gradlew test --no-daemon` *(fails: domain is not in allowlist)*

------
https://chatgpt.com/codex/tasks/task_e_687ab5543cf4832896643e5ffb1f7394