### PR TITLE
Προσθήκη επιλογής ημερομηνίας στη δήλωση διαδρομής

### DIFF
--- a/app/src/main/java/com/ioannapergamali/mysmartroute/data/local/MySmartRouteDatabase.kt
+++ b/app/src/main/java/com/ioannapergamali/mysmartroute/data/local/MySmartRouteDatabase.kt
@@ -38,7 +38,7 @@ import com.ioannapergamali.mysmartroute.data.local.Converters
         RoutePointEntity::class,
         TransportDeclarationEntity::class
     ],
-    version = 31
+    version = 32
 )
 @TypeConverters(Converters::class)
 abstract class MySmartRouteDatabase : RoomDatabase() {
@@ -454,6 +454,14 @@ abstract class MySmartRouteDatabase : RoomDatabase() {
             }
         }
 
+        private val MIGRATION_31_32 = object : Migration(31, 32) {
+            override fun migrate(database: SupportSQLiteDatabase) {
+                database.execSQL(
+                    "ALTER TABLE `transport_declarations` ADD COLUMN `date` INTEGER NOT NULL DEFAULT 0"
+                )
+            }
+        }
+
         private fun prepopulate(db: SupportSQLiteDatabase) {
             Log.d(TAG, "Prepopulating database")
             db.execSQL(
@@ -559,7 +567,8 @@ abstract class MySmartRouteDatabase : RoomDatabase() {
                     MIGRATION_27_28,
                     MIGRATION_28_29,
                     MIGRATION_29_30,
-                    MIGRATION_30_31
+                    MIGRATION_30_31,
+                    MIGRATION_31_32
                 )
                     .addCallback(object : RoomDatabase.Callback() {
                         override fun onCreate(db: SupportSQLiteDatabase) {

--- a/app/src/main/java/com/ioannapergamali/mysmartroute/data/local/TransportDeclarationEntity.kt
+++ b/app/src/main/java/com/ioannapergamali/mysmartroute/data/local/TransportDeclarationEntity.kt
@@ -10,5 +10,7 @@ data class TransportDeclarationEntity(
     val routeId: String = "",
     val vehicleType: String = "",
     val cost: Double = 0.0,
-    val durationMinutes: Int = 0
+    val durationMinutes: Int = 0,
+    /** Ημερομηνία πραγματοποίησης της διαδρομής */
+    val date: Long = 0L
 )

--- a/app/src/main/java/com/ioannapergamali/mysmartroute/utils/FirestoreMappers.kt
+++ b/app/src/main/java/com/ioannapergamali/mysmartroute/utils/FirestoreMappers.kt
@@ -263,7 +263,8 @@ fun TransportDeclarationEntity.toFirestoreMap(): Map<String, Any> = mapOf(
     "routeId" to FirebaseFirestore.getInstance().collection("routes").document(routeId),
     "vehicleType" to vehicleType,
     "cost" to cost,
-    "durationMinutes" to durationMinutes
+    "durationMinutes" to durationMinutes,
+    "date" to date
 )
 
 fun DocumentSnapshot.toTransportDeclarationEntity(): TransportDeclarationEntity? {
@@ -276,5 +277,6 @@ fun DocumentSnapshot.toTransportDeclarationEntity(): TransportDeclarationEntity?
     val type = getString("vehicleType") ?: return null
     val costVal = getDouble("cost") ?: 0.0
     val durVal = (getLong("durationMinutes") ?: 0L).toInt()
-    return TransportDeclarationEntity(declId, routeId, type, costVal, durVal)
+    val dateVal = getLong("date") ?: 0L
+    return TransportDeclarationEntity(declId, routeId, type, costVal, durVal, dateVal)
 }

--- a/app/src/main/java/com/ioannapergamali/mysmartroute/viewmodel/TransportDeclarationViewModel.kt
+++ b/app/src/main/java/com/ioannapergamali/mysmartroute/viewmodel/TransportDeclarationViewModel.kt
@@ -16,12 +16,13 @@ class TransportDeclarationViewModel : ViewModel() {
         routeId: String,
         vehicleType: VehicleType,
         cost: Double,
-        durationMinutes: Int
+        durationMinutes: Int,
+        date: Long
     ) {
         viewModelScope.launch {
             val dao = MySmartRouteDatabase.getInstance(context).transportDeclarationDao()
             val id = UUID.randomUUID().toString()
-            val entity = TransportDeclarationEntity(id, routeId, vehicleType.name, cost, durationMinutes)
+            val entity = TransportDeclarationEntity(id, routeId, vehicleType.name, cost, durationMinutes, date)
             dao.insert(entity)
         }
     }


### PR DESCRIPTION
## Περιγραφή
Προστέθηκε πεδίο ημερομηνίας στην οθόνη `AnnounceTransportScreen` που εμφανίζει DatePicker για την επιλογή ημερομηνίας. Η ημερομηνία αποθηκεύεται πλέον και στη βάση μέσω της νέας στήλης `date` στον πίνακα `transport_declarations`.

## Αλλαγές
- Νέο πεδίο `date` στο `TransportDeclarationEntity`.
- Ενημέρωση `TransportDeclarationViewModel` και `FirestoreMappers`.
- Προσθήκη migration `MIGRATION_31_32` και αναβάθμιση έκδοσης βάσης σε 32.
- Εμπλουτισμός της `AnnounceTransportScreen` με DatePicker.

## Testing
- `./gradlew test` *(απέτυχε λόγω περιορισμών δικτύου)*

------
https://chatgpt.com/codex/tasks/task_e_6880f8eb22d08328954f55e620fd24cc