### PR TITLE
fix: avoid nested scroll in PrintTicketScreen

### DIFF
--- a/app/src/main/java/com/ioannapergamali/mysmartroute/view/ui/screens/PrintTicketScreen.kt
+++ b/app/src/main/java/com/ioannapergamali/mysmartroute/view/ui/screens/PrintTicketScreen.kt
@@ -49,7 +49,7 @@ fun PrintTicketScreen(navController: NavController, openDrawer: () -> Unit) {
             )
         }
     ) { paddingValues ->
-        ScreenContainer(modifier = Modifier.padding(paddingValues)) {
+        ScreenContainer(modifier = Modifier.padding(paddingValues), scrollable = false) {
             if (reservations.isEmpty()) {
                 Text(text = stringResource(R.string.no_reservations))
             } else {


### PR DESCRIPTION
## Summary
- prevent nested vertical scroll by disabling ScreenContainer scrollable in PrintTicketScreen

## Testing
- `./gradlew test` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_6890e8997340832883e4ec748636fa98