### PR TITLE
Fix driver name display in PrepareCompleteRouteScreen

### DIFF
--- a/app/src/main/java/com/ioannapergamali/mysmartroute/view/ui/screens/PrepareCompleteRouteScreen.kt
+++ b/app/src/main/java/com/ioannapergamali/mysmartroute/view/ui/screens/PrepareCompleteRouteScreen.kt
@@ -158,9 +158,9 @@ fun PrepareCompleteRouteScreen(navController: NavController, openDrawer: () -> U
                     )
                     ExposedDropdownMenu(expanded = expandedDriver, onDismissRequest = { expandedDriver = false }) {
                         drivers.forEach { driver ->
-                            DropdownMenuItem(text = { Text("${'$'}{driver.name} ${'$'}{driver.surname}") }, onClick = {
+                            DropdownMenuItem(text = { Text("${driver.name} ${driver.surname}") }, onClick = {
                                 selectedDriverId = driver.id
-                                selectedDriverName = "${'$'}{driver.name} ${'$'}{driver.surname}"
+                                selectedDriverName = "${driver.name} ${driver.surname}"
                                 expandedDriver = false
                                 selectedRoute = null
                                 selectedDate = null


### PR DESCRIPTION
## Summary
- show the driver's full name using string interpolation in PrepareCompleteRouteScreen

## Testing
- `./gradlew tasks --all` *(fails: Could not download dependencies due to network restrictions)*

------
https://chatgpt.com/codex/tasks/task_e_688a3cedabc883288d004e23766b5125