### PR TITLE
Add route POI selection screen

### DIFF
--- a/app/src/main/assets/menus.json
+++ b/app/src/main/assets/menus.json
@@ -12,6 +12,7 @@
           {"titleKey": "find_way", "route": "findWay"},
           {"titleKey": "book_seat", "route": "bookSeat"},
           {"titleKey": "view_routes", "route": "viewRoutes"},
+          {"titleKey": "select_pois_screen_title", "route": "selectRoutePois"},
           {"titleKey": "view_transports", "route": "viewTransports"},
           {"titleKey": "print_ticket", "route": "printTicket"},
           {"titleKey": "cancel_seat", "route": "cancelSeat"},

--- a/app/src/main/java/com/ioannapergamali/mysmartroute/model/navigation/NavigationHost.kt
+++ b/app/src/main/java/com/ioannapergamali/mysmartroute/model/navigation/NavigationHost.kt
@@ -36,6 +36,7 @@ import com.ioannapergamali.mysmartroute.view.ui.screens.RouteModeScreen
 import com.ioannapergamali.mysmartroute.view.ui.screens.ViewVehiclesScreen
 import com.ioannapergamali.mysmartroute.view.ui.screens.BookSeatScreen
 import com.ioannapergamali.mysmartroute.view.ui.screens.ViewRoutesScreen
+import com.ioannapergamali.mysmartroute.view.ui.screens.SelectRoutePoisScreen
 
 
 
