### PR TITLE
Implement vehicles subcollection for favorites

### DIFF
--- a/app/src/main/java/com/ioannapergamali/mysmartroute/viewmodel/DatabaseViewModel.kt
+++ b/app/src/main/java/com/ioannapergamali/mysmartroute/viewmodel/DatabaseViewModel.kt
@@ -236,7 +236,7 @@ class DatabaseViewModel : ViewModel() {
             val availabilities = firestore.collection("availabilities").get().await()
                 .documents.mapNotNull { it.toAvailabilityEntity() }
 
-            val favorites = firestore.collection("favorites").get().await()
+            val favorites = firestore.collection("favorites/vehicles").get().await()
                 .documents.mapNotNull { it.toFavoriteEntity() }
 
             Log.d(TAG, "Firebase data -> users:${users.size} vehicles:${vehicles.size} pois:${pois.size} types:${poiTypes.size} settings:${settings.size} roles:${roles.size} menus:${menus.size} options:${menuOptions.size} routes:${routes.size} movings:${movings.size} declarations:${declarations.size} availabilities:${availabilities.size} favorites:${favorites.size}")
@@ -369,7 +369,7 @@ class DatabaseViewModel : ViewModel() {
 
                     val availabilities = firestore.collection("availabilities").get().await()
                         .documents.mapNotNull { it.toAvailabilityEntity() }
-                    val favorites = firestore.collection("favorites").get().await()
+                    val favorites = firestore.collection("favorites/vehicles").get().await()
                         .documents.mapNotNull { it.toFavoriteEntity() }
 
                     Log.d(
@@ -494,7 +494,7 @@ class DatabaseViewModel : ViewModel() {
                             .set(it.toFirestoreMap()).await()
                     }
                     favorites.forEach {
-                        firestore.collection("favorites")
+                        firestore.collection("favorites/vehicles")
                             .document(it.id)
                             .set(it.toFirestoreMap()).await()
                     }


### PR DESCRIPTION
## Summary
- store user favorites under `users/<id>/favorites/vehicles`
- move global favorites to `favorites/vehicles` collection

## Testing
- `./gradlew test` *(fails: maven.pkg.jetbrains.space blocked)*

------
https://chatgpt.com/codex/tasks/task_e_688a7b8269e88328b026e8b440d9e57d