### PR TITLE
Φιλτράρισμα οχημάτων βάσει αγαπημένων τύπων

### DIFF
--- a/app/src/main/java/com/ioannapergamali/mysmartroute/utils/TransportFilters.kt
+++ b/app/src/main/java/com/ioannapergamali/mysmartroute/utils/TransportFilters.kt
@@ -1,0 +1,18 @@
+package com.ioannapergamali.mysmartroute.utils
+
+import com.ioannapergamali.mysmartroute.data.local.TransportDeclarationEntity
+import com.ioannapergamali.mysmartroute.model.enumerations.VehicleType
+
+/**
+ * Επιστρέφει `true` εάν η συγκεκριμένη δήλωση μεταφοράς συμβαδίζει με τις προτιμήσεις
+ * αγαπημένων ή μη αγαπημένων μέσων μεταφοράς του χρήστη.
+ */
+fun TransportDeclarationEntity.matchesFavorites(
+    preferred: Set<VehicleType>,
+    nonPreferred: Set<VehicleType>
+): Boolean {
+    val type = runCatching { VehicleType.valueOf(vehicleType) }.getOrNull() ?: return true
+    if (preferred.isNotEmpty() && !preferred.contains(type)) return false
+    if (nonPreferred.contains(type)) return false
+    return true
+}

--- a/app/src/main/java/com/ioannapergamali/mysmartroute/view/ui/screens/AvailableTransportsScreen.kt
+++ b/app/src/main/java/com/ioannapergamali/mysmartroute/view/ui/screens/AvailableTransportsScreen.kt
@@ -28,6 +28,7 @@ import com.ioannapergamali.mysmartroute.viewmodel.ReservationViewModel
 import com.ioannapergamali.mysmartroute.viewmodel.BookingViewModel
 import com.ioannapergamali.mysmartroute.viewmodel.UserViewModel
 import com.ioannapergamali.mysmartroute.viewmodel.VehicleViewModel
+import com.ioannapergamali.mysmartroute.utils.matchesFavorites
 import kotlin.math.max
 import java.time.Instant
 import java.time.ZoneId
@@ -107,12 +108,7 @@ fun AvailableTransportsScreen(
         if (startIndex < 0 || endIndex < 0 || startIndex >= endIndex) return@filter false
         if (maxCost != null && decl.cost > maxCost) return@filter false
         if (date != null && decl.date != date) return@filter false
-        val type = runCatching { VehicleType.valueOf(decl.vehicleType) }.getOrNull()
-        if (type != null) {
-            // Αν υπάρχουν προτιμώμενοι τύποι, εμφανίζονται μόνο αυτοί
-            if (preferred.isNotEmpty() && !preferred.contains(type)) return@filter false
-            if (nonPreferred.contains(type)) return@filter false
-        }
+        if (!decl.matchesFavorites(preferred, nonPreferred)) return@filter false
         true
     }
         // ταξινόμηση βάσει κόστους ώστε οι φθηνότερες επιλογές να εμφανίζονται πρώτες


### PR DESCRIPTION
## Περίληψη
- Προστέθηκε βοηθητική συνάρτηση `matchesFavorites` για έλεγχο αγαπημένων τύπων οχημάτων.
- Ενημερώθηκε η `AvailableTransportsScreen` ώστε η αναζήτηση οχημάτων με ημερομηνία/κόστος να λαμβάνει υπόψη τα αγαπημένα μέσα μεταφοράς.

## Έλεγχοι
- `./gradlew test` *(αποτυχία: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_688f7c5eaf288328b75c2e016cad430a