### PR TITLE
Fix map initialization crash

### DIFF
--- a/app/src/main/java/com/ioannapergamali/mysmartroute/view/ui/screens/BookSeatScreen.kt
+++ b/app/src/main/java/com/ioannapergamali/mysmartroute/view/ui/screens/BookSeatScreen.kt
@@ -21,6 +21,7 @@ import androidx.compose.ui.unit.dp
 import androidx.lifecycle.viewmodel.compose.viewModel
 import androidx.navigation.NavController
 import com.google.android.gms.maps.CameraUpdateFactory
+import com.google.android.gms.maps.MapsInitializer
 import com.google.android.gms.maps.model.LatLng
 import com.google.maps.android.compose.GoogleMap
 import com.google.maps.android.compose.Marker
@@ -98,6 +99,7 @@ fun BookSeatScreen(navController: NavController, openDrawer: () -> Unit) {
                                     pathPoints = path
                                     pois = routeViewModel.getRoutePois(context, route.id)
                                     path.firstOrNull()?.let {
+                                        MapsInitializer.initialize(context)
                                         cameraPositionState.move(
                                             CameraUpdateFactory.newLatLngZoom(it, 13f)
                                         )


### PR DESCRIPTION
## Summary
- initialize Google Maps before moving camera in BookSeatScreen

## Testing
- `./gradlew help` *(fails: blocked maven.pkg.jetbrains.space)*
- `./gradlew test` *(fails: blocked maven.pkg.jetbrains.space)*

------
https://chatgpt.com/codex/tasks/task_e_687fd741025c832885b09a121b45bbba