### PR TITLE
Προσθήκη ημερομηνίας και διαγραφής αιτημάτων μεταφοράς

### DIFF
--- a/app/src/main/java/com/ioannapergamali/mysmartroute/data/local/MovingDao.kt
+++ b/app/src/main/java/com/ioannapergamali/mysmartroute/data/local/MovingDao.kt
@@ -15,4 +15,7 @@ interface MovingDao {
 
     @Query("SELECT * FROM movings")
     fun getAll(): kotlinx.coroutines.flow.Flow<List<MovingEntity>>
+
+    @Query("DELETE FROM movings WHERE id IN (:ids)")
+    suspend fun deleteByIds(ids: List<String>)
 }

--- a/app/src/main/java/com/ioannapergamali/mysmartroute/view/ui/screens/ViewTransportRequestsScreen.kt
+++ b/app/src/main/java/com/ioannapergamali/mysmartroute/view/ui/screens/ViewTransportRequestsScreen.kt
@@ -3,11 +3,13 @@ package com.ioannapergamali.mysmartroute.view.ui.screens
 import androidx.compose.foundation.layout.*
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.items
+import androidx.compose.material3.Button
+import androidx.compose.material3.Checkbox
 import androidx.compose.material3.Divider
 import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Scaffold
 import androidx.compose.material3.Text
-import androidx.compose.material3.MaterialTheme
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.collectAsState
@@ -15,6 +17,7 @@ import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateMapOf
 import androidx.compose.runtime.remember
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.Alignment
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.unit.dp
@@ -26,6 +29,8 @@ import com.ioannapergamali.mysmartroute.view.ui.components.TopBar
 import com.ioannapergamali.mysmartroute.viewmodel.PoIViewModel
 import com.ioannapergamali.mysmartroute.viewmodel.UserViewModel
 import com.ioannapergamali.mysmartroute.viewmodel.VehicleRequestViewModel
