### PR TITLE
Add boarding/drop-off buttons

### DIFF
--- a/app/src/main/java/com/ioannapergamali/mysmartroute/view/ui/screens/BookSeatScreen.kt
+++ b/app/src/main/java/com/ioannapergamali/mysmartroute/view/ui/screens/BookSeatScreen.kt
@@ -378,6 +378,13 @@ fun BookSeatScreen(navController: NavController, openDrawer: () -> Unit) {
                             Text("${index + 1}. ${poi.name}", modifier = Modifier.weight(1f))
                             Text(poi.type.name, modifier = Modifier.weight(1f))
 
+                            IconButton(onClick = { startIndex = index }) {
+                                Text("\uD83C\uDD95")
+                            }
+                            IconButton(onClick = { endIndex = index }) {
+                                Text("\uD83D\uDD1A")
+                            }
+
                             IconButton(onClick = {
                                 val removedId = poiIds.removeAt(index)
                                 userPoiIds.remove(removedId)


### PR DESCRIPTION
## Summary
- enable selecting start and end stops in the stop list
- show emoji buttons next to each stop
- keep boarding and drop-off fields without emojis

## Testing
- `./gradlew test` *(fails: SDK location not found and maven pkg blocked)*

------
https://chatgpt.com/codex/tasks/task_e_6883911c52cc8328b6632c243046f500