### PR TITLE
Handle short route case in seat booking

### DIFF
--- a/app/src/main/java/com/ioannapergamali/mysmartroute/view/ui/screens/BookSeatScreen.kt
+++ b/app/src/main/java/com/ioannapergamali/mysmartroute/view/ui/screens/BookSeatScreen.kt
@@ -96,13 +96,23 @@ fun BookSeatScreen(navController: NavController, openDrawer: () -> Unit) {
                 val origin = LatLng(pois.first().lat, pois.first().lng)
                 val destination = LatLng(pois.last().lat, pois.last().lng)
                 val waypoints = pois.drop(1).dropLast(1).map { LatLng(it.lat, it.lng) }
-                val data = MapsUtils.fetchDurationAndPath(origin, destination, apiKey, VehicleType.CAR, waypoints)
+                val data = MapsUtils.fetchDurationAndPath(
+                    origin,
+                    destination,
+                    apiKey,
+                    VehicleType.CAR,
+                    waypoints
+                )
                 pathPoints = data.points
                 data.points.firstOrNull()?.let {
-                    cameraPositionState.move(CameraUpdateFactory.newLatLngZoom(it, 13f))
+                    cameraPositionState.move(
+                        CameraUpdateFactory.newLatLngZoom(it, 13f)
+                    )
                 }
                 calculating = false
             }
+        } else {
+            pathPoints = emptyList()
         }
     }
 


### PR DESCRIPTION
## Summary
- clear map path when user removes stops and fewer than two remain

## Testing
- `./gradlew test` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_6880587ff4408328b1fbcb0f189ec07c