### PR TITLE
Προσθήκη σύνδεσης κράτησης με δήλωση μεταφοράς

### DIFF
--- a/app/src/main/java/com/ioannapergamali/mysmartroute/data/local/MySmartRouteDatabase.kt
+++ b/app/src/main/java/com/ioannapergamali/mysmartroute/data/local/MySmartRouteDatabase.kt
@@ -44,7 +44,7 @@ import com.ioannapergamali.mysmartroute.data.local.Converters
         AvailabilityEntity::class,
         SeatReservationEntity::class
     ],
-    version = 39
+    version = 40
 )
 @TypeConverters(Converters::class)
 abstract class MySmartRouteDatabase : RoomDatabase() {
@@ -499,6 +499,7 @@ abstract class MySmartRouteDatabase : RoomDatabase() {
                 database.execSQL(
                     "CREATE TABLE IF NOT EXISTS `seat_reservations` (" +
                         "`id` TEXT NOT NULL, " +
+                        "`declarationId` TEXT NOT NULL, " +
                         "`routeId` TEXT NOT NULL, " +
                         "`userId` TEXT NOT NULL, " +
                         "PRIMARY KEY(`id`)" +
@@ -538,6 +539,14 @@ abstract class MySmartRouteDatabase : RoomDatabase() {
                 )
                 database.execSQL(
                     "ALTER TABLE `seat_reservations` ADD COLUMN `endPoiId` TEXT NOT NULL DEFAULT ''"
+                )
+            }
+        }
+
+        private val MIGRATION_39_40 = object : Migration(39, 40) {
+            override fun migrate(database: SupportSQLiteDatabase) {
+                database.execSQL(
+                    "ALTER TABLE `seat_reservations` ADD COLUMN `declarationId` TEXT NOT NULL DEFAULT ''"
                 )
             }
         }
@@ -656,7 +665,8 @@ abstract class MySmartRouteDatabase : RoomDatabase() {
                     MIGRATION_35_36,
                     MIGRATION_36_37,
                     MIGRATION_37_38,
-                    MIGRATION_38_39
+                    MIGRATION_38_39,
+                    MIGRATION_39_40
                 )
                     .addCallback(object : RoomDatabase.Callback() {
                         override fun onCreate(db: SupportSQLiteDatabase) {

--- a/app/src/main/java/com/ioannapergamali/mysmartroute/data/local/SeatReservationDao.kt
+++ b/app/src/main/java/com/ioannapergamali/mysmartroute/data/local/SeatReservationDao.kt
@@ -19,4 +19,7 @@ interface SeatReservationDao {
 
     @Query("SELECT * FROM seat_reservations WHERE routeId = :routeId AND date = :date")
     fun getReservationsForRouteAndDate(routeId: String, date: Long): Flow<List<SeatReservationEntity>>
+
+    @Query("SELECT * FROM seat_reservations WHERE declarationId = :declarationId")
+    fun getReservationsForDeclaration(declarationId: String): Flow<List<SeatReservationEntity>>
 }

--- a/app/src/main/java/com/ioannapergamali/mysmartroute/data/local/SeatReservationEntity.kt
+++ b/app/src/main/java/com/ioannapergamali/mysmartroute/data/local/SeatReservationEntity.kt
@@ -7,6 +7,8 @@ import androidx.room.PrimaryKey
 @Entity(tableName = "seat_reservations")
 data class SeatReservationEntity(
     @PrimaryKey val id: String = "",
+    /** Δήλωση μεταφοράς στην οποία ανήκει η θέση */
+    val declarationId: String = "",
     val routeId: String = "",
     val userId: String = "",
     /** Ημερομηνία κράτησης σε millis */

--- a/app/src/main/java/com/ioannapergamali/mysmartroute/utils/FirestoreMappers.kt
+++ b/app/src/main/java/com/ioannapergamali/mysmartroute/utils/FirestoreMappers.kt
@@ -315,6 +315,7 @@ fun DocumentSnapshot.toAvailabilityEntity(): AvailabilityEntity? {
 
 fun SeatReservationEntity.toFirestoreMap(): Map<String, Any> = mapOf(
     "id" to id,
+    "declarationId" to FirebaseFirestore.getInstance().collection("transport_declarations").document(declarationId),
     "routeId" to FirebaseFirestore.getInstance().collection("routes").document(routeId),
     "userId" to FirebaseFirestore.getInstance().collection("users").document(userId),
     "date" to date,
@@ -329,6 +330,11 @@ fun DocumentSnapshot.toSeatReservationEntity(): SeatReservationEntity? {
         is String -> r
         else -> getString("routeId")
     } ?: return null
+    val declarationId = when (val d = get("declarationId")) {
+        is DocumentReference -> d.id
+        is String -> d
+        else -> getString("declarationId")
+    } ?: ""
     val userId = when (val u = get("userId")) {
         is DocumentReference -> u.id
         is String -> u
@@ -345,5 +351,5 @@ fun DocumentSnapshot.toSeatReservationEntity(): SeatReservationEntity? {
         is String -> e
         else -> getString("endPoiId")
     } ?: ""
-    return SeatReservationEntity(resId, routeId, userId, dateVal, startPoiId, endPoiId)
+    return SeatReservationEntity(resId, declarationId, routeId, userId, dateVal, startPoiId, endPoiId)
 }

--- a/app/src/main/java/com/ioannapergamali/mysmartroute/view/ui/screens/PrepareCompleteRouteScreen.kt
+++ b/app/src/main/java/com/ioannapergamali/mysmartroute/view/ui/screens/PrepareCompleteRouteScreen.kt
@@ -68,7 +68,8 @@ fun PrepareCompleteRouteScreen(navController: NavController, openDrawer: () -> U
             pathPoints = path
             pois = routeViewModel.getRoutePois(context, route.id)
             if (date != null) {
-                reservationViewModel.loadReservations(context, route.id, date)
+                val declId = declarations.firstOrNull { it.routeId == route.id && it.date == date }?.id ?: ""
+                reservationViewModel.loadReservations(context, route.id, date, declId)
             }
             path.firstOrNull()?.let {
                 MapsInitializer.initialize(context)

--- a/app/src/main/java/com/ioannapergamali/mysmartroute/viewmodel/BookingViewModel.kt
+++ b/app/src/main/java/com/ioannapergamali/mysmartroute/viewmodel/BookingViewModel.kt
@@ -61,6 +61,7 @@ class BookingViewModel : ViewModel() {
                 }
                 val reservation = SeatReservationEntity(
                     reservationId,
+                    declaration.id,
                     routeId,
                     userId,
                     date,

--- a/app/src/main/java/com/ioannapergamali/mysmartroute/viewmodel/ReservationViewModel.kt
+++ b/app/src/main/java/com/ioannapergamali/mysmartroute/viewmodel/ReservationViewModel.kt
@@ -20,15 +20,16 @@ class ReservationViewModel : ViewModel() {
     private val _reservations = MutableStateFlow<List<SeatReservationEntity>>(emptyList())
     val reservations: StateFlow<List<SeatReservationEntity>> = _reservations
 
-    fun loadReservations(context: Context, routeId: String, date: Long) {
+    fun loadReservations(context: Context, routeId: String, date: Long, declarationId: String) {
         viewModelScope.launch {
             val dao = MySmartRouteDatabase.getInstance(context).seatReservationDao()
-            _reservations.value = dao.getReservationsForRouteAndDate(routeId, date).first()
+            _reservations.value = dao.getReservationsForDeclaration(declarationId).first()
 
             if (NetworkUtils.isInternetAvailable(context)) {
                 val remote = db.collection("seat_reservations")
                     .whereEqualTo("routeId", routeId)
                     .whereEqualTo("date", date)
+                    .whereEqualTo("declarationId", declarationId)
                     .get()
                     .await()
                 val list = remote.documents.mapNotNull { it.toSeatReservationEntity() }


### PR DESCRIPTION
## Summary
- σύνδεση κράτησης θέσης με τη δήλωση μεταφοράς μέσω `declarationId`
- ενημέρωση Room και Firestore mappers
- migration 39→40 για τον νέο πίνακα
- προσαρμογή ViewModel και οθόνης προετοιμασίας διαδρομής

## Testing
- `./gradlew test` *(απέτυχε λόγω περιορισμών δικτύου)*

------
https://chatgpt.com/codex/tasks/task_e_6884e91d2cf88328b6422d55450abde0