### PR TITLE
Implement passenger favorite transport selection

### DIFF
--- a/app/src/main/java/com/ioannapergamali/mysmartroute/utils/FavoritesPreferenceManager.kt
+++ b/app/src/main/java/com/ioannapergamali/mysmartroute/utils/FavoritesPreferenceManager.kt
@@ -1,0 +1,68 @@
+package com.ioannapergamali.mysmartroute.utils
+
+import android.content.Context
+import androidx.datastore.preferences.core.edit
+import androidx.datastore.preferences.core.stringSetPreferencesKey
+import androidx.datastore.preferences.preferencesDataStore
+import com.ioannapergamali.mysmartroute.model.enumerations.VehicleType
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.map
+
+private val Context.favoritesDataStore by preferencesDataStore(name = "favorites_settings")
+
+object FavoritesPreferenceManager {
+    private val PREFERRED_KEY = stringSetPreferencesKey("preferred")
+    private val NON_PREFERRED_KEY = stringSetPreferencesKey("non_preferred")
+
+    fun preferredFlow(context: Context): Flow<Set<VehicleType>> =
+        context.favoritesDataStore.data.map { prefs ->
+            prefs[PREFERRED_KEY]
+                ?.mapNotNull { runCatching { VehicleType.valueOf(it) }.getOrNull() }
+                ?.toSet() ?: emptySet()
+        }
+
+    fun nonPreferredFlow(context: Context): Flow<Set<VehicleType>> =
+        context.favoritesDataStore.data.map { prefs ->
+            prefs[NON_PREFERRED_KEY]
+                ?.mapNotNull { runCatching { VehicleType.valueOf(it) }.getOrNull() }
+                ?.toSet() ?: emptySet()
+        }
+
+    suspend fun addPreferred(context: Context, type: VehicleType) {
+        context.favoritesDataStore.edit { prefs ->
+            val preferred = prefs[PREFERRED_KEY]?.toMutableSet() ?: mutableSetOf()
+            preferred.add(type.name)
+            prefs[PREFERRED_KEY] = preferred
+            val non = prefs[NON_PREFERRED_KEY]?.toMutableSet()
+            non?.remove(type.name)
+            non?.let { prefs[NON_PREFERRED_KEY] = it }
+        }
+    }
+
+    suspend fun addNonPreferred(context: Context, type: VehicleType) {
+        context.favoritesDataStore.edit { prefs ->
+            val non = prefs[NON_PREFERRED_KEY]?.toMutableSet() ?: mutableSetOf()
+            non.add(type.name)
+            prefs[NON_PREFERRED_KEY] = non
+            val preferred = prefs[PREFERRED_KEY]?.toMutableSet()
+            preferred?.remove(type.name)
+            preferred?.let { prefs[PREFERRED_KEY] = it }
+        }
+    }
+
+    suspend fun removePreferred(context: Context, type: VehicleType) {
+        context.favoritesDataStore.edit { prefs ->
+            val preferred = prefs[PREFERRED_KEY]?.toMutableSet() ?: mutableSetOf()
+            preferred.remove(type.name)
+            prefs[PREFERRED_KEY] = preferred
+        }
+    }
+
+    suspend fun removeNonPreferred(context: Context, type: VehicleType) {
+        context.favoritesDataStore.edit { prefs ->
+            val non = prefs[NON_PREFERRED_KEY]?.toMutableSet() ?: mutableSetOf()
+            non.remove(type.name)
+            prefs[NON_PREFERRED_KEY] = non
+        }
+    }
+}

--- a/app/src/main/java/com/ioannapergamali/mysmartroute/view/ui/screens/ManageFavoritesScreen.kt
+++ b/app/src/main/java/com/ioannapergamali/mysmartroute/view/ui/screens/ManageFavoritesScreen.kt
@@ -1,18 +1,35 @@
 package com.ioannapergamali.mysmartroute.view.ui.screens
 
-import androidx.compose.foundation.layout.padding
-import androidx.compose.material3.Scaffold
-import androidx.compose.material3.Text
-import androidx.compose.runtime.Composable
+import androidx.compose.foundation.layout.*
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.Delete
+import androidx.compose.material3.*
+import androidx.compose.runtime.*
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.unit.dp
+import androidx.lifecycle.viewmodel.compose.viewModel
 import androidx.navigation.NavController
 import com.ioannapergamali.mysmartroute.R
+import com.ioannapergamali.mysmartroute.model.enumerations.VehicleType
 import com.ioannapergamali.mysmartroute.view.ui.components.ScreenContainer
 import com.ioannapergamali.mysmartroute.view.ui.components.TopBar
