### PR TITLE
Store creator info with transport requests

### DIFF
--- a/app/src/main/java/com/ioannapergamali/mysmartroute/data/local/MovingEntity.kt
+++ b/app/src/main/java/com/ioannapergamali/mysmartroute/data/local/MovingEntity.kt
@@ -2,6 +2,7 @@ package com.ioannapergamali.mysmartroute.data.local
 
 import androidx.room.Entity
 import androidx.room.PrimaryKey
+import androidx.room.Ignore
 
 @Entity(tableName = "movings")
 data class MovingEntity(
@@ -16,4 +17,27 @@ data class MovingEntity(
     val startPoiId: String = "",
     /** Σημείο αποβίβασης */
     val endPoiId: String = ""
-)
+) {
+    @Ignore
+    var createdById: String = ""
+
+    @Ignore
+    var createdByName: String = ""
+
+    constructor(
+        id: String = "",
+        routeId: String = "",
+        userId: String = "",
+        date: Long = 0L,
+        vehicleId: String = "",
+        cost: Double = 0.0,
+        durationMinutes: Int = 0,
+        startPoiId: String = "",
+        endPoiId: String = "",
+        createdById: String = "",
+        createdByName: String = ""
+    ) : this(id, routeId, userId, date, vehicleId, cost, durationMinutes, startPoiId, endPoiId) {
+        this.createdById = createdById
+        this.createdByName = createdByName
+    }
+}

--- a/app/src/main/java/com/ioannapergamali/mysmartroute/utils/FirestoreMappers.kt
+++ b/app/src/main/java/com/ioannapergamali/mysmartroute/utils/FirestoreMappers.kt
@@ -242,6 +242,10 @@ fun MovingEntity.toFirestoreMap(): Map<String, Any> {
     if (vehicleId.isNotEmpty()) {
         map["vehicleId"] = FirebaseFirestore.getInstance().collection("vehicles").document(vehicleId)
     }
+    if (createdById.isNotEmpty()) {
+        map["createdById"] = FirebaseFirestore.getInstance().collection("users").document(createdById)
+        map["createdByName"] = createdByName
+    }
     return map
 }
 
@@ -275,7 +279,25 @@ fun DocumentSnapshot.toMovingEntity(): MovingEntity? {
         is String -> e
         else -> getString("endPoiId")
     } ?: ""
-    return MovingEntity(movingId, routeId, userId, dateVal, vehicleId, costVal, durVal, startPoiId, endPoiId)
+    val createdById = when (val c = get("createdById")) {
+        is DocumentReference -> c.id
+        is String -> c
+        else -> getString("createdById")
+    } ?: ""
+    val createdByName = getString("createdByName") ?: ""
+    return MovingEntity(
+        movingId,
+        routeId,
+        userId,
+        dateVal,
+        vehicleId,
+        costVal,
+        durVal,
+        startPoiId,
+        endPoiId,
+        createdById,
+        createdByName
+    )
 }
 
 fun TransportDeclarationEntity.toFirestoreMap(): Map<String, Any> = mapOf(

--- a/app/src/main/java/com/ioannapergamali/mysmartroute/view/ui/screens/ViewRequestsScreen.kt
+++ b/app/src/main/java/com/ioannapergamali/mysmartroute/view/ui/screens/ViewRequestsScreen.kt
@@ -63,6 +63,7 @@ fun ViewRequestsScreen(navController: NavController, openDrawer: () -> Unit) {
                             val fromName = poiNames[req.startPoiId] ?: ""
                             val toName = poiNames[req.endPoiId] ?: ""
                             Row(modifier = Modifier.padding(vertical = 8.dp)) {
+                                Text(req.createdByName, modifier = Modifier.width(columnWidth))
                                 Text(fromName, modifier = Modifier.width(columnWidth))
                                 Text(toName, modifier = Modifier.width(columnWidth))
                                 val costText = if (req.cost == Double.MAX_VALUE) "∞" else req.cost.toString()

--- a/app/src/main/java/com/ioannapergamali/mysmartroute/viewmodel/VehicleRequestViewModel.kt
+++ b/app/src/main/java/com/ioannapergamali/mysmartroute/viewmodel/VehicleRequestViewModel.kt
@@ -79,11 +79,15 @@ class VehicleRequestViewModel : ViewModel() {
         fromPoiId: String,
         toPoiId: String,
         maxCost: Double,
-        date: Long
+        date: Long,
+        targetUserId: String? = null
     ) {
         viewModelScope.launch {
             val dao = MySmartRouteDatabase.getInstance(context).movingDao()
-            val userId = FirebaseAuth.getInstance().currentUser?.uid ?: ""
+            val creator = FirebaseAuth.getInstance().currentUser
+            val creatorId = creator?.uid ?: ""
+            val creatorName = UserViewModel().getUserName(context, creatorId)
+            val userId = targetUserId ?: creatorId
             val id = UUID.randomUUID().toString()
             val entity = MovingEntity(
                 id = id,
@@ -94,7 +98,9 @@ class VehicleRequestViewModel : ViewModel() {
                 cost = maxCost,
                 durationMinutes = 0,
                 startPoiId = fromPoiId,
-                endPoiId = toPoiId
+                endPoiId = toPoiId,
+                createdById = creatorId,
+                createdByName = creatorName
             )
             dao.insert(entity)
             try {


### PR DESCRIPTION
## Summary
- keep admin id and name inside `MovingEntity` so passengers see the request creator
- map new fields to Firestore and show creator name in request list

## Testing
- `./gradlew test` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_688fb4770eb08328b18bbbbda8f940a2