### PR TITLE
Εναρμόνιση προσθήκης POI

### DIFF
--- a/app/src/main/java/com/ioannapergamali/mysmartroute/view/ui/screens/FindVehicleScreen.kt
+++ b/app/src/main/java/com/ioannapergamali/mysmartroute/view/ui/screens/FindVehicleScreen.kt
@@ -179,7 +179,10 @@ fun FindVehicleScreen(navController: NavController, openDrawer: () -> Unit) {
 
             if (selectedRouteId != null) {
                 Row(horizontalArrangement = Arrangement.spacedBy(8.dp)) {
-                    Button(onClick = { navController.navigate("definePoi?routeId=${'$'}selectedRouteId") }) {
+                    Button(onClick = {
+                        val rId = selectedRouteId ?: ""
+                        navController.navigate("definePoi?lat=&lng=&source=&view=false&routeId=$rId")
+                    }) {
                         Text(stringResource(R.string.add_poi_option))
                     }
                     Button(onClick = { refreshRoute() }, enabled = !calculating) {


### PR DESCRIPTION
## Summary
- στην οθόνη αναζήτησης οχήματος (`FindVehicleScreen`) η επιλογή *Προσθήκη POI* καλεί πλέον την οθόνη ορισμού POI με τα ίδια παραμέτρα όπως και στην κράτηση θέσης

## Testing
- `./gradlew test` *(απέτυχε λόγω έλλειψης Android SDK)*

------
https://chatgpt.com/codex/tasks/task_e_688ac7f423e4832897443338b923ddde