### PR TITLE
Επιδιόρθωση σφάλματος με CameraUpdateFactory

### DIFF
--- a/app/src/main/java/com/ioannapergamali/mysmartroute/view/ui/screens/PrepareCompleteRouteScreen.kt
+++ b/app/src/main/java/com/ioannapergamali/mysmartroute/view/ui/screens/PrepareCompleteRouteScreen.kt
@@ -10,6 +10,7 @@ import androidx.compose.ui.unit.dp
 import androidx.lifecycle.viewmodel.compose.viewModel
 import androidx.navigation.NavController
 import com.google.android.gms.maps.CameraUpdateFactory
+import com.google.android.gms.maps.MapsInitializer
 import com.google.android.gms.maps.model.LatLng
 import com.google.maps.android.compose.GoogleMap
 import com.google.maps.android.compose.Marker
@@ -50,7 +51,10 @@ fun PrepareCompleteRouteScreen(navController: NavController, openDrawer: () -> U
             pathPoints = path
             pois = routeViewModel.getRoutePois(context, route.id)
             reservationViewModel.loadReservations(context, route.id)
-            path.firstOrNull()?.let { cameraPositionState.move(CameraUpdateFactory.newLatLngZoom(it, 13f)) }
+            path.firstOrNull()?.let {
+                MapsInitializer.initialize(context)
+                cameraPositionState.move(CameraUpdateFactory.newLatLngZoom(it, 13f))
+            }
         }
     }
 


### PR DESCRIPTION
## Περιγραφή
Προστέθηκε κλήση `MapsInitializer.initialize(context)` πριν από τη μετακίνηση της κάμερας στο `PrepareCompleteRouteScreen` για αποφυγή του σφάλματος `CameraUpdateFactory is not initialized`.

## Δοκιμές
- `./gradlew test` *(απέτυχε λόγω έλλειψης Android SDK)*

------
https://chatgpt.com/codex/tasks/task_e_68840c42ddc48328b1099f9742220027