### PR TITLE
Επανατοποθέτηση κουμπιών και χάρτη

### DIFF
--- a/app/src/main/java/com/ioannapergamali/mysmartroute/view/ui/screens/FindVehicleScreen.kt
+++ b/app/src/main/java/com/ioannapergamali/mysmartroute/view/ui/screens/FindVehicleScreen.kt
@@ -177,6 +177,41 @@ fun FindVehicleScreen(navController: NavController, openDrawer: () -> Unit) {
 
             Spacer(Modifier.height(16.dp))
 
+            if (selectedRouteId != null) {
+                Row(horizontalArrangement = Arrangement.spacedBy(8.dp)) {
+                    Button(onClick = { navController.navigate("definePoi?routeId=${'$'}selectedRouteId") }) {
+                        Text(stringResource(R.string.add_poi_option))
+                    }
+                    Button(onClick = { refreshRoute() }, enabled = !calculating) {
+                        Text(stringResource(R.string.recalculate_route))
+                    }
+                }
+
+                Spacer(Modifier.height(16.dp))
+            }
+
+            if (routePois.isNotEmpty() && pathPoints.isNotEmpty() && !isKeyMissing) {
+                GoogleMap(
+                    modifier = Modifier
+                        .fillMaxWidth()
+                        .height(200.dp),
+                    cameraPositionState = cameraPositionState
+                ) {
+                    Polyline(points = pathPoints)
+                    routePois.forEach { poi ->
+                        Marker(
+                            state = MarkerState(position = LatLng(poi.lat, poi.lng)),
+                            title = poi.name
+                        )
+                    }
+                }
+
+                Spacer(Modifier.height(16.dp))
+            } else if (isKeyMissing) {
+                Text(stringResource(R.string.map_api_key_missing))
+                Spacer(Modifier.height(16.dp))
+            }
+
             if (routePois.isNotEmpty()) {
                 Text(stringResource(R.string.stops_header))
                 Column(modifier = Modifier.fillMaxWidth()) {
@@ -279,29 +314,6 @@ fun FindVehicleScreen(navController: NavController, openDrawer: () -> Unit) {
                 Spacer(Modifier.height(16.dp))
             }
 
-            if (routePois.isNotEmpty() && pathPoints.isNotEmpty() && !isKeyMissing) {
-                GoogleMap(
-                    modifier = Modifier
-                        .fillMaxWidth()
-                        .height(200.dp),
-                    cameraPositionState = cameraPositionState
-                ) {
-                    Polyline(points = pathPoints)
-                    routePois.forEach { poi ->
-                        Marker(
-                            state = MarkerState(position = LatLng(poi.lat, poi.lng)),
-                            title = poi.name
-                        )
-                    }
-                }
-
-                Spacer(Modifier.height(16.dp))
-            } else if (isKeyMissing) {
-                Text(stringResource(R.string.map_api_key_missing))
-                Spacer(Modifier.height(16.dp))
-            }
-
-
             OutlinedTextField(
                 value = maxCostText,
                 onValueChange = { maxCostText = it },
@@ -312,18 +324,6 @@ fun FindVehicleScreen(navController: NavController, openDrawer: () -> Unit) {
 
             Spacer(Modifier.height(16.dp))
 
-            if (selectedRouteId != null) {
-                Row(horizontalArrangement = Arrangement.spacedBy(8.dp)) {
-                    Button(onClick = { navController.navigate("definePoi?routeId=${'$'}selectedRouteId") }) {
-                        Text(stringResource(R.string.add_poi_option))
-                    }
-
-                        Text(stringResource(R.string.recalculate_route))
-                    }
-                }
-
-                Spacer(Modifier.height(16.dp))
-            }
 
             Button(
                 onClick = {


### PR DESCRIPTION
## Περιγραφή
Μετακινήθηκαν τα κουμπιά «Προσθήκη POI» και «Επανασχεδίαση διαδρομής» καθώς και ο χάρτης στην οθόνη εύρεσης οχήματος. Πλέον τοποθετούνται αμέσως μετά την επιλογή διαδρομής και πριν από την εμφάνιση των στάσεων.

## Δοκιμές
- `./gradlew test` *(αποτυχία: λείπει το Android SDK)*

------
https://chatgpt.com/codex/tasks/task_e_688ac27df43c8328bdbe1b3b7fd01c9c