### PR TITLE
Προσθήκη οθόνης λεπτομερειών κράτησης

### DIFF
--- a/app/src/main/java/com/ioannapergamali/mysmartroute/model/navigation/NavigationHost.kt
+++ b/app/src/main/java/com/ioannapergamali/mysmartroute/model/navigation/NavigationHost.kt
@@ -43,6 +43,7 @@ import com.ioannapergamali.mysmartroute.view.ui.screens.ViewRoutesScreen
 import com.ioannapergamali.mysmartroute.view.ui.screens.SelectRoutePoisScreen
 import com.ioannapergamali.mysmartroute.view.ui.screens.AvailableTransportsScreen
 import com.ioannapergamali.mysmartroute.view.ui.screens.NotificationsScreen
+import com.ioannapergamali.mysmartroute.view.ui.screens.ReservationDetailsScreen
 import com.ioannapergamali.mysmartroute.R
 
 
@@ -227,6 +228,14 @@ fun NavigationHost(navController : NavHostController, openDrawer: () -> Unit) {
 
         composable("printTicket") {
             PrintTicketScreen(navController = navController, openDrawer = openDrawer)
+        }
+
+        composable(
+            route = "reservationDetails/{reservation}",
+            arguments = listOf(navArgument("reservation") { defaultValue = "" })
+        ) { backStackEntry ->
+            val reservationJson = backStackEntry.arguments?.getString("reservation")
+            ReservationDetailsScreen(navController = navController, reservationJson = reservationJson)
         }
 
         composable("printList") {

--- a/app/src/main/java/com/ioannapergamali/mysmartroute/view/ui/screens/PrintTicketScreen.kt
+++ b/app/src/main/java/com/ioannapergamali/mysmartroute/view/ui/screens/PrintTicketScreen.kt
@@ -1,5 +1,7 @@
 package com.ioannapergamali.mysmartroute.view.ui.screens
 
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
@@ -7,8 +9,12 @@ import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.items
 
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.Info
 import androidx.compose.material3.Card
 import androidx.compose.material3.CardDefaults
+import androidx.compose.material3.Icon
+import androidx.compose.material3.IconButton
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Scaffold
 import androidx.compose.material3.Text
@@ -22,6 +28,8 @@ import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.unit.dp
 import androidx.lifecycle.viewmodel.compose.viewModel
 import androidx.navigation.NavController
+import android.net.Uri
+import com.google.gson.Gson
 import com.ioannapergamali.mysmartroute.R
 import com.ioannapergamali.mysmartroute.view.ui.components.TopBar
 import com.ioannapergamali.mysmartroute.data.local.SeatReservationEntity
@@ -62,7 +70,7 @@ fun PrintTicketScreen(navController: NavController, openDrawer: () -> Unit) {
                     .padding(paddingValues)
             ) {
                 items(reservations) { res ->
-                    ReservationItem(res)
+                    ReservationItem(res, navController)
                     Spacer(modifier = Modifier.height(8.dp))
                 }
             }
@@ -71,7 +79,7 @@ fun PrintTicketScreen(navController: NavController, openDrawer: () -> Unit) {
 }
 
 @Composable
-fun ReservationItem(reservation: SeatReservationEntity) {
+fun ReservationItem(reservation: SeatReservationEntity, navController: NavController) {
     val formatter = SimpleDateFormat("dd/MM/yyyy", Locale.getDefault())
     val dateText = formatter.format(Date(reservation.date))
     Card(
@@ -79,10 +87,20 @@ fun ReservationItem(reservation: SeatReservationEntity) {
         colors = CardDefaults.cardColors(containerColor = MaterialTheme.colorScheme.surface),
         elevation = CardDefaults.cardElevation(defaultElevation = 2.dp)
     ) {
-        Text(
-            text = dateText,
-            modifier = Modifier.padding(16.dp)
-        )
+        Row(
+            modifier = Modifier
+                .fillMaxWidth()
+                .padding(16.dp),
+            horizontalArrangement = Arrangement.SpaceBetween
+        ) {
+            Text(text = dateText)
+            IconButton(onClick = {
+                val json = Uri.encode(Gson().toJson(reservation))
+                navController.navigate("reservationDetails/$json")
+            }) {
+                Icon(Icons.Filled.Info, contentDescription = stringResource(R.string.view_details))
+            }
+        }
     }
 }
 

--- a/app/src/main/java/com/ioannapergamali/mysmartroute/view/ui/screens/ReservationDetailsScreen.kt
+++ b/app/src/main/java/com/ioannapergamali/mysmartroute/view/ui/screens/ReservationDetailsScreen.kt
@@ -1,0 +1,55 @@
+package com.ioannapergamali.mysmartroute.view.ui.screens
+
+import android.net.Uri
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.padding
+import androidx.compose.material3.Scaffold
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.remember
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.unit.dp
+import androidx.navigation.NavController
+import com.google.gson.Gson
+import com.ioannapergamali.mysmartroute.R
+import com.ioannapergamali.mysmartroute.data.local.SeatReservationEntity
+import com.ioannapergamali.mysmartroute.view.ui.components.TopBar
+import java.text.SimpleDateFormat
+import java.util.Date
+import java.util.Locale
+
+@Composable
+fun ReservationDetailsScreen(
+    navController: NavController,
+    reservationJson: String?
+) {
+    val reservation = remember(reservationJson) {
+        reservationJson?.let {
+            Gson().fromJson(Uri.decode(it), SeatReservationEntity::class.java)
+        }
+    }
+
+    Scaffold(
+        topBar = {
+            TopBar(
+                title = stringResource(R.string.reservation_details),
+                navController = navController,
+                showMenu = false
+            )
+        }
+    ) { paddingValues ->
+        reservation?.let { res ->
+            val formatter = SimpleDateFormat("dd/MM/yyyy", Locale.getDefault())
+            Column(Modifier.padding(paddingValues).padding(16.dp)) {
+                Text("${stringResource(R.string.date)}: ${formatter.format(Date(res.date))}")
+                Text("${stringResource(R.string.route)}: ${res.routeId}")
+                Text("${stringResource(R.string.start_point)}: ${res.startPoiId}")
+                Text("${stringResource(R.string.destination)}: ${res.endPoiId}")
+            }
+        } ?: Text(
+            text = stringResource(R.string.no_reservation_found),
+            modifier = Modifier.padding(paddingValues).padding(16.dp)
+        )
+    }
+}

--- a/app/src/main/res/values-el/strings.xml
+++ b/app/src/main/res/values-el/strings.xml
@@ -180,5 +180,8 @@
     <string name="find_now">Εύρεση τώρα</string>
     <string name="save_request">Αποθήκευση αιτήματος</string>
     <string name="departure_date">Επιθυμητή ημερομηνία</string>
+    <string name="view_details">Προβολή λεπτομερειών</string>
+    <string name="reservation_details">Λεπτομέρειες κράτησης</string>
+    <string name="no_reservation_found">Δεν βρέθηκε η κράτηση</string>
 
 </resources>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -193,4 +193,7 @@
     <string name="save_request">Save request</string>
     <string name="available_transports">Available transports</string>
     <string name="no_transports_found">No transports found</string>
+    <string name="view_details">View details</string>
+    <string name="reservation_details">Reservation details</string>
+    <string name="no_reservation_found">No reservation found</string>
 </resources>


### PR DESCRIPTION
## Σύνοψη
- Προσθήκη εικονιδίου σε κάθε κράτηση για εμφάνιση λεπτομερειών
- Νέα οθόνη `ReservationDetailsScreen`
- Ενημέρωση πλοήγησης και κειμένων

## Έλεγχοι
- `./gradlew test` απέτυχε: SDK location not found


------
https://chatgpt.com/codex/tasks/task_e_68910260af508328a1b9a6607efb62c7