### PR TITLE
Fix import for Alignment

### DIFF
--- a/app/src/main/java/com/ioannapergamali/mysmartroute/view/ui/screens/ManageFavoritesScreen.kt
+++ b/app/src/main/java/com/ioannapergamali/mysmartroute/view/ui/screens/ManageFavoritesScreen.kt
@@ -6,6 +6,7 @@ import androidx.compose.material.icons.filled.Delete
 import androidx.compose.material3.*
 import androidx.compose.runtime.*
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.Alignment
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.unit.dp


### PR DESCRIPTION
## Summary
- add missing Alignment import in `ManageFavoritesScreen`

## Testing
- `./gradlew assembleDebug` *(fails: Maven packages blocked)*

------
https://chatgpt.com/codex/tasks/task_e_688a5bf889648328b97d3f344f6ee451