### PR TITLE
Προσθήκη οθόνης προβολής αιτημάτων μεταφοράς για οδηγούς

### DIFF
--- a/app/src/main/assets/menus.json
+++ b/app/src/main/assets/menus.json
@@ -35,7 +35,8 @@
           {"titleKey": "print_list", "route": "printList"},
           {"titleKey": "print_scheduled", "route": "printScheduled"},
           {"titleKey": "print_completed", "route": "printCompleted"},
-          {"titleKey": "prepare_complete_route", "route": "prepareCompleteRoute"}
+          {"titleKey": "prepare_complete_route", "route": "prepareCompleteRoute"},
+          {"titleKey": "view_transport_requests", "route": "viewTransportRequests"}
         ]
       }
     ]

--- a/app/src/main/java/com/ioannapergamali/mysmartroute/data/local/MySmartRouteDatabase.kt
+++ b/app/src/main/java/com/ioannapergamali/mysmartroute/data/local/MySmartRouteDatabase.kt
@@ -47,7 +47,7 @@ import com.ioannapergamali.mysmartroute.data.local.Converters
         SeatReservationEntity::class,
         FavoriteEntity::class
     ],
-    version = 42
+    version = 43
 )
 @TypeConverters(Converters::class)
 abstract class MySmartRouteDatabase : RoomDatabase() {
@@ -583,6 +583,15 @@ abstract class MySmartRouteDatabase : RoomDatabase() {
             }
         }
 
