### PR TITLE
Προσθήκη κουμπιού Δήλωση διαδρομής

### DIFF
--- a/app/src/main/java/com/ioannapergamali/mysmartroute/view/ui/screens/FindVehicleScreen.kt
+++ b/app/src/main/java/com/ioannapergamali/mysmartroute/view/ui/screens/FindVehicleScreen.kt
@@ -58,6 +58,12 @@ fun FindVehicleScreen(navController: NavController, openDrawer: () -> Unit) {
         }
     ) { padding ->
         ScreenContainer(modifier = Modifier.padding(padding)) {
+            Button(onClick = { navController.navigate("declareRoute") }) {
+                Text(stringResource(R.string.declare_route))
+            }
+
+            Spacer(Modifier.height(16.dp))
+
             ExposedDropdownMenuBox(expanded = routeExpanded, onExpandedChange = { routeExpanded = !routeExpanded }) {
                 val selectedRoute = routes.find { it.id == selectedRouteId }
                 OutlinedTextField(


### PR DESCRIPTION
## Περιγραφή
Προστέθηκε κουμπί «Δήλωση διαδρομής» στην οθόνη **Εύρεση οχήματος**. Το κουμπί μεταφέρει τον χρήστη στην οθόνη δημιουργίας διαδρομής.

## Οδηγίες δοκιμών
- Η οθόνη «Εύρεση οχήματος» πρέπει να εμφανίζει το νέο κουμπί πάνω από την επιλογή διαδρομής.
- Πατώντας το κουμπί μεταφέρεστε στην οθόνη «Δήλωση διαδρομής».

Έγινε προσπάθεια εκτέλεσης των δοκιμών αλλά η διαδικασία απέτυχε λόγω περιορισμών λήψης εξαρτήσεων.

------
https://chatgpt.com/codex/tasks/task_e_688ab08d7fec83288a5d575213518c27