### PR TITLE
Fix Firestore moving storage

### DIFF
--- a/app/src/main/java/com/ioannapergamali/mysmartroute/utils/FirestoreMappers.kt
+++ b/app/src/main/java/com/ioannapergamali/mysmartroute/utils/FirestoreMappers.kt
@@ -228,15 +228,20 @@ fun DocumentSnapshot.toPoiTypeEntity(): PoiTypeEntity? {
     return PoiTypeEntity(typeId, typeName)
 }
 
-fun MovingEntity.toFirestoreMap(): Map<String, Any> = mapOf(
-    "id" to id,
-    "routeId" to FirebaseFirestore.getInstance().collection("routes").document(routeId),
-    "userId" to FirebaseFirestore.getInstance().collection("users").document(userId),
-    "date" to date,
-    "vehicleId" to FirebaseFirestore.getInstance().collection("vehicles").document(vehicleId),
-    "cost" to cost,
-    "durationMinutes" to durationMinutes
-)
+fun MovingEntity.toFirestoreMap(): Map<String, Any> {
+    val map = mutableMapOf<String, Any>(
+        "id" to id,
+        "routeId" to FirebaseFirestore.getInstance().collection("routes").document(routeId),
+        "userId" to FirebaseFirestore.getInstance().collection("users").document(userId),
+        "date" to date,
+        "cost" to cost,
+        "durationMinutes" to durationMinutes
+    )
+    if (vehicleId.isNotEmpty()) {
+        map["vehicleId"] = FirebaseFirestore.getInstance().collection("vehicles").document(vehicleId)
+    }
+    return map
+}
 
 fun DocumentSnapshot.toMovingEntity(): MovingEntity? {
     val movingId = getString("id") ?: id

--- a/app/src/main/java/com/ioannapergamali/mysmartroute/viewmodel/VehicleRequestViewModel.kt
+++ b/app/src/main/java/com/ioannapergamali/mysmartroute/viewmodel/VehicleRequestViewModel.kt
@@ -1,6 +1,7 @@
 package com.ioannapergamali.mysmartroute.viewmodel
 
 import android.content.Context
+import android.util.Log
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import com.google.firebase.auth.FirebaseAuth
@@ -23,6 +24,10 @@ class VehicleRequestViewModel : ViewModel() {
 
     private val _requests = MutableStateFlow<List<MovingEntity>>(emptyList())
     val requests: StateFlow<List<MovingEntity>> = _requests
+
+    companion object {
+        private const val TAG = "VehicleRequestVM"
+    }
 
     fun loadRequests(context: Context, allUsers: Boolean = false) {
         viewModelScope.launch {
@@ -77,7 +82,8 @@ class VehicleRequestViewModel : ViewModel() {
                     .document(id)
                     .set(entity.toFirestoreMap())
                     .await()
-            } catch (_: Exception) {
+            } catch (e: Exception) {
+                Log.e(TAG, "Failed to store moving", e)
             }
         }
     }


### PR DESCRIPTION
## Summary
- avoid empty `vehicleId` in Firestore map
- log failures when storing new movings

## Testing
- `./gradlew test --no-daemon` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_688aa108643c83289dd1a10467357831