### PR TITLE
Updated movings to store real route id

### DIFF
--- a/app/src/main/java/com/ioannapergamali/mysmartroute/data/local/MovingEntity.kt
+++ b/app/src/main/java/com/ioannapergamali/mysmartroute/data/local/MovingEntity.kt
@@ -11,5 +11,9 @@ data class MovingEntity(
     val date: Int = 0,
     val vehicleId: String = "",
     val cost: Double = 0.0,
-    val durationMinutes: Int = 0
+    val durationMinutes: Int = 0,
+    /** Σημείο επιβίβασης */
+    val startPoiId: String = "",
+    /** Σημείο αποβίβασης */
+    val endPoiId: String = ""
 )

--- a/app/src/main/java/com/ioannapergamali/mysmartroute/data/local/MySmartRouteDatabase.kt
+++ b/app/src/main/java/com/ioannapergamali/mysmartroute/data/local/MySmartRouteDatabase.kt
@@ -47,7 +47,7 @@ import com.ioannapergamali.mysmartroute.data.local.Converters
         SeatReservationEntity::class,
         FavoriteEntity::class
     ],
-    version = 43
+    version = 44
 )
 @TypeConverters(Converters::class)
 abstract class MySmartRouteDatabase : RoomDatabase() {
@@ -592,6 +592,17 @@ abstract class MySmartRouteDatabase : RoomDatabase() {
             }
         }
 
+        private val MIGRATION_43_44 = object : Migration(43, 44) {
+            override fun migrate(database: SupportSQLiteDatabase) {
+                database.execSQL(
+                    "ALTER TABLE `movings` ADD COLUMN `startPoiId` TEXT NOT NULL DEFAULT ''"
+                )
+                database.execSQL(
+                    "ALTER TABLE `movings` ADD COLUMN `endPoiId` TEXT NOT NULL DEFAULT ''"
+                )
+            }
+        }
+
         private fun prepopulate(db: SupportSQLiteDatabase) {
             Log.d(TAG, "Prepopulating database")
             db.execSQL(
@@ -712,7 +723,8 @@ abstract class MySmartRouteDatabase : RoomDatabase() {
                     MIGRATION_39_40,
                     MIGRATION_40_41,
                     MIGRATION_41_42,
-                    MIGRATION_42_43
+                    MIGRATION_42_43,
+                    MIGRATION_43_44
                 )
                     .addCallback(object : RoomDatabase.Callback() {
                         override fun onCreate(db: SupportSQLiteDatabase) {

--- a/app/src/main/java/com/ioannapergamali/mysmartroute/utils/FirestoreMappers.kt
+++ b/app/src/main/java/com/ioannapergamali/mysmartroute/utils/FirestoreMappers.kt
@@ -235,7 +235,9 @@ fun MovingEntity.toFirestoreMap(): Map<String, Any> {
         "userId" to FirebaseFirestore.getInstance().collection("users").document(userId),
         "date" to date,
         "cost" to cost,
-        "durationMinutes" to durationMinutes
+        "durationMinutes" to durationMinutes,
+        "startPoiId" to FirebaseFirestore.getInstance().collection("pois").document(startPoiId),
+        "endPoiId" to FirebaseFirestore.getInstance().collection("pois").document(endPoiId)
     )
     if (vehicleId.isNotEmpty()) {
         map["vehicleId"] = FirebaseFirestore.getInstance().collection("vehicles").document(vehicleId)
@@ -263,7 +265,17 @@ fun DocumentSnapshot.toMovingEntity(): MovingEntity? {
     val dateVal = (getLong("date") ?: 0L).toInt()
     val costVal = getDouble("cost") ?: 0.0
     val durVal = (getLong("durationMinutes") ?: 0L).toInt()
-    return MovingEntity(movingId, routeId, userId, dateVal, vehicleId, costVal, durVal)
+    val startPoiId = when (val s = get("startPoiId")) {
+        is DocumentReference -> s.id
+        is String -> s
+        else -> getString("startPoiId")
+    } ?: ""
+    val endPoiId = when (val e = get("endPoiId")) {
+        is DocumentReference -> e.id
+        is String -> e
+        else -> getString("endPoiId")
+    } ?: ""
+    return MovingEntity(movingId, routeId, userId, dateVal, vehicleId, costVal, durVal, startPoiId, endPoiId)
 }
 
 fun TransportDeclarationEntity.toFirestoreMap(): Map<String, Any> = mapOf(

--- a/app/src/main/java/com/ioannapergamali/mysmartroute/view/ui/screens/ViewRequestsScreen.kt
+++ b/app/src/main/java/com/ioannapergamali/mysmartroute/view/ui/screens/ViewRequestsScreen.kt
@@ -55,9 +55,8 @@ fun ViewRequestsScreen(navController: NavController, openDrawer: () -> Unit) {
             } else {
                 LazyColumn {
                     items(requests) { req ->
-                        val parts = req.routeId.split("-")
-                        val fromName = poiNames[parts.getOrNull(0)] ?: ""
-                        val toName = poiNames[parts.getOrNull(1)] ?: ""
+                        val fromName = poiNames[req.startPoiId] ?: ""
+                        val toName = poiNames[req.endPoiId] ?: ""
                         Row(modifier = Modifier.fillMaxWidth().padding(vertical = 8.dp)) {
                             Text(fromName, modifier = Modifier.weight(1f))
                             Text(toName, modifier = Modifier.weight(1f))

--- a/app/src/main/java/com/ioannapergamali/mysmartroute/view/ui/screens/ViewTransportRequestsScreen.kt
+++ b/app/src/main/java/com/ioannapergamali/mysmartroute/view/ui/screens/ViewTransportRequestsScreen.kt
@@ -89,9 +89,8 @@ fun ViewTransportRequestsScreen(navController: NavController, openDrawer: () -> 
                         Divider()
                     }
                     items(requests) { req ->
-                        val parts = req.routeId.split("-")
-                        val fromName = poiNames[parts.getOrNull(0)] ?: ""
-                        val toName = poiNames[parts.getOrNull(1)] ?: ""
+                        val fromName = poiNames[req.startPoiId] ?: ""
+                        val toName = poiNames[req.endPoiId] ?: ""
                         val routeName = if (fromName.isNotBlank() && toName.isNotBlank()) "$fromName - $toName" else ""
                         val userName = userNames[req.userId] ?: ""
                         Row(modifier = Modifier.fillMaxWidth().padding(vertical = 8.dp)) {

--- a/app/src/main/java/com/ioannapergamali/mysmartroute/viewmodel/VehicleRequestViewModel.kt
+++ b/app/src/main/java/com/ioannapergamali/mysmartroute/viewmodel/VehicleRequestViewModel.kt
@@ -79,7 +79,9 @@ class VehicleRequestViewModel : ViewModel() {
                 date = 0,
                 vehicleId = "",
                 cost = maxCost,
-                durationMinutes = 0
+                durationMinutes = 0,
+                startPoiId = fromPoiId,
+                endPoiId = toPoiId
             )
             dao.insert(entity)
             try {


### PR DESCRIPTION
## Summary
- προστέθηκαν `startPoiId` και `endPoiId` στο `MovingEntity`
- ενημερώθηκαν οι mapper συνάρτησεις και η αποθήκευση αιτημάτων
- προστέθηκαν migrations στη βάση δεδομένων (v44)
- οι οθόνες εμφάνισης αιτημάτων χρησιμοποιούν τα νέα πεδία

## Testing
- `./gradlew test` *(απέτυχε: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_688ac700c13483289491e2208baa5385