### PR TITLE
Add icons for booking stops

### DIFF
--- a/app/src/main/java/com/ioannapergamali/mysmartroute/view/ui/screens/BookSeatScreen.kt
+++ b/app/src/main/java/com/ioannapergamali/mysmartroute/view/ui/screens/BookSeatScreen.kt
@@ -402,6 +402,7 @@ fun BookSeatScreen(navController: NavController, openDrawer: () -> Unit) {
                     onValueChange = {},
                     readOnly = true,
                     label = { Text(stringResource(R.string.boarding_stop)) },
+                    leadingIcon = { Text("\uD83C\uDD95") },
                     modifier = Modifier.fillMaxWidth(),
                     shape = MaterialTheme.shapes.small,
                     colors = OutlinedTextFieldDefaults.colors(
@@ -417,6 +418,7 @@ fun BookSeatScreen(navController: NavController, openDrawer: () -> Unit) {
                     onValueChange = {},
                     readOnly = true,
                     label = { Text(stringResource(R.string.dropoff_stop)) },
+                    leadingIcon = { Text("\uD83D\uDD1A") },
                     modifier = Modifier.fillMaxWidth(),
                     shape = MaterialTheme.shapes.small,
                     colors = OutlinedTextFieldDefaults.colors(


### PR DESCRIPTION
## Summary
- show a start emoji next to the boarding stop field
- show an end emoji next to the drop-off stop field

## Testing
- `./gradlew test` *(fails: maven.pkg.jetbrains.space blocked)*

------
https://chatgpt.com/codex/tasks/task_e_6883911c52cc8328b6632c243046f500