### PR TITLE
Add view requests screen

### DIFF
--- a/app/src/main/java/com/ioannapergamali/mysmartroute/data/local/MySmartRouteDatabase.kt
+++ b/app/src/main/java/com/ioannapergamali/mysmartroute/data/local/MySmartRouteDatabase.kt
@@ -47,7 +47,7 @@ import com.ioannapergamali.mysmartroute.data.local.Converters
         SeatReservationEntity::class,
         FavoriteEntity::class
     ],
-    version = 41
+    version = 42
 )
 @TypeConverters(Converters::class)
 abstract class MySmartRouteDatabase : RoomDatabase() {
@@ -244,6 +244,7 @@ abstract class MySmartRouteDatabase : RoomDatabase() {
                 insertOption("opt_passenger_9", passengerMenuId, "cancel_seat", "cancelSeat")
                 insertOption("opt_passenger_10", passengerMenuId, "rank_transports", "rankTransports")
                 insertOption("opt_passenger_11", passengerMenuId, "shutdown", "shutdown")
+                insertOption("opt_passenger_12", passengerMenuId, "view_requests", "viewRequests")
 
                 val driverMenuId = "menu_driver_main"
                 insertMenu(driverMenuId, "role_driver", "driver_menu_title")
@@ -573,6 +574,15 @@ abstract class MySmartRouteDatabase : RoomDatabase() {
             }
         }
 
+        private val MIGRATION_41_42 = object : Migration(41, 42) {
+            override fun migrate(database: SupportSQLiteDatabase) {
+                database.execSQL(
+                    "INSERT INTO `menu_options` (`id`, `menuId`, `titleResKey`, `route`) " +
+                        "VALUES ('opt_passenger_12', 'menu_passenger_main', 'view_requests', 'viewRequests')"
+                )
+            }
+        }
+
         private fun prepopulate(db: SupportSQLiteDatabase) {
             Log.d(TAG, "Prepopulating database")
             db.execSQL(
@@ -620,6 +630,7 @@ abstract class MySmartRouteDatabase : RoomDatabase() {
             insertOption("opt_passenger_9", passengerMenuId, "cancel_seat", "cancelSeat")
             insertOption("opt_passenger_10", passengerMenuId, "rank_transports", "rankTransports")
             insertOption("opt_passenger_11", passengerMenuId, "shutdown", "shutdown")
+            insertOption("opt_passenger_12", passengerMenuId, "view_requests", "viewRequests")
 
             val driverMenuId = "menu_driver_main"
             insertMenu(driverMenuId, "role_driver", "driver_menu_title")
@@ -689,7 +700,8 @@ abstract class MySmartRouteDatabase : RoomDatabase() {
                     MIGRATION_37_38,
                     MIGRATION_38_39,
                     MIGRATION_39_40,
-                    MIGRATION_40_41
+                    MIGRATION_40_41,
+                    MIGRATION_41_42
                 )
                     .addCallback(object : RoomDatabase.Callback() {
                         override fun onCreate(db: SupportSQLiteDatabase) {

--- a/app/src/main/java/com/ioannapergamali/mysmartroute/model/navigation/NavigationHost.kt
+++ b/app/src/main/java/com/ioannapergamali/mysmartroute/model/navigation/NavigationHost.kt
@@ -38,6 +38,8 @@ import com.ioannapergamali.mysmartroute.view.ui.screens.ViewVehiclesScreen
 import com.ioannapergamali.mysmartroute.view.ui.screens.BookSeatScreen
 import com.ioannapergamali.mysmartroute.view.ui.screens.ViewRoutesScreen
 import com.ioannapergamali.mysmartroute.view.ui.screens.SelectRoutePoisScreen
+import com.ioannapergamali.mysmartroute.view.ui.screens.ViewRequestsScreen
+import com.ioannapergamali.mysmartroute.view.ui.screens.FindVehicleScreen
 
 
 
@@ -157,6 +159,14 @@ fun NavigationHost(navController : NavHostController, openDrawer: () -> Unit) {
 
         composable("routeMode") {
             RouteModeScreen(navController = navController, openDrawer = openDrawer)
+        }
+
+        composable("findVehicle") {
+            FindVehicleScreen(navController = navController, openDrawer = openDrawer)
+        }
+
+        composable("viewRequests") {
+            ViewRequestsScreen(navController = navController, openDrawer = openDrawer)
         }
 
         composable("bookSeat") {

--- a/app/src/main/java/com/ioannapergamali/mysmartroute/view/ui/screens/FindVehicleScreen.kt
+++ b/app/src/main/java/com/ioannapergamali/mysmartroute/view/ui/screens/FindVehicleScreen.kt
@@ -1,0 +1,146 @@
+package com.ioannapergamali.mysmartroute.view.ui.screens
+
+import androidx.compose.foundation.layout.*
+import androidx.compose.material3.*
+import androidx.compose.material3.menuAnchor
+import androidx.compose.runtime.*
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.text.input.KeyboardOptions
+import androidx.compose.ui.text.input.KeyboardType
+import androidx.compose.ui.unit.dp
+import androidx.lifecycle.viewmodel.compose.viewModel
+import androidx.navigation.NavController
+import com.ioannapergamali.mysmartroute.R
+import com.ioannapergamali.mysmartroute.data.local.PoIEntity
+import com.ioannapergamali.mysmartroute.view.ui.components.ScreenContainer
+import com.ioannapergamali.mysmartroute.view.ui.components.TopBar
+import com.ioannapergamali.mysmartroute.viewmodel.PoIViewModel
+import com.ioannapergamali.mysmartroute.viewmodel.VehicleRequestViewModel
+
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+fun FindVehicleScreen(navController: NavController, openDrawer: () -> Unit) {
+    val context = LocalContext.current
+    val poiViewModel: PoIViewModel = viewModel()
+    val requestViewModel: VehicleRequestViewModel = viewModel()
+    val pois by poiViewModel.pois.collectAsState()
+
+    var fromQuery by remember { mutableStateOf("") }
+    var toQuery by remember { mutableStateOf("") }
+    var fromExpanded by remember { mutableStateOf(false) }
+    var toExpanded by remember { mutableStateOf(false) }
+    var selectedFrom by remember { mutableStateOf<PoIEntity?>(null) }
+    var selectedTo by remember { mutableStateOf<PoIEntity?>(null) }
+    var maxCostText by remember { mutableStateOf("") }
+    var message by remember { mutableStateOf("") }
+
+    LaunchedEffect(Unit) { poiViewModel.loadPois(context) }
+
+    val filteredFrom = if (fromQuery.isBlank()) pois else pois.filter {
+        it.name.contains(fromQuery, true) ||
+            it.address.city.contains(fromQuery, true) ||
+            it.address.streetName.contains(fromQuery, true)
+    }
+    val filteredTo = if (toQuery.isBlank()) pois else pois.filter {
+        it.name.contains(toQuery, true) ||
+            it.address.city.contains(toQuery, true) ||
+            it.address.streetName.contains(toQuery, true)
+    }
+
+    Scaffold(
+        topBar = {
+            TopBar(
+                title = stringResource(R.string.find_vehicle),
+                navController = navController,
+                showMenu = true,
+                onMenuClick = openDrawer
+            )
+        }
+    ) { padding ->
+        ScreenContainer(modifier = Modifier.padding(padding)) {
+            ExposedDropdownMenuBox(expanded = fromExpanded, onExpandedChange = { fromExpanded = !fromExpanded }) {
+                OutlinedTextField(
+                    value = selectedFrom?.name ?: fromQuery,
+                    onValueChange = { fromQuery = it; selectedFrom = null },
+                    label = { Text(stringResource(R.string.start_point)) },
+                    trailingIcon = { ExposedDropdownMenuDefaults.TrailingIcon(expanded = fromExpanded) },
+                    modifier = Modifier.menuAnchor().fillMaxWidth()
+                )
+                DropdownMenu(expanded = fromExpanded, onDismissRequest = { fromExpanded = false }) {
+                    filteredFrom.forEach { poi ->
+                        DropdownMenuItem(text = { Text(poi.name) }, onClick = {
+                            selectedFrom = poi
+                            fromQuery = poi.name
+                            fromExpanded = false
+                        })
+                    }
+                }
+            }
+
+            Spacer(Modifier.height(8.dp))
+
+            Button(onClick = { navController.navigate("definePoi?lat=&lng=&source=from&view=false") }) {
+                Text(stringResource(R.string.add_point))
+            }
+
+            Spacer(Modifier.height(16.dp))
+
+            ExposedDropdownMenuBox(expanded = toExpanded, onExpandedChange = { toExpanded = !toExpanded }) {
+                OutlinedTextField(
+                    value = selectedTo?.name ?: toQuery,
+                    onValueChange = { toQuery = it; selectedTo = null },
+                    label = { Text(stringResource(R.string.destination)) },
+                    trailingIcon = { ExposedDropdownMenuDefaults.TrailingIcon(expanded = toExpanded) },
+                    modifier = Modifier.menuAnchor().fillMaxWidth()
+                )
+                DropdownMenu(expanded = toExpanded, onDismissRequest = { toExpanded = false }) {
+                    filteredTo.forEach { poi ->
+                        DropdownMenuItem(text = { Text(poi.name) }, onClick = {
+                            selectedTo = poi
+                            toQuery = poi.name
+                            toExpanded = false
+                        })
+                    }
+                }
+            }
+
+            Spacer(Modifier.height(8.dp))
+
+            Button(onClick = { navController.navigate("definePoi?lat=&lng=&source=to&view=false") }) {
+                Text(stringResource(R.string.add_point))
+            }
+
+            Spacer(Modifier.height(16.dp))
+
+            OutlinedTextField(
+                value = maxCostText,
+                onValueChange = { maxCostText = it },
+                label = { Text(stringResource(R.string.max_cost)) },
+                keyboardOptions = KeyboardOptions(keyboardType = KeyboardType.Number),
+                modifier = Modifier.fillMaxWidth()
+            )
+
+            Spacer(Modifier.height(16.dp))
+
+            Button(
+                onClick = {
+                    val fromId = selectedFrom?.id ?: return@Button
+                    val toId = selectedTo?.id ?: return@Button
+                    val cost = maxCostText.toDoubleOrNull() ?: Double.MAX_VALUE
+                    requestViewModel.requestTransport(context, fromId, toId, cost)
+                    message = context.getString(R.string.request_sent)
+                },
+                enabled = selectedFrom != null && selectedTo != null
+            ) {
+                Text(stringResource(R.string.find_vehicle))
+            }
+
+            if (message.isNotBlank()) {
+                Spacer(Modifier.height(8.dp))
+                Text(message)
+            }
+        }
+    }
+}

--- a/app/src/main/java/com/ioannapergamali/mysmartroute/view/ui/screens/ViewRequestsScreen.kt
+++ b/app/src/main/java/com/ioannapergamali/mysmartroute/view/ui/screens/ViewRequestsScreen.kt
@@ -1,0 +1,73 @@
+package com.ioannapergamali.mysmartroute.view.ui.screens
+
+import androidx.compose.foundation.layout.*
+import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.lazy.items
+import androidx.compose.material3.Divider
+import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.Scaffold
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.collectAsState
+import androidx.compose.runtime.getValue
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.unit.dp
+import androidx.lifecycle.viewmodel.compose.viewModel
+import androidx.navigation.NavController
+import com.ioannapergamali.mysmartroute.R
+import com.ioannapergamali.mysmartroute.view.ui.components.ScreenContainer
+import com.ioannapergamali.mysmartroute.view.ui.components.TopBar
+import com.ioannapergamali.mysmartroute.viewmodel.PoIViewModel
+import com.ioannapergamali.mysmartroute.viewmodel.VehicleRequestViewModel
+
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+fun ViewRequestsScreen(navController: NavController, openDrawer: () -> Unit) {
+    val context = LocalContext.current
+    val viewModel: VehicleRequestViewModel = viewModel()
+    val poiViewModel: PoIViewModel = viewModel()
+    val requests by viewModel.requests.collectAsState()
+    val pois by poiViewModel.pois.collectAsState()
+
+    LaunchedEffect(Unit) {
+        poiViewModel.loadPois(context)
+        viewModel.loadRequests(context)
+    }
+
+    val poiNames = pois.associate { it.id to it.name }
+
+    Scaffold(
+        topBar = {
+            TopBar(
+                title = stringResource(R.string.view_requests),
+                navController = navController,
+                showMenu = true,
+                onMenuClick = openDrawer
+            )
+        }
+    ) { padding ->
+        ScreenContainer(modifier = Modifier.padding(padding)) {
+            if (requests.isEmpty()) {
+                Text(stringResource(R.string.no_requests))
+            } else {
+                LazyColumn {
+                    items(requests) { req ->
+                        val parts = req.routeId.split("-")
+                        val fromName = poiNames[parts.getOrNull(0)] ?: ""
+                        val toName = poiNames[parts.getOrNull(1)] ?: ""
+                        Row(modifier = Modifier.fillMaxWidth().padding(vertical = 8.dp)) {
+                            Text(fromName, modifier = Modifier.weight(1f))
+                            Text(toName, modifier = Modifier.weight(1f))
+                            val costText = if (req.cost == Double.MAX_VALUE) "∞" else req.cost.toString()
+                            Text(costText, modifier = Modifier.weight(1f))
+                        }
+                        Divider()
+                    }
+                }
+            }
+        }
+    }
+}

--- a/app/src/main/java/com/ioannapergamali/mysmartroute/viewmodel/VehicleRequestViewModel.kt
+++ b/app/src/main/java/com/ioannapergamali/mysmartroute/viewmodel/VehicleRequestViewModel.kt
@@ -1,0 +1,78 @@
+package com.ioannapergamali.mysmartroute.viewmodel
+
+import android.content.Context
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.viewModelScope
+import com.google.firebase.auth.FirebaseAuth
+import com.google.firebase.firestore.FirebaseFirestore
+import com.ioannapergamali.mysmartroute.data.local.MovingEntity
+import com.ioannapergamali.mysmartroute.data.local.MySmartRouteDatabase
+import com.ioannapergamali.mysmartroute.utils.NetworkUtils
+import com.ioannapergamali.mysmartroute.utils.toFirestoreMap
+import com.ioannapergamali.mysmartroute.utils.toMovingEntity
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.first
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.tasks.await
+import java.util.UUID
+
+class VehicleRequestViewModel : ViewModel() {
+
+    private val db = FirebaseFirestore.getInstance()
+
+    private val _requests = MutableStateFlow<List<MovingEntity>>(emptyList())
+    val requests: StateFlow<List<MovingEntity>> = _requests
+
+    fun requestTransport(context: Context, fromPoiId: String, toPoiId: String, maxCost: Double) {
+        viewModelScope.launch {
+            val dao = MySmartRouteDatabase.getInstance(context).movingDao()
+            val userId = FirebaseAuth.getInstance().currentUser?.uid ?: ""
+            val id = UUID.randomUUID().toString()
+            val entity = MovingEntity(
+                id = id,
+                routeId = "${'$'}fromPoiId-${'$'}toPoiId",
+                userId = userId,
+                date = 0,
+                vehicleId = "",
+                cost = maxCost,
+                durationMinutes = 0
+            )
+            dao.insert(entity)
+            try {
+                FirebaseFirestore.getInstance()
+                    .collection("movings")
+                    .document(id)
+                    .set(entity.toFirestoreMap())
+                    .await()
+            } catch (_: Exception) {
+            }
+        }
+    }
+
+    fun loadRequests(context: Context) {
+        viewModelScope.launch {
+            val dao = MySmartRouteDatabase.getInstance(context).movingDao()
+            val userId = FirebaseAuth.getInstance().currentUser?.uid ?: return@launch
+
+            var list = dao.getMovingsForUser(userId).first()
+
+            if (NetworkUtils.isInternetAvailable(context)) {
+                val remote = runCatching {
+                    db.collection("movings")
+                        .whereEqualTo("userId", db.collection("users").document(userId))
+                        .get()
+                        .await()
+                        .documents.mapNotNull { it.toMovingEntity() }
+                }.getOrNull()
+
+                if (remote != null) {
+                    remote.forEach { dao.insert(it) }
+                    list = (list + remote).distinctBy { it.id }
+                }
+            }
+
+            _requests.value = list
+        }
+    }
+}

--- a/app/src/main/res/values-el/strings.xml
+++ b/app/src/main/res/values-el/strings.xml
@@ -161,4 +161,8 @@
     <string name="delete_favorite">Αφαίρεση</string>
     <string name="clear_selection">Καθαρισμός επιλογής</string>
     <string name="no_reservations">Δεν βρέθηκαν κρατήσεις</string>
+    <string name="max_cost">Μέγιστο κόστος</string>
+    <string name="request_sent">Το αίτημα καταχωρήθηκε</string>
+    <string name="view_requests">Προβολή αιτημάτων</string>
+    <string name="no_requests">Δεν βρέθηκαν αιτήματα</string>
 </resources>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -173,4 +173,8 @@
     <string name="add_favorite">Add</string>
     <string name="delete_favorite">Delete</string>
     <string name="no_reservations">No reservations found</string>
+    <string name="max_cost">Maximum cost</string>
+    <string name="request_sent">Request saved</string>
+    <string name="view_requests">View Requests</string>
+    <string name="no_requests">No requests found</string>
 </resources>


### PR DESCRIPTION
## Summary
- list stored transport requests in `ViewRequestsScreen`
- expose new route `viewRequests`
- extend `VehicleRequestViewModel` with request loading
- bump DB version and add migration for new menu option
- update English and Greek strings

## Testing
- `./gradlew test` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_688a8dc2312883288d7a8d7d5871a611