### PR TITLE
Fix vehicle name display in available transports

### DIFF
--- a/app/src/main/java/com/ioannapergamali/mysmartroute/data/local/MySmartRouteDatabase.kt
+++ b/app/src/main/java/com/ioannapergamali/mysmartroute/data/local/MySmartRouteDatabase.kt
@@ -47,7 +47,7 @@ import com.ioannapergamali.mysmartroute.data.local.Converters
         SeatReservationEntity::class,
         FavoriteEntity::class
     ],
-    version = 44
+    version = 45
 )
 @TypeConverters(Converters::class)
 abstract class MySmartRouteDatabase : RoomDatabase() {
@@ -603,6 +603,14 @@ abstract class MySmartRouteDatabase : RoomDatabase() {
             }
         }
 
+        private val MIGRATION_44_45 = object : Migration(44, 45) {
+            override fun migrate(database: SupportSQLiteDatabase) {
+                database.execSQL(
+                    "ALTER TABLE `transport_declarations` ADD COLUMN `vehicleId` TEXT NOT NULL DEFAULT ''"
+                )
+            }
+        }
+
         private fun prepopulate(db: SupportSQLiteDatabase) {
             Log.d(TAG, "Prepopulating database")
             db.execSQL(
@@ -724,7 +732,8 @@ abstract class MySmartRouteDatabase : RoomDatabase() {
                     MIGRATION_40_41,
                     MIGRATION_41_42,
                     MIGRATION_42_43,
-                    MIGRATION_43_44
+                    MIGRATION_43_44,
+                    MIGRATION_44_45
                 )
                     .addCallback(object : RoomDatabase.Callback() {
                         override fun onCreate(db: SupportSQLiteDatabase) {

--- a/app/src/main/java/com/ioannapergamali/mysmartroute/data/local/TransportDeclarationEntity.kt
+++ b/app/src/main/java/com/ioannapergamali/mysmartroute/data/local/TransportDeclarationEntity.kt
@@ -10,6 +10,8 @@ data class TransportDeclarationEntity(
     val routeId: String = "",
     /** Ο οδηγός που αναλαμβάνει τη μεταφορά */
     val driverId: String = "",
+    /** Το όχημα που χρησιμοποιείται */
+    val vehicleId: String = "",
     val vehicleType: String = "",
     val cost: Double = 0.0,
     val durationMinutes: Int = 0,

--- a/app/src/main/java/com/ioannapergamali/mysmartroute/utils/FirestoreMappers.kt
+++ b/app/src/main/java/com/ioannapergamali/mysmartroute/utils/FirestoreMappers.kt
@@ -283,6 +283,7 @@ fun TransportDeclarationEntity.toFirestoreMap(): Map<String, Any> = mapOf(
     // Αποθηκεύουμε απλά τα ids για ευκολότερη αναζήτηση
     "routeId" to routeId,
     "driverId" to driverId,
+    "vehicleId" to vehicleId,
     "vehicleType" to vehicleType,
     "cost" to cost,
     "durationMinutes" to durationMinutes,
@@ -302,12 +303,17 @@ fun DocumentSnapshot.toTransportDeclarationEntity(): TransportDeclarationEntity?
         is String -> d
         else -> getString("driverId")
     } ?: ""
+    val vehicleId = when (val v = get("vehicleId")) {
+        is DocumentReference -> v.id
+        is String -> v
+        else -> getString("vehicleId")
+    } ?: ""
     val type = getString("vehicleType") ?: return null
     val costVal = getDouble("cost") ?: 0.0
     val durVal = (getLong("durationMinutes") ?: 0L).toInt()
     val seatsVal = (getLong("seats") ?: 0L).toInt()
     val dateVal = getLong("date") ?: 0L
-    return TransportDeclarationEntity(declId, routeId, driverId, type, costVal, durVal, seatsVal, dateVal)
+    return TransportDeclarationEntity(declId, routeId, driverId, vehicleId, type, costVal, durVal, seatsVal, dateVal)
 }
 
 fun AvailabilityEntity.toFirestoreMap(): Map<String, Any> = mapOf(

--- a/app/src/main/java/com/ioannapergamali/mysmartroute/view/ui/screens/AnnounceTransportScreen.kt
+++ b/app/src/main/java/com/ioannapergamali/mysmartroute/view/ui/screens/AnnounceTransportScreen.kt
@@ -93,6 +93,7 @@ fun AnnounceTransportScreen(navController: NavController, openDrawer: () -> Unit
     var selectedRouteId by remember { mutableStateOf<String?>(null) }
     var expandedVehicle by remember { mutableStateOf(false) }
     var selectedVehicle by remember { mutableStateOf<VehicleType?>(null) }
+    var selectedVehicleId by remember { mutableStateOf("") }
     var selectedVehicleName by remember { mutableStateOf("") }
     var selectedVehicleDescription by remember { mutableStateOf("") }
     var selectedVehicleSeats by remember { mutableStateOf(0) }
@@ -195,6 +196,7 @@ fun AnnounceTransportScreen(navController: NavController, openDrawer: () -> Unit
         if (selectedVehicle == null && filteredVehicles.isNotEmpty()) {
             val first = filteredVehicles.first()
             selectedVehicle = VehicleType.valueOf(first.type)
+            selectedVehicleId = first.id
             selectedVehicleName = first.name
             selectedVehicleDescription = first.description
             selectedVehicleSeats = first.seat
@@ -284,6 +286,7 @@ fun AnnounceTransportScreen(navController: NavController, openDrawer: () -> Unit
                     filteredVehicles.forEach { vehicle ->
                         DropdownMenuItem(text = { Text(vehicle.name) }, onClick = {
                             selectedVehicle = VehicleType.valueOf(vehicle.type)
+                            selectedVehicleId = vehicle.id
                             selectedVehicleName = vehicle.name
                             selectedVehicleDescription = vehicle.description
                             selectedVehicleSeats = vehicle.seat
@@ -418,7 +421,17 @@ fun AnnounceTransportScreen(navController: NavController, openDrawer: () -> Unit
                     val date = datePickerState.selectedDateMillis ?: 0L
                     val driverId = selectedDriverId ?: ""
                     if (routeId != null && vehicle != null) {
-                        declarationViewModel.declareTransport(context, routeId, driverId, vehicle, selectedVehicleSeats, cost, duration, date)
+                        declarationViewModel.declareTransport(
+                            context,
+                            routeId,
+                            driverId,
+                            selectedVehicleId,
+                            vehicle,
+                            selectedVehicleSeats,
+                            cost,
+                            duration,
+                            date
+                        )
                         navController.popBackStack()
                     }
                 },

--- a/app/src/main/java/com/ioannapergamali/mysmartroute/view/ui/screens/AvailableTransportsScreen.kt
+++ b/app/src/main/java/com/ioannapergamali/mysmartroute/view/ui/screens/AvailableTransportsScreen.kt
@@ -90,7 +90,7 @@ fun AvailableTransportsScreen(
     }
 
     val driverNames = drivers.associate { it.id to "${it.name} ${it.surname}" }
-    val vehiclesByDriver = vehicles.groupBy { it.userId }
+    val vehiclesMap = vehicles.associateBy { it.id }
     val sortedDecls = declarations.filter { decl ->
         if (decl.routeId != routeId) return@filter false
         if (startIndex < 0 || endIndex < 0 || startIndex >= endIndex) return@filter false
@@ -125,9 +125,7 @@ fun AvailableTransportsScreen(
                         val type = runCatching { VehicleType.valueOf(decl.vehicleType) }.getOrNull()
                         val preferredType = type != null && preferred.contains(type)
 
-                        val vehicleName = vehiclesByDriver[decl.driverId]
-                            ?.firstOrNull { it.type == decl.vehicleType }
-                            ?.name ?: ""
+                        val vehicleName = vehiclesMap[decl.vehicleId]?.name ?: ""
 
                         val dateText = Instant.ofEpochMilli(decl.date)
                             .atZone(ZoneId.systemDefault())

--- a/app/src/main/java/com/ioannapergamali/mysmartroute/viewmodel/TransportDeclarationViewModel.kt
+++ b/app/src/main/java/com/ioannapergamali/mysmartroute/viewmodel/TransportDeclarationViewModel.kt
@@ -36,6 +36,7 @@ class TransportDeclarationViewModel : ViewModel() {
         context: Context,
         routeId: String,
         driverId: String,
+        vehicleId: String,
         vehicleType: VehicleType,
         seats: Int,
         cost: Double,
@@ -45,7 +46,7 @@ class TransportDeclarationViewModel : ViewModel() {
         viewModelScope.launch {
             val dao = MySmartRouteDatabase.getInstance(context).transportDeclarationDao()
             val id = UUID.randomUUID().toString()
-            val entity = TransportDeclarationEntity(id, routeId, driverId, vehicleType.name, cost, durationMinutes, seats, date)
+            val entity = TransportDeclarationEntity(id, routeId, driverId, vehicleId, vehicleType.name, cost, durationMinutes, seats, date)
             dao.insert(entity)
             try {
                 FirebaseFirestore.getInstance()


### PR DESCRIPTION
## Summary
- store selected vehicle ID when declaring a transport
- include vehicle ID in `TransportDeclarationEntity`
- handle new field in Firestore mappers
- show correct vehicle name in AvailableTransports screen
- add migration for new column and bump DB version

## Testing
- `./gradlew assembleDebug` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_688aef451dec8328b409449c858077e5