### PR TITLE
Fix vehicle search by date translation

### DIFF
--- a/app/src/main/res/values-el/strings.xml
+++ b/app/src/main/res/values-el/strings.xml
@@ -61,6 +61,7 @@
     <!-- Επιλογές μενού -->
     <string name="sign_out">Αποσύνδεση</string>
     <string name="manage_favorites">Διαχείριση αγαπημένων μέσων μεταφοράς</string>
+    <string name="route_mode">Εύρεση οχήματος βάσει ημερομηνίας</string>
 
     <string name="find_vehicle">Εύρεση οχήματος βάσει κόστους</string>
     <string name="find_way">Εύρεση μέσου μεταφοράς</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -59,7 +59,7 @@
     <!-- Menu options -->
     <string name="sign_out">Sign out</string>
     <string name="manage_favorites">Manage Favorite Means of Transport</string>
-    <string name="route_mode">Transportation mode with date</string>
+    <string name="route_mode">Find a Vehicle Based on Date</string>
     <string name="find_vehicle">Find a Vehicle based on Cost</string>
     <string name="find_way">Find Way of Transport</string>
     <string name="book_seat">Book a Seat or Buy a Ticket</string>


### PR DESCRIPTION
## Summary
- Rename vehicle-search-by-date option and fix Greek translation

## Testing
- `./gradlew test` *(fails: Could not determine dependencies; missing Android SDK packages and licenses)*

------
https://chatgpt.com/codex/tasks/task_e_688f7297b94c8328bc978a1bfd67a43d