### PR TITLE
Εμφάνιση ονόματος χρήστη και διαδρομής στα αιτήματα μεταφοράς

### DIFF
--- a/app/src/main/java/com/ioannapergamali/mysmartroute/view/ui/screens/ViewTransportRequestsScreen.kt
+++ b/app/src/main/java/com/ioannapergamali/mysmartroute/view/ui/screens/ViewTransportRequestsScreen.kt
@@ -7,10 +7,13 @@ import androidx.compose.material3.Divider
 import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.Scaffold
 import androidx.compose.material3.Text
+import androidx.compose.material3.MaterialTheme
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateMapOf
+import androidx.compose.runtime.remember
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.res.stringResource
@@ -21,6 +24,7 @@ import com.ioannapergamali.mysmartroute.R
 import com.ioannapergamali.mysmartroute.view.ui.components.ScreenContainer
 import com.ioannapergamali.mysmartroute.view.ui.components.TopBar
 import com.ioannapergamali.mysmartroute.viewmodel.PoIViewModel
+import com.ioannapergamali.mysmartroute.viewmodel.UserViewModel
 import com.ioannapergamali.mysmartroute.viewmodel.VehicleRequestViewModel
 
 @OptIn(ExperimentalMaterial3Api::class)
@@ -29,12 +33,22 @@ fun ViewTransportRequestsScreen(navController: NavController, openDrawer: () -> 
     val context = LocalContext.current
     val viewModel: VehicleRequestViewModel = viewModel()
     val poiViewModel: PoIViewModel = viewModel()
+    val userViewModel: UserViewModel = viewModel()
     val requests by viewModel.requests.collectAsState()
     val pois by poiViewModel.pois.collectAsState()
+    val userNames = remember { mutableStateMapOf<String, String>() }
 
     LaunchedEffect(Unit) {
         poiViewModel.loadPois(context)
         viewModel.loadRequests(context, allUsers = true)
+    }
+
+    LaunchedEffect(requests) {
+        requests.forEach { req ->
+            if (req.userId.isNotBlank() && userNames[req.userId] == null) {
+                userNames[req.userId] = userViewModel.getUserName(context, req.userId)
+            }
+        }
     }
 
     val poiNames = pois.associate { it.id to it.name }
@@ -54,13 +68,35 @@ fun ViewTransportRequestsScreen(navController: NavController, openDrawer: () -> 
                 Text(stringResource(R.string.no_requests))
             } else {
                 LazyColumn {
+                    item {
+                        Row(modifier = Modifier.fillMaxWidth()) {
+                            Text(
+                                stringResource(R.string.passenger),
+                                modifier = Modifier.weight(1f),
+                                style = MaterialTheme.typography.labelMedium
+                            )
+                            Text(
+                                stringResource(R.string.route_name),
+                                modifier = Modifier.weight(1f),
+                                style = MaterialTheme.typography.labelMedium
+                            )
+                            Text(
+                                stringResource(R.string.cost),
+                                modifier = Modifier.weight(1f),
+                                style = MaterialTheme.typography.labelMedium
+                            )
+                        }
+                        Divider()
+                    }
                     items(requests) { req ->
                         val parts = req.routeId.split("-")
                         val fromName = poiNames[parts.getOrNull(0)] ?: ""
                         val toName = poiNames[parts.getOrNull(1)] ?: ""
+                        val routeName = if (fromName.isNotBlank() && toName.isNotBlank()) "$fromName - $toName" else ""
+                        val userName = userNames[req.userId] ?: ""
                         Row(modifier = Modifier.fillMaxWidth().padding(vertical = 8.dp)) {
-                            Text(fromName, modifier = Modifier.weight(1f))
-                            Text(toName, modifier = Modifier.weight(1f))
+                            Text(userName, modifier = Modifier.weight(1f))
+                            Text(routeName, modifier = Modifier.weight(1f))
                             val costText = if (req.cost == Double.MAX_VALUE) "∞" else req.cost.toString()
                             Text(costText, modifier = Modifier.weight(1f))
                         }


### PR DESCRIPTION
## Ποιες αλλαγές έγιναν
- Εμπλουτίστηκε η οθόνη `ViewTransportRequestsScreen` ώστε να εμφανίζει το ονοματεπώνυμο του χρήστη, την περιγραφή της διαδρομής και το κόστος
- Προστέθηκε `UserViewModel` και προσωρινή αποθήκευση ονομάτων χρηστών
- Προστέθηκαν επικεφαλίδες στον πίνακα αποτελεσμάτων

## Οδηγίες δοκιμών
1. `./gradlew test --no-daemon`
   - Απέτυχε λόγω έλλειψης Android SDK


------
https://chatgpt.com/codex/tasks/task_e_688ab690c9608328a48ebb19aa8f0a98