### PR TITLE
Fix Kotlin syntax error from extra brace

### DIFF
--- a/app/src/main/java/com/ioannapergamali/mysmartroute/viewmodel/AuthenticationViewModel.kt
+++ b/app/src/main/java/com/ioannapergamali/mysmartroute/viewmodel/AuthenticationViewModel.kt
@@ -438,8 +438,6 @@ class AuthenticationViewModel : ViewModel() {
 
 
             }
-        }
-
         if (commitNeeded) {
             batch.commit().await()
         }


### PR DESCRIPTION
## Summary
- fix Kotlin file's unbalanced braces

## Testing
- `./gradlew assembleDebug` *(fails: Java home invalid)*

------
https://chatgpt.com/codex/tasks/task_e_68801ab734108328940b89439339f84a