### PR TITLE
Διόρθωση συντακτικού λάθους στο PrintTicketScreen

### DIFF
--- a/app/src/main/java/com/ioannapergamali/mysmartroute/view/ui/screens/PrintTicketScreen.kt
+++ b/app/src/main/java/com/ioannapergamali/mysmartroute/view/ui/screens/PrintTicketScreen.kt
@@ -63,7 +63,6 @@ fun PrintTicketScreen(navController: NavController, openDrawer: () -> Unit) {
             }
         }
     }
-}
 
 @Composable
 fun ReservationItem(reservation: SeatReservationEntity) {


### PR DESCRIPTION
## Περίληψη
- Αφαίρεση περιττής αγκύλης στο `PrintTicketScreen` για σωστή σύνταξη Kotlin.

## Δοκιμές
- `./gradlew test` *(αποτυχημένη προσπάθεια: Starting a Gradle Daemon, 1 busy Daemon could not be reused)*

------
https://chatgpt.com/codex/tasks/task_e_6890f6e4052883289fc00ca3bd37313e