### PR TITLE
Διόρθωση padding στην οθόνη εκτύπωσης

### DIFF
--- a/app/src/main/java/com/ioannapergamali/mysmartroute/view/ui/screens/PrintTicketScreen.kt
+++ b/app/src/main/java/com/ioannapergamali/mysmartroute/view/ui/screens/PrintTicketScreen.kt
@@ -50,15 +50,20 @@ fun PrintTicketScreen(navController: NavController, openDrawer: () -> Unit) {
             )
         }
     ) { paddingValues ->
-
-            if (reservations.isEmpty()) {
-                Text(text = stringResource(R.string.no_reservations))
-            } else {
-                LazyColumn(modifier = Modifier.fillMaxWidth()) {
-                    items(reservations) { res ->
-                        ReservationItem(res)
-                        Spacer(modifier = Modifier.height(8.dp))
-                    }
+        if (reservations.isEmpty()) {
+            Text(
+                text = stringResource(R.string.no_reservations),
+                modifier = Modifier.padding(paddingValues)
+            )
+        } else {
+            LazyColumn(
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .padding(paddingValues)
+            ) {
+                items(reservations) { res ->
+                    ReservationItem(res)
+                    Spacer(modifier = Modifier.height(8.dp))
                 }
             }
         }


### PR DESCRIPTION
## Περίληψη
- Προσθήκη του `Modifier.padding(paddingValues)` στην οθόνη εκτύπωσης εισιτηρίων για να μην αλληλοκαλύπτεται το περιεχόμενο από τον τίτλο.

## Έλεγχοι
- `./gradlew test` (αποτυχία: SDK location not found)


------
https://chatgpt.com/codex/tasks/task_e_6890fbf16d5c8328b45d72730654e63f