+import android.text.format.DateFormat
+import java.util.Date
 
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable
@@ -37,6 +42,7 @@ fun ViewTransportRequestsScreen(navController: NavController, openDrawer: () -> 
     val requests by viewModel.requests.collectAsState()
     val pois by poiViewModel.pois.collectAsState()
     val userNames = remember { mutableStateMapOf<String, String>() }
+    val selectedRequests = remember { mutableStateMapOf<String, Boolean>() }
 
     LaunchedEffect(Unit) {
         poiViewModel.loadPois(context)
@@ -67,9 +73,25 @@ fun ViewTransportRequestsScreen(navController: NavController, openDrawer: () -> 
             if (requests.isEmpty()) {
                 Text(stringResource(R.string.no_requests))
             } else {
+                val hasSelection = selectedRequests.values.any { it }
+                Button(
+                    onClick = {
+                        val ids = selectedRequests.filterValues { it }.keys
+                        viewModel.deleteRequests(context, ids.toSet())
+                        ids.forEach { selectedRequests.remove(it) }
+                    },
+                    enabled = hasSelection
+                ) {
+                    Text(stringResource(R.string.delete_selected))
+                }
+                Spacer(modifier = Modifier.height(8.dp))
                 LazyColumn {
                     item {
-                        Row(modifier = Modifier.fillMaxWidth()) {
+                        Row(
+                            modifier = Modifier.fillMaxWidth(),
+                            verticalAlignment = Alignment.CenterVertically
+                        ) {
+                            Spacer(modifier = Modifier.width(40.dp))
                             Text(
                                 stringResource(R.string.passenger),
                                 modifier = Modifier.weight(1f),
@@ -85,6 +107,11 @@ fun ViewTransportRequestsScreen(navController: NavController, openDrawer: () -> 
                                 modifier = Modifier.weight(1f),
                                 style = MaterialTheme.typography.labelMedium
                             )
+                            Text(
+                                stringResource(R.string.date),
+                                modifier = Modifier.weight(1f),
+                                style = MaterialTheme.typography.labelMedium
+                            )
                         }
                         Divider()
                     }
@@ -93,11 +120,26 @@ fun ViewTransportRequestsScreen(navController: NavController, openDrawer: () -> 
                         val toName = poiNames[req.endPoiId] ?: ""
                         val routeName = if (fromName.isNotBlank() && toName.isNotBlank()) "$fromName - $toName" else ""
                         val userName = userNames[req.userId] ?: ""
-                        Row(modifier = Modifier.fillMaxWidth().padding(vertical = 8.dp)) {
+                        val isChecked = selectedRequests[req.id] ?: false
+                        val dateText = if (req.date > 0L) {
+                            DateFormat.getDateFormat(context).format(Date(req.date))
+                        } else ""
+                        Row(
+                            modifier = Modifier
+                                .fillMaxWidth()
+                                .padding(vertical = 8.dp),
+                            verticalAlignment = Alignment.CenterVertically
+                        ) {
+                            Checkbox(
+                                checked = isChecked,
+                                onCheckedChange = { checked -> selectedRequests[req.id] = checked },
+                                modifier = Modifier.width(40.dp)
+                            )
                             Text(userName, modifier = Modifier.weight(1f))
                             Text(routeName, modifier = Modifier.weight(1f))
                             val costText = if (req.cost == Double.MAX_VALUE) "∞" else req.cost.toString()
                             Text(costText, modifier = Modifier.weight(1f))
+                            Text(dateText, modifier = Modifier.weight(1f))
                         }
                         Divider()
                     }

--- a/app/src/main/java/com/ioannapergamali/mysmartroute/viewmodel/VehicleRequestViewModel.kt
+++ b/app/src/main/java/com/ioannapergamali/mysmartroute/viewmodel/VehicleRequestViewModel.kt
@@ -8,6 +8,7 @@ import com.google.firebase.auth.FirebaseAuth
 import com.google.firebase.firestore.FirebaseFirestore
 import com.ioannapergamali.mysmartroute.data.local.MovingEntity
 import com.ioannapergamali.mysmartroute.data.local.MySmartRouteDatabase
+import kotlinx.coroutines.Dispatchers
 import com.ioannapergamali.mysmartroute.utils.toFirestoreMap
 import com.ioannapergamali.mysmartroute.utils.toMovingEntity
 import com.ioannapergamali.mysmartroute.utils.NetworkUtils
@@ -57,6 +58,17 @@ class VehicleRequestViewModel : ViewModel() {
                     _requests.value = list
                     list.forEach { dao.insert(it) }
                 }
+            }
+        }
+    }
+
+    fun deleteRequests(context: Context, ids: Set<String>) {
+        viewModelScope.launch(Dispatchers.IO) {
+            val dao = MySmartRouteDatabase.getInstance(context).movingDao()
+            dao.deleteByIds(ids.toList())
+            _requests.value = _requests.value.filterNot { it.id in ids }
+            ids.forEach { id ->
+                db.collection("movings").document(id).delete()
             }
         }
     }

--- a/app/src/main/res/values-el/strings.xml
+++ b/app/src/main/res/values-el/strings.xml
@@ -162,6 +162,7 @@
     <string name="favorites_non_preferred">Μη προτιμώμενα μέσα μεταφοράς</string>
     <string name="add_favorite">Προσθήκη</string>
     <string name="delete_favorite">Αφαίρεση</string>
+    <string name="delete_selected">Διαγραφή επιλεγμένων</string>
     <string name="clear_selection">Καθαρισμός επιλογής</string>
     <string name="no_reservations">Δεν βρέθηκαν κρατήσεις</string>
     <string name="max_cost">Μέγιστο κόστος</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -175,6 +175,7 @@
     <string name="favorites_non_preferred">Non-preferred transport modes</string>
     <string name="add_favorite">Add</string>
     <string name="delete_favorite">Delete</string>
+    <string name="delete_selected">Delete selected</string>
     <string name="no_reservations">No reservations found</string>
     <string name="max_cost">Maximum cost</string>
     <string name="request_sent">Request saved</string>


### PR DESCRIPTION
## Περίληψη
- Προστέθηκε δυνατότητα διαγραφής αιτημάτων μεταφοράς μέσω νέας μεθόδου στο DAO και στο ViewModel.
- Επεκτάθηκε η οθόνη προβολής αιτημάτων με επιλογή και διαγραφή πολλαπλών αιτημάτων, καθώς και εμφάνιση ημερομηνίας όπου υπάρχει.
- Ενημερώθηκαν τα strings με νέο κείμενο "Διαγραφή επιλεγμένων".

## Δοκιμές
- `./gradlew test` *(αποτυχία: SDK location not found)*


------
https://chatgpt.com/codex/tasks/task_e_688faf1b8dc48328a4599f514aa63ab3