### PR TITLE
Enable booking from available transports

### DIFF
--- a/app/src/main/res/values-el/strings.xml
+++ b/app/src/main/res/values-el/strings.xml
@@ -165,5 +165,7 @@
     <string name="request_sent">Το αίτημα καταχωρήθηκε</string>
     <string name="view_requests">Προβολή αιτημάτων</string>
     <string name="view_transport_requests">Προβολή αιτημάτων μεταφοράς</string>
+    <string name="available_transports">Διαθέσιμες μεταφορές</string>
+    <string name="no_transports_found">Δεν βρέθηκαν μεταφορές</string>
 
 </resources>


### PR DESCRIPTION
## Summary
- allow booking a seat directly from `AvailableTransportsScreen`
- show feedback message after reserving
- add missing Greek strings for available transports

## Testing
- `./gradlew test --quiet` *(fails: maven.pkg.jetbrains.space blocked)*

------
https://chatgpt.com/codex/tasks/task_e_688afb60cf2083289b72a0a1f8c6e1e1