### PR TITLE
Add filtering for preferred vehicles

### DIFF
--- a/app/src/main/java/com/ioannapergamali/mysmartroute/model/navigation/NavigationHost.kt
+++ b/app/src/main/java/com/ioannapergamali/mysmartroute/model/navigation/NavigationHost.kt
@@ -169,22 +169,25 @@ fun NavigationHost(navController : NavHostController, openDrawer: () -> Unit) {
         }
 
         composable(
-            "availableTransports?routeId={routeId}&startId={startId}&endId={endId}",
+            "availableTransports?routeId={routeId}&startId={startId}&endId={endId}&maxCost={maxCost}",
             arguments = listOf(
                 navArgument("routeId") { defaultValue = "" },
                 navArgument("startId") { defaultValue = "" },
-                navArgument("endId") { defaultValue = "" }
+                navArgument("endId") { defaultValue = "" },
+                navArgument("maxCost") { defaultValue = "" }
             )
         ) { backStackEntry ->
             val rid = backStackEntry.arguments?.getString("routeId")
             val sid = backStackEntry.arguments?.getString("startId")
             val eid = backStackEntry.arguments?.getString("endId")
+            val maxCost = backStackEntry.arguments?.getString("maxCost")?.toDoubleOrNull()
             AvailableTransportsScreen(
                 navController = navController,
                 openDrawer = openDrawer,
                 routeId = rid,
                 startId = sid,
-                endId = eid
+                endId = eid,
+                maxCost = maxCost
             )
         }
 

--- a/app/src/main/java/com/ioannapergamali/mysmartroute/view/ui/screens/AvailableTransportsScreen.kt
+++ b/app/src/main/java/com/ioannapergamali/mysmartroute/view/ui/screens/AvailableTransportsScreen.kt
@@ -59,7 +59,8 @@ fun AvailableTransportsScreen(
     openDrawer: () -> Unit,
     routeId: String?,
     startId: String?,
-    endId: String?
+    endId: String?,
+    maxCost: Double?
 ) {
     val context = LocalContext.current
     val routeViewModel: RouteViewModel = viewModel()
@@ -103,8 +104,14 @@ fun AvailableTransportsScreen(
     val sortedDecls = declarations.filter { decl ->
         if (decl.routeId != routeId) return@filter false
         if (startIndex < 0 || endIndex < 0 || startIndex >= endIndex) return@filter false
+        if (maxCost != null && decl.cost > maxCost) return@filter false
         val type = runCatching { VehicleType.valueOf(decl.vehicleType) }.getOrNull()
-        type == null || !nonPreferred.contains(type)
+        if (type != null) {
+            // Αν υπάρχουν προτιμώμενοι τύποι, εμφανίζονται μόνο αυτοί
+            if (preferred.isNotEmpty() && !preferred.contains(type)) return@filter false
+            if (nonPreferred.contains(type)) return@filter false
+        }
+        true
     }
         // ταξινόμηση βάσει κόστους ώστε οι φθηνότερες επιλογές να εμφανίζονται πρώτες
         .sortedBy { it.cost }

--- a/app/src/main/java/com/ioannapergamali/mysmartroute/view/ui/screens/FindVehicleScreen.kt
+++ b/app/src/main/java/com/ioannapergamali/mysmartroute/view/ui/screens/FindVehicleScreen.kt
@@ -373,7 +373,13 @@ fun FindVehicleScreen(navController: NavController, openDrawer: () -> Unit) {
                         val cost = maxCostText.toDoubleOrNull() ?: Double.MAX_VALUE
                         val routeId = selectedRouteId ?: return@Button
                         requestViewModel.requestTransport(context, routeId, fromId, toId, cost)
-                        navController.navigate("availableTransports?routeId=" + routeId + "&startId=" + fromId + "&endId=" + toId)
+                        navController.navigate(
+                            "availableTransports?routeId=" +
+                                routeId +
+                                "&startId=" + fromId +
+                                "&endId=" + toId +
+                                "&maxCost=" + cost
+                        )
                     },
                     enabled = selectedRouteId != null && startIndex != null && endIndex != null,
                 ) {


### PR DESCRIPTION
## Summary
- filter available transport declarations by passenger's preferred vehicle types
- keep the previous filtering for maximum cost

## Testing
- `./gradlew test` *(fails: maven.pkg.jetbrains.space blocked)*

------
https://chatgpt.com/codex/tasks/task_e_688b115a0b408328a843ff03f29b21c4