### PR TITLE
Add direct POI creation

### DIFF
--- a/app/src/main/java/com/ioannapergamali/mysmartroute/view/ui/screens/BookSeatScreen.kt
+++ b/app/src/main/java/com/ioannapergamali/mysmartroute/view/ui/screens/BookSeatScreen.kt
@@ -76,7 +76,6 @@ fun BookSeatScreen(navController: NavController, openDrawer: () -> Unit) {
     val pois = remember { mutableStateListOf<PoIEntity>() }
     val userPoiIds = remember { mutableStateListOf<String>() }
     var pathPoints by remember { mutableStateOf<List<LatLng>>(emptyList()) }
-    var addMenuExpanded by remember { mutableStateOf(false) }
     var calculating by remember { mutableStateOf(false) }
     var pendingPoi by remember { mutableStateOf<Triple<String, Double, Double>?>(null) }
     val datePickerState = rememberDatePickerState()
@@ -294,30 +293,10 @@ fun BookSeatScreen(navController: NavController, openDrawer: () -> Unit) {
             }
 
             if (selectedRoute != null) {
-                Box {
-                    Button(onClick = { addMenuExpanded = true }) {
-                        Text(stringResource(R.string.add_poi_option))
-                    }
-                    DropdownMenu(expanded = addMenuExpanded, onDismissRequest = { addMenuExpanded = false }) {
-                        allPois.forEach { poi ->
-                            DropdownMenuItem(text = { Text(poi.name) }, onClick = {
-                                if (pois.none { it.id == poi.id }) {
-                                    pois.add(poi)
-                                    userPoiIds.add(poi.id)
-                                    refreshRoute()
-                                }
-                                addMenuExpanded = false
-                            })
-                        }
-                        Divider()
-                        DropdownMenuItem(
-                            text = { Text(stringResource(R.string.define_poi)) },
-                            onClick = {
-                                addMenuExpanded = false
-                                navController.navigate("definePoi?lat=&lng=&source=&view=false")
-                            }
-                        )
-                    }
+                Button(onClick = {
+                    navController.navigate("definePoi?lat=&lng=&source=&view=false")
+                }) {
+                    Text(stringResource(R.string.add_poi_option))
                 }
 
                 Spacer(Modifier.height(16.dp))


### PR DESCRIPTION
## Summary
- simplify the Add POI action on the seat booking screen
- pressing the button now jumps straight to the Define POI screen

## Testing
- `./gradlew test` *(fails: domain `maven.pkg.jetbrains.space` blocked)*

------
https://chatgpt.com/codex/tasks/task_e_688053749e1083289ee68d1a47b2a4d6