### PR TITLE
Add startup sync and show all tables

### DIFF
--- a/app/src/main/java/com/ioannapergamali/mysmartroute/MySmartRouteApplication.kt
+++ b/app/src/main/java/com/ioannapergamali/mysmartroute/MySmartRouteApplication.kt
@@ -6,6 +6,7 @@ import com.ioannapergamali.mysmartroute.BuildConfig
 import com.ioannapergamali.mysmartroute.utils.ShortcutUtils
 import com.ioannapergamali.mysmartroute.utils.populatePoiTypes
 import com.ioannapergamali.mysmartroute.viewmodel.AuthenticationViewModel
+import com.ioannapergamali.mysmartroute.viewmodel.DatabaseViewModel
 import com.ioannapergamali.mysmartroute.utils.LanguagePreferenceManager
 import com.ioannapergamali.mysmartroute.utils.LocaleUtils
 import kotlinx.coroutines.runBlocking
@@ -30,6 +31,12 @@ class MySmartRouteApplication : Application() {
         FirebaseApp.initializeApp(this)
         AuthenticationViewModel().ensureMenusInitialized(this)
         populatePoiTypes(this)
+        runBlocking {
+            try {
+                DatabaseViewModel().syncDatabasesSuspend(this@MySmartRouteApplication)
+            } catch (_: Exception) {
+            }
+        }
         // Η υπηρεσία Firebase App Check απενεργοποιήθηκε προσωρινά
         //val apiKey = BuildConfig.MAPS_API_KEY
 //        Log.d("MySmartRoute Maps API key ", "Maps API key loaded: ${apiKey.isNotBlank()}")

--- a/app/src/main/java/com/ioannapergamali/mysmartroute/data/local/MovingDao.kt
+++ b/app/src/main/java/com/ioannapergamali/mysmartroute/data/local/MovingDao.kt
@@ -12,4 +12,7 @@ interface MovingDao {
 
     @Query("SELECT * FROM movings WHERE userId = :userId")
     fun getMovingsForUser(userId: String): kotlinx.coroutines.flow.Flow<List<MovingEntity>>
+
+    @Query("SELECT * FROM movings")
+    fun getAll(): kotlinx.coroutines.flow.Flow<List<MovingEntity>>
 }

--- a/app/src/main/java/com/ioannapergamali/mysmartroute/data/local/RoutePointDao.kt
+++ b/app/src/main/java/com/ioannapergamali/mysmartroute/data/local/RoutePointDao.kt
@@ -12,4 +12,7 @@ interface RoutePointDao {
 
     @Query("SELECT * FROM route_points WHERE routeId = :routeId ORDER BY position")
     fun getPointsForRoute(routeId: String): kotlinx.coroutines.flow.Flow<List<RoutePointEntity>>
+
+    @Query("SELECT * FROM route_points")
+    fun getAll(): kotlinx.coroutines.flow.Flow<List<RoutePointEntity>>
 }

--- a/app/src/main/java/com/ioannapergamali/mysmartroute/utils/FirestoreMappers.kt
+++ b/app/src/main/java/com/ioannapergamali/mysmartroute/utils/FirestoreMappers.kt
@@ -222,3 +222,57 @@ fun DocumentSnapshot.toPoiTypeEntity(): PoiTypeEntity? {
     val typeName = getString("name") ?: return null
     return PoiTypeEntity(typeId, typeName)
 }
+
+fun MovingEntity.toFirestoreMap(): Map<String, Any> = mapOf(
+    "id" to id,
+    "routeId" to FirebaseFirestore.getInstance().collection("routes").document(routeId),
+    "userId" to FirebaseFirestore.getInstance().collection("users").document(userId),
+    "date" to date,
+    "vehicleId" to FirebaseFirestore.getInstance().collection("vehicles").document(vehicleId),
+    "cost" to cost,
+    "durationMinutes" to durationMinutes
+)
+
+fun DocumentSnapshot.toMovingEntity(): MovingEntity? {
+    val movingId = getString("id") ?: id
+    val routeId = when (val r = get("routeId")) {
+        is DocumentReference -> r.id
+        is String -> r
+        else -> getString("routeId")
+    } ?: return null
+    val userId = when (val u = get("userId")) {
+        is DocumentReference -> u.id
+        is String -> u
+        else -> getString("userId")
+    } ?: ""
+    val vehicleId = when (val v = get("vehicleId")) {
+        is DocumentReference -> v.id
+        is String -> v
+        else -> getString("vehicleId")
+    } ?: ""
+    val dateVal = (getLong("date") ?: 0L).toInt()
+    val costVal = getDouble("cost") ?: 0.0
+    val durVal = (getLong("durationMinutes") ?: 0L).toInt()
+    return MovingEntity(movingId, routeId, userId, dateVal, vehicleId, costVal, durVal)
+}
+
+fun TransportDeclarationEntity.toFirestoreMap(): Map<String, Any> = mapOf(
+    "id" to id,
+    "routeId" to FirebaseFirestore.getInstance().collection("routes").document(routeId),
+    "vehicleType" to vehicleType,
+    "cost" to cost,
+    "durationMinutes" to durationMinutes
+)
+
+fun DocumentSnapshot.toTransportDeclarationEntity(): TransportDeclarationEntity? {
+    val declId = getString("id") ?: id
+    val routeId = when (val r = get("routeId")) {
+        is DocumentReference -> r.id
+        is String -> r
+        else -> getString("routeId")
+    } ?: return null
+    val type = getString("vehicleType") ?: return null
+    val costVal = getDouble("cost") ?: 0.0
+    val durVal = (getLong("durationMinutes") ?: 0L).toInt()
+    return TransportDeclarationEntity(declId, routeId, type, costVal, durVal)
+}

--- a/app/src/main/java/com/ioannapergamali/mysmartroute/view/ui/screens/FirebaseDatabaseScreen.kt
+++ b/app/src/main/java/com/ioannapergamali/mysmartroute/view/ui/screens/FirebaseDatabaseScreen.kt
@@ -59,9 +59,34 @@ fun FirebaseDatabaseScreen(navController: NavController, openDrawer: () -> Unit)
                     Text("${vehicle.description}, τύπος ${vehicle.type}, θέσεις ${vehicle.seat}")
                 }
                 item { Spacer(modifier = Modifier.padding(8.dp)) }
