### PR TITLE
Fix Compose dependency versions

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -80,11 +80,11 @@ dependencies {
     implementation("androidx.constraintlayout:constraintlayout:2.1.4")
 
     // Jetpack Compose
-    implementation(platform("androidx.compose:compose-bom:2025.08.00"))
-    androidTestImplementation(platform("androidx.compose:compose-bom:2025.08.00"))
+    implementation(platform("androidx.compose:compose-bom:2025.07.00"))
+    androidTestImplementation(platform("androidx.compose:compose-bom:2025.07.00"))
 
     // Χρήση της σταθερής έκδοσης Material3
-    implementation("androidx.compose.material3:material3:1.4.0")
+    implementation("androidx.compose.material3:material3:1.3.2")
     implementation("androidx.compose.ui:ui")
     implementation("androidx.compose.ui:ui-text")
     implementation("androidx.compose.ui:ui-tooling-preview")


### PR DESCRIPTION
## Summary
- update Compose BOM to latest available version
- use stable Material3

## Testing
- `./gradlew test --no-daemon` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_688cf182f5408328b3b9fbb3c579b5d7