### PR TITLE
Προσθήκη υποστήριξης Long στην ημερομηνία μεταφοράς

### DIFF
--- a/app/src/main/java/com/ioannapergamali/mysmartroute/data/local/MovingEntity.kt
+++ b/app/src/main/java/com/ioannapergamali/mysmartroute/data/local/MovingEntity.kt
@@ -8,7 +8,7 @@ data class MovingEntity(
     @PrimaryKey val id: String = "",
     val routeId: String = "",
     val userId: String = "",
-    val date: Int = 0,
+    val date: Long = 0L,
     val vehicleId: String = "",
     val cost: Double = 0.0,
     val durationMinutes: Int = 0,

--- a/app/src/main/java/com/ioannapergamali/mysmartroute/utils/FirestoreMappers.kt
+++ b/app/src/main/java/com/ioannapergamali/mysmartroute/utils/FirestoreMappers.kt
@@ -262,7 +262,7 @@ fun DocumentSnapshot.toMovingEntity(): MovingEntity? {
         is String -> v
         else -> getString("vehicleId")
     } ?: ""
-    val dateVal = (getLong("date") ?: 0L).toInt()
+    val dateVal = getLong("date") ?: 0L
     val costVal = getDouble("cost") ?: 0.0
     val durVal = (getLong("durationMinutes") ?: 0L).toInt()
     val startPoiId = when (val s = get("startPoiId")) {

--- a/app/src/main/java/com/ioannapergamali/mysmartroute/view/ui/screens/FindVehicleScreen.kt
+++ b/app/src/main/java/com/ioannapergamali/mysmartroute/view/ui/screens/FindVehicleScreen.kt
@@ -2,6 +2,9 @@ package com.ioannapergamali.mysmartroute.view.ui.screens
 
 import androidx.compose.foundation.layout.*
 import androidx.compose.material3.*
+import androidx.compose.material3.DatePicker
+import androidx.compose.material3.DatePickerDialog
+import androidx.compose.material3.rememberDatePickerState
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.Delete
 import androidx.compose.material.icons.filled.Refresh
@@ -35,6 +38,9 @@ import androidx.lifecycle.Lifecycle
 import androidx.lifecycle.LifecycleEventObserver
 import androidx.lifecycle.LifecycleOwner
 import kotlin.math.abs
+import java.time.Instant
+import java.time.ZoneId
+import java.time.format.DateTimeFormatter
 
 import com.ioannapergamali.mysmartroute.R
 import com.ioannapergamali.mysmartroute.view.ui.components.ScreenContainer
@@ -71,6 +77,13 @@ fun FindVehicleScreen(navController: NavController, openDrawer: () -> Unit) {
     var pathPoints by remember { mutableStateOf<List<LatLng>>(emptyList()) }
     var calculating by remember { mutableStateOf(false) }
     var pendingPoi by remember { mutableStateOf<Triple<String, Double, Double>?>(null) }
+
+    val datePickerState = rememberDatePickerState()
+    var showDatePicker by remember { mutableStateOf(false) }
+    val dateFormatter = remember { DateTimeFormatter.ofPattern("dd/MM/yyyy") }
+    val selectedDateText = datePickerState.selectedDateMillis?.let { millis ->
+        Instant.ofEpochMilli(millis).atZone(ZoneId.systemDefault()).toLocalDate().format(dateFormatter)
+    } ?: stringResource(R.string.select_date)
 
 
     val cameraPositionState = rememberCameraPositionState()
@@ -358,6 +371,21 @@ fun FindVehicleScreen(navController: NavController, openDrawer: () -> Unit) {
 
             Spacer(Modifier.height(16.dp))
 
+            Button(onClick = { showDatePicker = true }) { Text(selectedDateText) }
+
+            if (showDatePicker) {
+                DatePickerDialog(
+                    onDismissRequest = { showDatePicker = false },
+                    confirmButton = {
+                        TextButton(onClick = { showDatePicker = false }) {
+                            Text(stringResource(android.R.string.ok))
+                        }
+                    }
+                ) { DatePicker(state = datePickerState) }
+            }
+
+            Spacer(Modifier.height(16.dp))
+
 
             Row(horizontalArrangement = Arrangement.spacedBy(8.dp)) {
                 Button(
@@ -372,14 +400,15 @@ fun FindVehicleScreen(navController: NavController, openDrawer: () -> Unit) {
                         val toId = routePois[toIdx].id
                         val cost = maxCostText.toDoubleOrNull() ?: Double.MAX_VALUE
                         val routeId = selectedRouteId ?: return@Button
-                        requestViewModel.requestTransport(context, routeId, fromId, toId, cost)
+                        val dateMillis = datePickerState.selectedDateMillis ?: 0L
+                        requestViewModel.requestTransport(context, routeId, fromId, toId, cost, dateMillis)
                         navController.navigate(
                             "availableTransports?routeId=" +
                                 routeId +
                                 "&startId=" + fromId +
                             "&endId=" + toId +
                             "&maxCost=" + cost +
-                            "&date="
+                            "&date=" + dateMillis
                         )
                     },
                     enabled = selectedRouteId != null && startIndex != null && endIndex != null,
@@ -398,7 +427,8 @@ fun FindVehicleScreen(navController: NavController, openDrawer: () -> Unit) {
                         val toId = routePois[toIdx].id
                         val cost = maxCostText.toDoubleOrNull() ?: Double.MAX_VALUE
                         val routeId = selectedRouteId ?: return@Button
-                        requestViewModel.requestTransport(context, routeId, fromId, toId, cost)
+                        val dateMillis = datePickerState.selectedDateMillis ?: 0L
+                        requestViewModel.requestTransport(context, routeId, fromId, toId, cost, dateMillis)
                         message = context.getString(R.string.request_sent)
                     },
                     enabled = selectedRouteId != null && startIndex != null && endIndex != null,

--- a/app/src/main/java/com/ioannapergamali/mysmartroute/viewmodel/VehicleRequestViewModel.kt
+++ b/app/src/main/java/com/ioannapergamali/mysmartroute/viewmodel/VehicleRequestViewModel.kt
@@ -66,7 +66,8 @@ class VehicleRequestViewModel : ViewModel() {
         routeId: String,
         fromPoiId: String,
         toPoiId: String,
-        maxCost: Double
+        maxCost: Double,
+        date: Long
     ) {
         viewModelScope.launch {
             val dao = MySmartRouteDatabase.getInstance(context).movingDao()
@@ -76,7 +77,7 @@ class VehicleRequestViewModel : ViewModel() {
                 id = id,
                 routeId = routeId,
                 userId = userId,
-                date = 0,
+                date = date,
                 vehicleId = "",
                 cost = maxCost,
                 durationMinutes = 0,


### PR DESCRIPTION
## Περιγραφή
Μετατράπηκε ο τύπος της ημερομηνίας μεταφοράς σε `Long` ώστε να αποθηκεύεται σωστά το πλήρες timestamp. Ενημερώθηκαν οι σχετικές κλήσεις και mapper.

## Αλλαγές
- `MovingEntity.date` από `Int` σε `Long`
- Ενημέρωση `FirestoreMappers` για ανάγνωση `Long`
- Προσαρμογή `VehicleRequestViewModel` και `FindVehicleScreen` να χρησιμοποιούν `Long`

## Testing
- ❌ `./gradlew assembleDebug --quiet` (απέτυχε λόγω έλλειψης Android SDK και περιορισμών δικτύου)
- ❌ `./gradlew test --quiet` (απέτυχε λόγω έλλειψης Android SDK και περιορισμών δικτύου)


------
https://chatgpt.com/codex/tasks/task_e_688be46cd7408328818fc9777bb61232