### PR TITLE
Fix RouteModeScreen syntax error

### DIFF
--- a/app/src/main/java/com/ioannapergamali/mysmartroute/view/ui/screens/RouteModeScreen.kt
+++ b/app/src/main/java/com/ioannapergamali/mysmartroute/view/ui/screens/RouteModeScreen.kt
@@ -57,9 +57,6 @@ fun RouteModeScreen(navController: NavController, openDrawer: () -> Unit) {
     var endIndex by rememberSaveable { mutableStateOf<Int?>(null) }
     var message by remember { mutableStateOf("") }
 
-        }
-    }
-
     Scaffold(
         topBar = {
             TopBar(


### PR DESCRIPTION
## Summary
- remove stray closing braces in `RouteModeScreen.kt`

## Testing
- `./gradlew :app:assembleDebug --quiet` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_688bc72845b0832880b5a0062ccf8bbc