+import com.ioannapergamali.mysmartroute.viewmodel.FavoritesViewModel
 
+@OptIn(ExperimentalMaterial3Api::class)
 @Composable
 fun ManageFavoritesScreen(navController: NavController, openDrawer: () -> Unit) {
+    val context = LocalContext.current
+    val viewModel: FavoritesViewModel = viewModel()
+    val preferred by viewModel.preferredFlow(context).collectAsState(initial = emptySet())
+    val nonPreferred by viewModel.nonPreferredFlow(context).collectAsState(initial = emptySet())
+
+    var prefExpanded by remember { mutableStateOf(false) }
+    var nonPrefExpanded by remember { mutableStateOf(false) }
+    var selectedPref by remember { mutableStateOf(VehicleType.CAR) }
+    var selectedNonPref by remember { mutableStateOf(VehicleType.CAR) }
+
     Scaffold(
         topBar = {
             TopBar(
@@ -24,8 +41,79 @@ fun ManageFavoritesScreen(navController: NavController, openDrawer: () -> Unit) 
         }
     ) { padding ->
         ScreenContainer(modifier = Modifier.padding(padding)) {
-            Text(text = stringResource(R.string.manage_favorites))
+            Text(stringResource(R.string.favorites_preferred))
+            Row(verticalAlignment = Alignment.CenterVertically) {
+                ExposedDropdownMenuBox(expanded = prefExpanded, onExpandedChange = { prefExpanded = !prefExpanded }) {
+                    OutlinedTextField(
+                        readOnly = true,
+                        value = selectedPref.name,
+                        onValueChange = {},
+                        modifier = Modifier.menuAnchor().weight(1f),
+                        label = { Text(stringResource(R.string.vehicle_type)) },
+                        trailingIcon = { ExposedDropdownMenuDefaults.TrailingIcon(expanded = prefExpanded) }
+                    )
+                    DropdownMenu(expanded = prefExpanded, onDismissRequest = { prefExpanded = false }) {
+                        VehicleType.values().forEach { type ->
+                            DropdownMenuItem(text = { Text(type.name) }, onClick = {
+                                selectedPref = type
+                                prefExpanded = false
+                            })
+                        }
+                    }
+                }
+                Spacer(Modifier.width(8.dp))
+                Button(onClick = { viewModel.addPreferred(context, selectedPref) }) {
+                    Text(stringResource(R.string.add_favorite))
+                }
+            }
+            preferred.forEach { type ->
+                Row(
+                    verticalAlignment = Alignment.CenterVertically,
+                    modifier = Modifier.fillMaxWidth()
+                ) {
+                    Text(type.name, modifier = Modifier.weight(1f))
+                    IconButton(onClick = { viewModel.removePreferred(context, type) }) {
+                        Icon(Icons.Default.Delete, contentDescription = stringResource(R.string.delete_favorite))
+                    }
+                }
+            }
+            Divider(modifier = Modifier.padding(vertical = 8.dp))
+            Text(stringResource(R.string.favorites_non_preferred))
+            Row(verticalAlignment = Alignment.CenterVertically) {
+                ExposedDropdownMenuBox(expanded = nonPrefExpanded, onExpandedChange = { nonPrefExpanded = !nonPrefExpanded }) {
+                    OutlinedTextField(
+                        readOnly = true,
+                        value = selectedNonPref.name,
+                        onValueChange = {},
+                        modifier = Modifier.menuAnchor().weight(1f),
+                        label = { Text(stringResource(R.string.vehicle_type)) },
+                        trailingIcon = { ExposedDropdownMenuDefaults.TrailingIcon(expanded = nonPrefExpanded) }
+                    )
+                    DropdownMenu(expanded = nonPrefExpanded, onDismissRequest = { nonPrefExpanded = false }) {
+                        VehicleType.values().forEach { type ->
+                            DropdownMenuItem(text = { Text(type.name) }, onClick = {
+                                selectedNonPref = type
+                                nonPrefExpanded = false
+                            })
+                        }
+                    }
+                }
+                Spacer(Modifier.width(8.dp))
+                Button(onClick = { viewModel.addNonPreferred(context, selectedNonPref) }) {
+                    Text(stringResource(R.string.add_favorite))
+                }
+            }
+            nonPreferred.forEach { type ->
+                Row(
+                    verticalAlignment = Alignment.CenterVertically,
+                    modifier = Modifier.fillMaxWidth()
+                ) {
+                    Text(type.name, modifier = Modifier.weight(1f))
+                    IconButton(onClick = { viewModel.removeNonPreferred(context, type) }) {
+                        Icon(Icons.Default.Delete, contentDescription = stringResource(R.string.delete_favorite))
+                    }
+                }
+            }
         }
     }
 }
-

--- a/app/src/main/java/com/ioannapergamali/mysmartroute/viewmodel/FavoritesViewModel.kt
+++ b/app/src/main/java/com/ioannapergamali/mysmartroute/viewmodel/FavoritesViewModel.kt
@@ -1,0 +1,33 @@
+package com.ioannapergamali.mysmartroute.viewmodel
+
+import android.content.Context
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.viewModelScope
+import com.ioannapergamali.mysmartroute.model.enumerations.VehicleType
+import com.ioannapergamali.mysmartroute.utils.FavoritesPreferenceManager
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.launch
+
+class FavoritesViewModel : ViewModel() {
+    fun preferredFlow(context: Context): Flow<Set<VehicleType>> =
+        FavoritesPreferenceManager.preferredFlow(context)
+
+    fun nonPreferredFlow(context: Context): Flow<Set<VehicleType>> =
+        FavoritesPreferenceManager.nonPreferredFlow(context)
+
+    fun addPreferred(context: Context, type: VehicleType) {
+        viewModelScope.launch { FavoritesPreferenceManager.addPreferred(context, type) }
+    }
+
+    fun addNonPreferred(context: Context, type: VehicleType) {
+        viewModelScope.launch { FavoritesPreferenceManager.addNonPreferred(context, type) }
+    }
+
+    fun removePreferred(context: Context, type: VehicleType) {
+        viewModelScope.launch { FavoritesPreferenceManager.removePreferred(context, type) }
+    }
+
+    fun removeNonPreferred(context: Context, type: VehicleType) {
+        viewModelScope.launch { FavoritesPreferenceManager.removeNonPreferred(context, type) }
+    }
+}

--- a/app/src/main/res/values-el/strings.xml
+++ b/app/src/main/res/values-el/strings.xml
@@ -76,6 +76,7 @@
     <string name="vehicle_name">Όνομα οχήματος</string>
     <string name="license_plate">Πινακίδα</string>
     <string name="seats_label">Θέσεις</string>
+    <string name="vehicle_type">Τύπος οχήματος</string>
     <string name="announce_availability">Δήλωση διαθεσιμότητας για μεταφορά</string>
     <string name="find_passengers">Εύρεση επιβατών</string>
     <string name="print_list">Εκτύπωση λίστας επιβατών</string>
@@ -154,6 +155,10 @@
     <string name="boarding_stop">Στάση εκκίνησης</string>
     <string name="dropoff_stop">Στάση αποβίβασης</string>
     <string name="invalid_stop_order">Η στάση αποβίβασης πρέπει να είναι μετά τη στάση εκκίνησης.</string>
+    <string name="favorites_preferred">Προτιμώμενα μέσα μεταφοράς</string>
+    <string name="favorites_non_preferred">Μη προτιμώμενα μέσα μεταφοράς</string>
+    <string name="add_favorite">Προσθήκη</string>
+    <string name="delete_favorite">Αφαίρεση</string>
     <string name="clear_selection">Καθαρισμός επιλογής</string>
     <string name="no_reservations">Δεν βρέθηκαν κρατήσεις</string>
 </resources>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -79,6 +79,7 @@
     <string name="print_list">Print Passenger List</string>
     <string name="print_scheduled">Print Passenger List for Scheduled Transports</string>
     <string name="print_completed">Print Passenger List for Completed Transports</string>
+    <string name="vehicle_type">Vehicle type</string>
     <string name="prepare_complete_route">Prepare Route Completion</string>
     <string name="init_system">Initialize System</string>
     <string name="create_user">Create User Account</string>
@@ -167,5 +168,9 @@
     <string name="invalid_stop_order">Drop-off stop must be after boarding stop.</string>
     <string name="clear_selection">Clear selection</string>
     <string name="passenger">Passenger</string>
+    <string name="favorites_preferred">Preferred transport modes</string>
+    <string name="favorites_non_preferred">Non-preferred transport modes</string>
+    <string name="add_favorite">Add</string>
+    <string name="delete_favorite">Delete</string>
     <string name="no_reservations">No reservations found</string>
 </resources>


### PR DESCRIPTION
## Summary
- add `FavoritesPreferenceManager` for saving favorite vehicle types
- create `FavoritesViewModel` to handle preference operations
- implement favorites UI in `ManageFavoritesScreen`
- add resource strings for favorites management in English and Greek

## Testing
- `./gradlew test` *(failed: blocked access to maven.pkg.jetbrains.space)*

------
https://chatgpt.com/codex/tasks/task_e_688a58e1cfa083288ef38e082f1ddabc