### PR TITLE
Fix routePoiIds initialization

### DIFF
--- a/app/src/main/java/com/ioannapergamali/mysmartroute/view/ui/screens/RouteModeScreen.kt
+++ b/app/src/main/java/com/ioannapergamali/mysmartroute/view/ui/screens/RouteModeScreen.kt
@@ -58,12 +58,9 @@ fun RouteModeScreen(navController: NavController, openDrawer: () -> Unit) {
 
     var routeExpanded by remember { mutableStateOf(false) }
     var selectedRouteId by rememberSaveable { mutableStateOf<String?>(null) }
-    val routePoiIds = rememberSaveable(
-        saver = listSaver(
-            save = { it.toList() },
-            restore = { mutableStateListOf<String>().apply { addAll(it) } }
-        )
-    ) { mutableStateListOf<String>() }
+    val routePoiIds = remember {
+        mutableStateListOf<String>()
+    }
     val routePois = routePoiIds.mapNotNull { id -> allPois.find { it.id == id } }
     var startIndex by rememberSaveable { mutableStateOf<Int?>(null) }
     var endIndex by rememberSaveable { mutableStateOf<Int?>(null) }


### PR DESCRIPTION
## Summary
- use `remember` instead of `rememberSaveable` for `routePoiIds` in `RouteModeScreen`

## Testing
- `./gradlew test` *(fails: could not resolve dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_688c3280ed248328a07886a06fdf09a3