### PR TITLE
Προσθήκη απλής ειδοποίησης

### DIFF
--- a/app/src/main/java/com/ioannapergamali/mysmartroute/utils/NotificationUtils.kt
+++ b/app/src/main/java/com/ioannapergamali/mysmartroute/utils/NotificationUtils.kt
@@ -1,0 +1,35 @@
+package com.ioannapergamali.mysmartroute.utils
+
+import android.app.NotificationChannel
+import android.app.NotificationManager
+import android.content.Context
+import android.os.Build
+import androidx.core.app.NotificationCompat
+import androidx.core.app.NotificationManagerCompat
+import com.ioannapergamali.mysmartroute.R
+
+object NotificationUtils {
+    private const val CHANNEL_ID = "default_channel"
+
+    fun showNotification(context: Context, title: String, text: String) {
+        // Δημιουργία καναλιού ειδοποίησης για Android 8+
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
+            val channel = NotificationChannel(
+                CHANNEL_ID,
+                context.getString(R.string.notifications),
+                NotificationManager.IMPORTANCE_DEFAULT
+            )
+            context.getSystemService(NotificationManager::class.java)
+                .createNotificationChannel(channel)
+        }
+
+        val notification = NotificationCompat.Builder(context, CHANNEL_ID)
+            .setSmallIcon(R.drawable.ic_notification)
+            .setContentTitle(title)
+            .setContentText(text)
+            .setPriority(NotificationCompat.PRIORITY_DEFAULT)
+            .build()
+
+        NotificationManagerCompat.from(context).notify(0, notification)
+    }
+}

--- a/app/src/main/java/com/ioannapergamali/mysmartroute/viewmodel/MainActivity.kt
+++ b/app/src/main/java/com/ioannapergamali/mysmartroute/viewmodel/MainActivity.kt
@@ -30,6 +30,7 @@ import com.ioannapergamali.mysmartroute.viewmodel.SettingsViewModel
 import com.ioannapergamali.mysmartroute.utils.MapsUtils
 import com.ioannapergamali.mysmartroute.utils.LanguagePreferenceManager
 import com.ioannapergamali.mysmartroute.utils.LocaleUtils
+import com.ioannapergamali.mysmartroute.utils.NotificationUtils
 import kotlinx.coroutines.runBlocking
 import kotlinx.coroutines.launch
 import com.ioannapergamali.mysmartroute.model.interfaces.ThemeOption
@@ -64,6 +65,11 @@ class MainActivity : ComponentActivity() {
         // Έλεγχος φόρτωσης του Maps API key
         val apiKey = MapsUtils.getApiKey(this)
         Log.d("Maps", "API key loaded? ${apiKey.isNotEmpty()}")
+        NotificationUtils.showNotification(
+            this,
+            getString(R.string.welcome),
+            getString(R.string.app_started_notification)
+        )
         // Initialize the soundtrack and start playback based on saved preferences.
         SoundManager.initialize(applicationContext)
         lifecycleScope.launch {

--- a/app/src/main/res/drawable/ic_notification.xml
+++ b/app/src/main/res/drawable/ic_notification.xml
@@ -1,0 +1,9 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="24dp"
+    android:height="24dp"
+    android:viewportWidth="24"
+    android:viewportHeight="24">
+    <path
+        android:fillColor="#FFFFFF"
+        android:pathData="M12,22c1.1,0 2,-0.9 2,-2h-4c0,1.1 0.9,2 2,2zm6,-6v-5c0,-3.07 -1.63,-5.64 -4.5,-6.32v-0.68c0,-0.83 -0.67,-1.5 -1.5,-1.5s-1.5,0.67 -1.5,1.5v0.68c-2.87,0.68 -4.5,3.25 -4.5,6.32v5l-1.7,1.7c-0.29,0.29 -0.3,0.77 0,1.06 0.15,0.15 0.34,0.24 0.53,0.24h14.34c0.4,0 0.77,-0.16 1.06,-0.46 0.29,-0.29 0.3,-0.77 0,-1.06l-1.73,-1.76z"/>
+</vector>

--- a/app/src/main/res/values-el/strings.xml
+++ b/app/src/main/res/values-el/strings.xml
@@ -167,6 +167,8 @@
     <string name="view_requests">Προβολή αιτημάτων</string>
     <string name="view_transport_requests">Προβολή αιτημάτων μεταφοράς</string>
     <string name="no_notifications">Καμία ειδοποίηση</string>
+    <!-- Notification text -->
+    <string name="app_started_notification">Η εφαρμογή ξεκίνησε</string>
     <string name="available_transports">Διαθέσιμες μεταφορές</string>
     <string name="no_transports_found">Δεν βρέθηκαν μεταφορές</string>
 

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -180,6 +180,9 @@
     <string name="view_requests">View Requests</string>
     <string name="no_requests">No requests found</string>
     <string name="no_notifications">No notifications</string>
+
+    <!-- Notification text -->
+    <string name="app_started_notification">App started successfully</string>
     
     <string name="find_now">Find now</string>
     <string name="save_request">Save request</string>


### PR DESCRIPTION
## Συνοπτικά
- προστέθηκε βοηθητική κλάση `NotificationUtils`
- δημιουργήθηκε vector `ic_notification`
- κλήση ειδοποίησης κατά την εκκίνηση
- ενημερώθηκαν strings για το μήνυμα έναρξης

## Οδηγίες
Τρέξτε `./gradlew assembleDebug` πριν την εκτέλεση της εφαρμογής.

------
https://chatgpt.com/codex/tasks/task_e_688b12d72d9c832888455e9b9340c35f