+                item { Text("Poi Types", style = MaterialTheme.typography.titleMedium) }
+                items(data!!.poiTypes) { t ->
+                    Text("${t.id} -> ${t.name}")
+                }
+                item { Spacer(modifier = Modifier.padding(8.dp)) }
                 item { Text("PoIs", style = MaterialTheme.typography.titleMedium) }
                 items(data!!.pois) { poi ->
                     Text("${poi.name} (${poi.type}) - ${poi.address.city}")
+                }
+                item { Spacer(modifier = Modifier.padding(8.dp)) }
+                item { Text("Routes", style = MaterialTheme.typography.titleMedium) }
+                items(data!!.routes) { r ->
+                    Text("${r.id} -> ${r.name}")
+                }
+                item { Spacer(modifier = Modifier.padding(8.dp)) }
+                item { Text("Route Points", style = MaterialTheme.typography.titleMedium) }
+                items(data!!.routePoints) { p ->
+                    Text("${p.routeId} : ${p.position} -> ${p.poiId}")
+                }
+                item { Spacer(modifier = Modifier.padding(8.dp)) }
+                item { Text("Movings", style = MaterialTheme.typography.titleMedium) }
+                items(data!!.movings) { m ->
+                    Text("${m.id} route:${m.routeId} user:${m.userId}")
+                }
+                item { Spacer(modifier = Modifier.padding(8.dp)) }
+                item { Text("Transport Declarations", style = MaterialTheme.typography.titleMedium) }
+                items(data!!.declarations) { d ->
+                    Text("${d.id} route:${d.routeId} type:${d.vehicleType}")
                 }
                 item { Spacer(modifier = Modifier.padding(8.dp)) }
                 item { Text("Settings", style = MaterialTheme.typography.titleMedium) }

