### PR TITLE
Fix reservation lookup with Firestore references

### DIFF
--- a/app/src/main/java/com/ioannapergamali/mysmartroute/viewmodel/BookingViewModel.kt
+++ b/app/src/main/java/com/ioannapergamali/mysmartroute/viewmodel/BookingViewModel.kt
@@ -55,10 +55,12 @@ class BookingViewModel : ViewModel() {
                 val declaration = declarations.firstOrNull() ?: return@runBlocking false
 
                 // Έλεγχος αν ο επιβάτης έχει ήδη κάνει κράτηση για τη συγκεκριμένη διαδρομή
+                val routeRef = db.collection("routes").document(routeId)
+                val userRef = db.collection("users").document(userId)
                 val existingUserReservation = db.collection("seat_reservations")
-                    .whereEqualTo("routeId", routeId)
+                    .whereEqualTo("routeId", routeRef)
                     .whereEqualTo("date", date)
-                    .whereEqualTo("userId", userId)
+                    .whereEqualTo("userId", userRef)
                     .get().await()
                 if (existingUserReservation.size() > 0) {
                     return@runBlocking false
@@ -66,7 +68,7 @@ class BookingViewModel : ViewModel() {
 
                 // Έλεγχος διαθεσιμότητας θέσεων
                 val existing = db.collection("seat_reservations")
-                    .whereEqualTo("routeId", routeId)
+                    .whereEqualTo("routeId", routeRef)
                     .whereEqualTo("date", date)
                     .get().await()
                 if (existing.size() >= declaration.seats) {

--- a/app/src/main/java/com/ioannapergamali/mysmartroute/viewmodel/ReservationViewModel.kt
+++ b/app/src/main/java/com/ioannapergamali/mysmartroute/viewmodel/ReservationViewModel.kt
@@ -26,10 +26,12 @@ class ReservationViewModel : ViewModel() {
             _reservations.value = dao.getReservationsForDeclaration(declarationId).first()
 
             if (NetworkUtils.isInternetAvailable(context)) {
+                val routeRef = db.collection("routes").document(routeId)
+                val declRef = db.collection("transport_declarations").document(declarationId)
                 val remote = db.collection("seat_reservations")
-                    .whereEqualTo("routeId", routeId)
+                    .whereEqualTo("routeId", routeRef)
                     .whereEqualTo("date", date)
-                    .whereEqualTo("declarationId", declarationId)
+                    .whereEqualTo("declarationId", declRef)
                     .get()
                     .await()
                 val list = remote.documents.mapNotNull { it.toSeatReservationEntity() }


### PR DESCRIPTION
## Summary
- query Firestore seat reservations using `DocumentReference`
- use document references when checking bookings in `BookingViewModel`

## Testing
- `./gradlew test --no-daemon` *(fails: domain is not in allowlist)*

------
https://chatgpt.com/codex/tasks/task_e_688a342ef90c83289f2e0ded4aeb8b3a