### PR TITLE
Fix nested scroll crash

### DIFF
--- a/app/src/main/java/com/ioannapergamali/mysmartroute/view/ui/screens/ViewRequestsScreen.kt
+++ b/app/src/main/java/com/ioannapergamali/mysmartroute/view/ui/screens/ViewRequestsScreen.kt
@@ -49,7 +49,7 @@ fun ViewRequestsScreen(navController: NavController, openDrawer: () -> Unit) {
             )
         }
     ) { padding ->
-        ScreenContainer(modifier = Modifier.padding(padding)) {
+        ScreenContainer(modifier = Modifier.padding(padding), scrollable = false) {
             if (requests.isEmpty()) {
                 Text(stringResource(R.string.no_requests))
             } else {

--- a/app/src/main/java/com/ioannapergamali/mysmartroute/view/ui/screens/ViewTransportRequestsScreen.kt
+++ b/app/src/main/java/com/ioannapergamali/mysmartroute/view/ui/screens/ViewTransportRequestsScreen.kt
@@ -49,7 +49,7 @@ fun ViewTransportRequestsScreen(navController: NavController, openDrawer: () -> 
             )
         }
     ) { padding ->
-        ScreenContainer(modifier = Modifier.padding(padding)) {
+        ScreenContainer(modifier = Modifier.padding(padding), scrollable = false) {
             if (requests.isEmpty()) {
                 Text(stringResource(R.string.no_requests))
             } else {


### PR DESCRIPTION
## Summary
- prevent nested scrolling by disabling ScreenContainer scroll in request screens

## Testing
- `./gradlew test --no-daemon` *(fails: maven.pkg.jetbrains.space blocked)*

------
https://chatgpt.com/codex/tasks/task_e_688aa9efca6083288c26480cec5c745a