### PR TITLE
Fix missing request date in passenger menu

### DIFF
--- a/app/src/main/java/com/ioannapergamali/mysmartroute/view/ui/screens/ViewRequestsScreen.kt
+++ b/app/src/main/java/com/ioannapergamali/mysmartroute/view/ui/screens/ViewRequestsScreen.kt
@@ -82,19 +82,37 @@ fun ViewRequestsScreen(navController: NavController, openDrawer: () -> Unit) {
                 Spacer(modifier = Modifier.height(8.dp))
                 Row(modifier = Modifier.horizontalScroll(scrollState)) {
                     LazyColumn {
+                        item {
+                            Row(verticalAlignment = Alignment.CenterVertically) {
+                                Text(
+                                    stringResource(R.string.route_name),
+                                    modifier = Modifier.width(columnWidth)
+                                )
+                                Text(
+                                    stringResource(R.string.cost),
+                                    modifier = Modifier.width(columnWidth)
+                                )
+                                Text(
+                                    stringResource(R.string.date),
+                                    modifier = Modifier.width(columnWidth)
+                                )
+                            }
+                            Divider()
+                        }
                         items(sortedRequests) { req ->
                             val fromName = poiNames[req.startPoiId] ?: ""
                             val toName = poiNames[req.endPoiId] ?: ""
+                            val routeName = if (fromName.isNotBlank() && toName.isNotBlank())
+                                "$fromName → $toName" else ""
                             val dateText = if (req.date > 0L) {
                                 DateFormat.getDateFormat(context).format(Date(req.date))
                             } else ""
+                            val costText = if (req.cost == Double.MAX_VALUE) "-" else req.cost.toString()
                             Row(
                                 modifier = Modifier.padding(vertical = 8.dp),
-                                verticalAlignment = Alignment.CenterVertically
+                                verticalAlignment = Alignment.CenterVertically,
                             ) {
-                                Text(fromName, modifier = Modifier.width(columnWidth))
-                                Text(toName, modifier = Modifier.width(columnWidth))
-                                val costText = if (req.cost == Double.MAX_VALUE) "∞" else req.cost.toString()
+                                Text(routeName, modifier = Modifier.width(columnWidth))
                                 Text(costText, modifier = Modifier.width(columnWidth))
                                 Text(dateText, modifier = Modifier.width(columnWidth))
                                 Button(onClick = { viewModel.deleteRequests(context, setOf(req.id)) }) {
@@ -109,3 +127,4 @@ fun ViewRequestsScreen(navController: NavController, openDrawer: () -> Unit) {
         }
     }
 }
+


### PR DESCRIPTION
## Summary
- προσθήκη κεφαλίδας με Διαδρομή, Κόστος και Ημερομηνία
- εμφάνιση της διαδρομής με βέλος και του κόστους για κάθε αίτημα

## Testing
- `./gradlew test` *(αποτυχία: δεν βρέθηκε το Android SDK)*


------
https://chatgpt.com/codex/tasks/task_e_688fc65844fc83288a25554af7dd13d4