### PR TITLE
Διόρθωση ροής κρατήσεων χρήστη

### DIFF
--- a/app/src/main/java/com/ioannapergamali/mysmartroute/viewmodel/UserReservationsViewModel.kt
+++ b/app/src/main/java/com/ioannapergamali/mysmartroute/viewmodel/UserReservationsViewModel.kt
@@ -22,11 +22,14 @@ class UserReservationsViewModel : ViewModel() {
     private val db = FirebaseFirestore.getInstance()
     private val auth = FirebaseAuth.getInstance()
 
+    private val _reservations = MutableStateFlow<List<SeatReservationEntity>>(emptyList())
+    val reservations: StateFlow<List<SeatReservationEntity>> = _reservations
 
     fun load(context: Context) {
         viewModelScope.launch {
             val userId = auth.currentUser?.uid ?: return@launch
-
+            val dao = MySmartRouteDatabase.getInstance(context).seatReservationDao()
+            _reservations.value = dao.getReservationsForUser(userId).first()
 
             if (NetworkUtils.isInternetAvailable(context)) {
                 val userRef = db.collection("users").document(userId)
@@ -36,6 +39,11 @@ class UserReservationsViewModel : ViewModel() {
                     .await()
                 val list = remote.documents.mapNotNull { it.toSeatReservationEntity() }
                 if (list.isNotEmpty()) {
-
+                    _reservations.value = list
+                    list.forEach { dao.insert(it) }
+                }
+            }
+        }
+    }
 }
 


### PR DESCRIPTION
## Σύνοψη
- Προστέθηκε ροή `reservations` στο `UserReservationsViewModel`
- Φόρτωση κρατήσεων από τοπική βάση και Firestore

## Έλεγχοι
- `./gradlew test` (αποτυχία: SDK location not found)


------
https://chatgpt.com/codex/tasks/task_e_6890f53adee083289605781b24d9d1ba