### PR TITLE
feat: differentiate booking screen

### DIFF
--- a/app/src/main/java/com/ioannapergamali/mysmartroute/model/navigation/NavigationHost.kt
+++ b/app/src/main/java/com/ioannapergamali/mysmartroute/model/navigation/NavigationHost.kt
@@ -41,6 +41,7 @@ import com.ioannapergamali.mysmartroute.view.ui.screens.ViewRoutesScreen
 import com.ioannapergamali.mysmartroute.view.ui.screens.SelectRoutePoisScreen
 import com.ioannapergamali.mysmartroute.view.ui.screens.AvailableTransportsScreen
 import com.ioannapergamali.mysmartroute.view.ui.screens.NotificationsScreen
+import com.ioannapergamali.mysmartroute.R
 
 
 
@@ -159,7 +160,12 @@ fun NavigationHost(navController : NavHostController, openDrawer: () -> Unit) {
         }
 
         composable("routeMode") {
-            BookSeatScreen(navController = navController, openDrawer = openDrawer)
+            BookSeatScreen(
+                navController = navController,
+                openDrawer = openDrawer,
+                titleRes = R.string.route_mode,
+                restrictToAvailableDates = false
+            )
         }
 
         composable("findVehicle") {
@@ -193,7 +199,12 @@ fun NavigationHost(navController : NavHostController, openDrawer: () -> Unit) {
         }
 
         composable("bookSeat") {
-            BookSeatScreen(navController = navController, openDrawer = openDrawer)
+            BookSeatScreen(
+                navController = navController,
+                openDrawer = openDrawer,
+                titleRes = R.string.book_seat,
+                restrictToAvailableDates = true
+            )
         }
 
         composable("viewRoutes") {


### PR DESCRIPTION
## Summary
- allow BookSeatScreen to show dynamic titles and optional date restriction
- pass proper titles for "find vehicle by date" and seat booking in NavigationHost

## Testing
- `./gradlew test` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_688f8764e9f88328ae35b88491f33b5d