### PR TITLE
Add route id to moving requests

### DIFF
--- a/app/src/main/java/com/ioannapergamali/mysmartroute/view/ui/screens/FindVehicleScreen.kt
+++ b/app/src/main/java/com/ioannapergamali/mysmartroute/view/ui/screens/FindVehicleScreen.kt
@@ -266,7 +266,8 @@ fun FindVehicleScreen(navController: NavController, openDrawer: () -> Unit) {
                     val fromId = routePois[fromIdx].id
                     val toId = routePois[toIdx].id
                     val cost = maxCostText.toDoubleOrNull() ?: Double.MAX_VALUE
-                    requestViewModel.requestTransport(context, fromId, toId, cost)
+                    val routeId = selectedRouteId ?: return@Button
+                    requestViewModel.requestTransport(context, routeId, fromId, toId, cost)
                     message = context.getString(R.string.request_sent)
                 },
                 enabled = selectedRouteId != null && selectedFromIndex != null && selectedToIndex != null

--- a/app/src/main/java/com/ioannapergamali/mysmartroute/viewmodel/VehicleRequestViewModel.kt
+++ b/app/src/main/java/com/ioannapergamali/mysmartroute/viewmodel/VehicleRequestViewModel.kt
@@ -61,14 +61,20 @@ class VehicleRequestViewModel : ViewModel() {
         }
     }
 
-    fun requestTransport(context: Context, fromPoiId: String, toPoiId: String, maxCost: Double) {
+    fun requestTransport(
+        context: Context,
+        routeId: String,
+        fromPoiId: String,
+        toPoiId: String,
+        maxCost: Double
+    ) {
         viewModelScope.launch {
             val dao = MySmartRouteDatabase.getInstance(context).movingDao()
             val userId = FirebaseAuth.getInstance().currentUser?.uid ?: ""
             val id = UUID.randomUUID().toString()
             val entity = MovingEntity(
                 id = id,
-                routeId = "${'$'}fromPoiId-${'$'}toPoiId",
+                routeId = routeId,
                 userId = userId,
                 date = 0,
                 vehicleId = "",


### PR DESCRIPTION
## Summary
- pass the selected route ID when creating a moving request
- update VehicleRequestViewModel to store the real route ID

## Testing
- `./gradlew test` *(fails: network restrictions)*

------
https://chatgpt.com/codex/tasks/task_e_688ab92b89308328a1e40c724b44e138