### PR TITLE
Add refresh option for boarding/dropoff

### DIFF
--- a/app/src/main/java/com/ioannapergamali/mysmartroute/view/ui/screens/BookSeatScreen.kt
+++ b/app/src/main/java/com/ioannapergamali/mysmartroute/view/ui/screens/BookSeatScreen.kt
@@ -422,6 +422,11 @@ fun BookSeatScreen(navController: NavController, openDrawer: () -> Unit) {
                     readOnly = true,
                     label = { Text(stringResource(R.string.boarding_stop)) },
                     leadingIcon = { Text("\uD83C\uDD95") },
+                    trailingIcon = {
+                        IconButton(onClick = { startIndex = null }) {
+                            Icon(Icons.Default.Refresh, contentDescription = stringResource(R.string.clear_selection))
+                        }
+                    },
                     modifier = Modifier.fillMaxWidth(),
                     shape = MaterialTheme.shapes.small,
                     colors = OutlinedTextFieldDefaults.colors(
@@ -438,6 +443,11 @@ fun BookSeatScreen(navController: NavController, openDrawer: () -> Unit) {
                     readOnly = true,
                     label = { Text(stringResource(R.string.dropoff_stop)) },
                     leadingIcon = { Text("\uD83D\uDD1A") },
+                    trailingIcon = {
+                        IconButton(onClick = { endIndex = null }) {
+                            Icon(Icons.Default.Refresh, contentDescription = stringResource(R.string.clear_selection))
+                        }
+                    },
                     modifier = Modifier.fillMaxWidth(),
                     shape = MaterialTheme.shapes.small,
                     colors = OutlinedTextFieldDefaults.colors(

--- a/app/src/main/res/values-el/strings.xml
+++ b/app/src/main/res/values-el/strings.xml
@@ -154,5 +154,6 @@
     <string name="boarding_stop">Στάση εκκίνησης</string>
     <string name="dropoff_stop">Στάση αποβίβασης</string>
     <string name="invalid_stop_order">Η στάση αποβίβασης πρέπει να είναι μετά τη στάση εκκίνησης.</string>
+    <string name="clear_selection">Καθαρισμός επιλογής</string>
     <string name="no_reservations">Δεν βρέθηκαν κρατήσεις</string>
 </resources>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -165,6 +165,7 @@
     <string name="boarding_stop">Boarding stop</string>
     <string name="dropoff_stop">Drop-off stop</string>
     <string name="invalid_stop_order">Drop-off stop must be after boarding stop.</string>
+    <string name="clear_selection">Clear selection</string>
     <string name="passenger">Passenger</string>
     <string name="no_reservations">No reservations found</string>
 </resources>


### PR DESCRIPTION
## Summary
- allow clearing the selected boarding and dropoff stops
- add "clear selection" string in English and Greek

## Testing
- `./gradlew test --no-daemon` *(fails: domain `maven.pkg.jetbrains.space` blocked)*

------
https://chatgpt.com/codex/tasks/task_e_6885c075524c83288274b54980b1f6b6