### PR TITLE
Add Book Seat feature

### DIFF
--- a/app/src/main/java/com/ioannapergamali/mysmartroute/model/navigation/NavigationHost.kt
+++ b/app/src/main/java/com/ioannapergamali/mysmartroute/model/navigation/NavigationHost.kt
@@ -34,6 +34,7 @@ import com.ioannapergamali.mysmartroute.view.ui.screens.PrintListScreen
 import com.ioannapergamali.mysmartroute.view.ui.screens.PrintScheduledScreen
 import com.ioannapergamali.mysmartroute.view.ui.screens.RouteModeScreen
 import com.ioannapergamali.mysmartroute.view.ui.screens.ViewVehiclesScreen
+import com.ioannapergamali.mysmartroute.view.ui.screens.BookSeatScreen
 
 
 
@@ -150,6 +151,10 @@ fun NavigationHost(navController : NavHostController, openDrawer: () -> Unit) {
 
         composable("routeMode") {
             RouteModeScreen(navController = navController, openDrawer = openDrawer)
+        }
+
+        composable("bookSeat") {
+            BookSeatScreen(navController = navController, openDrawer = openDrawer)
         }
 
         composable("printList") {

--- a/app/src/main/java/com/ioannapergamali/mysmartroute/view/ui/screens/BookSeatScreen.kt
+++ b/app/src/main/java/com/ioannapergamali/mysmartroute/view/ui/screens/BookSeatScreen.kt
@@ -1,0 +1,84 @@
+package com.ioannapergamali.mysmartroute.view.ui.screens
+
+import androidx.compose.foundation.layout.*
+import androidx.compose.material3.Button
+import androidx.compose.material3.DropdownMenu
+import androidx.compose.material3.DropdownMenuItem
+import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.Scaffold
+import androidx.compose.material3.Text
+import androidx.compose.runtime.*
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.unit.dp
+import androidx.lifecycle.viewmodel.compose.viewModel
+import androidx.navigation.NavController
+import com.ioannapergamali.mysmartroute.R
+import com.ioannapergamali.mysmartroute.data.local.RouteEntity
+import com.ioannapergamali.mysmartroute.view.ui.components.ScreenContainer
+import com.ioannapergamali.mysmartroute.view.ui.components.TopBar
+import com.ioannapergamali.mysmartroute.viewmodel.BookingViewModel
+
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+fun BookSeatScreen(navController: NavController, openDrawer: () -> Unit) {
+    val viewModel: BookingViewModel = viewModel()
+    val routes by viewModel.availableRoutes.collectAsState()
+    var selectedRoute by remember { mutableStateOf<RouteEntity?>(null) }
+    var message by remember { mutableStateOf("") }
+
+    Scaffold(
+        topBar = {
+            TopBar(
+                title = stringResource(R.string.book_seat),
+                navController = navController,
+                showMenu = true,
+                onMenuClick = openDrawer
+            )
+        }
+    ) { paddingValues ->
+        ScreenContainer(modifier = Modifier.padding(paddingValues)) {
+            var expanded by remember { mutableStateOf(false) }
+
+            Box {
+                Button(onClick = { expanded = true }) {
+                    Text(selectedRoute?.name ?: stringResource(R.string.select_route))
+                }
+                DropdownMenu(expanded = expanded, onDismissRequest = { expanded = false }) {
+                    routes.forEach { route ->
+                        DropdownMenuItem(
+                            text = { Text(route.name) },
+                            onClick = {
+                                selectedRoute = route
+                                expanded = false
+                            }
+                        )
+                    }
+                }
+            }
+
+            Spacer(Modifier.height(16.dp))
+
+            Button(
+                enabled = selectedRoute != null,
+                onClick = {
+                    selectedRoute?.let { r ->
+                        val success = viewModel.reserveSeat(r.id)
+                        message = if (success) {
+                            stringResource(R.string.seat_booked)
+                        } else {
+                            stringResource(R.string.seat_unavailable)
+                        }
+                    }
+                }
+            ) {
+                Text(stringResource(R.string.reserve_seat))
+            }
+
+            if (message.isNotBlank()) {
+                Spacer(Modifier.height(8.dp))
+                Text(message)
+            }
+        }
+    }
+}

--- a/app/src/main/java/com/ioannapergamali/mysmartroute/viewmodel/BookingViewModel.kt
+++ b/app/src/main/java/com/ioannapergamali/mysmartroute/viewmodel/BookingViewModel.kt
@@ -1,0 +1,42 @@
+package com.ioannapergamali.mysmartroute.viewmodel
+
+import androidx.lifecycle.ViewModel
+import com.google.firebase.auth.FirebaseAuth
+import com.google.firebase.firestore.FirebaseFirestore
+import com.ioannapergamali.mysmartroute.data.local.RouteEntity
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+
+class BookingViewModel : ViewModel() {
+    private val db = FirebaseFirestore.getInstance()
+    private val auth = FirebaseAuth.getInstance()
+
+    private val _availableRoutes = MutableStateFlow<List<RouteEntity>>(emptyList())
+    val availableRoutes: StateFlow<List<RouteEntity>> = _availableRoutes
+
+    init {
+        db.collection("routes").get().addOnSuccessListener { snapshot ->
+            val list = snapshot.documents.mapNotNull { it.toObject(RouteEntity::class.java) }
+            _availableRoutes.value = list
+        }
+    }
+
+    fun reserveSeat(routeId: String): Boolean {
+        val userId = auth.currentUser?.uid ?: return false
+        val routeRef = db.collection("served_movings").document(routeId)
+        return try {
+            db.runTransaction { tx ->
+                val served = tx.get(routeRef).toObject(com.ioannapergamali.mysmartroute.model.classes.transports.ServedMoving::class.java)
+                    ?: return@runTransaction false
+                if (served.hasAvailableSeat(capacity = 4)) {
+                    served.passengers.add(userId)
+                    tx.set(routeRef, served)
+                    true
+                } else false
+            }
+            true
+        } catch (e: Exception) {
+            false
+        }
+    }
+}

--- a/app/src/main/res/values-el/strings.xml
+++ b/app/src/main/res/values-el/strings.xml
@@ -137,4 +137,8 @@
     <string name="poi_outside_heraklion">Επιλέξτε σημείο εντός Ηρακλείου</string>
     <string name="search_address">Αναζήτηση διεύθυνσης</string>
     <string name="fill_all_fields">Συμπλήρωσε όλα τα πεδία</string>
+    <string name="seat_booked">Η θέση κλείστηκε!</string>
+    <string name="seat_unavailable">Δεν υπάρχουν διαθέσιμες θέσεις.</string>
+    <string name="reserve_seat">Κλείσε Θέση</string>
+    <string name="select_route">Επιλογή διαδρομής</string>
 </resources>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -146,4 +146,8 @@
     <string name="search_address">Search address</string>
     <string name="fill_all_fields">Please fill in all fields</string>
     <string name="poi_already_last">Το σημείο έχει ήδη προστεθεί</string>
+    <string name="seat_booked">Seat booked!</string>
+    <string name="seat_unavailable">No available seats.</string>
+    <string name="reserve_seat">Reserve Seat</string>
+    <string name="select_route">Select route</string>
 </resources>


### PR DESCRIPTION
## Summary
- implement `BookSeatScreen` for seat reservations
- add `BookingViewModel` to handle Firestore transactions
- wire new screen in `NavigationHost`
- provide strings for seat booking messages in English and Greek

## Testing
- `./gradlew test` *(fails: maven.pkg.jetbrains.space blocked)*

------
https://chatgpt.com/codex/tasks/task_e_687cb1159a9c8328a12209ae1b58a7a0