### PR TITLE
Use RouteModeScreen for find vehicle option

### DIFF
--- a/app/src/main/java/com/ioannapergamali/mysmartroute/model/navigation/NavigationHost.kt
+++ b/app/src/main/java/com/ioannapergamali/mysmartroute/model/navigation/NavigationHost.kt
@@ -164,8 +164,9 @@ fun NavigationHost(navController : NavHostController, openDrawer: () -> Unit) {
             RouteModeScreen(navController = navController, openDrawer = openDrawer)
         }
 
+        // Χρησιμοποιούμε την ίδια οθόνη με την επιλογή "Τρόπος μεταφοράς για συγκεκριμένη διαδρομή"
         composable("findVehicle") {
-            FindVehicleScreen(navController = navController, openDrawer = openDrawer)
+            RouteModeScreen(navController = navController, openDrawer = openDrawer)
         }
 
         composable(


### PR DESCRIPTION
## Summary
- show the same screen for `findVehicle` as `routeMode`

## Testing
- `./gradlew test --console=plain -q` *(fails: could not download dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_688c125df40c8328a0c095f37f3655fa