@@ -160,6 +161,10 @@ fun NavigationHost(navController : NavHostController, openDrawer: () -> Unit) {
 
         composable("viewRoutes") {
             ViewRoutesScreen(navController = navController, openDrawer = openDrawer)
+        }
+
+        composable("selectRoutePois") {
+            SelectRoutePoisScreen(navController = navController, openDrawer = openDrawer)
         }
 
         composable("printList") {

--- a/app/src/main/java/com/ioannapergamali/mysmartroute/view/ui/screens/SelectRoutePoisScreen.kt
+++ b/app/src/main/java/com/ioannapergamali/mysmartroute/view/ui/screens/SelectRoutePoisScreen.kt
@@ -1,0 +1,154 @@
+package com.ioannapergamali.mysmartroute.view.ui.screens
+
+import androidx.compose.foundation.layout.*
+import androidx.compose.foundation.selection.toggleable
+import androidx.compose.material3.*
+import androidx.compose.runtime.*
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.unit.dp
+import androidx.lifecycle.viewmodel.compose.viewModel
+import androidx.navigation.NavController
+import com.google.android.gms.maps.CameraUpdateFactory
+import com.google.android.gms.maps.model.LatLng
+import com.google.maps.android.compose.GoogleMap
+import com.google.maps.android.compose.Marker
+import com.google.maps.android.compose.MarkerState
+import com.google.maps.android.compose.Polyline
+import com.google.maps.android.compose.rememberCameraPositionState
+import com.ioannapergamali.mysmartroute.R
+import com.ioannapergamali.mysmartroute.data.local.PoIEntity
+import com.ioannapergamali.mysmartroute.data.local.RouteEntity
+import com.ioannapergamali.mysmartroute.model.enumerations.VehicleType
+import com.ioannapergamali.mysmartroute.utils.MapsUtils
+import com.ioannapergamali.mysmartroute.view.ui.components.ScreenContainer
+import com.ioannapergamali.mysmartroute.view.ui.components.TopBar
+import com.ioannapergamali.mysmartroute.viewmodel.RouteViewModel
+import kotlinx.coroutines.launch
+
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+fun SelectRoutePoisScreen(navController: NavController, openDrawer: () -> Unit) {
+    val context = LocalContext.current
+    val routeViewModel: RouteViewModel = viewModel()
+    val routes by routeViewModel.routes.collectAsState()
+    val scope = rememberCoroutineScope()
+
+    var selectedRoute by remember { mutableStateOf<RouteEntity?>(null) }
+    var pois by remember { mutableStateOf<List<PoIEntity>>(emptyList()) }
+    var pathPoints by remember { mutableStateOf<List<LatLng>>(emptyList()) }
+    var expanded by remember { mutableStateOf(false) }
+    val selectedPoiIds = remember { mutableStateListOf<String>() }
+
+    val cameraPositionState = rememberCameraPositionState()
+    val apiKey = MapsUtils.getApiKey(context)
+    val isKeyMissing = apiKey.isBlank()
+
+    LaunchedEffect(Unit) { routeViewModel.loadRoutes(context, includeAll = true) }
+
+    Scaffold(
+        topBar = {
+            TopBar(
+                title = stringResource(R.string.select_pois_screen_title),
+                navController = navController,
+                showMenu = true,
+                onMenuClick = openDrawer
+            )
+        }
+    ) { padding ->
+        ScreenContainer(modifier = Modifier.padding(padding)) {
+            Box {
+                Button(onClick = { expanded = true }) {
+                    Text(selectedRoute?.name ?: stringResource(R.string.select_route))
+                }
+                DropdownMenu(expanded = expanded, onDismissRequest = { expanded = false }) {
+                    routes.forEach { route ->
+                        DropdownMenuItem(
+                            text = { Text(route.name) },
+                            onClick = {
+                                selectedRoute = route
+                                expanded = false
+                                scope.launch {
+                                    val (_, path) = routeViewModel.getRouteDirections(
+                                        context,
+                                        route.id,
+                                        VehicleType.CAR
+                                    )
+                                    pathPoints = path
+                                    pois = routeViewModel.getRoutePois(context, route.id)
+                                    selectedPoiIds.clear()
+                                    selectedPoiIds.addAll(pois.map { it.id })
+                                    path.firstOrNull()?.let {
+                                        cameraPositionState.move(
+                                            CameraUpdateFactory.newLatLngZoom(it, 13f)
+                                        )
+                                    }
+                                }
+                            }
+                        )
+                    }
+                }
+            }
+
+            Spacer(Modifier.height(16.dp))
+
+            if (selectedRoute != null && pathPoints.isNotEmpty() && !isKeyMissing) {
+                GoogleMap(
+                    modifier = Modifier
+                        .fillMaxWidth()
+                        .height(200.dp),
+                    cameraPositionState = cameraPositionState
+                ) {
+                    Polyline(points = pathPoints)
+                    pois.forEach { poi ->
+                        Marker(
+                            state = MarkerState(position = LatLng(poi.lat, poi.lng)),
+                            title = poi.name
+                        )
+                    }
+                }
+
+                Spacer(Modifier.height(16.dp))
+            } else if (isKeyMissing) {
+                Text(stringResource(R.string.map_api_key_missing))
+                Spacer(Modifier.height(16.dp))
+            }
+
+            if (pois.isNotEmpty()) {
+                Text(stringResource(R.string.choose_pois))
+                Column(modifier = Modifier.fillMaxWidth()) {
+                    pois.forEachIndexed { index, poi ->
+                        Row(
+                            verticalAlignment = Alignment.CenterVertically,
+                            modifier = Modifier
+                                .fillMaxWidth()
+                                .padding(vertical = 4.dp)
+                        ) {
+                            Checkbox(
+                                checked = poi.id in selectedPoiIds,
+                                onCheckedChange = { checked ->
+                                    if (checked) {
+                                        if (poi.id !in selectedPoiIds) selectedPoiIds.add(poi.id)
+                                    } else {
+                                        selectedPoiIds.remove(poi.id)
+                                    }
+                                }
+                            )
+                            Spacer(Modifier.width(8.dp))
+                            Text("${index + 1}. ${poi.name}")
+                        }
+                    }
+                }
+
+                Spacer(Modifier.height(16.dp))
+
+                Button(onClick = { /* TODO: Handle confirmation */ }) {
+                    Text(stringResource(R.string.confirm_poi_selection))
+                }
+            }
+        }
+    }
+}
+

--- a/app/src/main/res/values-el/strings.xml
+++ b/app/src/main/res/values-el/strings.xml
@@ -143,4 +143,7 @@
     <string name="select_route">Επιλογή διαδρομής</string>
     <string name="add_poi_option">Προσθήκη POI</string>
     <string name="select_date">Επιλογή ημερομηνίας</string>
+    <string name="select_pois_screen_title">Επιλογή POI διαδρομής</string>
+    <string name="choose_pois">Επιλογή σημείων ενδιαφέροντος</string>
+    <string name="confirm_poi_selection">Επιβεβαίωση επιλογής</string>
 </resources>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -152,4 +152,7 @@
     <string name="select_route">Select route</string>
     <string name="add_poi_option">Add POI</string>
     <string name="select_date">Select date</string>
+    <string name="select_pois_screen_title">Select Route POIs</string>
+    <string name="choose_pois">Choose points of interest</string>
+    <string name="confirm_poi_selection">Confirm selection</string>
 </resources>


### PR DESCRIPTION
## Summary
- create `SelectRoutePoisScreen` to allow passengers to choose POIs of a route
- register new screen in `NavigationHost`
- add menu item for the new screen
- update string resources (en & el)

## Testing
- `./gradlew test` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_687fd36077b083288f05ec18b9df77ec