### PR TITLE
Διόρθωση ViewRequestsScreen

### DIFF
--- a/app/src/main/java/com/ioannapergamali/mysmartroute/view/ui/screens/ViewRequestsScreen.kt
+++ b/app/src/main/java/com/ioannapergamali/mysmartroute/view/ui/screens/ViewRequestsScreen.kt
@@ -80,9 +80,47 @@ fun ViewRequestsScreen(navController: NavController, openDrawer: () -> Unit) {
                     }
                 }
                 Spacer(modifier = Modifier.height(8.dp))
-           }
+                Row(modifier = Modifier.horizontalScroll(scrollState)) {
+                    LazyColumn {
+                        item {
+                            Row(verticalAlignment = Alignment.CenterVertically) {
+                                Text(
+                                    stringResource(R.string.route_name),
+                                    modifier = Modifier.width(columnWidth)
+                                )
+                                Text(
+                                    stringResource(R.string.cost),
+                                    modifier = Modifier.width(columnWidth)
+                                )
+                                Text(
+                                    stringResource(R.string.date),
+                                    modifier = Modifier.width(columnWidth)
+                                )
+                            }
+                            Divider()
                         }
-                        Divider()
+                        items(sortedRequests) { req ->
+                            val fromName = poiNames[req.startPoiId] ?: ""
+                            val toName = poiNames[req.endPoiId] ?: ""
+                            val routeName = if (fromName.isNotBlank() && toName.isNotBlank())
+                                "$fromName → $toName" else ""
+                            val dateText = if (req.date > 0L) {
+                                DateFormat.getDateFormat(context).format(Date(req.date))
+                            } else ""
+                            val costText = if (req.cost == Double.MAX_VALUE) "-" else req.cost.toString()
+                            Row(
+                                modifier = Modifier.padding(vertical = 8.dp),
+                                verticalAlignment = Alignment.CenterVertically,
+                            ) {
+                                Text(routeName, modifier = Modifier.width(columnWidth))
+                                Text(costText, modifier = Modifier.width(columnWidth))
+                                Text(dateText, modifier = Modifier.width(columnWidth))
+                                Button(onClick = { viewModel.deleteRequests(context, setOf(req.id)) }) {
+                                    Text(stringResource(R.string.cancel_request))
+                                }
+                            }
+                            Divider()
+                        }
                     }
                 }
             }


### PR DESCRIPTION
## Περίληψη
- Επαναφορά του ViewRequestsScreen ώστε να εμφανίζει σωστά τις αιτήσεις με ταξινόμηση, ονόματα διαδρομής, κόστος και ημερομηνία.

## Έλεγχοι
- `./gradlew test` *(αποτυχία: δεν βρέθηκε Android SDK)*

------
https://chatgpt.com/codex/tasks/task_e_6890dff2df648328a80921b13862b1a0