### PR TITLE
Add passenger bookings view

### DIFF
--- a/app/src/main/java/com/ioannapergamali/mysmartroute/model/navigation/NavigationHost.kt
+++ b/app/src/main/java/com/ioannapergamali/mysmartroute/model/navigation/NavigationHost.kt
@@ -32,6 +32,7 @@ import com.ioannapergamali.mysmartroute.view.ui.screens.ManageFavoritesScreen
 import com.ioannapergamali.mysmartroute.view.ui.screens.PrintCompletedScreen
 import com.ioannapergamali.mysmartroute.view.ui.screens.PrintListScreen
 import com.ioannapergamali.mysmartroute.view.ui.screens.PrintScheduledScreen
+import com.ioannapergamali.mysmartroute.view.ui.screens.PrintTicketScreen
 import com.ioannapergamali.mysmartroute.view.ui.screens.PrepareCompleteRouteScreen
 import com.ioannapergamali.mysmartroute.view.ui.screens.ViewVehiclesScreen
 import com.ioannapergamali.mysmartroute.view.ui.screens.ViewTransportRequestsScreen
@@ -222,6 +223,10 @@ fun NavigationHost(navController : NavHostController, openDrawer: () -> Unit) {
 
         composable("viewRequests") {
             ViewRequestsScreen(navController = navController, openDrawer = openDrawer)
+        }
+
+        composable("printTicket") {
+            PrintTicketScreen(navController = navController, openDrawer = openDrawer)
         }
 
         composable("printList") {

--- a/app/src/main/java/com/ioannapergamali/mysmartroute/view/ui/screens/PrintTicketScreen.kt
+++ b/app/src/main/java/com/ioannapergamali/mysmartroute/view/ui/screens/PrintTicketScreen.kt
@@ -1,0 +1,97 @@
+package com.ioannapergamali.mysmartroute.view.ui.screens
+
+import androidx.compose.foundation.horizontalScroll
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.lazy.items
+import androidx.compose.foundation.rememberScrollState
+import androidx.compose.material3.Card
+import androidx.compose.material3.CardDefaults
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Scaffold
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.collectAsState
+import androidx.compose.runtime.getValue
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.unit.dp
+import androidx.lifecycle.viewmodel.compose.viewModel
+import androidx.navigation.NavController
+import com.ioannapergamali.mysmartroute.R
+import com.ioannapergamali.mysmartroute.view.ui.components.ScreenContainer
+import com.ioannapergamali.mysmartroute.view.ui.components.TopBar
+import com.ioannapergamali.mysmartroute.viewmodel.UserReservationsViewModel
+import java.text.SimpleDateFormat
+import java.util.Date
+import java.util.Locale
+
+@Composable
+fun PrintTicketScreen(navController: NavController, openDrawer: () -> Unit) {
+    val viewModel: UserReservationsViewModel = viewModel()
+    val reservations by viewModel.reservations.collectAsState()
+    val context = LocalContext.current
+
+    LaunchedEffect(Unit) {
+        viewModel.load(context)
+    }
+
+    Scaffold(
+        topBar = {
+            TopBar(
+                title = stringResource(R.string.print_ticket),
+                navController = navController,
+                showMenu = true,
+                onMenuClick = openDrawer
+            )
+        }
+    ) { paddingValues ->
+        ScreenContainer(modifier = Modifier.padding(paddingValues)) {
+            if (reservations.isEmpty()) {
+                Text(text = stringResource(R.string.no_reservations))
+            } else {
+                LazyColumn(modifier = Modifier.fillMaxWidth()) {
+                    items(reservations) { res ->
+                        ReservationItem(res)
+                        Spacer(modifier = Modifier.height(8.dp))
+                    }
+                }
+            }
+        }
+    }
+}
+
+@Composable
+private fun ReservationItem(reservation: UserReservationsViewModel.ReservationInfo) {
+    val formatter = SimpleDateFormat("dd/MM/yyyy", Locale.getDefault())
+    val dateText = formatter.format(Date(reservation.date))
+    Card(
+        modifier = Modifier.fillMaxWidth(),
+        colors = CardDefaults.cardColors(containerColor = MaterialTheme.colorScheme.surface),
+        elevation = CardDefaults.cardElevation(defaultElevation = 2.dp)
+    ) {
+        Row(
+            modifier = Modifier
+                .horizontalScroll(rememberScrollState())
+                .padding(16.dp)
+        ) {
+            Text(text = "Επιβάτης: ${reservation.passengerName}")
+            Spacer(modifier = Modifier.width(16.dp))
+            Text(text = "Οδηγός: ${reservation.driverName}")
+            Spacer(modifier = Modifier.width(16.dp))
+            Text(text = "Διαδρομή: ${reservation.routeName}")
+            Spacer(modifier = Modifier.width(16.dp))
+            Text(text = "Ημ/νία: $dateText")
+            Spacer(modifier = Modifier.width(16.dp))
+            Text(text = "Κόστος: ${reservation.cost}€")
+        }
+    }
+}
+

--- a/app/src/main/java/com/ioannapergamali/mysmartroute/viewmodel/UserReservationsViewModel.kt
+++ b/app/src/main/java/com/ioannapergamali/mysmartroute/viewmodel/UserReservationsViewModel.kt
@@ -1,0 +1,83 @@
+package com.ioannapergamali.mysmartroute.viewmodel
+
+import android.content.Context
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.viewModelScope
+import com.google.firebase.auth.FirebaseAuth
+import com.google.firebase.firestore.FirebaseFirestore
+import com.ioannapergamali.mysmartroute.data.local.MySmartRouteDatabase
+import com.ioannapergamali.mysmartroute.data.local.SeatReservationEntity
+import com.ioannapergamali.mysmartroute.utils.NetworkUtils
+import com.ioannapergamali.mysmartroute.utils.toSeatReservationEntity
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.first
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.tasks.await
+
+/**
+ * ViewModel που φορτώνει τις κρατήσεις του τρέχοντος επιβάτη.
+ */
+class UserReservationsViewModel : ViewModel() {
+    private val db = FirebaseFirestore.getInstance()
+    private val auth = FirebaseAuth.getInstance()
+
+    /** Πληροφορίες που χρειάζονται για την εμφάνιση μιας κράτησης. */
+    data class ReservationInfo(
+        val passengerName: String,
+        val driverName: String,
+        val routeName: String,
+        val date: Long,
+        val cost: Double
+    )
+
+    private val _reservations = MutableStateFlow<List<ReservationInfo>>(emptyList())
+    val reservations: StateFlow<List<ReservationInfo>> = _reservations
+
+    fun load(context: Context) {
+        viewModelScope.launch {
+            val userId = auth.currentUser?.uid ?: return@launch
+            val dbLocal = MySmartRouteDatabase.getInstance(context)
+            buildReservationInfo(dbLocal, userId)
+
+            if (NetworkUtils.isInternetAvailable(context)) {
+                val userRef = db.collection("users").document(userId)
+                val remote = db.collection("seat_reservations")
+                    .whereEqualTo("userId", userRef)
+                    .get()
+                    .await()
+                val list = remote.documents.mapNotNull { it.toSeatReservationEntity() }
+                if (list.isNotEmpty()) {
+                    val dao = dbLocal.seatReservationDao()
+                    list.forEach { dao.insert(it) }
+                    buildReservationInfo(dbLocal, userId)
+                }
+            }
+        }
+    }
+
+    private suspend fun buildReservationInfo(
+        dbLocal: MySmartRouteDatabase,
+        userId: String
+    ) {
+        val seatDao = dbLocal.seatReservationDao()
+        val declarations = dbLocal.transportDeclarationDao().getAll().first()
+        val routes = dbLocal.routeDao().getAll().first()
+        val users = dbLocal.userDao().getAllUsers().first()
+
+        val passenger = users.find { it.id == userId }
+        _reservations.value = seatDao.getReservationsForUser(userId).first().map { res ->
+            val declaration = declarations.find { it.id == res.declarationId }
+            val driver = users.find { it.id == declaration?.driverId }
+            val route = routes.find { it.id == res.routeId }
+            ReservationInfo(
+                passengerName = listOfNotNull(passenger?.name, passenger?.surname).joinToString(" "),
+                driverName = listOfNotNull(driver?.name, driver?.surname).joinToString(" "),
+                routeName = route?.name ?: res.routeId,
+                date = res.date,
+                cost = declaration?.cost ?: 0.0
+            )
+        }
+    }
+}
+


### PR DESCRIPTION
## Summary
- add navigation route for passenger booking print screen
- show list of user seat reservations with passenger, driver, route, date, cost
- load reservations for current user from Firestore/local database

## Testing
- `./gradlew test` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_688fca9ce8308328ab4bd52dc23e316d