### PR TITLE
Έλεγχος σειράς στάσεων κατά την κράτηση

### DIFF
--- a/app/src/main/java/com/ioannapergamali/mysmartroute/view/ui/screens/BookSeatScreen.kt
+++ b/app/src/main/java/com/ioannapergamali/mysmartroute/view/ui/screens/BookSeatScreen.kt
@@ -378,10 +378,22 @@ fun BookSeatScreen(navController: NavController, openDrawer: () -> Unit) {
                             Text("${index + 1}. ${poi.name}", modifier = Modifier.weight(1f))
                             Text(poi.type.name, modifier = Modifier.weight(1f))
 
-                            IconButton(onClick = { startIndex = index }) {
+                            IconButton(onClick = {
+                                if (endIndex == null || index < endIndex!!) {
+                                    startIndex = index
+                                } else {
+                                    message = context.getString(R.string.invalid_stop_order)
+                                }
+                            }) {
                                 Text("\uD83C\uDD95")
                             }
-                            IconButton(onClick = { endIndex = index }) {
+                            IconButton(onClick = {
+                                if (startIndex == null || index > startIndex!!) {
+                                    endIndex = index
+                                } else {
+                                    message = context.getString(R.string.invalid_stop_order)
+                                }
+                            }) {
                                 Text("\uD83D\uDD1A")
                             }
 

--- a/app/src/main/res/values-el/strings.xml
+++ b/app/src/main/res/values-el/strings.xml
@@ -153,5 +153,6 @@
     <string name="select_dropoff">Επιλογή ως στάση αποβίβασης</string>
     <string name="boarding_stop">Στάση εκκίνησης</string>
     <string name="dropoff_stop">Στάση αποβίβασης</string>
+    <string name="invalid_stop_order">Η στάση αποβίβασης πρέπει να είναι μετά τη στάση εκκίνησης.</string>
     <string name="no_reservations">Δεν βρέθηκαν κρατήσεις</string>
 </resources>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -164,6 +164,7 @@
     <string name="select_dropoff">Set as drop-off stop</string>
     <string name="boarding_stop">Boarding stop</string>
     <string name="dropoff_stop">Drop-off stop</string>
+    <string name="invalid_stop_order">Drop-off stop must be after boarding stop.</string>
     <string name="passenger">Passenger</string>
     <string name="no_reservations">No reservations found</string>
 </resources>


### PR DESCRIPTION
## Περιγραφή
Προστέθηκε έλεγχος ώστε η στάση αποβίβασης να μην μπορεί να προηγείται της στάσης επιβίβασης κατά την κράτηση θέσης.

### Κύριες αλλαγές
- Ενημέρωση `BookSeatScreen` για εμφάνιση μηνύματος λάθους και αποτροπή μη έγκυρης επιλογής στάσεων.
- Νέα συμβολοσειρά `invalid_stop_order` στα ελληνικά και αγγλικά.

## Δοκιμές
- Εκτέλεση `./gradlew test` (απέτυχε λόγω περιορισμών δικτύου για λήψη εξαρτήσεων).

------
https://chatgpt.com/codex/tasks/task_e_6885b97b93408328ab275d880e69506f