### PR TITLE
Fix BookingStepsIndicator text parameter

### DIFF
--- a/app/src/main/java/com/ioannapergamali/mysmartroute/view/ui/components/BookingStepsIndicator.kt
+++ b/app/src/main/java/com/ioannapergamali/mysmartroute/view/ui/components/BookingStepsIndicator.kt
@@ -20,7 +20,7 @@ fun BookingStepsIndicator(currentStep: BookingStep) {
         BookingStep.ordered.forEach { step ->
             val isCurrent = step == currentStep
             Text(
-
+                text = step.localizedName(),
                 color = if (isCurrent) MaterialTheme.colorScheme.primary
                 else MaterialTheme.colorScheme.onSurface,
                 style = if (isCurrent) MaterialTheme.typography.bodyLarge


### PR DESCRIPTION
## Summary
- add text argument to `BookingStepsIndicator` composable

## Testing
- `./gradlew test` *(fails: blocked download from maven.pkg.jetbrains.space)*

------
https://chatgpt.com/codex/tasks/task_e_68809074597c8328a8c523d6d24a81da