### PR TITLE
Fix datePicker state usage in FindVehicleScreen

### DIFF
--- a/app/src/main/java/com/ioannapergamali/mysmartroute/view/ui/screens/FindVehicleScreen.kt
+++ b/app/src/main/java/com/ioannapergamali/mysmartroute/view/ui/screens/FindVehicleScreen.kt
@@ -3,6 +3,8 @@ package com.ioannapergamali.mysmartroute.view.ui.screens
 import androidx.compose.foundation.layout.*
 import androidx.compose.material3.*
 import androidx.compose.material3.rememberDatePickerState
+import androidx.compose.material3.DatePicker
+import androidx.compose.material3.DatePickerDialog
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.Delete
 import androidx.compose.material.icons.filled.Refresh
@@ -37,6 +39,9 @@ import androidx.lifecycle.Lifecycle
 import androidx.lifecycle.LifecycleEventObserver
 import androidx.lifecycle.LifecycleOwner
 import kotlin.math.abs
+import java.time.Instant
+import java.time.ZoneId
+import java.time.format.DateTimeFormatter
 
 import com.ioannapergamali.mysmartroute.R
 import com.ioannapergamali.mysmartroute.view.ui.components.ScreenContainer
@@ -75,8 +80,12 @@ fun FindVehicleScreen(navController: NavController, openDrawer: () -> Unit) {
     var pendingPoi by remember { mutableStateOf<Triple<String, Double, Double>?>(null) }
 
     // Κατάσταση επιλογής ημερομηνίας για το DatePickerDialog
-    // Χρησιμοποιούμε την προεπιλεγμένη ημερομηνία (σήμερα)
     val datePickerState = rememberDatePickerState()
+    var showDatePicker by remember { mutableStateOf(false) }
+    val dateFormatter = remember { DateTimeFormatter.ofPattern("dd/MM/yyyy") }
+    val selectedDateText = datePickerState.selectedDateMillis?.let { millis ->
+        Instant.ofEpochMilli(millis).atZone(ZoneId.systemDefault()).toLocalDate().format(dateFormatter)
+    } ?: stringResource(R.string.select_date)
 
     val cameraPositionState = rememberCameraPositionState()
     val coroutineScope = rememberCoroutineScope()
@@ -363,6 +372,24 @@ fun FindVehicleScreen(navController: NavController, openDrawer: () -> Unit) {
 
             Spacer(Modifier.height(16.dp))
 
+            Button(onClick = { showDatePicker = true }) {
+                Text(selectedDateText)
+            }
+
+            if (showDatePicker) {
+                DatePickerDialog(
+                    onDismissRequest = { showDatePicker = false },
+                    confirmButton = {
+                        TextButton(onClick = { showDatePicker = false }) {
+                            Text(stringResource(android.R.string.ok))
+                        }
+                    }
+                ) {
+                    DatePicker(state = datePickerState)
+                }
+            }
+
+            Spacer(Modifier.height(16.dp))
 
             Row(horizontalArrangement = Arrangement.spacedBy(8.dp)) {
                 Button(
@@ -377,7 +404,7 @@ fun FindVehicleScreen(navController: NavController, openDrawer: () -> Unit) {
                         val toId = routePois[toIdx].id
                         val cost = maxCostText.toDoubleOrNull() ?: Double.MAX_VALUE
                         val routeId = selectedRouteId ?: return@Button
-                        val dateMillis = System.currentTimeMillis()
+                        val dateMillis = datePickerState.selectedDateMillis ?: System.currentTimeMillis()
                         requestViewModel.requestTransport(context, routeId, fromId, toId, cost, dateMillis)
                         navController.navigate(
                             "availableTransports?routeId=" +
@@ -404,7 +431,7 @@ fun FindVehicleScreen(navController: NavController, openDrawer: () -> Unit) {
                         val toId = routePois[toIdx].id
                         val cost = maxCostText.toDoubleOrNull() ?: Double.MAX_VALUE
                         val routeId = selectedRouteId ?: return@Button
-                        val dateMillis = System.currentTimeMillis()
+                        val dateMillis = datePickerState.selectedDateMillis ?: System.currentTimeMillis()
                         requestViewModel.requestTransport(context, routeId, fromId, toId, cost, dateMillis)
                         message = context.getString(R.string.request_sent)
                     },


### PR DESCRIPTION
## Summary
- add material3 DatePicker imports
- add java.time imports
- remember date picker state and show dialog
- allow user to select date when finding vehicles

## Testing
- `./gradlew help`

------
https://chatgpt.com/codex/tasks/task_e_688c24c113508328b2d7b40f1b166a27