### PR TITLE
Fix missing request date in passenger menu

### DIFF
--- a/app/src/main/java/com/ioannapergamali/mysmartroute/view/ui/screens/ViewRequestsScreen.kt
+++ b/app/src/main/java/com/ioannapergamali/mysmartroute/view/ui/screens/ViewRequestsScreen.kt
@@ -80,29 +80,29 @@ fun ViewRequestsScreen(navController: NavController, openDrawer: () -> Unit) {
                     }
                 }
                 Spacer(modifier = Modifier.height(8.dp))
-                Row(modifier = Modifier.horizontalScroll(scrollState)) {
-                    LazyColumn {
-                        items(sortedRequests) { req ->
-                            val fromName = poiNames[req.startPoiId] ?: ""
-                            val toName = poiNames[req.endPoiId] ?: ""
-                            val dateText = if (req.date > 0L) {
-                                DateFormat.getDateFormat(context).format(Date(req.date))
-                            } else ""
-                            Row(
-                                modifier = Modifier.padding(vertical = 8.dp),
-                                verticalAlignment = Alignment.CenterVertically
-                            ) {
-                                Text(fromName, modifier = Modifier.width(columnWidth))
-                                Text(toName, modifier = Modifier.width(columnWidth))
-                                val costText = if (req.cost == Double.MAX_VALUE) "∞" else req.cost.toString()
-                                Text(costText, modifier = Modifier.width(columnWidth))
-                                Text(dateText, modifier = Modifier.width(columnWidth))
-                                Button(onClick = { viewModel.deleteRequests(context, setOf(req.id)) }) {
-                                    Text(stringResource(R.string.cancel_request))
-                                }
+                LazyColumn {
+                    items(sortedRequests) { req ->
+                        val fromName = poiNames[req.startPoiId] ?: ""
+                        val toName = poiNames[req.endPoiId] ?: ""
+                        val dateText = if (req.date > 0L) {
+                            DateFormat.getDateFormat(context).format(Date(req.date))
+                        } else ""
+                        Row(
+                            modifier = Modifier
+                                .horizontalScroll(scrollState)
+                                .padding(vertical = 8.dp),
+                            verticalAlignment = Alignment.CenterVertically
+                        ) {
+                            Text(fromName, modifier = Modifier.width(columnWidth))
+                            Text(toName, modifier = Modifier.width(columnWidth))
+                            val costText = if (req.cost == Double.MAX_VALUE) "∞" else req.cost.toString()
+                            Text(costText, modifier = Modifier.width(columnWidth))
+                            Text(dateText, modifier = Modifier.width(columnWidth))
+                            Button(onClick = { viewModel.deleteRequests(context, setOf(req.id)) }) {
+                                Text(stringResource(R.string.cancel_request))
                             }
-                            Divider()
                         }
+                        Divider()
                     }
                 }
             }


### PR DESCRIPTION
## Summary
- enable horizontal scrolling in request rows so the desired date column is visible

## Testing
- `./gradlew test` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_688fc65844fc83288a25554af7dd13d4