### PR TITLE
Ενημέρωση ελληνικού τίτλου και βελτίωση κράτησης

### DIFF
--- a/app/src/main/java/com/ioannapergamali/mysmartroute/model/enumerations/BookingStep.kt
+++ b/app/src/main/java/com/ioannapergamali/mysmartroute/model/enumerations/BookingStep.kt
@@ -19,8 +19,8 @@ enum class BookingStep(@StringRes val titleRes: Int, val position: Int) {
     RECALCULATE_ROUTE(R.string.recalculate_route, 4),
     /** Επιλογή ημερομηνίας */
     SELECT_DATE(R.string.select_date, 5),
-    /** Κλείσιμο θέσης */
-    RESERVE_SEAT(R.string.reserve_seat, 6);
+    /** Εύρεση τώρα */
+    RESERVE_SEAT(R.string.find_now, 6);
 
     companion object {
         /** Βήματα στη σωστή σειρά. */

--- a/app/src/main/java/com/ioannapergamali/mysmartroute/view/ui/screens/BookSeatScreen.kt
+++ b/app/src/main/java/com/ioannapergamali/mysmartroute/view/ui/screens/BookSeatScreen.kt
@@ -58,6 +58,7 @@ import com.ioannapergamali.mysmartroute.viewmodel.BookingViewModel
 import com.ioannapergamali.mysmartroute.viewmodel.RouteViewModel
 import com.ioannapergamali.mysmartroute.viewmodel.PoIViewModel
 import com.ioannapergamali.mysmartroute.viewmodel.TransportDeclarationViewModel
+import com.ioannapergamali.mysmartroute.viewmodel.VehicleRequestViewModel
 import kotlinx.coroutines.launch
 import java.time.Instant
 import java.time.ZoneId
@@ -75,6 +76,7 @@ fun BookSeatScreen(navController: NavController, openDrawer: () -> Unit) {
     val routeViewModel: RouteViewModel = viewModel()
     val poiViewModel: PoIViewModel = viewModel()
     val declarationViewModel: TransportDeclarationViewModel = viewModel()
+    val requestViewModel: VehicleRequestViewModel = viewModel()
     val routes by viewModel.availableRoutes.collectAsState()
     val allPois by poiViewModel.pois.collectAsState()
     val declarations by declarationViewModel.declarations.collectAsState()
@@ -511,16 +513,25 @@ fun BookSeatScreen(navController: NavController, openDrawer: () -> Unit) {
                         val dateMillis = datePickerState.selectedDateMillis ?: 0L
                         val startId = startIndex?.let { pois[it].id } ?: ""
                         val endId = endIndex?.let { pois[it].id } ?: ""
-                        val success = viewModel.reserveSeat(context, r.id, dateMillis, startId, endId)
-                        message = if (success) {
-                            context.getString(R.string.seat_booked)
-                        } else {
-                            context.getString(R.string.seat_unavailable)
-                        }
+                        requestViewModel.requestTransport(
+                            context,
+                            r.id,
+                            startId,
+                            endId,
+                            Double.MAX_VALUE,
+                            dateMillis
+                        )
+                        navController.navigate(
+                            "availableTransports?routeId=" +
+                                    r.id +
+                                    "&startId=" + startId +
+                                    "&endId=" + endId +
+                                    "&maxCost=&date=" + dateMillis
+                        )
                     }
                 }
             ) {
-                Text(stringResource(R.string.reserve_seat))
+                Text(stringResource(R.string.find_now))
             }
 
             if (message.isNotBlank()) {

--- a/app/src/main/res/values-el/strings.xml
+++ b/app/src/main/res/values-el/strings.xml
@@ -61,7 +61,7 @@
     <!-- Επιλογές μενού -->
     <string name="sign_out">Αποσύνδεση</string>
     <string name="manage_favorites">Διαχείριση αγαπημένων μέσων μεταφοράς</string>
-    <string name="route_mode">Τρόπος μεταφοράς για συγκεκριμένη διαδρομή</string>
+    <string name="route_mode">Τρόπος μεταφοράς με ημερομηνία</string>
     <string name="find_vehicle">Εύρεση οχήματος για συγκεκριμένη μεταφορά</string>
     <string name="find_way">Εύρεση μέσου μεταφοράς</string>
     <string name="book_seat">Κράτηση θέσης ή αγορά εισιτηρίου</string>
@@ -171,5 +171,8 @@
     <string name="app_started_notification">Η εφαρμογή ξεκίνησε</string>
     <string name="available_transports">Διαθέσιμες μεταφορές</string>
     <string name="no_transports_found">Δεν βρέθηκαν μεταφορές</string>
+    <string name="find_now">Εύρεση τώρα</string>
+    <string name="save_request">Αποθήκευση αιτήματος</string>
+    <string name="departure_date">Επιθυμητή ημερομηνία</string>
 
 </resources>


### PR DESCRIPTION
## Summary
- άλλαξε ο τίτλος `route_mode` σε «Τρόπος μεταφοράς με ημερομηνία»
- προστέθηκαν μεταφράσεις `find_now`, `save_request` και `departure_date`
- προστέθηκαν κλήσεις σε `VehicleRequestViewModel` και αντικαταστάθηκε το κουμπί «Κλείσε Θέση» με «Εύρεση τώρα» στην `BookSeatScreen`
- το βήμα `RESERVE_SEAT` του `BookingStep` εμφανίζει πλέον «Εύρεση τώρα»

## Testing
- `./gradlew test` *(απέτυχε λόγω περιορισμένης πρόσβασης στο διαδίκτυο)*

------
https://chatgpt.com/codex/tasks/task_e_688cfc0383188328b9082d01de0104f9