### PR TITLE
Fix Gradle JDK path

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -25,4 +25,3 @@ android.nonTransitiveRClass=true
 
 kotlin.jvm.target=11
 kotlin.version=2.1.21
-org.gradle.java.home=/root/.local/share/mise/installs/java/21.0.2


### PR DESCRIPTION
## Summary
- remove invalid `org.gradle.java.home` entry so Gradle uses Android Studio's JDK

## Testing
- `./gradlew tasks --all` *(fails: maven.pkg.jetbrains.space blocked)*

------
https://chatgpt.com/codex/tasks/task_e_68804a3c0ac083289b4042cf8a08fe8f