### PR TITLE
Αποφυγή διπλού scrolling στη λίστα οχημάτων

### DIFF
--- a/app/src/main/java/com/ioannapergamali/mysmartroute/view/ui/screens/ViewVehiclesScreen.kt
+++ b/app/src/main/java/com/ioannapergamali/mysmartroute/view/ui/screens/ViewVehiclesScreen.kt
@@ -62,7 +62,7 @@ fun ViewVehiclesScreen(navController: NavController, openDrawer: () -> Unit) {
             )
         }
     ) { paddingValues ->
-        ScreenContainer(modifier = Modifier.padding(paddingValues)) {
+        ScreenContainer(modifier = Modifier.padding(paddingValues), scrollable = false) {
             if (vehicles.isEmpty()) {
 
             } else {


### PR DESCRIPTION
## Περιγραφή
Διορθώνει την εξαίρεση `Vertically scrollable component was measured with an infinity maximum height constraints` στην οθόνη προβολής οχημάτων. Η `ViewVehiclesScreen` χρησιμοποιούσε `ScreenContainer` με προεπιλεγμένο `scrollable = true` ενώ περιείχε `LazyColumn`. Πλέον ορίζεται `scrollable = false` για να μην υπάρχει διπλό scrolling.

## Έλεγχοι
- `./gradlew test` *(απέτυχε λόγω έλλειψης Android SDK)*

------
https://chatgpt.com/codex/tasks/task_e_687ae598895083288b270231a85e918f