### PR TITLE
Refresh route list after adding new route

### DIFF
--- a/app/src/main/java/com/ioannapergamali/mysmartroute/view/ui/screens/BookSeatScreen.kt
+++ b/app/src/main/java/com/ioannapergamali/mysmartroute/view/ui/screens/BookSeatScreen.kt
@@ -145,6 +145,31 @@ fun BookSeatScreen(navController: NavController, openDrawer: () -> Unit) {
                     pendingPoi = Triple(newName, lat, lng)
                     poiViewModel.loadPois(context)
                 }
+
+                val newRoute = savedStateHandle?.get<String>("newRouteId")
+                if (newRoute != null) {
+                    savedStateHandle.remove<String>("newRouteId")
+                    selectedRouteId = newRoute
+                    viewModel.refreshRoutes()
+                    routeViewModel.loadRoutes(context, includeAll = true)
+                    scope.launch {
+                        val (_, path) = routeViewModel.getRouteDirections(
+                            context,
+                            newRoute,
+                            VehicleType.CAR
+                        )
+                        pathPoints = path
+                        poiIds.clear()
+                        userPoiIds.clear()
+                        poiIds.addAll(routeViewModel.getRoutePois(context, newRoute).map { it.id })
+                        path.firstOrNull()?.let {
+                            MapsInitializer.initialize(context)
+                            cameraPositionState.move(
+                                CameraUpdateFactory.newLatLngZoom(it, 13f)
+                            )
+                        }
+                    }
+                }
             }
         }
         lifecycleOwner.lifecycle.addObserver(observer)

--- a/app/src/main/java/com/ioannapergamali/mysmartroute/view/ui/screens/DeclareRouteScreen.kt
+++ b/app/src/main/java/com/ioannapergamali/mysmartroute/view/ui/screens/DeclareRouteScreen.kt
@@ -578,13 +578,15 @@ fun DeclareRouteScreen(navController: NavController, openDrawer: () -> Unit) {
                     val ids = routePois.map { it.id }
                     scope.launch {
                         if (ids.size >= 2 && routeName.isNotBlank()) {
-                            val inserted = routeViewModel.addRoute(context, ids, routeName)
-                            if (inserted) {
+                            val newId = routeViewModel.addRoute(context, ids, routeName)
+                            if (newId != null) {
                                 routeSaved = true
                                 selectedPoiId = null
                                 unsavedPoint = null
                                 unsavedAddress = null
                                 Toast.makeText(context, context.getString(R.string.route_saved_success), Toast.LENGTH_SHORT).show()
+                                navController.previousBackStackEntry?.savedStateHandle?.set("newRouteId", newId)
+                                navController.popBackStack()
                             } else {
                                 Toast.makeText(context, context.getString(R.string.route_exists), Toast.LENGTH_SHORT).show()
                             }

--- a/app/src/main/java/com/ioannapergamali/mysmartroute/viewmodel/BookingViewModel.kt
+++ b/app/src/main/java/com/ioannapergamali/mysmartroute/viewmodel/BookingViewModel.kt
@@ -15,6 +15,10 @@ class BookingViewModel : ViewModel() {
     val availableRoutes: StateFlow<List<RouteEntity>> = _availableRoutes
 
     init {
+        refreshRoutes()
+    }
+
+    fun refreshRoutes() {
         db.collection("routes").get().addOnSuccessListener { snapshot ->
             val list = snapshot.documents.mapNotNull { it.toObject(RouteEntity::class.java) }
             _availableRoutes.value = list

--- a/app/src/main/java/com/ioannapergamali/mysmartroute/viewmodel/RouteViewModel.kt
+++ b/app/src/main/java/com/ioannapergamali/mysmartroute/viewmodel/RouteViewModel.kt
@@ -109,15 +109,15 @@ class RouteViewModel : ViewModel() {
         return points.mapNotNull { poiDao.findById(it.poiId) }
     }
 
-    suspend fun addRoute(context: Context, poiIds: List<String>, name: String): Boolean {
-        if (poiIds.size < 2 || name.isBlank()) return false
+    suspend fun addRoute(context: Context, poiIds: List<String>, name: String): String? {
+        if (poiIds.size < 2 || name.isBlank()) return null
         val db = MySmartRouteDatabase.getInstance(context)
         val routeDao = db.routeDao()
         val pointDao = db.routePointDao()
 
-        if (routeDao.findByName(name) != null) return false
+        if (routeDao.findByName(name) != null) return null
 
-        val userId = FirebaseAuth.getInstance().currentUser?.uid ?: return false
+        val userId = FirebaseAuth.getInstance().currentUser?.uid ?: return null
         val id = UUID.randomUUID().toString()
         val entity = RouteEntity(id, userId, name, poiIds.first(), poiIds.last())
         val points = poiIds.mapIndexed { index, p -> RoutePointEntity(id, index, p) }
@@ -129,7 +129,7 @@ class RouteViewModel : ViewModel() {
         routeDao.insert(entity)
         points.forEach { pointDao.insert(it) }
 
-        return true
+        return id
     }
 
     /**


### PR DESCRIPTION
## Summary
- update `BookingViewModel` with `refreshRoutes` helper
- allow `RouteViewModel.addRoute` to return the newly created id
- in `DeclareRouteScreen` return to `BookSeatScreen` with the new route
- in `BookSeatScreen` listen for new route id and reload list

## Testing
- `./gradlew assembleDebug` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_688098b416ec83289601a57853899175