### PR TITLE
Add boarding and drop-off stop selection

### DIFF
--- a/app/src/main/java/com/ioannapergamali/mysmartroute/view/ui/screens/BookSeatScreen.kt
+++ b/app/src/main/java/com/ioannapergamali/mysmartroute/view/ui/screens/BookSeatScreen.kt
@@ -26,6 +26,7 @@ import androidx.compose.runtime.saveable.listSaver
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.Alignment
 import androidx.compose.ui.unit.dp
 import androidx.lifecycle.viewmodel.compose.viewModel
 import androidx.navigation.NavController
@@ -90,6 +91,8 @@ fun BookSeatScreen(navController: NavController, openDrawer: () -> Unit) {
             restore = { mutableStateListOf<String>().apply { addAll(it) } }
         )
     ) { mutableStateListOf<String>() }
+    var startIndex by rememberSaveable { mutableStateOf<Int?>(null) }
+    var endIndex by rememberSaveable { mutableStateOf<Int?>(null) }
     val pois = poiIds.mapNotNull { id -> allPois.find { it.id == id } }
     var pathPoints by remember { mutableStateOf<List<LatLng>>(emptyList()) }
     var calculating by remember { mutableStateOf(false) }
@@ -163,6 +166,8 @@ fun BookSeatScreen(navController: NavController, openDrawer: () -> Unit) {
                         pathPoints = path
                         poiIds.clear()
                         userPoiIds.clear()
+                        startIndex = null
+                        endIndex = null
                         poiIds.addAll(routeViewModel.getRoutePois(context, newRoute).map { it.id })
                         path.firstOrNull()?.let {
                             MapsInitializer.initialize(context)
@@ -284,6 +289,8 @@ fun BookSeatScreen(navController: NavController, openDrawer: () -> Unit) {
                                     pathPoints = path
                                     poiIds.clear()
                                     userPoiIds.clear()
+                                    startIndex = null
+                                    endIndex = null
                                     poiIds.addAll(routeViewModel.getRoutePois(context, route.id).map { it.id })
                                     path.firstOrNull()?.let {
                                         MapsInitializer.initialize(context)
@@ -362,12 +369,36 @@ fun BookSeatScreen(navController: NavController, openDrawer: () -> Unit) {
                     }
                     Divider()
                     pois.forEachIndexed { index, poi ->
-                        Row(modifier = Modifier.fillMaxWidth()) {
+                        Row(
+                            modifier = Modifier.fillMaxWidth(),
+                            verticalAlignment = Alignment.CenterVertically
+                        ) {
                             Text("${index + 1}. ${poi.name}", modifier = Modifier.weight(1f))
                             Text(poi.type.name, modifier = Modifier.weight(1f))
+                            Button(
+                                onClick = {
+                                    startIndex = index
+                                    if (endIndex != null && endIndex!! < index) endIndex = null
+                                },
+                                modifier = Modifier.padding(end = 4.dp)
+                            ) { Text(stringResource(R.string.select_boarding)) }
+                            Button(
+                                onClick = {
+                                    if (startIndex == null || index >= startIndex!!) {
+                                        endIndex = index
+                                    }
+                                },
+                                modifier = Modifier.padding(end = 4.dp)
+                            ) { Text(stringResource(R.string.select_dropoff)) }
                             IconButton(onClick = {
                                 val removedId = poiIds.removeAt(index)
                                 userPoiIds.remove(removedId)
+                                if (startIndex != null) {
+                                    if (index == startIndex) startIndex = null else if (index < startIndex!!) startIndex = startIndex!! - 1
+                                }
+                                if (endIndex != null) {
+                                    if (index == endIndex) endIndex = null else if (index < endIndex!!) endIndex = endIndex!! - 1
+                                }
                                 refreshRoute()
                             }) {
                                 Icon(Icons.Default.Delete, contentDescription = stringResource(R.string.remove_point))
@@ -375,6 +406,36 @@ fun BookSeatScreen(navController: NavController, openDrawer: () -> Unit) {
                         }
                     }
                 }
+
+                Spacer(Modifier.height(16.dp))
+
+                OutlinedTextField(
+                    value = startIndex?.let { "${it + 1}. ${pois[it].name}" } ?: "",
+                    onValueChange = {},
+                    readOnly = true,
+                    label = { Text(stringResource(R.string.boarding_stop)) },
+                    modifier = Modifier.fillMaxWidth(),
+                    shape = MaterialTheme.shapes.small,
+                    colors = OutlinedTextFieldDefaults.colors(
+                        focusedBorderColor = MaterialTheme.colorScheme.primary,
+                        unfocusedBorderColor = MaterialTheme.colorScheme.primary
+                    )
+                )
+
+                Spacer(Modifier.height(8.dp))
+
+                OutlinedTextField(
+                    value = endIndex?.let { "${it + 1}. ${pois[it].name}" } ?: "",
+                    onValueChange = {},
+                    readOnly = true,
+                    label = { Text(stringResource(R.string.dropoff_stop)) },
+                    modifier = Modifier.fillMaxWidth(),
+                    shape = MaterialTheme.shapes.small,
+                    colors = OutlinedTextFieldDefaults.colors(
+                        focusedBorderColor = MaterialTheme.colorScheme.primary,
+                        unfocusedBorderColor = MaterialTheme.colorScheme.primary
+                    )
+                )
 
                 Spacer(Modifier.height(16.dp))
             }

--- a/app/src/main/res/values-el/strings.xml
+++ b/app/src/main/res/values-el/strings.xml
@@ -147,4 +147,8 @@
     <string name="choose_pois">Επιλογή σημείων ενδιαφέροντος</string>
     <string name="confirm_poi_selection">Επιβεβαίωση επιλογής</string>
     <string name="recalculate_route">Επανασχεδίαση διαδρομής</string>
+    <string name="select_boarding">Επιλογή ως στάση επιβίβασης</string>
+    <string name="select_dropoff">Επιλογή ως στάση αποβίβασης</string>
+    <string name="boarding_stop">Στάση εκκίνησης</string>
+    <string name="dropoff_stop">Στάση αποβίβασης</string>
 </resources>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -158,4 +158,8 @@
     <string name="recalculate_route">Recalculate route</string>
     <string name="departure_date">Departure date</string>
     <string name="no_departures">No scheduled departures</string>
+    <string name="select_boarding">Set as boarding stop</string>
+    <string name="select_dropoff">Set as drop-off stop</string>
+    <string name="boarding_stop">Boarding stop</string>
+    <string name="dropoff_stop">Drop-off stop</string>
 </resources>


### PR DESCRIPTION
## Summary
- allow selecting boarding and drop-off stops in `BookSeatScreen`
- show selected stops in readonly text fields
- add translation strings for boarding/drop-off stops

## Testing
- `./gradlew test` *(fails: maven.pkg.jetbrains.space blocked)*
- `./gradlew assembleDebug` *(fails: maven.pkg.jetbrains.space blocked)*

------
https://chatgpt.com/codex/tasks/task_e_688249ddc4d083289b707b4bcb4bc650