+        private val MIGRATION_42_43 = object : Migration(42, 43) {
+            override fun migrate(database: SupportSQLiteDatabase) {
+                database.execSQL(
+                    "INSERT INTO `menu_options` (`id`, `menuId`, `titleResKey`, `route`) " +
+                        "VALUES ('opt_driver_9', 'menu_driver_main', 'view_transport_requests', 'viewTransportRequests')"
+                )
+            }
+        }
+
         private fun prepopulate(db: SupportSQLiteDatabase) {
             Log.d(TAG, "Prepopulating database")
             db.execSQL(
@@ -642,6 +651,7 @@ abstract class MySmartRouteDatabase : RoomDatabase() {
             insertOption("opt_driver_6", driverMenuId, "print_scheduled", "printScheduled")
             insertOption("opt_driver_7", driverMenuId, "print_completed", "printCompleted")
             insertOption("opt_driver_8", driverMenuId, "prepare_complete_route", "prepareCompleteRoute")
+            insertOption("opt_driver_9", driverMenuId, "view_transport_requests", "viewTransportRequests")
 
             val adminMenuId = "menu_admin_main"
             insertMenu(adminMenuId, "role_admin", "admin_menu_title")
@@ -701,7 +711,8 @@ abstract class MySmartRouteDatabase : RoomDatabase() {
                     MIGRATION_38_39,
                     MIGRATION_39_40,
                     MIGRATION_40_41,
-                    MIGRATION_41_42
+                    MIGRATION_41_42,
+                    MIGRATION_42_43
                 )
                     .addCallback(object : RoomDatabase.Callback() {
                         override fun onCreate(db: SupportSQLiteDatabase) {

--- a/app/src/main/java/com/ioannapergamali/mysmartroute/model/navigation/NavigationHost.kt
+++ b/app/src/main/java/com/ioannapergamali/mysmartroute/model/navigation/NavigationHost.kt
@@ -35,6 +35,7 @@ import com.ioannapergamali.mysmartroute.view.ui.screens.PrintScheduledScreen
 import com.ioannapergamali.mysmartroute.view.ui.screens.PrepareCompleteRouteScreen
 import com.ioannapergamali.mysmartroute.view.ui.screens.RouteModeScreen
 import com.ioannapergamali.mysmartroute.view.ui.screens.ViewVehiclesScreen
+import com.ioannapergamali.mysmartroute.view.ui.screens.ViewTransportRequestsScreen
 import com.ioannapergamali.mysmartroute.view.ui.screens.BookSeatScreen
 import com.ioannapergamali.mysmartroute.view.ui.screens.ViewRoutesScreen
 import com.ioannapergamali.mysmartroute.view.ui.screens.SelectRoutePoisScreen
@@ -191,6 +192,10 @@ fun NavigationHost(navController : NavHostController, openDrawer: () -> Unit) {
 
         composable("prepareCompleteRoute") {
             PrepareCompleteRouteScreen(navController = navController, openDrawer = openDrawer)
+        }
+
+        composable("viewTransportRequests") {
+            ViewTransportRequestsScreen(navController = navController, openDrawer = openDrawer)
         }
 
         composable("viewVehicles") {

--- a/app/src/main/java/com/ioannapergamali/mysmartroute/view/ui/screens/ViewTransportRequestsScreen.kt
+++ b/app/src/main/java/com/ioannapergamali/mysmartroute/view/ui/screens/ViewTransportRequestsScreen.kt
@@ -1,0 +1,73 @@
+package com.ioannapergamali.mysmartroute.view.ui.screens
+
+import androidx.compose.foundation.layout.*
+import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.lazy.items
+import androidx.compose.material3.Divider
+import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.Scaffold
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.collectAsState
+import androidx.compose.runtime.getValue
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.unit.dp
+import androidx.lifecycle.viewmodel.compose.viewModel
+import androidx.navigation.NavController
+import com.ioannapergamali.mysmartroute.R
+import com.ioannapergamali.mysmartroute.view.ui.components.ScreenContainer
+import com.ioannapergamali.mysmartroute.view.ui.components.TopBar
+import com.ioannapergamali.mysmartroute.viewmodel.PoIViewModel
+import com.ioannapergamali.mysmartroute.viewmodel.VehicleRequestViewModel
+
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+fun ViewTransportRequestsScreen(navController: NavController, openDrawer: () -> Unit) {
+    val context = LocalContext.current
+    val viewModel: VehicleRequestViewModel = viewModel()
+    val poiViewModel: PoIViewModel = viewModel()
+    val requests by viewModel.requests.collectAsState()
+    val pois by poiViewModel.pois.collectAsState()
+
+    LaunchedEffect(Unit) {
+        poiViewModel.loadPois(context)
+        viewModel.loadRequests(context, allUsers = true)
+    }
+
+    val poiNames = pois.associate { it.id to it.name }
+
+    Scaffold(
+        topBar = {
+            TopBar(
+                title = stringResource(R.string.view_transport_requests),
+                navController = navController,
+                showMenu = true,
+                onMenuClick = openDrawer
+            )
+        }
+    ) { padding ->
+        ScreenContainer(modifier = Modifier.padding(padding)) {
+            if (requests.isEmpty()) {
+                Text(stringResource(R.string.no_requests))
+            } else {
+                LazyColumn {
+                    items(requests) { req ->
+                        val parts = req.routeId.split("-")
+                        val fromName = poiNames[parts.getOrNull(0)] ?: ""
+                        val toName = poiNames[parts.getOrNull(1)] ?: ""
+                        Row(modifier = Modifier.fillMaxWidth().padding(vertical = 8.dp)) {
+                            Text(fromName, modifier = Modifier.weight(1f))
+                            Text(toName, modifier = Modifier.weight(1f))
+                            val costText = if (req.cost == Double.MAX_VALUE) "∞" else req.cost.toString()
+                            Text(costText, modifier = Modifier.weight(1f))
+                        }
+                        Divider()
+                    }
+                }
+            }
+        }
+    }
+}

--- a/app/src/main/res/values-el/strings.xml
+++ b/app/src/main/res/values-el/strings.xml
@@ -163,5 +163,7 @@
     <string name="no_reservations">Δεν βρέθηκαν κρατήσεις</string>
     <string name="max_cost">Μέγιστο κόστος</string>
     <string name="request_sent">Το αίτημα καταχωρήθηκε</string>
+    <string name="view_requests">Προβολή αιτημάτων</string>
+    <string name="view_transport_requests">Προβολή αιτημάτων μεταφοράς</string>
 
 </resources>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -65,6 +65,7 @@
     <string name="book_seat">Book a Seat or Buy a Ticket</string>
     <string name="view_routes">View Interesting Routes</string>
     <string name="view_transports">View Transports</string>
+    <string name="view_transport_requests">View Transport Requests</string>
     <string name="print_ticket">Print Booked Seat or Ticket</string>
     <string name="cancel_seat">Cancel Booked Seat</string>
     <string name="rank_transports">View, Rank and Comment on Completed Transports</string>


### PR DESCRIPTION
## Περιγραφή
- νέα οθόνη `ViewTransportRequestsScreen` για οδηγούς
- επέκταση του `VehicleRequestViewModel` ώστε να φορτώνει όλα τα αιτήματα
- προσθήκη διαδρομής στο `NavigationHost`
- εισαγωγή νέας επιλογής μενού και migration στη βάση
- ενημέρωση μεταφράσεων και αρχείου μενού

## Testing
- `./gradlew test` *(απέτυχε λόγω περιορισμών δικτύου)*

------
https://chatgpt.com/codex/tasks/task_e_688a9c323f7c8328b0d95661f4ff7bda