### PR TITLE
Prevent crash when vehicleId is missing

### DIFF
--- a/app/src/main/java/com/ioannapergamali/mysmartroute/viewmodel/VehicleViewModel.kt
+++ b/app/src/main/java/com/ioannapergamali/mysmartroute/viewmodel/VehicleViewModel.kt
@@ -155,6 +155,7 @@ class VehicleViewModel : ViewModel() {
 
     fun loadVehicleById(context: Context, vehicleId: String) {
         viewModelScope.launch {
+            if (vehicleId.isBlank()) return@launch
             if (_vehicles.value.any { it.id == vehicleId }) return@launch
 
             val dbLocal = MySmartRouteDatabase.getInstance(context)


### PR DESCRIPTION
## Summary
- avoid building a Firestore document reference if the vehicle id is empty

## Testing
- `./gradlew test` *(fails: blocked downloading from maven.pkg.jetbrains.space)*

------
https://chatgpt.com/codex/tasks/task_e_688bb912ae4c8328bfa622b6169eb269