### PR TITLE
Προσθήκη κλάσεων διαθεσιμότητας

### DIFF
--- a/app/src/main/java/com/ioannapergamali/mysmartroute/data/local/AvailabilityDao.kt
+++ b/app/src/main/java/com/ioannapergamali/mysmartroute/data/local/AvailabilityDao.kt
@@ -1,0 +1,19 @@
+package com.ioannapergamali.mysmartroute.data.local
+
+import androidx.room.Dao
+import androidx.room.Insert
+import androidx.room.OnConflictStrategy
+import androidx.room.Query
+import kotlinx.coroutines.flow.Flow
+
+@Dao
+interface AvailabilityDao {
+    @Insert(onConflict = OnConflictStrategy.REPLACE)
+    suspend fun insert(availability: AvailabilityEntity)
+
+    @Query("SELECT * FROM availabilities")
+    fun getAll(): Flow<List<AvailabilityEntity>>
+
+    @Query("SELECT * FROM availabilities WHERE userId = :userId")
+    fun getForUser(userId: String): Flow<List<AvailabilityEntity>>
+}

--- a/app/src/main/java/com/ioannapergamali/mysmartroute/data/local/AvailabilityEntity.kt
+++ b/app/src/main/java/com/ioannapergamali/mysmartroute/data/local/AvailabilityEntity.kt
@@ -1,0 +1,14 @@
+package com.ioannapergamali.mysmartroute.data.local
+
+import androidx.room.Entity
+import androidx.room.PrimaryKey
+
+/** Δήλωση διαθεσιμότητας οδηγού. */
+@Entity(tableName = "availabilities")
+data class AvailabilityEntity(
+    @PrimaryKey val id: String = "",
+    val userId: String = "",
+    val date: Long = 0L,
+    val fromTime: Int = 0,
+    val toTime: Int = 0
+)

--- a/app/src/main/java/com/ioannapergamali/mysmartroute/data/local/MySmartRouteDatabase.kt
+++ b/app/src/main/java/com/ioannapergamali/mysmartroute/data/local/MySmartRouteDatabase.kt
@@ -19,6 +19,8 @@ import com.ioannapergamali.mysmartroute.data.local.RoutePointEntity
 import com.ioannapergamali.mysmartroute.data.local.RoutePointDao
 import com.ioannapergamali.mysmartroute.data.local.TransportDeclarationEntity
 import com.ioannapergamali.mysmartroute.data.local.TransportDeclarationDao
+import com.ioannapergamali.mysmartroute.data.local.AvailabilityEntity
+import com.ioannapergamali.mysmartroute.data.local.AvailabilityDao
 import androidx.room.TypeConverters
 import com.ioannapergamali.mysmartroute.data.local.Converters
 
@@ -36,9 +38,10 @@ import com.ioannapergamali.mysmartroute.data.local.Converters
         RouteEntity::class,
         MovingEntity::class,
         RoutePointEntity::class,
-        TransportDeclarationEntity::class
+        TransportDeclarationEntity::class,
+        AvailabilityEntity::class
     ],
