### PR TITLE
Προσθήκη enum BookingStep

### DIFF
--- a/app/src/main/java/com/ioannapergamali/mysmartroute/model/enumerations/BookingStep.kt
+++ b/app/src/main/java/com/ioannapergamali/mysmartroute/model/enumerations/BookingStep.kt
@@ -1,0 +1,28 @@
+package com.ioannapergamali.mysmartroute.model.enumerations
+
+import androidx.annotation.StringRes
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.res.stringResource
+import com.ioannapergamali.mysmartroute.R
+
+/**
+ * Βήματα για την κράτηση θέσης.
+ */
+enum class BookingStep(@StringRes val titleRes: Int) {
+    /** Δήλωση Διαδρομής */
+    DECLARE_ROUTE(R.string.declare_route),
+    /** Επιλογή Διαδρομής */
+    SELECT_ROUTE(R.string.select_route),
+    /** Προσθήκη σημείου ενδιαφέροντος */
+    ADD_POI(R.string.add_poi_option),
+    /** Επανασχεδίαση διαδρομής */
+    RECALCULATE_ROUTE(R.string.recalculate_route),
+    /** Επιλογή ημερομηνίας */
+    SELECT_DATE(R.string.select_date),
+    /** Κλείσιμο θέσης */
+    RESERVE_SEAT(R.string.reserve_seat)
+}
+
+/** Επιστρέφει το τοπικοποιημένο όνομα του βήματος. */
+@Composable
+fun BookingStep.localizedName(): String = stringResource(id = titleRes)


### PR DESCRIPTION
## Summary
- δημιουργήθηκε νέο enum `BookingStep` για τα βήματα κράτησης

## Testing
- `./gradlew test` *(αποτυχία: δεν βρέθηκε Android SDK)*

------
https://chatgpt.com/codex/tasks/task_e_68806e0851a08328b55a89e3fa326c14