### PR TITLE
Fix unresolved reference in AnnounceTransportScreen

### DIFF
--- a/app/src/main/java/com/ioannapergamali/mysmartroute/view/ui/screens/AnnounceTransportScreen.kt
+++ b/app/src/main/java/com/ioannapergamali/mysmartroute/view/ui/screens/AnnounceTransportScreen.kt
@@ -94,6 +94,22 @@ fun AnnounceTransportScreen(navController: NavController, openDrawer: () -> Unit
     var pathPoints by remember { mutableStateOf<List<LatLng>>(emptyList()) }
     val cameraPositionState = rememberCameraPositionState()
 
+    fun refreshRoute() {
+        val rId = selectedRouteId
+        val vehicle = selectedVehicle
+        if (rId != null && vehicle != null) {
+            scope.launch {
+                val (dur, path) = routeViewModel.getRouteDirections(context, rId, vehicle)
+                duration = dur
+                pathPoints = path
+                pois = routeViewModel.getRoutePois(context, rId)
+                path.firstOrNull()?.let { first ->
+                    cameraPositionState.move(CameraUpdateFactory.newLatLngZoom(first, 13f))
+                }
+            }
+        }
+    }
+
     LaunchedEffect(routes, vehicles, selectedVehicle, selectedRouteId, selectedDriverId) {
         val driverFiltered = selectedDriverId?.let { id ->
             routes.filter { it.userId == id }
@@ -142,22 +158,6 @@ fun AnnounceTransportScreen(navController: NavController, openDrawer: () -> Unit
             if (uid != null) {
                 selectedDriverId = uid
                 selectedDriverName = userViewModel.getUserName(context, uid)
-            }
-        }
-    }
-
-    fun refreshRoute() {
-        val rId = selectedRouteId
-        val vehicle = selectedVehicle
-        if (rId != null && vehicle != null) {
-            scope.launch {
-                val (dur, path) = routeViewModel.getRouteDirections(context, rId, vehicle)
-                duration = dur
-                pathPoints = path
-                pois = routeViewModel.getRoutePois(context, rId)
-                path.firstOrNull()?.let { first ->
-                    cameraPositionState.move(CameraUpdateFactory.newLatLngZoom(first, 13f))
-                }
             }
         }
     }


### PR DESCRIPTION
## Summary
- define `refreshRoute` before first usage
- remove old duplicate definition

## Testing
- `./gradlew test --no-daemon` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_687aba468fd883288fef343ffa4d1185