### PR TITLE
Βελτίωση διαχείρισης αγαπημένων

### DIFF
--- a/app/src/main/java/com/ioannapergamali/mysmartroute/view/ui/screens/ManageFavoritesScreen.kt
+++ b/app/src/main/java/com/ioannapergamali/mysmartroute/view/ui/screens/ManageFavoritesScreen.kt
@@ -3,6 +3,7 @@ package com.ioannapergamali.mysmartroute.view.ui.screens
 import androidx.compose.foundation.layout.*
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.Delete
+import androidx.compose.ui.graphics.vector.ImageVector
 import androidx.compose.material3.*
 import androidx.compose.runtime.*
 import androidx.compose.ui.Modifier
@@ -16,6 +17,8 @@ import com.ioannapergamali.mysmartroute.R
 import com.ioannapergamali.mysmartroute.model.enumerations.VehicleType
 import com.ioannapergamali.mysmartroute.view.ui.components.ScreenContainer
 import com.ioannapergamali.mysmartroute.view.ui.components.TopBar
+import com.ioannapergamali.mysmartroute.view.ui.util.iconForVehicle
+import com.ioannapergamali.mysmartroute.view.ui.util.labelForVehicle
 import com.ioannapergamali.mysmartroute.viewmodel.FavoritesViewModel
 
 @OptIn(ExperimentalMaterial3Api::class)
@@ -47,18 +50,23 @@ fun ManageFavoritesScreen(navController: NavController, openDrawer: () -> Unit) 
                 ExposedDropdownMenuBox(expanded = prefExpanded, onExpandedChange = { prefExpanded = !prefExpanded }) {
                     OutlinedTextField(
                         readOnly = true,
-                        value = selectedPref.name,
+                        value = labelForVehicle(selectedPref),
                         onValueChange = {},
                         modifier = Modifier.menuAnchor().weight(1f),
                         label = { Text(stringResource(R.string.vehicle_type)) },
+                        leadingIcon = { Icon(iconForVehicle(selectedPref), contentDescription = null) },
                         trailingIcon = { ExposedDropdownMenuDefaults.TrailingIcon(expanded = prefExpanded) }
                     )
                     DropdownMenu(expanded = prefExpanded, onDismissRequest = { prefExpanded = false }) {
                         VehicleType.values().forEach { type ->
-                            DropdownMenuItem(text = { Text(type.name) }, onClick = {
-                                selectedPref = type
-                                prefExpanded = false
-                            })
+                            DropdownMenuItem(
+                                text = { Text(labelForVehicle(type)) },
+                                leadingIcon = { Icon(iconForVehicle(type), contentDescription = null) },
+                                onClick = {
+                                    selectedPref = type
+                                    prefExpanded = false
+                                }
+                            )
                         }
                     }
                 }
