### PR TITLE
Εμφάνιση πλήρων λεπτομερειών κράτησης

### DIFF
--- a/app/src/main/java/com/ioannapergamali/mysmartroute/data/local/RouteDao.kt
+++ b/app/src/main/java/com/ioannapergamali/mysmartroute/data/local/RouteDao.kt
@@ -18,4 +18,7 @@ interface RouteDao {
 
     @Query("SELECT * FROM routes WHERE name = :name LIMIT 1")
     suspend fun findByName(name: String): RouteEntity?
+
+    @Query("SELECT * FROM routes WHERE id = :id LIMIT 1")
+    suspend fun findById(id: String): RouteEntity?
 }

--- a/app/src/main/java/com/ioannapergamali/mysmartroute/data/local/TransportDeclarationDao.kt
+++ b/app/src/main/java/com/ioannapergamali/mysmartroute/data/local/TransportDeclarationDao.kt
@@ -13,4 +13,7 @@ interface TransportDeclarationDao {
 
     @Query("SELECT * FROM transport_declarations")
     fun getAll(): Flow<List<TransportDeclarationEntity>>
+
+    @Query("SELECT * FROM transport_declarations WHERE id = :id LIMIT 1")
+    suspend fun getById(id: String): TransportDeclarationEntity?
 }

--- a/app/src/main/java/com/ioannapergamali/mysmartroute/view/ui/screens/ReservationDetailsScreen.kt
+++ b/app/src/main/java/com/ioannapergamali/mysmartroute/view/ui/screens/ReservationDetailsScreen.kt
@@ -5,14 +5,15 @@ import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.padding
 import androidx.compose.material3.Scaffold
 import androidx.compose.material3.Text
-import androidx.compose.runtime.Composable
-import androidx.compose.runtime.remember
+import androidx.compose.runtime.*
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.unit.dp
 import androidx.navigation.NavController
 import com.google.gson.Gson
 import com.ioannapergamali.mysmartroute.R
+import com.ioannapergamali.mysmartroute.data.local.MySmartRouteDatabase
 import com.ioannapergamali.mysmartroute.data.local.SeatReservationEntity
 import com.ioannapergamali.mysmartroute.view.ui.components.TopBar
 import java.text.SimpleDateFormat
@@ -30,6 +31,29 @@ fun ReservationDetailsScreen(
         }
     }
 
+    val context = LocalContext.current
+    var routeName by remember { mutableStateOf("") }
+    var startPoiName by remember { mutableStateOf("") }
+    var endPoiName by remember { mutableStateOf("") }
+    var driverName by remember { mutableStateOf("") }
+    var passengerName by remember { mutableStateOf("") }
+    var cost by remember { mutableStateOf<Double?>(null) }
+
+    LaunchedEffect(reservation) {
+        reservation?.let { res ->
+            val db = MySmartRouteDatabase.getInstance(context)
+            routeName = db.routeDao().findById(res.routeId)?.name ?: res.routeId
+            startPoiName = db.poIDao().findById(res.startPoiId)?.name ?: res.startPoiId
+            endPoiName = db.poIDao().findById(res.endPoiId)?.name ?: res.endPoiId
+            val decl = db.transportDeclarationDao().getById(res.declarationId)
+            cost = decl?.cost
+            driverName = decl?.driverId?.let { db.userDao().getUser(it) }
+                ?.let { "${it.name} ${it.surname}" } ?: decl?.driverId.orEmpty()
+            passengerName = db.userDao().getUser(res.userId)
+                ?.let { "${it.name} ${it.surname}" } ?: res.userId
+        }
+    }
+
     Scaffold(
         topBar = {
             TopBar(
@@ -43,9 +67,12 @@ fun ReservationDetailsScreen(
             val formatter = SimpleDateFormat("dd/MM/yyyy", Locale.getDefault())
             Column(Modifier.padding(paddingValues).padding(16.dp)) {
                 Text("${stringResource(R.string.date)}: ${formatter.format(Date(res.date))}")
-                Text("${stringResource(R.string.route)}: ${res.routeId}")
-                Text("${stringResource(R.string.start_point)}: ${res.startPoiId}")
-                Text("${stringResource(R.string.destination)}: ${res.endPoiId}")
+                Text("${stringResource(R.string.route)}: $routeName")
+                Text("${stringResource(R.string.start_point)}: $startPoiName")
+                Text("${stringResource(R.string.destination)}: $endPoiName")
+                Text("${stringResource(R.string.driver)}: $driverName")
+                cost?.let { Text("${stringResource(R.string.cost)}: $it") }
+                Text("${stringResource(R.string.passenger)}: $passengerName")
             }
         } ?: Text(
             text = stringResource(R.string.no_reservation_found),


### PR DESCRIPTION
## Περίληψη
- Ανάκτηση διαδρομής με id για εμφάνιση ονόματος
- Εύρεση δήλωσης μεταφοράς από id για κόστος και οδηγό
- Προσθήκη στοιχείων ονόματος διαδρομής, POI, οδηγού, κόστους και επιβάτη στην οθόνη λεπτομερειών κράτησης

## Δοκιμές
- `./gradlew test` *(απέτυχε: η διεργασία δεν ολοκληρώθηκε)*
- `./gradlew help`


------
https://chatgpt.com/codex/tasks/task_e_689106114af88328a3ab6dc81da18d33