### PR TITLE
Enable cost-based vehicle search

### DIFF
--- a/app/src/main/java/com/ioannapergamali/mysmartroute/model/navigation/NavigationHost.kt
+++ b/app/src/main/java/com/ioannapergamali/mysmartroute/model/navigation/NavigationHost.kt
@@ -36,6 +36,7 @@ import com.ioannapergamali.mysmartroute.view.ui.screens.PrepareCompleteRouteScre
 import com.ioannapergamali.mysmartroute.view.ui.screens.ViewVehiclesScreen
 import com.ioannapergamali.mysmartroute.view.ui.screens.ViewTransportRequestsScreen
 import com.ioannapergamali.mysmartroute.view.ui.screens.BookSeatScreen
+import com.ioannapergamali.mysmartroute.view.ui.screens.FindVehicleScreen
 import com.ioannapergamali.mysmartroute.view.ui.screens.ViewRoutesScreen
 import com.ioannapergamali.mysmartroute.view.ui.screens.SelectRoutePoisScreen
 import com.ioannapergamali.mysmartroute.view.ui.screens.AvailableTransportsScreen
@@ -161,9 +162,8 @@ fun NavigationHost(navController : NavHostController, openDrawer: () -> Unit) {
             BookSeatScreen(navController = navController, openDrawer = openDrawer)
         }
 
