### PR TITLE
Limit booking dates to availability and update screen title

### DIFF
--- a/app/src/main/java/com/ioannapergamali/mysmartroute/view/ui/screens/BookSeatScreen.kt
+++ b/app/src/main/java/com/ioannapergamali/mysmartroute/view/ui/screens/BookSeatScreen.kt
@@ -18,6 +18,7 @@ import androidx.compose.material3.Scaffold
 import androidx.compose.material3.Text
 import androidx.compose.material3.DatePicker
 import androidx.compose.material3.DatePickerDialog
+import androidx.compose.material3.SelectableDates
 import androidx.compose.material3.TextButton
 import androidx.compose.material3.rememberDatePickerState
 import androidx.compose.material3.OutlinedTextField
@@ -105,7 +106,21 @@ fun BookSeatScreen(navController: NavController, openDrawer: () -> Unit) {
     var pathPoints by remember { mutableStateOf<List<LatLng>>(emptyList()) }
     var calculating by remember { mutableStateOf(false) }
     var pendingPoi by remember { mutableStateOf<Triple<String, Double, Double>?>(null) }
-    val datePickerState = rememberDatePickerState()
+
+    val availableDates = remember(declarations, selectedRouteId) {
+        declarations.filter { it.routeId == selectedRouteId }.map {
+            Instant.ofEpochMilli(it.date).atZone(ZoneId.systemDefault()).toLocalDate()
+        }.toSet()
+    }
+
+    val datePickerState = rememberDatePickerState(
+        selectableDates = object : SelectableDates {
+            override fun isSelectableDate(dateMillis: Long): Boolean {
+                val date = Instant.ofEpochMilli(dateMillis).atZone(ZoneId.systemDefault()).toLocalDate()
+                return availableDates.contains(date)
+            }
+        }
+    )
     var showDatePicker by remember { mutableStateOf(false) }
     val dateFormatter = remember { DateTimeFormatter.ofPattern("dd/MM/yyyy") }
     val selectedDateText = datePickerState.selectedDateMillis?.let { millis ->
@@ -224,7 +239,7 @@ fun BookSeatScreen(navController: NavController, openDrawer: () -> Unit) {
     Scaffold(
         topBar = {
             TopBar(
-                title = stringResource(R.string.route_mode),
+                title = stringResource(R.string.reserve_seat_title),
                 navController = navController,
                 showMenu = true,
                 onMenuClick = openDrawer

--- a/app/src/main/res/values-el/strings.xml
+++ b/app/src/main/res/values-el/strings.xml
@@ -144,6 +144,7 @@
     <string name="seat_booked">Η θέση κλείστηκε!</string>
     <string name="seat_unavailable">Δεν υπάρχουν διαθέσιμες θέσεις.</string>
     <string name="reserve_seat">Κλείσε Θέση</string>
+    <string name="reserve_seat_title">Κράτηση θέσης</string>
     <string name="available_seats">Διαθέσιμες θέσεις: %1$d</string>
     <string name="select_route">Επιλογή διαδρομής</string>
     <string name="add_poi_option">Προσθήκη POI</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -153,6 +153,7 @@
     <string name="seat_booked">Seat booked!</string>
     <string name="seat_unavailable">No available seats.</string>
     <string name="reserve_seat">Reserve Seat</string>
+    <string name="reserve_seat_title">Seat reservation</string>
     <string name="available_seats">Available seats: %1$d</string>
     <string name="select_route">Select route</string>
     <string name="add_poi_option">Add POI</string>


### PR DESCRIPTION
## Summary
- rename BookSeatScreen top bar to "Κράτηση θέσης"
- date picker now allows only dates with declared availability

## Testing
- `./gradlew test` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_688f7f0b9d488328b6fb295654bee487