### PR TITLE
Βελτίωση εύρεσης οχήματος

### DIFF
--- a/app/src/main/java/com/ioannapergamali/mysmartroute/model/navigation/NavigationHost.kt
+++ b/app/src/main/java/com/ioannapergamali/mysmartroute/model/navigation/NavigationHost.kt
@@ -41,6 +41,7 @@ import com.ioannapergamali.mysmartroute.view.ui.screens.ViewRoutesScreen
 import com.ioannapergamali.mysmartroute.view.ui.screens.SelectRoutePoisScreen
 
 import com.ioannapergamali.mysmartroute.view.ui.screens.FindVehicleScreen
+import com.ioannapergamali.mysmartroute.view.ui.screens.AvailableTransportsScreen
 
 
 
@@ -164,6 +165,26 @@ fun NavigationHost(navController : NavHostController, openDrawer: () -> Unit) {
 
         composable("findVehicle") {
             FindVehicleScreen(navController = navController, openDrawer = openDrawer)
+        }
+
+        composable(
+            "availableTransports?routeId={routeId}&startId={startId}&endId={endId}",
+            arguments = listOf(
+                navArgument("routeId") { defaultValue = "" },
+                navArgument("startId") { defaultValue = "" },
+                navArgument("endId") { defaultValue = "" }
+            )
+        ) { backStackEntry ->
+            val rid = backStackEntry.arguments?.getString("routeId")
+            val sid = backStackEntry.arguments?.getString("startId")
+            val eid = backStackEntry.arguments?.getString("endId")
+            AvailableTransportsScreen(
+                navController = navController,
+                openDrawer = openDrawer,
+                routeId = rid,
+                startId = sid,
+                endId = eid
+            )
         }
 
         composable("bookSeat") {

--- a/app/src/main/java/com/ioannapergamali/mysmartroute/view/ui/screens/AvailableTransportsScreen.kt
+++ b/app/src/main/java/com/ioannapergamali/mysmartroute/view/ui/screens/AvailableTransportsScreen.kt
@@ -1,0 +1,98 @@
+package com.ioannapergamali.mysmartroute.view.ui.screens
+
+import androidx.compose.foundation.layout.*
+import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.lazy.items
+import androidx.compose.material3.*
+import androidx.compose.runtime.*
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.unit.dp
+import androidx.lifecycle.viewmodel.compose.viewModel
+import androidx.navigation.NavController
+import com.ioannapergamali.mysmartroute.R
+import com.ioannapergamali.mysmartroute.data.local.PoIEntity
+import com.ioannapergamali.mysmartroute.model.enumerations.VehicleType
+import com.ioannapergamali.mysmartroute.view.ui.components.ScreenContainer
+import com.ioannapergamali.mysmartroute.view.ui.components.TopBar
+import com.ioannapergamali.mysmartroute.view.ui.util.labelForVehicle
+import com.ioannapergamali.mysmartroute.viewmodel.FavoritesViewModel
+import com.ioannapergamali.mysmartroute.viewmodel.RouteViewModel
+import com.ioannapergamali.mysmartroute.viewmodel.TransportDeclarationViewModel
+import com.ioannapergamali.mysmartroute.viewmodel.UserViewModel
+
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+fun AvailableTransportsScreen(
+    navController: NavController,
+    openDrawer: () -> Unit,
+    routeId: String?,
+    startId: String?,
+    endId: String?
+) {
+    val context = LocalContext.current
+    val routeViewModel: RouteViewModel = viewModel()
+    val declarationViewModel: TransportDeclarationViewModel = viewModel()
+    val userViewModel: UserViewModel = viewModel()
+    val favoritesViewModel: FavoritesViewModel = viewModel()
+
+    val declarations by declarationViewModel.declarations.collectAsState()
+    val drivers by userViewModel.drivers.collectAsState()
+    val preferred by favoritesViewModel.preferredFlow(context).collectAsState(initial = emptySet())
+
+    val pois = remember { mutableStateListOf<PoIEntity>() }
+    var startIndex by remember { mutableStateOf(-1) }
+    var endIndex by remember { mutableStateOf(-1) }
+
+    LaunchedEffect(Unit) {
+        declarationViewModel.loadDeclarations(context)
+        userViewModel.loadDrivers(context)
+    }
+
+    LaunchedEffect(routeId) {
+        if (routeId != null) {
+            pois.clear()
+            pois.addAll(routeViewModel.getRoutePois(context, routeId))
+            startIndex = pois.indexOfFirst { it.id == startId }
+            endIndex = pois.indexOfFirst { it.id == endId }
+        }
+    }
+
+    val driverNames = drivers.associate { it.id to "${'$'}{it.name} ${'$'}{it.surname}" }
+    val list = declarations.filter { decl ->
+        decl.routeId == routeId &&
+        preferred.contains(runCatching { VehicleType.valueOf(decl.vehicleType) }.getOrNull()) &&
+        startIndex >= 0 && endIndex >= 0 && startIndex < endIndex
+    }
+
+    Scaffold(
+        topBar = {
+            TopBar(
+                title = stringResource(R.string.available_transports),
+                navController = navController,
+                showMenu = true,
+                onMenuClick = openDrawer
+            )
+        }
+    ) { padding ->
+        ScreenContainer(modifier = Modifier.padding(padding), scrollable = false) {
+            if (list.isEmpty()) {
+                Text(stringResource(R.string.no_transports_found))
+            } else {
+                LazyColumn {
+                    items(list) { decl ->
+                        val driver = driverNames[decl.driverId] ?: ""
+                        val type = runCatching { VehicleType.valueOf(decl.vehicleType) }.getOrNull()
+                        Row(modifier = Modifier.fillMaxWidth().padding(vertical = 8.dp)) {
+                            Text(driver, modifier = Modifier.weight(1f))
+                            Text(type?.let { labelForVehicle(it) } ?: "", modifier = Modifier.weight(1f))
+                            Text(decl.cost.toString(), modifier = Modifier.weight(1f))
+                        }
+                        Divider()
+                    }
+                }
+            }
+        }
+    }
+}

--- a/app/src/main/java/com/ioannapergamali/mysmartroute/view/ui/screens/FindVehicleScreen.kt
+++ b/app/src/main/java/com/ioannapergamali/mysmartroute/view/ui/screens/FindVehicleScreen.kt
@@ -328,26 +328,46 @@ fun FindVehicleScreen(navController: NavController, openDrawer: () -> Unit) {
             Spacer(Modifier.height(16.dp))
 
 
-            Button(
-                onClick = {
-                    val fromIdx = startIndex ?: return@Button
-                    val toIdx = endIndex ?: return@Button
-                    if (fromIdx >= toIdx) {
-                        message = context.getString(R.string.invalid_stop_order)
-                        return@Button
-                    }
-                    val fromId = routePois[fromIdx].id
-                    val toId = routePois[toIdx].id
-                    val cost = maxCostText.toDoubleOrNull() ?: Double.MAX_VALUE
-                    val routeId = selectedRouteId ?: return@Button
-                    requestViewModel.requestTransport(context, routeId, fromId, toId, cost)
-                    message = context.getString(R.string.request_sent)
-                },
-                enabled = selectedRouteId != null && startIndex != null && endIndex != null
-            ) {
-                Text(stringResource(R.string.find_vehicle))
+            Row(horizontalArrangement = Arrangement.spacedBy(8.dp)) {
+                Button(
+                    onClick = {
+                        val fromIdx = startIndex ?: return@Button
+                        val toIdx = endIndex ?: return@Button
+                        if (fromIdx >= toIdx) {
+                            message = context.getString(R.string.invalid_stop_order)
+                            return@Button
+                        }
+                        val fromId = routePois[fromIdx].id
+                        val toId = routePois[toIdx].id
+                        val cost = maxCostText.toDoubleOrNull() ?: Double.MAX_VALUE
+                        val routeId = selectedRouteId ?: return@Button
+                        requestViewModel.requestTransport(context, routeId, fromId, toId, cost)
+                        navController.navigate("availableTransports?routeId=" + routeId + "&startId=" + fromId + "&endId=" + toId)
+                    },
+                    enabled = selectedRouteId != null && startIndex != null && endIndex != null,
+                ) {
+                    Text(stringResource(R.string.find_now))
+                }
+                Button(
+                    onClick = {
+                        val fromIdx = startIndex ?: return@Button
+                        val toIdx = endIndex ?: return@Button
+                        if (fromIdx >= toIdx) {
+                            message = context.getString(R.string.invalid_stop_order)
+                            return@Button
+                        }
+                        val fromId = routePois[fromIdx].id
+                        val toId = routePois[toIdx].id
+                        val cost = maxCostText.toDoubleOrNull() ?: Double.MAX_VALUE
+                        val routeId = selectedRouteId ?: return@Button
+                        requestViewModel.requestTransport(context, routeId, fromId, toId, cost)
+                        message = context.getString(R.string.request_sent)
+                    },
+                    enabled = selectedRouteId != null && startIndex != null && endIndex != null,
+                ) {
+                    Text(stringResource(R.string.save_request))
+                }
             }
-
             if (message.isNotBlank()) {
                 Spacer(Modifier.height(8.dp))
                 Text(message)

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -179,4 +179,8 @@
     <string name="view_requests">View Requests</string>
     <string name="no_requests">No requests found</string>
 
+    <string name="find_now">Find now</string>
+    <string name="save_request">Save request</string>
+    <string name="available_transports">Available transports</string>
+    <string name="no_transports_found">No transports found</string>
 </resources>


### PR DESCRIPTION
## Περιγραφή
- προστέθηκαν νέες συμβολοσειρές διεπαφής για αναζήτηση τώρα και αποθήκευση
- δημιουργήθηκε νέα οθόνη `AvailableTransportsScreen` που εμφανίζει διαθέσιμες μεταφορές
- ενημερώθηκε το `NavigationHost` ώστε να περιλαμβάνει τη νέα διαδρομή
- τροποποιήθηκε η `FindVehicleScreen` με δύο κουμπιά (Εύρεση τώρα/Καταχώρηση)

## Έλεγχος
- `./gradlew test` *(αποτυχημένο λόγω περιορισμών δικτύου κατά τη λήψη εξαρτήσεων)*

------
https://chatgpt.com/codex/tasks/task_e_688acc90edb08328973e30aa23a603ec