-        // Χρησιμοποιούμε την ίδια οθόνη κράτησης θέσης
         composable("findVehicle") {
-            BookSeatScreen(navController = navController, openDrawer = openDrawer)
+            FindVehicleScreen(navController = navController, openDrawer = openDrawer)
         }
 
         composable(

--- a/app/src/main/java/com/ioannapergamali/mysmartroute/view/ui/screens/FindVehicleScreen.kt
+++ b/app/src/main/java/com/ioannapergamali/mysmartroute/view/ui/screens/FindVehicleScreen.kt
@@ -2,13 +2,9 @@ package com.ioannapergamali.mysmartroute.view.ui.screens
 
 import androidx.compose.foundation.layout.*
 import androidx.compose.material3.*
-import androidx.compose.material3.DatePicker
-import androidx.compose.material3.DatePickerDialog
-import androidx.compose.material3.rememberDatePickerState
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.Delete
 import androidx.compose.material.icons.filled.Refresh
-import androidx.compose.material3.IconButton
 import androidx.compose.material3.menuAnchor
 import androidx.compose.runtime.*
 import androidx.compose.runtime.saveable.rememberSaveable
@@ -38,9 +34,6 @@ import androidx.lifecycle.Lifecycle
 import androidx.lifecycle.LifecycleEventObserver
 import androidx.lifecycle.LifecycleOwner
 import kotlin.math.abs
-import java.time.Instant
-import java.time.ZoneId
-import java.time.format.DateTimeFormatter
 
 import com.ioannapergamali.mysmartroute.R
 import com.ioannapergamali.mysmartroute.view.ui.components.ScreenContainer
@@ -78,13 +71,6 @@ fun FindVehicleScreen(navController: NavController, openDrawer: () -> Unit) {
     var calculating by remember { mutableStateOf(false) }
     var pendingPoi by remember { mutableStateOf<Triple<String, Double, Double>?>(null) }
 
-    val datePickerState = rememberDatePickerState(System.currentTimeMillis())
-    var showDatePicker by remember { mutableStateOf(false) }
-    val datePickerState = rememberDatePickerState()
-    val dateFormatter = remember { DateTimeFormatter.ofPattern("dd/MM/yyyy") }
-    val selectedDateText = datePickerState.selectedDateMillis?.let { millis ->
-        Instant.ofEpochMilli(millis).atZone(ZoneId.systemDefault()).toLocalDate().format(dateFormatter)
-    } ?: stringResource(R.string.select_date)
     val cameraPositionState = rememberCameraPositionState()
     val coroutineScope = rememberCoroutineScope()
     val apiKey = MapsUtils.getApiKey(context)
@@ -363,25 +349,10 @@ fun FindVehicleScreen(navController: NavController, openDrawer: () -> Unit) {
             OutlinedTextField(
                 value = maxCostText,
                 onValueChange = { maxCostText = it },
-                label = { Text(stringResource(R.string.max_cost)) },
+                label = { Text(stringResource(R.string.cost)) },
                 keyboardOptions = KeyboardOptions(keyboardType = KeyboardType.Number),
                 modifier = Modifier.fillMaxWidth()
             )
-
-            Spacer(Modifier.height(16.dp))
-
-            Button(onClick = { showDatePicker = true }) { Text(selectedDateText) }
-
-            if (showDatePicker) {
-                DatePickerDialog(
-                    onDismissRequest = { showDatePicker = false },
-                    confirmButton = {
-                        TextButton(onClick = { showDatePicker = false }) {
-                            Text(stringResource(android.R.string.ok))
-                        }
-                    }
-                ) { DatePicker(state = datePickerState) }
-            }
 
             Spacer(Modifier.height(16.dp))
 
@@ -399,15 +370,14 @@ fun FindVehicleScreen(navController: NavController, openDrawer: () -> Unit) {
                         val toId = routePois[toIdx].id
                         val cost = maxCostText.toDoubleOrNull() ?: Double.MAX_VALUE
                         val routeId = selectedRouteId ?: return@Button
-                        val dateMillis = datePickerState.selectedDateMillis ?: 0L
-                        requestViewModel.requestTransport(context, routeId, fromId, toId, cost, dateMillis)
+                        requestViewModel.requestTransport(context, routeId, fromId, toId, cost, 0L)
                         navController.navigate(
                             "availableTransports?routeId=" +
                                 routeId +
                                 "&startId=" + fromId +
-                            "&endId=" + toId +
-                            "&maxCost=" + cost +
-                            "&date=" + dateMillis
+                                "&endId=" + toId +
+                                "&maxCost=" + cost +
+                                "&date="
                         )
                     },
                     enabled = selectedRouteId != null && startIndex != null && endIndex != null,
@@ -426,8 +396,7 @@ fun FindVehicleScreen(navController: NavController, openDrawer: () -> Unit) {
                         val toId = routePois[toIdx].id
                         val cost = maxCostText.toDoubleOrNull() ?: Double.MAX_VALUE
                         val routeId = selectedRouteId ?: return@Button
-                        val dateMillis = datePickerState.selectedDateMillis ?: 0L
-                        requestViewModel.requestTransport(context, routeId, fromId, toId, cost, dateMillis)
+                        requestViewModel.requestTransport(context, routeId, fromId, toId, cost, 0L)
                         message = context.getString(R.string.request_sent)
                     },
                     enabled = selectedRouteId != null && startIndex != null && endIndex != null,

--- a/app/src/main/res/values-el/strings.xml
+++ b/app/src/main/res/values-el/strings.xml
@@ -62,7 +62,7 @@
     <string name="sign_out">Αποσύνδεση</string>
     <string name="manage_favorites">Διαχείριση αγαπημένων μέσων μεταφοράς</string>
 
-    <string name="find_vehicle">Εύρεση οχήματος για συγκεκριμένη μεταφορά</string>
+    <string name="find_vehicle">Εύρεση οχήματος βάσει κόστους</string>
     <string name="find_way">Εύρεση μέσου μεταφοράς</string>
     <string name="book_seat">Κράτηση θέσης ή αγορά εισιτηρίου</string>
     <string name="view_routes">Προβολή ενδιαφερουσών διαδρομών</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -60,7 +60,7 @@
     <string name="sign_out">Sign out</string>
     <string name="manage_favorites">Manage Favorite Means of Transport</string>
     <string name="route_mode">Transportation mode with date</string>
-    <string name="find_vehicle">Find a Vehicle for a specific Transport</string>
+    <string name="find_vehicle">Find a Vehicle based on Cost</string>
     <string name="find_way">Find Way of Transport</string>
     <string name="book_seat">Book a Seat or Buy a Ticket</string>
     <string name="view_routes">View Interesting Routes</string>


### PR DESCRIPTION
## Summary
- Rename menu option and screen to "Find a Vehicle based on Cost"
- Use dedicated `FindVehicleScreen` without departure date picker
- Add cost input for vehicle search

## Testing
- `./gradlew test --no-daemon` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_688f6546650083288e68c123bb0d0e28