### PR TITLE
Ενημέρωση ελληνικής μετάφρασης τίτλου

### DIFF
--- a/app/src/main/res/values-el/strings.xml
+++ b/app/src/main/res/values-el/strings.xml
@@ -61,7 +61,7 @@
     <!-- Επιλογές μενού -->
     <string name="sign_out">Αποσύνδεση</string>
     <string name="manage_favorites">Διαχείριση αγαπημένων μέσων μεταφοράς</string>
-    <string name="route_mode">Τρόπος μεταφοράς για συγκεκριμένη διαδρομή</string>
+    <string name="route_mode">ΤΡΟΠΟΣ ΜΕΤΑΦΟΡΑΣ ΓΙΑ ΣΥΓΚΕΚΡΙΜΕΝΗ ΔΙΑΔΡΟΜΗ</string>
     <string name="find_vehicle">Εύρεση οχήματος για συγκεκριμένη μεταφορά</string>
     <string name="find_way">Εύρεση μέσου μεταφοράς</string>
     <string name="book_seat">Κράτηση θέσης ή αγορά εισιτηρίου</string>


### PR DESCRIPTION
## Summary
- ενημερώθηκε το κείμενο `route_mode` στη μετάφραση για τα ελληνικά

## Testing
- `./gradlew test` *(απέτυχε λόγω περιορισμένης πρόσβασης στο διαδίκτυο)*

------
https://chatgpt.com/codex/tasks/task_e_688cfc0383188328b9082d01de0104f9