@@ -72,7 +80,12 @@ fun ManageFavoritesScreen(navController: NavController, openDrawer: () -> Unit) 
                     verticalAlignment = Alignment.CenterVertically,
                     modifier = Modifier.fillMaxWidth()
                 ) {
-                    Text(type.name, modifier = Modifier.weight(1f))
+                    Icon(
+                        imageVector = iconForVehicle(type),
+                        contentDescription = null,
+                        modifier = Modifier.padding(end = 8.dp)
+                    )
+                    Text(labelForVehicle(type), modifier = Modifier.weight(1f))
                     IconButton(onClick = { viewModel.removePreferred(context, type) }) {
                         Icon(Icons.Default.Delete, contentDescription = stringResource(R.string.delete_favorite))
                     }
@@ -84,18 +97,23 @@ fun ManageFavoritesScreen(navController: NavController, openDrawer: () -> Unit) 
                 ExposedDropdownMenuBox(expanded = nonPrefExpanded, onExpandedChange = { nonPrefExpanded = !nonPrefExpanded }) {
                     OutlinedTextField(
                         readOnly = true,
-                        value = selectedNonPref.name,
+                        value = labelForVehicle(selectedNonPref),
                         onValueChange = {},
                         modifier = Modifier.menuAnchor().weight(1f),
                         label = { Text(stringResource(R.string.vehicle_type)) },
+                        leadingIcon = { Icon(iconForVehicle(selectedNonPref), contentDescription = null) },
                         trailingIcon = { ExposedDropdownMenuDefaults.TrailingIcon(expanded = nonPrefExpanded) }
                     )
                     DropdownMenu(expanded = nonPrefExpanded, onDismissRequest = { nonPrefExpanded = false }) {
                         VehicleType.values().forEach { type ->
-                            DropdownMenuItem(text = { Text(type.name) }, onClick = {
-                                selectedNonPref = type
-                                nonPrefExpanded = false
-                            })
+                            DropdownMenuItem(
+                                text = { Text(labelForVehicle(type)) },
+                                leadingIcon = { Icon(iconForVehicle(type), contentDescription = null) },
+                                onClick = {
+                                    selectedNonPref = type
+                                    nonPrefExpanded = false
+                                }
+                            )
                         }
                     }
                 }
@@ -109,7 +127,12 @@ fun ManageFavoritesScreen(navController: NavController, openDrawer: () -> Unit) 
                     verticalAlignment = Alignment.CenterVertically,
                     modifier = Modifier.fillMaxWidth()
                 ) {
-                    Text(type.name, modifier = Modifier.weight(1f))
+                    Icon(
+                        imageVector = iconForVehicle(type),
+                        contentDescription = null,
+                        modifier = Modifier.padding(end = 8.dp)
+                    )
+                    Text(labelForVehicle(type), modifier = Modifier.weight(1f))
                     IconButton(onClick = { viewModel.removeNonPreferred(context, type) }) {
                         Icon(Icons.Default.Delete, contentDescription = stringResource(R.string.delete_favorite))
                     }

--- a/app/src/main/java/com/ioannapergamali/mysmartroute/view/ui/util/VehicleDisplay.kt
+++ b/app/src/main/java/com/ioannapergamali/mysmartroute/view/ui/util/VehicleDisplay.kt
@@ -1,0 +1,27 @@
+package com.ioannapergamali.mysmartroute.view.ui.util
+
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.AirportShuttle
+import androidx.compose.material.icons.filled.DirectionsBike
+import androidx.compose.material.icons.filled.DirectionsBus
+import androidx.compose.material.icons.filled.DirectionsCar
+import androidx.compose.material.icons.filled.LocalTaxi
+import androidx.compose.material.icons.filled.TwoWheeler
+import androidx.compose.ui.graphics.vector.ImageVector
+import com.ioannapergamali.mysmartroute.model.enumerations.VehicleType
+
+fun iconForVehicle(type: VehicleType): ImageVector = when (type) {
+    VehicleType.CAR, VehicleType.TAXI -> Icons.Default.DirectionsCar
+    VehicleType.BIGBUS, VehicleType.SMALLBUS -> Icons.Default.DirectionsBus
+    VehicleType.BICYCLE -> Icons.Default.DirectionsBike
+    VehicleType.MOTORBIKE -> Icons.Default.TwoWheeler
+}
+
+fun labelForVehicle(type: VehicleType): String = when (type) {
+    VehicleType.CAR -> "Αυτοκίνητο"
+    VehicleType.TAXI -> "Ταξί"
+    VehicleType.BIGBUS -> "Λεωφορείο"
+    VehicleType.SMALLBUS -> "Βαν"
+    VehicleType.BICYCLE -> "Ποδήλατο"
+    VehicleType.MOTORBIKE -> "Μηχανάκι"
+}


### PR DESCRIPTION
## Summary
- εμφάνιση εικονιδίων τύπων οχημάτων στην οθόνη διαχείρισης αγαπημένων
- προσθήκη βοηθητικής κλάσης `VehicleDisplay`

## Testing
- `./gradlew test --quiet` *(απέτυχε: αδυναμία λήψης εξαρτήσεων)*

------
https://chatgpt.com/codex/tasks/task_e_688a5f5e7c448328889da339a7e806c5