### PR TITLE
Fix Kotlin syntax in RouteModeScreen

### DIFF
--- a/app/src/main/java/com/ioannapergamali/mysmartroute/view/ui/screens/RouteModeScreen.kt
+++ b/app/src/main/java/com/ioannapergamali/mysmartroute/view/ui/screens/RouteModeScreen.kt
@@ -58,10 +58,10 @@ fun RouteModeScreen(navController: NavController, openDrawer: () -> Unit) {
 
     var routeExpanded by remember { mutableStateOf(false) }
     var selectedRouteId by rememberSaveable { mutableStateOf<String?>(null) }
-    val routePoiIds = remember {
-        mutableStateListOf<String>()
+    val routePoiIds = remember { mutableStateListOf<String>() }
+    val routePois = routePoiIds.mapNotNull { id ->
+        allPois.find { it.id == id }
     }
-    val routePois = routePoiIds.mapNotNull { id -> allPois.find { it.id == id } }
     var startIndex by rememberSaveable { mutableStateOf<Int?>(null) }
     var endIndex by rememberSaveable { mutableStateOf<Int?>(null) }
     var message by remember { mutableStateOf("") }


### PR DESCRIPTION
## Summary
- tidy up `RouteModeScreen` state initialization

## Testing
- `./gradlew assembleDebug -x lint` *(fails: domain maven.pkg.jetbrains.space blocked)*

------
https://chatgpt.com/codex/tasks/task_e_688cd522166c8328bfce92d31ac16c23