### PR TITLE
Add route preview when defining new POI

### DIFF
--- a/app/src/main/java/com/ioannapergamali/mysmartroute/model/navigation/NavigationHost.kt
+++ b/app/src/main/java/com/ioannapergamali/mysmartroute/model/navigation/NavigationHost.kt
@@ -91,25 +91,28 @@ fun NavigationHost(navController : NavHostController, openDrawer: () -> Unit) {
             RouteEditorScreen(navController = navController, openDrawer = openDrawer)
         }
         composable(
-            route = "definePoi?lat={lat}&lng={lng}&source={source}&view={view}",
+            route = "definePoi?lat={lat}&lng={lng}&source={source}&view={view}&routeId={routeId}",
             arguments = listOf(
                 navArgument("lat") { defaultValue = "" },
                 navArgument("lng") { defaultValue = "" },
                 navArgument("source") { defaultValue = "" },
-                navArgument("view") { defaultValue = "false" }
+                navArgument("view") { defaultValue = "false" },
+                navArgument("routeId") { defaultValue = "" }
             )
         ) { backStackEntry ->
             val lat = backStackEntry.arguments?.getString("lat")?.toDoubleOrNull()
             val lng = backStackEntry.arguments?.getString("lng")?.toDoubleOrNull()
             val source = backStackEntry.arguments?.getString("source")
             val viewOnly = backStackEntry.arguments?.getString("view")?.toBoolean() ?: false
+            val routeIdArg = backStackEntry.arguments?.getString("routeId")
             DefinePoiScreen(
                 navController = navController,
                 openDrawer = openDrawer,
                 initialLat = lat,
                 initialLng = lng,
                 source = source,
-                viewOnly = viewOnly
+                viewOnly = viewOnly,
+                routeId = routeIdArg
             )
         }
 

--- a/app/src/main/java/com/ioannapergamali/mysmartroute/view/ui/screens/BookSeatScreen.kt
+++ b/app/src/main/java/com/ioannapergamali/mysmartroute/view/ui/screens/BookSeatScreen.kt
@@ -299,7 +299,8 @@ fun BookSeatScreen(navController: NavController, openDrawer: () -> Unit) {
 
             if (selectedRoute != null) {
                 Button(onClick = {
-                    navController.navigate("definePoi?lat=&lng=&source=&view=false")
+                    val rId = selectedRouteId ?: ""
+                    navController.navigate("definePoi?lat=&lng=&source=&view=false&routeId=$rId")
                 }) {
                     Text(stringResource(R.string.add_poi_option))
                 }


### PR DESCRIPTION
## Summary
- pass selected route id to `DefinePoiScreen`
- show current route path and markers on the POI definition map
- draw new POI with orange marker

## Testing
- `./gradlew assembleDebug` *(fails: could not download dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_68809d6d9ec48328a6425406d2d470b8