--- a/app/src/main/java/com/ioannapergamali/mysmartroute/view/ui/screens/LocalDatabaseScreen.kt
+++ b/app/src/main/java/com/ioannapergamali/mysmartroute/view/ui/screens/LocalDatabaseScreen.kt
@@ -69,12 +69,57 @@ fun LocalDatabaseScreen(navController: NavController, openDrawer: () -> Unit) {
                     }
                 }
                 item { Spacer(modifier = Modifier.padding(8.dp)) }
+                item { Text("Poi Types", style = MaterialTheme.typography.titleMedium) }
+                if (data!!.poiTypes.isEmpty()) {
+                    item { Text("Ο πίνακας είναι άδειος") }
+                } else {
+                    items(data!!.poiTypes) { t ->
+                        Text("${t.id} -> ${t.name}")
+                    }
+                }
+                item { Spacer(modifier = Modifier.padding(8.dp)) }
                 item { Text("PoIs", style = MaterialTheme.typography.titleMedium) }
                 if (data!!.pois.isEmpty()) {
                     item { Text("Ο πίνακας είναι άδειος") }
                 } else {
                     items(data!!.pois) { poi ->
                         Text("${poi.name} (${poi.type}) - ${poi.address.city}")
+                    }
+                }
+                item { Spacer(modifier = Modifier.padding(8.dp)) }
+                item { Text("Routes", style = MaterialTheme.typography.titleMedium) }
+                if (data!!.routes.isEmpty()) {
+                    item { Text("Ο πίνακας είναι άδειος") }
+                } else {
+                    items(data!!.routes) { r ->
+                        Text("${r.id} -> ${r.name}")
+                    }
+                }
+                item { Spacer(modifier = Modifier.padding(8.dp)) }
+                item { Text("Route Points", style = MaterialTheme.typography.titleMedium) }
+                if (data!!.routePoints.isEmpty()) {
+                    item { Text("Ο πίνακας είναι άδειος") }
+                } else {
+                    items(data!!.routePoints) { p ->
+                        Text("${p.routeId} : ${p.position} -> ${p.poiId}")
+                    }
+                }
+                item { Spacer(modifier = Modifier.padding(8.dp)) }
+                item { Text("Movings", style = MaterialTheme.typography.titleMedium) }
+                if (data!!.movings.isEmpty()) {
+                    item { Text("Ο πίνακας είναι άδειος") }
+                } else {
+                    items(data!!.movings) { m ->
+                        Text("${m.id} route:${m.routeId} user:${m.userId}")
+                    }
+                }
+                item { Spacer(modifier = Modifier.padding(8.dp)) }
+                item { Text("Transport Declarations", style = MaterialTheme.typography.titleMedium) }
+                if (data!!.declarations.isEmpty()) {
+                    item { Text("Ο πίνακας είναι άδειος") }
+                } else {
+                    items(data!!.declarations) { d ->
+                        Text("${d.id} route:${d.routeId} type:${d.vehicleType}")
                     }
                 }
                 item { Spacer(modifier = Modifier.padding(8.dp)) }


### PR DESCRIPTION
## Summary
- sync databases from Firebase on app startup
- expose Dao methods to list all route points and movings
- extend Firestore mappers for new entities
- expand viewmodel to handle routes, movings and more
- display all database tables in local/Firebase DB screens

## Testing
- `./gradlew test --quiet` *(failed: blocked by network)*

------
https://chatgpt.com/codex/tasks/task_e_687ad6771e808328b2d7407a542e4445