### PR TITLE
Fix filter lambda in AvailableTransportsScreen

### DIFF
--- a/app/src/main/java/com/ioannapergamali/mysmartroute/view/ui/screens/AvailableTransportsScreen.kt
+++ b/app/src/main/java/com/ioannapergamali/mysmartroute/view/ui/screens/AvailableTransportsScreen.kt
@@ -69,6 +69,7 @@ fun AvailableTransportsScreen(
         if (startIndex < 0 || endIndex < 0 || startIndex >= endIndex) return@filter false
         val type = runCatching { VehicleType.valueOf(decl.vehicleType) }.getOrNull()
         type == null || !nonPreferred.contains(type)
+    }
 
 
     Scaffold(


### PR DESCRIPTION
## Summary
- close filter lambda before Scaffold

## Testing
- `./gradlew assembleDebug` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_688ad7df5c808328a10b9aff9e522b7d