### PR TITLE
Fix unmatched brace in FindVehicleScreen

### DIFF
--- a/app/src/main/java/com/ioannapergamali/mysmartroute/view/ui/screens/FindVehicleScreen.kt
+++ b/app/src/main/java/com/ioannapergamali/mysmartroute/view/ui/screens/FindVehicleScreen.kt
@@ -349,4 +349,3 @@ fun FindVehicleScreen(navController: NavController, openDrawer: () -> Unit) {
             }
         }
     }
-}


### PR DESCRIPTION
## Summary
- remove extra closing brace at the end of `FindVehicleScreen.kt`

## Testing
- `./gradlew test` *(fails: maven.pkg.jetbrains.space blocked)*

------
https://chatgpt.com/codex/tasks/task_e_688abd0c7c3c8328a384033eea66e5b1