-    version = 32
+    version = 33
 )
 @TypeConverters(Converters::class)
 abstract class MySmartRouteDatabase : RoomDatabase() {
@@ -55,6 +58,7 @@ abstract class MySmartRouteDatabase : RoomDatabase() {
     abstract fun movingDao(): MovingDao
     abstract fun routePointDao(): RoutePointDao
     abstract fun transportDeclarationDao(): TransportDeclarationDao
+    abstract fun availabilityDao(): AvailabilityDao
 
     companion object {
         @Volatile
@@ -462,6 +466,21 @@ abstract class MySmartRouteDatabase : RoomDatabase() {
             }
         }
 
+        private val MIGRATION_32_33 = object : Migration(32, 33) {
+            override fun migrate(database: SupportSQLiteDatabase) {
+                database.execSQL(
+                    "CREATE TABLE IF NOT EXISTS `availabilities` (" +
+                        "`id` TEXT NOT NULL, " +
+                        "`userId` TEXT NOT NULL, " +
+                        "`date` INTEGER NOT NULL, " +
+                        "`fromTime` INTEGER NOT NULL, " +
+                        "`toTime` INTEGER NOT NULL, " +
+                        "PRIMARY KEY(`id`)" +
+                        ")"
+                )
+            }
+        }
+
         private fun prepopulate(db: SupportSQLiteDatabase) {
             Log.d(TAG, "Prepopulating database")
             db.execSQL(
@@ -568,7 +587,8 @@ abstract class MySmartRouteDatabase : RoomDatabase() {
                     MIGRATION_28_29,
                     MIGRATION_29_30,
                     MIGRATION_30_31,
-                    MIGRATION_31_32
+                    MIGRATION_31_32,
+                    MIGRATION_32_33
                 )
                     .addCallback(object : RoomDatabase.Callback() {
                         override fun onCreate(db: SupportSQLiteDatabase) {

--- a/app/src/main/java/com/ioannapergamali/mysmartroute/viewmodel/AvailabilityViewModel.kt
+++ b/app/src/main/java/com/ioannapergamali/mysmartroute/viewmodel/AvailabilityViewModel.kt
@@ -1,0 +1,27 @@
+package com.ioannapergamali.mysmartroute.viewmodel
+
+import android.content.Context
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.viewModelScope
+import com.ioannapergamali.mysmartroute.data.local.AvailabilityEntity
+import com.ioannapergamali.mysmartroute.data.local.MySmartRouteDatabase
+import kotlinx.coroutines.launch
+import java.util.UUID
+
+/** ViewModel για αποθήκευση διαθεσιμότητας οδηγού. */
+class AvailabilityViewModel : ViewModel() {
+    fun declareAvailability(
+        context: Context,
+        date: Long,
+        fromTime: Int,
+        toTime: Int
+    ) {
+        viewModelScope.launch {
+            val dao = MySmartRouteDatabase.getInstance(context).availabilityDao()
+            val id = UUID.randomUUID().toString()
+            val userId = com.google.firebase.auth.FirebaseAuth.getInstance().currentUser?.uid ?: ""
+            val entity = AvailabilityEntity(id, userId, date, fromTime, toTime)
+            dao.insert(entity)
+        }
+    }
+}

--- a/app/src/main/java/com/ioannapergamali/mysmartroute/viewmodel/DatabaseViewModel.kt
+++ b/app/src/main/java/com/ioannapergamali/mysmartroute/viewmodel/DatabaseViewModel.kt
@@ -28,6 +28,7 @@ import com.ioannapergamali.mysmartroute.data.local.RouteEntity
 import com.ioannapergamali.mysmartroute.data.local.RoutePointEntity
 import com.ioannapergamali.mysmartroute.data.local.MovingEntity
 import com.ioannapergamali.mysmartroute.data.local.TransportDeclarationEntity
+import com.ioannapergamali.mysmartroute.data.local.AvailabilityEntity
 import com.ioannapergamali.mysmartroute.utils.toRouteWithPoints
 import com.ioannapergamali.mysmartroute.utils.toMovingEntity
 import com.ioannapergamali.mysmartroute.utils.toTransportDeclarationEntity
@@ -83,7 +84,8 @@ class DatabaseViewModel : ViewModel() {
                 db.routeDao().getAll(),
                 db.routePointDao().getAll(),
                 db.movingDao().getAll(),
-                db.transportDeclarationDao().getAll()
+                db.transportDeclarationDao().getAll(),
+                db.availabilityDao().getAll()
             ) { values ->
                 val users = values[0] as List<UserEntity>
                 val vehicles = values[1] as List<VehicleEntity>
@@ -98,15 +100,32 @@ class DatabaseViewModel : ViewModel() {
                 val routePoints = values[10] as List<RoutePointEntity>
                 val movings = values[11] as List<MovingEntity>
                 val declarations = values[12] as List<TransportDeclarationEntity>
+                val availabilities = values[13] as List<AvailabilityEntity>
 
-                DatabaseData(users, vehicles, pois, poiTypes, settings, roles, menus, options, languages, routes, routePoints, movings, declarations)
+                DatabaseData(
+                    users,
+                    vehicles,
+                    pois,
+                    poiTypes,
+                    settings,
+                    roles,
+                    menus,
+                    options,
+                    languages,
+                    routes,
+                    routePoints,
+                    movings,
+                    declarations,
+                    availabilities
+                )
             }.collect { data ->
                 Log.d(
                     TAG,
                     "Local data -> users:${data.users.size} vehicles:${data.vehicles.size} " +
                     "pois:${data.pois.size} poiTypes:${data.poiTypes.size} settings:${data.settings.size} roles:${data.roles.size} " +
                         "menus:${data.menus.size} options:${data.menuOptions.size} routes:${data.routes.size} " +
-                        "points:${data.routePoints.size} movings:${data.movings.size} declarations:${data.declarations.size}"
+                    "points:${data.routePoints.size} movings:${data.movings.size} declarations:${data.declarations.size}"
+                        + " availabilities:${data.availabilities.size}"
                 )
                 _localData.value = data
             }
@@ -208,7 +227,7 @@ class DatabaseViewModel : ViewModel() {
                 .documents.mapNotNull { it.toTransportDeclarationEntity() }
 
             Log.d(TAG, "Firebase data -> users:${users.size} vehicles:${vehicles.size} pois:${pois.size} types:${poiTypes.size} settings:${settings.size} roles:${roles.size} menus:${menus.size} options:${menuOptions.size} routes:${routes.size} movings:${movings.size} declarations:${declarations.size}")
-            _firebaseData.value = DatabaseData(users, vehicles, pois, poiTypes, settings, roles, menus, menuOptions, emptyList(), routes, routePoints, movings, declarations)
+            _firebaseData.value = DatabaseData(users, vehicles, pois, poiTypes, settings, roles, menus, menuOptions, emptyList(), routes, routePoints, movings, declarations, emptyList())
         }
     }
 
@@ -479,7 +498,8 @@ data class DatabaseData(
     val routes: List<RouteEntity>,
     val routePoints: List<RoutePointEntity>,
     val movings: List<MovingEntity>,
-    val declarations: List<TransportDeclarationEntity>
+    val declarations: List<TransportDeclarationEntity>,
+    val availabilities: List<AvailabilityEntity>
 )
 
 sealed class SyncState {


### PR DESCRIPTION
## Πραγματοποιημένες αλλαγές
- Δημιουργήθηκε `AvailabilityEntity` και `AvailabilityDao` για την αποθήκευση δηλώσεων διαθεσιμότητας οδηγών.
- Προστέθηκε `AvailabilityViewModel`.
- Ενημερώθηκε το `MySmartRouteDatabase` με νέο πίνακα, DAO και migration (version 33).
- Επεκτάθηκε το `DatabaseViewModel` ώστε να συλλέγει και να επιστρέφει τις δηλώσεις διαθεσιμότητας.

## Οδηγίες ελέγχου
- `./gradlew test` *(απαιτεί Android SDK)*

------
https://chatgpt.com/codex/tasks/task_e_6880fd697e5083288e6fbc0a6d0e18c6