### PR TITLE
Add driver route preparation feature

### DIFF
--- a/app/src/main/assets/menus.json
+++ b/app/src/main/assets/menus.json
@@ -34,7 +34,8 @@
           {"titleKey": "find_passengers", "route": "findPassengers"},
           {"titleKey": "print_list", "route": "printList"},
           {"titleKey": "print_scheduled", "route": "printScheduled"},
-          {"titleKey": "print_completed", "route": "printCompleted"}
+          {"titleKey": "print_completed", "route": "printCompleted"},
+          {"titleKey": "prepare_complete_route", "route": "prepareCompleteRoute"}
         ]
       }
     ]

--- a/app/src/main/java/com/ioannapergamali/mysmartroute/data/local/MySmartRouteDatabase.kt
+++ b/app/src/main/java/com/ioannapergamali/mysmartroute/data/local/MySmartRouteDatabase.kt
@@ -44,7 +44,7 @@ import com.ioannapergamali.mysmartroute.data.local.Converters
         AvailabilityEntity::class,
         SeatReservationEntity::class
     ],
-    version = 36
+    version = 37
 )
 @TypeConverters(Converters::class)
 abstract class MySmartRouteDatabase : RoomDatabase() {
@@ -250,6 +250,7 @@ abstract class MySmartRouteDatabase : RoomDatabase() {
                 insertOption("opt_driver_5", driverMenuId, "print_list", "printList")
                 insertOption("opt_driver_6", driverMenuId, "print_scheduled", "printScheduled")
                 insertOption("opt_driver_7", driverMenuId, "print_completed", "printCompleted")
+                insertOption("opt_driver_8", driverMenuId, "prepare_complete_route", "prepareCompleteRoute")
 
                 val adminMenuId = "menu_admin_main"
                 insertMenu(adminMenuId, "role_admin", "admin_menu_title")
@@ -514,6 +515,14 @@ abstract class MySmartRouteDatabase : RoomDatabase() {
             }
         }
 
+        private val MIGRATION_36_37 = object : Migration(36, 37) {
+            override fun migrate(database: SupportSQLiteDatabase) {
+                database.execSQL(
+                    "INSERT INTO `menu_options` (`id`, `menuId`, `titleResKey`, `route`) VALUES ('opt_driver_8', 'menu_driver_main', 'prepare_complete_route', 'prepareCompleteRoute')"
+                )
+            }
+        }
+
         private fun prepopulate(db: SupportSQLiteDatabase) {
             Log.d(TAG, "Prepopulating database")
             db.execSQL(
@@ -571,6 +580,7 @@ abstract class MySmartRouteDatabase : RoomDatabase() {
             insertOption("opt_driver_5", driverMenuId, "print_list", "printList")
             insertOption("opt_driver_6", driverMenuId, "print_scheduled", "printScheduled")
             insertOption("opt_driver_7", driverMenuId, "print_completed", "printCompleted")
+            insertOption("opt_driver_8", driverMenuId, "prepare_complete_route", "prepareCompleteRoute")
 
             val adminMenuId = "menu_admin_main"
             insertMenu(adminMenuId, "role_admin", "admin_menu_title")
@@ -624,7 +634,8 @@ abstract class MySmartRouteDatabase : RoomDatabase() {
                     MIGRATION_32_33,
                     MIGRATION_33_34,
                     MIGRATION_34_35,
-                    MIGRATION_35_36
+                    MIGRATION_35_36,
+                    MIGRATION_36_37
                 )
                     .addCallback(object : RoomDatabase.Callback() {
                         override fun onCreate(db: SupportSQLiteDatabase) {

--- a/app/src/main/java/com/ioannapergamali/mysmartroute/data/local/SeatReservationDao.kt
+++ b/app/src/main/java/com/ioannapergamali/mysmartroute/data/local/SeatReservationDao.kt
@@ -13,4 +13,7 @@ interface SeatReservationDao {
 
     @Query("SELECT * FROM seat_reservations WHERE userId = :userId")
     fun getReservationsForUser(userId: String): Flow<List<SeatReservationEntity>>
+
+    @Query("SELECT * FROM seat_reservations WHERE routeId = :routeId")
+    fun getReservationsForRoute(routeId: String): Flow<List<SeatReservationEntity>>
 }

--- a/app/src/main/java/com/ioannapergamali/mysmartroute/model/navigation/NavigationHost.kt
+++ b/app/src/main/java/com/ioannapergamali/mysmartroute/model/navigation/NavigationHost.kt
@@ -32,6 +32,7 @@ import com.ioannapergamali.mysmartroute.view.ui.screens.ManageFavoritesScreen
 import com.ioannapergamali.mysmartroute.view.ui.screens.PrintCompletedScreen
 import com.ioannapergamali.mysmartroute.view.ui.screens.PrintListScreen
 import com.ioannapergamali.mysmartroute.view.ui.screens.PrintScheduledScreen
+import com.ioannapergamali.mysmartroute.view.ui.screens.PrepareCompleteRouteScreen
 import com.ioannapergamali.mysmartroute.view.ui.screens.RouteModeScreen
 import com.ioannapergamali.mysmartroute.view.ui.screens.ViewVehiclesScreen
 import com.ioannapergamali.mysmartroute.view.ui.screens.BookSeatScreen
@@ -180,6 +181,10 @@ fun NavigationHost(navController : NavHostController, openDrawer: () -> Unit) {
 
         composable("printCompleted") {
             PrintCompletedScreen(navController = navController, openDrawer = openDrawer)
+        }
+
+        composable("prepareCompleteRoute") {
+            PrepareCompleteRouteScreen(navController = navController, openDrawer = openDrawer)
         }
 
         composable("viewVehicles") {

--- a/app/src/main/java/com/ioannapergamali/mysmartroute/view/ui/screens/PrepareCompleteRouteScreen.kt
+++ b/app/src/main/java/com/ioannapergamali/mysmartroute/view/ui/screens/PrepareCompleteRouteScreen.kt
@@ -1,0 +1,120 @@
+package com.ioannapergamali.mysmartroute.view.ui.screens
+
+import androidx.compose.foundation.layout.*
+import androidx.compose.material3.*
+import androidx.compose.runtime.*
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.unit.dp
+import androidx.lifecycle.viewmodel.compose.viewModel
+import androidx.navigation.NavController
+import com.google.android.gms.maps.CameraUpdateFactory
+import com.google.android.gms.maps.model.LatLng
+import com.google.maps.android.compose.GoogleMap
+import com.google.maps.android.compose.Marker
+import com.google.maps.android.compose.MarkerState
+import com.google.maps.android.compose.Polyline
+import com.google.maps.android.compose.rememberCameraPositionState
+import com.ioannapergamali.mysmartroute.R
+import com.ioannapergamali.mysmartroute.data.local.PoIEntity
+import com.ioannapergamali.mysmartroute.data.local.RouteEntity
+import com.ioannapergamali.mysmartroute.model.enumerations.VehicleType
+import com.ioannapergamali.mysmartroute.utils.MapsUtils
+import com.ioannapergamali.mysmartroute.view.ui.components.ScreenContainer
+import com.ioannapergamali.mysmartroute.view.ui.components.TopBar
+import com.ioannapergamali.mysmartroute.viewmodel.ReservationViewModel
+import com.ioannapergamali.mysmartroute.viewmodel.RouteViewModel
+
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+fun PrepareCompleteRouteScreen(navController: NavController, openDrawer: () -> Unit) {
+    val context = LocalContext.current
+    val routeViewModel: RouteViewModel = viewModel()
+    val reservationViewModel: ReservationViewModel = viewModel()
+    val routes by routeViewModel.routes.collectAsState()
+    val reservations by reservationViewModel.reservations.collectAsState()
+    var selectedRoute by remember { mutableStateOf<RouteEntity?>(null) }
+    var pois by remember { mutableStateOf<List<PoIEntity>>(emptyList()) }
+    var pathPoints by remember { mutableStateOf<List<LatLng>>(emptyList()) }
+    var expanded by remember { mutableStateOf(false) }
+    val cameraPositionState = rememberCameraPositionState()
+    val apiKey = MapsUtils.getApiKey(context)
+    val isKeyMissing = apiKey.isBlank()
+
+    LaunchedEffect(Unit) { routeViewModel.loadRoutes(context, includeAll = true) }
+
+    LaunchedEffect(selectedRoute) {
+        selectedRoute?.let { route ->
+            val (_, path) = routeViewModel.getRouteDirections(context, route.id, VehicleType.CAR)
+            pathPoints = path
+            pois = routeViewModel.getRoutePois(context, route.id)
+            reservationViewModel.loadReservations(context, route.id)
+            path.firstOrNull()?.let { cameraPositionState.move(CameraUpdateFactory.newLatLngZoom(it, 13f)) }
+        }
+    }
+
+    Scaffold(
+        topBar = {
+            TopBar(
+                title = stringResource(R.string.prepare_complete_route),
+                navController = navController,
+                showMenu = true,
+                onMenuClick = openDrawer
+            )
+        }
+    ) { padding ->
+        ScreenContainer(modifier = Modifier.padding(padding)) {
+            Box {
+                Button(onClick = { expanded = true }) {
+                    Text(selectedRoute?.name ?: stringResource(R.string.select_route))
+                }
+                DropdownMenu(expanded = expanded, onDismissRequest = { expanded = false }) {
+                    routes.forEach { route ->
+                        DropdownMenuItem(text = { Text(route.name) }, onClick = {
+                            selectedRoute = route
+                            expanded = false
+                        })
+                    }
+                }
+            }
+
+            Spacer(Modifier.height(16.dp))
+
+            if (selectedRoute != null && pathPoints.isNotEmpty() && !isKeyMissing) {
+                GoogleMap(
+                    modifier = Modifier
+                        .fillMaxWidth()
+                        .height(200.dp),
+                    cameraPositionState = cameraPositionState
+                ) {
+                    Polyline(points = pathPoints)
+                    pois.forEach { poi ->
+                        Marker(state = MarkerState(position = LatLng(poi.lat, poi.lng)), title = poi.name)
+                    }
+                }
+                Spacer(Modifier.height(16.dp))
+            } else if (isKeyMissing) {
+                Text(stringResource(R.string.map_api_key_missing))
+                Spacer(Modifier.height(16.dp))
+            }
+
+            if (reservations.isNotEmpty()) {
+                Text(stringResource(R.string.print_list))
+                Column(modifier = Modifier.fillMaxWidth()) {
+                    Row(modifier = Modifier.fillMaxWidth()) {
+                        Text(stringResource(R.string.driver), modifier = Modifier.weight(1f), style = MaterialTheme.typography.labelMedium)
+                        Text(stringResource(R.string.cost), modifier = Modifier.weight(1f), style = MaterialTheme.typography.labelMedium)
+                    }
+                    Divider()
+                    reservations.forEach { res ->
+                        Row(modifier = Modifier.fillMaxWidth()) {
+                            Text(res.userId, modifier = Modifier.weight(1f))
+                            Text("-", modifier = Modifier.weight(1f))
+                        }
+                    }
+                }
+            }
+        }
+    }
+}

--- a/app/src/main/java/com/ioannapergamali/mysmartroute/viewmodel/ReservationViewModel.kt
+++ b/app/src/main/java/com/ioannapergamali/mysmartroute/viewmodel/ReservationViewModel.kt
@@ -1,0 +1,39 @@
+package com.ioannapergamali.mysmartroute.viewmodel
+
+import android.content.Context
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.viewModelScope
+import com.google.firebase.firestore.FirebaseFirestore
+import com.ioannapergamali.mysmartroute.data.local.MySmartRouteDatabase
+import com.ioannapergamali.mysmartroute.data.local.SeatReservationEntity
+import com.ioannapergamali.mysmartroute.utils.NetworkUtils
+import com.ioannapergamali.mysmartroute.utils.toSeatReservationEntity
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.first
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.tasks.await
+
+class ReservationViewModel : ViewModel() {
+    private val db = FirebaseFirestore.getInstance()
+
+    private val _reservations = MutableStateFlow<List<SeatReservationEntity>>(emptyList())
+    val reservations: StateFlow<List<SeatReservationEntity>> = _reservations
+
+    fun loadReservations(context: Context, routeId: String) {
+        viewModelScope.launch {
+            val dao = MySmartRouteDatabase.getInstance(context).seatReservationDao()
+            _reservations.value = dao.getReservationsForRoute(routeId).first()
+
+            if (NetworkUtils.isInternetAvailable(context)) {
+                val remote = db.collection("seat_reservations")
+                    .whereEqualTo("routeId", routeId)
+                    .get()
+                    .await()
+                val list = remote.documents.mapNotNull { it.toSeatReservationEntity() }
+                _reservations.value = list
+                list.forEach { dao.insert(it) }
+            }
+        }
+    }
+}

--- a/app/src/main/res/values-el/strings.xml
+++ b/app/src/main/res/values-el/strings.xml
@@ -81,6 +81,7 @@
     <string name="print_list">Εκτύπωση λίστας επιβατών</string>
     <string name="print_scheduled">Εκτύπωση λίστας για προγραμματισμένες μεταφορές</string>
     <string name="print_completed">Εκτύπωση λίστας για ολοκληρωμένες μεταφορές</string>
+    <string name="prepare_complete_route">Προετοιμασία ολοκλήρωσης διαδρομής</string>
     <string name="init_system">Αρχικοποίηση συστήματος</string>
     <string name="create_user">Δημιουργία λογαριασμού χρήστη</string>
     <string name="edit_privileges">Αλλαγή δικαιωμάτων χρήστη</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -79,6 +79,7 @@
     <string name="print_list">Print Passenger List</string>
     <string name="print_scheduled">Print Passenger List for Scheduled Transports</string>
     <string name="print_completed">Print Passenger List for Completed Transports</string>
+    <string name="prepare_complete_route">Prepare Route Completion</string>
     <string name="init_system">Initialize System</string>
     <string name="create_user">Create User Account</string>
     <string name="edit_privileges">Promote or Demote User</string>


### PR DESCRIPTION
## Summary
- add new menu option and strings for route preparation
- extend seat reservation DAO and add ReservationViewModel
- implement `PrepareCompleteRouteScreen`
- include screen in navigation
- update database migration and prepopulate data

## Testing
- `./gradlew test` *(fails: blocked network)*

------
https://chatgpt.com/codex/tasks/task_e_6883eb5dab3c832885aa81d447cb9737