### PR TITLE
Enable POI editing when booking seats

### DIFF
--- a/app/src/main/res/values-el/strings.xml
+++ b/app/src/main/res/values-el/strings.xml
@@ -146,4 +146,5 @@
     <string name="select_pois_screen_title">Επιλογή POI διαδρομής</string>
     <string name="choose_pois">Επιλογή σημείων ενδιαφέροντος</string>
     <string name="confirm_poi_selection">Επιβεβαίωση επιλογής</string>
+    <string name="recalculate_route">Επανασχεδίαση διαδρομής</string>
 </resources>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -155,4 +155,5 @@
     <string name="select_pois_screen_title">Select Route POIs</string>
     <string name="choose_pois">Choose points of interest</string>
     <string name="confirm_poi_selection">Confirm selection</string>
+    <string name="recalculate_route">Recalculate route</string>
 </resources>


### PR DESCRIPTION
## Summary
- allow adding/removing POIs when booking a seat
- refresh route path after POI updates
- add button to recalc route on demand
- translate new string

## Testing
- `./gradlew test` *(fails: could not download dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_687ff1adfea483289c168baa551da9c7