### PR TITLE
Fix DatePickerState duplication

### DIFF
--- a/app/src/main/java/com/ioannapergamali/mysmartroute/view/ui/screens/FindVehicleScreen.kt
+++ b/app/src/main/java/com/ioannapergamali/mysmartroute/view/ui/screens/FindVehicleScreen.kt
@@ -86,16 +86,6 @@ fun FindVehicleScreen(navController: NavController, openDrawer: () -> Unit) {
     val selectedDateText = datePickerState.selectedDateMillis?.let { millis ->
         Instant.ofEpochMilli(millis).atZone(ZoneId.systemDefault()).toLocalDate().format(dateFormatter)
     } ?: stringResource(R.string.select_date)
-
-
-    var showDatePicker by remember { mutableStateOf(false) }
-    val datePickerState = rememberDatePickerState()
-    val dateFormatter = remember { DateTimeFormatter.ofPattern("dd/MM/yyyy") }
-    val selectedDateText = datePickerState.selectedDateMillis?.let { millis ->
-        Instant.ofEpochMilli(millis).atZone(ZoneId.systemDefault()).toLocalDate().format(dateFormatter)
-    } ?: stringResource(R.string.select_date)
-
-
     val cameraPositionState = rememberCameraPositionState()
     val coroutineScope = rememberCoroutineScope()
     val apiKey = MapsUtils.getApiKey(context)


### PR DESCRIPTION
## Summary
- remove duplicate `DatePickerState` setup in `FindVehicleScreen`

## Testing
- `./gradlew test --stacktrace` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_688bfcff48208328a66fd3419380660e