### PR TITLE
Fix AvailableTransportsScreen filter

### DIFF
--- a/app/src/main/java/com/ioannapergamali/mysmartroute/view/ui/screens/AvailableTransportsScreen.kt
+++ b/app/src/main/java/com/ioannapergamali/mysmartroute/view/ui/screens/AvailableTransportsScreen.kt
@@ -63,6 +63,8 @@ fun AvailableTransportsScreen(
         }
     }
 
+    val driverNames = drivers.associate { it.id to "${it.name} ${it.surname}" }
+    val sortedDecls = declarations.filter { decl ->
         if (decl.routeId != routeId) return@filter false
         if (startIndex < 0 || endIndex < 0 || startIndex >= endIndex) return@filter false
         val type = runCatching { VehicleType.valueOf(decl.vehicleType) }.getOrNull()


### PR DESCRIPTION
## Summary
- restore filtering and sorting logic in `AvailableTransportsScreen`

## Testing
- `./gradlew test` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_688ade7c1f7083289b9e345be67cd3c1