### PR TITLE
Fix BookingStep enum

### DIFF
--- a/app/src/main/java/com/ioannapergamali/mysmartroute/model/enumerations/BookingStep.kt
+++ b/app/src/main/java/com/ioannapergamali/mysmartroute/model/enumerations/BookingStep.kt
@@ -7,7 +7,25 @@ import com.ioannapergamali.mysmartroute.R
 
 /**
  * Βήματα για την κράτηση θέσης.
+ */
+enum class BookingStep(@StringRes val titleRes: Int, val position: Int) {
+    /** Δήλωση Διαδρομής */
+    DECLARE_ROUTE(R.string.declare_route, 1),
+    /** Επιλογή Διαδρομής */
+    SELECT_ROUTE(R.string.select_route, 2),
+    /** Προσθήκη σημείου ενδιαφέροντος */
+    ADD_POI(R.string.add_poi_option, 3),
+    /** Επανασχεδίαση διαδρομής */
+    RECALCULATE_ROUTE(R.string.recalculate_route, 4),
+    /** Επιλογή ημερομηνίας */
+    SELECT_DATE(R.string.select_date, 5),
+    /** Κλείσιμο θέσης */
+    RESERVE_SEAT(R.string.reserve_seat, 6);
 
+    companion object {
+        /** Βήματα στη σωστή σειρά. */
+        val ordered: List<BookingStep> = values().sortedBy { it.position }
+    }
 }
 
 /** Επιστρέφει το τοπικοποιημένο όνομα του βήματος. */


### PR DESCRIPTION
## Summary
- επαναφορά του κώδικα για το enum `BookingStep`

## Testing
- `./gradlew test --no-daemon` *(απέτυχε: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_688077118fa08328951f9a469d158074