### PR TITLE
Fix Room compilation error

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -132,3 +132,7 @@ dependencies {
     androidTestImplementation("androidx.test.ext:junit:1.1.5")
     androidTestImplementation("androidx.test.espresso:espresso-core:3.5.1")
 }
+
+kapt {
+    correctErrorTypes = true
+}


### PR DESCRIPTION
## Summary
- adjust KAPT options to tolerate missing types

## Testing
- `./gradlew --no-daemon tasks`

------
https://chatgpt.com/codex/tasks/task_e_688a76826d848328b1e2d4c724eee9a3