### PR TITLE
Implement vehicles subcollection for favorites

### DIFF
--- a/app/src/main/java/com/ioannapergamali/mysmartroute/viewmodel/DatabaseViewModel.kt
+++ b/app/src/main/java/com/ioannapergamali/mysmartroute/viewmodel/DatabaseViewModel.kt
@@ -236,7 +236,11 @@ class DatabaseViewModel : ViewModel() {
             val availabilities = firestore.collection("availabilities").get().await()
                 .documents.mapNotNull { it.toAvailabilityEntity() }
 
-            val favorites = firestore.collection("favorites").get().await()
+            val favorites = firestore.collection("favorites")
+                .document("vehicles")
+                .collection("items")
+                .get()
+                .await()
                 .documents.mapNotNull { it.toFavoriteEntity() }
 
             Log.d(TAG, "Firebase data -> users:${users.size} vehicles:${vehicles.size} pois:${pois.size} types:${poiTypes.size} settings:${settings.size} roles:${roles.size} menus:${menus.size} options:${menuOptions.size} routes:${routes.size} movings:${movings.size} declarations:${declarations.size} availabilities:${availabilities.size} favorites:${favorites.size}")
@@ -369,7 +373,11 @@ class DatabaseViewModel : ViewModel() {
 
                     val availabilities = firestore.collection("availabilities").get().await()
                         .documents.mapNotNull { it.toAvailabilityEntity() }
-                    val favorites = firestore.collection("favorites").get().await()
+                    val favorites = firestore.collection("favorites")
+                        .document("vehicles")
+                        .collection("items")
+                        .get()
+                        .await()
                         .documents.mapNotNull { it.toFavoriteEntity() }
 
                     Log.d(
@@ -495,6 +503,8 @@ class DatabaseViewModel : ViewModel() {
                     }
                     favorites.forEach {
                         firestore.collection("favorites")
+                            .document("vehicles")
+                            .collection("items")
                             .document(it.id)
                             .set(it.toFirestoreMap()).await()
                     }

--- a/app/src/main/java/com/ioannapergamali/mysmartroute/viewmodel/FavoritesViewModel.kt
+++ b/app/src/main/java/com/ioannapergamali/mysmartroute/viewmodel/FavoritesViewModel.kt
@@ -18,6 +18,18 @@ import java.util.UUID
 class FavoritesViewModel : ViewModel() {
     private val firestore = FirebaseFirestore.getInstance()
 
+    private val globalVehicles
+        get() = firestore.collection("favorites")
+            .document("vehicles")
+            .collection("items")
+
+    private fun userVehicles(uid: String) =
+        firestore.collection("users")
+            .document(uid)
+            .collection("favorites")
+            .document("vehicles")
+            .collection("items")
+
     private fun userId() = FirebaseAuth.getInstance().currentUser?.uid ?: ""
 
     fun preferredFlow(context: Context): Flow<Set<VehicleType>> {
@@ -43,9 +55,8 @@ class FavoritesViewModel : ViewModel() {
             val fav = com.ioannapergamali.mysmartroute.data.local.FavoriteEntity(id, uid, type.name, true)
             insertFavoriteSafely(db.favoriteDao(), db.userDao(), fav)
             runCatching {
-                val userDoc = firestore.collection("users").document(uid)
-                userDoc.collection("favorites").document(id).set(fav.toFirestoreMap()).await()
-                firestore.collection("favorites").document(id).set(fav.toFirestoreMap()).await()
+                userVehicles(uid).document(id).set(fav.toFirestoreMap()).await()
+                globalVehicles.document(id).set(fav.toFirestoreMap()).await()
             }
         }
     }
@@ -59,9 +70,8 @@ class FavoritesViewModel : ViewModel() {
             val fav = com.ioannapergamali.mysmartroute.data.local.FavoriteEntity(id, uid, type.name, false)
             insertFavoriteSafely(db.favoriteDao(), db.userDao(), fav)
             runCatching {
-                val userDoc = firestore.collection("users").document(uid)
-                userDoc.collection("favorites").document(id).set(fav.toFirestoreMap()).await()
-                firestore.collection("favorites").document(id).set(fav.toFirestoreMap()).await()
+                userVehicles(uid).document(id).set(fav.toFirestoreMap()).await()
+                globalVehicles.document(id).set(fav.toFirestoreMap()).await()
             }
         }
     }
@@ -73,14 +83,13 @@ class FavoritesViewModel : ViewModel() {
             val db = MySmartRouteDatabase.getInstance(context)
             db.favoriteDao().delete(uid, type.name)
             runCatching {
-                val userDoc = firestore.collection("users").document(uid)
-                userDoc.collection("favorites")
+                userVehicles(uid)
                     .whereEqualTo("vehicleType", type.name)
                     .whereEqualTo("preferred", true)
                     .get()
                     .await()
                     .documents.forEach { it.reference.delete().await() }
-                firestore.collection("favorites")
+                globalVehicles
                     .whereEqualTo("userId", uid)
                     .whereEqualTo("vehicleType", type.name)
                     .whereEqualTo("preferred", true)
@@ -98,14 +107,13 @@ class FavoritesViewModel : ViewModel() {
             val db = MySmartRouteDatabase.getInstance(context)
             db.favoriteDao().delete(uid, type.name)
             runCatching {
-                val userDoc = firestore.collection("users").document(uid)
-                userDoc.collection("favorites")
+                userVehicles(uid)
                     .whereEqualTo("vehicleType", type.name)
                     .whereEqualTo("preferred", false)
                     .get()
                     .await()
                     .documents.forEach { it.reference.delete().await() }
-                firestore.collection("favorites")
+                globalVehicles
                     .whereEqualTo("userId", uid)
                     .whereEqualTo("vehicleType", type.name)
                     .whereEqualTo("preferred", false)


### PR DESCRIPTION
## Summary
- store user favorites under `users/<id>/favorites/vehicles`
- move global favorites to `favorites/vehicles` collection
- fix Firestore paths for vehicles favorites

## Testing
- `./gradlew test` *(fails: maven.pkg.jetbrains.space blocked)*

------
https://chatgpt.com/codex/tasks/task_e_688a7b8269e88328b026e8b440d9e57d