### PR TITLE
Κατάργηση πεδίου ημερομηνίας στην αναζήτηση οχήματος βάσει κόστους

### DIFF
--- a/app/src/main/java/com/ioannapergamali/mysmartroute/view/ui/screens/FindVehicleScreen.kt
+++ b/app/src/main/java/com/ioannapergamali/mysmartroute/view/ui/screens/FindVehicleScreen.kt
@@ -34,9 +34,6 @@ import androidx.lifecycle.Lifecycle
 import androidx.lifecycle.LifecycleEventObserver
 import androidx.lifecycle.LifecycleOwner
 import kotlin.math.abs
-import java.time.Instant
-import java.time.ZoneId
-import java.time.format.DateTimeFormatter
 
 import com.ioannapergamali.mysmartroute.R
 import com.ioannapergamali.mysmartroute.view.ui.components.ScreenContainer
@@ -73,14 +70,6 @@ fun FindVehicleScreen(navController: NavController, openDrawer: () -> Unit) {
     var pathPoints by remember { mutableStateOf<List<LatLng>>(emptyList()) }
     var calculating by remember { mutableStateOf(false) }
     var pendingPoi by remember { mutableStateOf<Triple<String, Double, Double>?>(null) }
-
-    val datePickerState = rememberDatePickerState()
-    var showDatePicker by remember { mutableStateOf(false) }
-    val dateFormatter = remember { DateTimeFormatter.ofPattern("dd/MM/yyyy") }
-    val selectedDateText = datePickerState.selectedDateMillis?.let { millis ->
-        Instant.ofEpochMilli(millis).atZone(ZoneId.systemDefault()).toLocalDate().format(dateFormatter)
-    } ?: stringResource(R.string.select_date)
-
 
     val cameraPositionState = rememberCameraPositionState()
     val coroutineScope = rememberCoroutineScope()
@@ -366,22 +355,6 @@ fun FindVehicleScreen(navController: NavController, openDrawer: () -> Unit) {
             )
 
             Spacer(Modifier.height(16.dp))
-            Text(stringResource(R.string.departure_date))
-            Button(onClick = { showDatePicker = true }) { Text(selectedDateText) }
-            if (showDatePicker) {
-                DatePickerDialog(
-                    onDismissRequest = { showDatePicker = false },
-                    confirmButton = {
-                        TextButton(onClick = { showDatePicker = false }) {
-                            Text(stringResource(android.R.string.ok))
-                        }
-                    }
-                ) {
-                    DatePicker(state = datePickerState)
-                }
-            }
-
-            Spacer(Modifier.height(16.dp))
 
             Row(horizontalArrangement = Arrangement.spacedBy(8.dp)) {
                 Button(
@@ -396,7 +369,7 @@ fun FindVehicleScreen(navController: NavController, openDrawer: () -> Unit) {
                         val toId = routePois[toIdx].id
                         val cost = maxCostText.toDoubleOrNull() ?: Double.MAX_VALUE
                         val routeId = selectedRouteId ?: return@Button
-                        val dateMillis = datePickerState.selectedDateMillis ?: return@Button
+                        val dateMillis = System.currentTimeMillis()
                         requestViewModel.requestTransport(context, routeId, fromId, toId, cost, dateMillis)
                         navController.navigate(
                             "availableTransports?routeId=" +
@@ -407,7 +380,7 @@ fun FindVehicleScreen(navController: NavController, openDrawer: () -> Unit) {
                                 "&date=" + dateMillis
                         )
                     },
-                    enabled = selectedRouteId != null && startIndex != null && endIndex != null && datePickerState.selectedDateMillis != null,
+                    enabled = selectedRouteId != null && startIndex != null && endIndex != null,
                 ) {
                     Text(stringResource(R.string.find_now))
                 }
@@ -423,11 +396,11 @@ fun FindVehicleScreen(navController: NavController, openDrawer: () -> Unit) {
                         val toId = routePois[toIdx].id
                         val cost = maxCostText.toDoubleOrNull() ?: Double.MAX_VALUE
                         val routeId = selectedRouteId ?: return@Button
-                        val dateMillis = datePickerState.selectedDateMillis ?: return@Button
+                        val dateMillis = System.currentTimeMillis()
                         requestViewModel.requestTransport(context, routeId, fromId, toId, cost, dateMillis)
                         message = context.getString(R.string.request_sent)
                     },
-                    enabled = selectedRouteId != null && startIndex != null && endIndex != null && datePickerState.selectedDateMillis != null,
+                    enabled = selectedRouteId != null && startIndex != null && endIndex != null,
                 ) {
                     Text(stringResource(R.string.save_request))
                 }


### PR DESCRIPTION
## Περίληψη
- Αφαίρεση του πεδίου επιθυμητής ημερομηνίας από την οθόνη εύρεσης οχήματος.
- Χρήση της τρέχουσας χρονικής σήμανσης στις κλήσεις για εύρεση και αποθήκευση αιτήματος.

## Δοκιμές
- `./gradlew test` *(απέτυχε: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_688f8c7aa00c8328b71f332d05cfa769