### PR TITLE
Προσθήκη επιλογής Ειδοποιήσεις

### DIFF
--- a/app/src/main/assets/menus.json
+++ b/app/src/main/assets/menus.json
@@ -17,6 +17,7 @@
           {"titleKey": "print_ticket", "route": "printTicket"},
           {"titleKey": "cancel_seat", "route": "cancelSeat"},
           {"titleKey": "rank_transports", "route": "rankTransports"},
+          {"titleKey": "notifications", "route": "notifications"},
           {"titleKey": "shutdown", "route": "shutdown"}
         ]
       }

--- a/app/src/main/java/com/ioannapergamali/mysmartroute/model/navigation/NavigationHost.kt
+++ b/app/src/main/java/com/ioannapergamali/mysmartroute/model/navigation/NavigationHost.kt
@@ -42,6 +42,7 @@ import com.ioannapergamali.mysmartroute.view.ui.screens.SelectRoutePoisScreen
 
 import com.ioannapergamali.mysmartroute.view.ui.screens.FindVehicleScreen
 import com.ioannapergamali.mysmartroute.view.ui.screens.AvailableTransportsScreen
+import com.ioannapergamali.mysmartroute.view.ui.screens.NotificationsScreen
 
 
 
@@ -193,6 +194,10 @@ fun NavigationHost(navController : NavHostController, openDrawer: () -> Unit) {
 
         composable("viewRoutes") {
             ViewRoutesScreen(navController = navController, openDrawer = openDrawer)
+        }
+
+        composable("notifications") {
+            NotificationsScreen(navController = navController, openDrawer = openDrawer)
         }
 
         composable("selectRoutePois") {

--- a/app/src/main/java/com/ioannapergamali/mysmartroute/view/ui/screens/NotificationsScreen.kt
+++ b/app/src/main/java/com/ioannapergamali/mysmartroute/view/ui/screens/NotificationsScreen.kt
@@ -1,0 +1,32 @@
+package com.ioannapergamali.mysmartroute.view.ui.screens
+
+import androidx.compose.foundation.layout.padding
+import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.Scaffold
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.res.stringResource
+import androidx.navigation.NavController
+import com.ioannapergamali.mysmartroute.R
+import com.ioannapergamali.mysmartroute.view.ui.components.ScreenContainer
+import com.ioannapergamali.mysmartroute.view.ui.components.TopBar
+
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+fun NotificationsScreen(navController: NavController, openDrawer: () -> Unit) {
+    Scaffold(
+        topBar = {
+            TopBar(
+                title = stringResource(R.string.notifications),
+                navController = navController,
+                showMenu = true,
+                onMenuClick = openDrawer
+            )
+        }
+    ) { padding ->
+        ScreenContainer(modifier = Modifier.padding(padding)) {
+            Text(stringResource(R.string.no_notifications))
+        }
+    }
+}

--- a/app/src/main/res/values-el/strings.xml
+++ b/app/src/main/res/values-el/strings.xml
@@ -70,6 +70,7 @@
     <string name="print_ticket">Εκτύπωση κράτησης ή εισιτηρίου</string>
     <string name="cancel_seat">Ακύρωση κράτησης</string>
     <string name="rank_transports">Βαθμολόγηση και σχόλια μεταφορών</string>
+    <string name="notifications">Ειδοποιήσεις</string>
     <string name="shutdown">Τερματισμός συστήματος</string>
     <string name="register_vehicle">Καταχώρηση οχήματος</string>
     <string name="vehicle_color">Χρώμα</string>
@@ -165,6 +166,7 @@
     <string name="request_sent">Το αίτημα καταχωρήθηκε</string>
     <string name="view_requests">Προβολή αιτημάτων</string>
     <string name="view_transport_requests">Προβολή αιτημάτων μεταφοράς</string>
+    <string name="no_notifications">Καμία ειδοποίηση</string>
     <string name="available_transports">Διαθέσιμες μεταφορές</string>
     <string name="no_transports_found">Δεν βρέθηκαν μεταφορές</string>
 

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -69,6 +69,7 @@
     <string name="print_ticket">Print Booked Seat or Ticket</string>
     <string name="cancel_seat">Cancel Booked Seat</string>
     <string name="rank_transports">View, Rank and Comment on Completed Transports</string>
+    <string name="notifications">Notifications</string>
     <string name="shutdown">Shut Down the System</string>
     <string name="register_vehicle">Register Vehicle</string>
     <string name="vehicle_color">Color</string>
@@ -178,7 +179,8 @@
     <string name="request_sent">Request saved</string>
     <string name="view_requests">View Requests</string>
     <string name="no_requests">No requests found</string>
-
+    <string name="no_notifications">No notifications</string>
+    
     <string name="find_now">Find now</string>
     <string name="save_request">Save request</string>
     <string name="available_transports">Available transports</string>


### PR DESCRIPTION
## Συνοπτικά
- προστέθηκε νέα επιλογή "Ειδοποιήσεις" στο menus.json
- δημιουργήθηκε οθόνη `NotificationsScreen`
- προστέθηκε αντίστοιχη πλοήγηση στο `NavigationHost`
- ενημερώθηκαν τα αρχεία strings (Ελληνικά και Αγγλικά)

## Έλεγχοι
- `./gradlew test` (απέτυχε λόγω περιορισμών δικτύου)


------
https://chatgpt.com/codex/tasks/task_e_688b091b486c832892810c4c69b56711