### PR TITLE
Fix menu initialization logic

### DIFF
--- a/app/src/main/java/com/ioannapergamali/mysmartroute/viewmodel/AuthenticationViewModel.kt
+++ b/app/src/main/java/com/ioannapergamali/mysmartroute/viewmodel/AuthenticationViewModel.kt
@@ -435,6 +435,17 @@ class AuthenticationViewModel : ViewModel() {
 
             roleDao.insert(RoleEntity(id = roleId, name = roleName, parentRoleId = parentId))
 
+            val menusSnap = roleRef.collection("menus").get().await()
+            val existingMenus = menusSnap.documents.associateBy { it.getString("id") ?: it.id }
+            cfg.menus.forEachIndexed { menuIndex, menu ->
+                val menuId = "menu_${role.name.lowercase()}_${menuIndex}"
+                val menuDoc = roleRef.collection("menus").document(menuId)
+
+                if (!existingMenus.containsKey(menuId)) {
+                    batch.set(menuDoc, mapOf("id" to menuId, "titleKey" to menu.titleKey))
+                    commitNeeded = true
+                }
+
                 val existingOptions = menuDoc.collection("options").get().await()
                     .documents.associateBy { it.getString("id") ?: it.id }
                 menu.options.forEachIndexed { optionIndex, option ->


### PR DESCRIPTION
## Summary
- restore missing menu and option creation logic in `AuthenticationViewModel`

## Testing
- `./gradlew test --no-daemon` *(fails: maven.pkg.jetbrains.space blocked)*

------
https://chatgpt.com/codex/tasks/task_e_68801099a53483288e1df859e4ebcf9f