### PR TITLE
Fix unmatched braces in FindVehicleScreen

### DIFF
--- a/app/src/main/java/com/ioannapergamali/mysmartroute/view/ui/screens/FindVehicleScreen.kt
+++ b/app/src/main/java/com/ioannapergamali/mysmartroute/view/ui/screens/FindVehicleScreen.kt
@@ -125,16 +125,11 @@ fun FindVehicleScreen(navController: NavController, openDrawer: () -> Unit) {
                     refreshRoute()
                 }
 
-                    poiViewModel.loadPois(context)
-                }
+                poiViewModel.loadPois(context)
             }
         }
         lifecycleOwner.lifecycle.addObserver(observer)
         onDispose { lifecycleOwner.lifecycle.removeObserver(observer) }
-    }
-
-
-        }
     }
 
 


### PR DESCRIPTION
## Summary
- fix unmatched braces in FindVehicleScreen

## Testing
- `./gradlew tasks --all` *(fails: domain maven.pkg.jetbrains.space blocked)*

------
https://chatgpt.com/codex/tasks/task_e_688ad0d404288328b509552a369722d7