### PR TITLE
Διόρθωση αποθήκευσης δήλωσης στη Firebase

### DIFF
--- a/app/src/main/java/com/ioannapergamali/mysmartroute/data/local/MySmartRouteDatabase.kt
+++ b/app/src/main/java/com/ioannapergamali/mysmartroute/data/local/MySmartRouteDatabase.kt
@@ -41,7 +41,7 @@ import com.ioannapergamali.mysmartroute.data.local.Converters
         TransportDeclarationEntity::class,
         AvailabilityEntity::class
     ],
-    version = 33
+    version = 34
 )
 @TypeConverters(Converters::class)
 abstract class MySmartRouteDatabase : RoomDatabase() {
@@ -481,6 +481,14 @@ abstract class MySmartRouteDatabase : RoomDatabase() {
             }
         }
 
+        private val MIGRATION_33_34 = object : Migration(33, 34) {
+            override fun migrate(database: SupportSQLiteDatabase) {
+                database.execSQL(
+                    "ALTER TABLE `transport_declarations` ADD COLUMN `driverId` TEXT NOT NULL DEFAULT ''"
+                )
+            }
+        }
+
         private fun prepopulate(db: SupportSQLiteDatabase) {
             Log.d(TAG, "Prepopulating database")
             db.execSQL(
@@ -588,7 +596,8 @@ abstract class MySmartRouteDatabase : RoomDatabase() {
                     MIGRATION_29_30,
                     MIGRATION_30_31,
                     MIGRATION_31_32,
-                    MIGRATION_32_33
+                    MIGRATION_32_33,
+                    MIGRATION_33_34
                 )
                     .addCallback(object : RoomDatabase.Callback() {
                         override fun onCreate(db: SupportSQLiteDatabase) {

--- a/app/src/main/java/com/ioannapergamali/mysmartroute/data/local/TransportDeclarationEntity.kt
+++ b/app/src/main/java/com/ioannapergamali/mysmartroute/data/local/TransportDeclarationEntity.kt
@@ -8,6 +8,8 @@ import androidx.room.PrimaryKey
 data class TransportDeclarationEntity(
     @PrimaryKey val id: String = "",
     val routeId: String = "",
+    /** Ο οδηγός που αναλαμβάνει τη μεταφορά */
+    val driverId: String = "",
     val vehicleType: String = "",
     val cost: Double = 0.0,
     val durationMinutes: Int = 0,

--- a/app/src/main/java/com/ioannapergamali/mysmartroute/utils/FirestoreMappers.kt
+++ b/app/src/main/java/com/ioannapergamali/mysmartroute/utils/FirestoreMappers.kt
@@ -261,7 +261,9 @@ fun DocumentSnapshot.toMovingEntity(): MovingEntity? {
 
 fun TransportDeclarationEntity.toFirestoreMap(): Map<String, Any> = mapOf(
     "id" to id,
-    "routeId" to FirebaseFirestore.getInstance().collection("routes").document(routeId),
+    // Αποθηκεύουμε απλά τα ids για ευκολότερη αναζήτηση
+    "routeId" to routeId,
+    "driverId" to driverId,
     "vehicleType" to vehicleType,
     "cost" to cost,
     "durationMinutes" to durationMinutes,
@@ -275,11 +277,16 @@ fun DocumentSnapshot.toTransportDeclarationEntity(): TransportDeclarationEntity?
         is String -> r
         else -> getString("routeId")
     } ?: return null
+    val driverId = when (val d = get("driverId")) {
+        is DocumentReference -> d.id
+        is String -> d
+        else -> getString("driverId")
+    } ?: ""
     val type = getString("vehicleType") ?: return null
     val costVal = getDouble("cost") ?: 0.0
     val durVal = (getLong("durationMinutes") ?: 0L).toInt()
     val dateVal = getLong("date") ?: 0L
-    return TransportDeclarationEntity(declId, routeId, type, costVal, durVal, dateVal)
+    return TransportDeclarationEntity(declId, routeId, driverId, type, costVal, durVal, dateVal)
 }
 
 fun AvailabilityEntity.toFirestoreMap(): Map<String, Any> = mapOf(

--- a/app/src/main/java/com/ioannapergamali/mysmartroute/view/ui/screens/AnnounceTransportScreen.kt
+++ b/app/src/main/java/com/ioannapergamali/mysmartroute/view/ui/screens/AnnounceTransportScreen.kt
@@ -412,8 +412,9 @@ fun AnnounceTransportScreen(navController: NavController, openDrawer: () -> Unit
                     val vehicle = selectedVehicle
                     val cost = costText.toDoubleOrNull() ?: 0.0
                     val date = datePickerState.selectedDateMillis ?: 0L
+                    val driverId = selectedDriverId ?: ""
                     if (routeId != null && vehicle != null) {
-                        declarationViewModel.declareTransport(context, routeId, vehicle, cost, duration, date)
+                        declarationViewModel.declareTransport(context, routeId, driverId, vehicle, cost, duration, date)
                         navController.popBackStack()
                     }
                 },


### PR DESCRIPTION
## Πυρήνας αλλαγών
- Στο `FirestoreMappers` η `TransportDeclarationEntity` μετατρέπεται πλέον σε map με απλά `routeId` και `driverId` αντί για `DocumentReference`
- Προστέθηκε `TAG` και καταγραφή αποτελέσματος στην `TransportDeclarationViewModel`

## Οδηγίες δοκιμών
- `./gradlew test --stacktrace` αποτυγχάνει λόγω έλλειψης Android SDK.


------
https://chatgpt.com/codex/tasks/task_e_6881226eb52083288cf14f862538c761