### PR TITLE
Fix FindVehicleScreen imports

### DIFF
--- a/app/src/main/java/com/ioannapergamali/mysmartroute/view/ui/screens/FindVehicleScreen.kt
+++ b/app/src/main/java/com/ioannapergamali/mysmartroute/view/ui/screens/FindVehicleScreen.kt
@@ -27,6 +27,10 @@ import com.google.maps.android.compose.Polyline
 import com.google.maps.android.compose.rememberCameraPositionState
 import androidx.compose.runtime.rememberCoroutineScope
 import kotlinx.coroutines.launch
+import androidx.compose.ui.Alignment
+import androidx.lifecycle.compose.LocalLifecycleOwner
+import androidx.lifecycle.Lifecycle
+import androidx.lifecycle.LifecycleEventObserver
 
 import com.ioannapergamali.mysmartroute.R
 import com.ioannapergamali.mysmartroute.data.local.PoIEntity
@@ -125,25 +129,6 @@ fun FindVehicleScreen(navController: NavController, openDrawer: () -> Unit) {
             }
         } else {
             pathPoints = emptyList()
-        }
-    }
-
-
-    fun refreshRoute() {
-        selectedRouteId?.let { id ->
-            coroutineScope.launch {
-                val (_, path) = routeViewModel.getRouteDirections(
-                    context,
-                    id,
-                    VehicleType.CAR
-                )
-                pathPoints = path
-                path.firstOrNull()?.let {
-                    cameraPositionState.move(
-                        CameraUpdateFactory.newLatLngZoom(it, 13f)
-                    )
-                }
-            }
         }
     }
 


### PR DESCRIPTION
## Summary
- resolve missing imports for lifecycle observers and alignment
- remove duplicate `refreshRoute` definition causing conflicts

## Testing
- `./gradlew tasks --all --offline`
- `./gradlew lintDebug --offline` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_688aba3e07848328bf5d7cb89fa37f64