### PR TITLE
Add driver option to print transport declarations

### DIFF
--- a/app/src/main/assets/menus.json
+++ b/app/src/main/assets/menus.json
@@ -33,6 +33,7 @@
           {"titleKey": "register_vehicle", "route": "registerVehicle"},
           {"titleKey": "declare_route", "route": "declareRoute"},
           {"titleKey": "announce_availability", "route": "announceAvailability"},
+          {"titleKey": "print_declarations", "route": "printDeclarations"},
           {"titleKey": "find_passengers", "route": "findPassengers"},
           {"titleKey": "print_list", "route": "printList"},
           {"titleKey": "print_scheduled", "route": "printScheduled"},

--- a/app/src/main/java/com/ioannapergamali/mysmartroute/model/navigation/NavigationHost.kt
+++ b/app/src/main/java/com/ioannapergamali/mysmartroute/model/navigation/NavigationHost.kt
@@ -32,6 +32,7 @@ import com.ioannapergamali.mysmartroute.view.ui.screens.ManageFavoritesScreen
 import com.ioannapergamali.mysmartroute.view.ui.screens.PrintCompletedScreen
 import com.ioannapergamali.mysmartroute.view.ui.screens.PrintListScreen
 import com.ioannapergamali.mysmartroute.view.ui.screens.PrintScheduledScreen
+import com.ioannapergamali.mysmartroute.view.ui.screens.PrintDeclarationsScreen
 import com.ioannapergamali.mysmartroute.view.ui.screens.PrintTicketScreen
 import com.ioannapergamali.mysmartroute.view.ui.screens.PrepareCompleteRouteScreen
 import com.ioannapergamali.mysmartroute.view.ui.screens.ViewVehiclesScreen
@@ -248,6 +249,10 @@ fun NavigationHost(navController : NavHostController, openDrawer: () -> Unit) {
 
         composable("printCompleted") {
             PrintCompletedScreen(navController = navController, openDrawer = openDrawer)
+        }
+
+        composable("printDeclarations") {
+            PrintDeclarationsScreen(navController = navController, openDrawer = openDrawer)
         }
 
         composable("prepareCompleteRoute") {

--- a/app/src/main/java/com/ioannapergamali/mysmartroute/view/ui/screens/PrintDeclarationsScreen.kt
+++ b/app/src/main/java/com/ioannapergamali/mysmartroute/view/ui/screens/PrintDeclarationsScreen.kt
@@ -1,0 +1,94 @@
+package com.ioannapergamali.mysmartroute.view.ui.screens
+
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.lazy.items
+import androidx.compose.material3.Card
+import androidx.compose.material3.CardDefaults
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Scaffold
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.collectAsState
+import androidx.compose.runtime.getValue
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.unit.dp
+import androidx.lifecycle.viewmodel.compose.viewModel
+import androidx.navigation.NavController
+import com.ioannapergamali.mysmartroute.R
+import com.ioannapergamali.mysmartroute.data.local.TransportDeclarationEntity
+import com.ioannapergamali.mysmartroute.view.ui.components.TopBar
+import com.ioannapergamali.mysmartroute.viewmodel.TransportDeclarationViewModel
+import java.text.SimpleDateFormat
+import java.util.Date
+import java.util.Locale
+
+@Composable
+fun PrintDeclarationsScreen(navController: NavController, openDrawer: () -> Unit) {
+    val viewModel: TransportDeclarationViewModel = viewModel()
+    val declarations by viewModel.declarations.collectAsState()
+    val context = LocalContext.current
+
+    LaunchedEffect(Unit) {
+        viewModel.loadDeclarations(context)
+    }
+
+    Scaffold(
+        topBar = {
+            TopBar(
+                title = stringResource(R.string.print_declarations),
+                navController = navController,
+                showMenu = true,
+                onMenuClick = openDrawer
+            )
+        }
+    ) { paddingValues ->
+        if (declarations.isEmpty()) {
+            Text(
+                text = stringResource(R.string.no_declarations),
+                modifier = Modifier.padding(paddingValues)
+            )
+        } else {
+            LazyColumn(
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .padding(paddingValues)
+            ) {
+                items(declarations) { decl ->
+                    DeclarationItem(decl)
+                    Spacer(modifier = Modifier.height(8.dp))
+                }
+            }
+        }
+    }
+}
+
+@Composable
+private fun DeclarationItem(declaration: TransportDeclarationEntity) {
+    val formatter = SimpleDateFormat("dd/MM/yyyy", Locale.getDefault())
+    val dateText = formatter.format(Date(declaration.date))
+    Card(
+        modifier = Modifier.fillMaxWidth(),
+        colors = CardDefaults.cardColors(containerColor = MaterialTheme.colorScheme.surface),
+        elevation = CardDefaults.cardElevation(defaultElevation = 2.dp)
+    ) {
+        Column(
+            modifier = Modifier
+                .fillMaxWidth()
+                .padding(16.dp),
+            verticalArrangement = Arrangement.spacedBy(4.dp)
+        ) {
+            Text(text = "${stringResource(R.string.route)}: ${declaration.routeId}")
+            Text(text = "${stringResource(R.string.vehicle_type)}: ${declaration.vehicleType}")
+            Text(text = "${stringResource(R.string.date)}: $dateText")
+        }
+    }
+}

--- a/app/src/main/res/values-el/strings.xml
+++ b/app/src/main/res/values-el/strings.xml
@@ -84,6 +84,7 @@
     <string name="print_list">Εκτύπωση λίστας επιβατών</string>
     <string name="print_scheduled">Εκτύπωση λίστας για προγραμματισμένες μεταφορές</string>
     <string name="print_completed">Εκτύπωση λίστας για ολοκληρωμένες μεταφορές</string>
+    <string name="print_declarations">Εκτύπωση δηλώσεων διαθεσιμότητας</string>
     <string name="prepare_complete_route">Προετοιμασία ολοκλήρωσης διαδρομής</string>
     <string name="init_system">Αρχικοποίηση συστήματος</string>
     <string name="create_user">Δημιουργία λογαριασμού χρήστη</string>
@@ -165,6 +166,7 @@
     <string name="delete_selected">Διαγραφή επιλεγμένων</string>
     <string name="clear_selection">Καθαρισμός επιλογής</string>
     <string name="no_reservations">Δεν βρέθηκαν κρατήσεις</string>
+    <string name="no_declarations">Δεν βρέθηκαν δηλώσεις</string>
     <string name="max_cost">Μέγιστο κόστος</string>
     <string name="request_sent">Το αίτημα καταχωρήθηκε</string>
     <string name="view_requests">Προβολή αιτημάτων</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -81,6 +81,7 @@
     <string name="print_list">Print Passenger List</string>
     <string name="print_scheduled">Print Passenger List for Scheduled Transports</string>
     <string name="print_completed">Print Passenger List for Completed Transports</string>
+    <string name="print_declarations">Print Transport Declarations</string>
     <string name="vehicle_type">Vehicle type</string>
     <string name="prepare_complete_route">Prepare Route Completion</string>
     <string name="init_system">Initialize System</string>
@@ -177,6 +178,7 @@
     <string name="delete_favorite">Delete</string>
     <string name="delete_selected">Delete selected</string>
     <string name="no_reservations">No reservations found</string>
+    <string name="no_declarations">No declarations found</string>
     <string name="max_cost">Maximum cost</string>
     <string name="request_sent">Request saved</string>
     <string name="view_requests">View Requests</string>


### PR DESCRIPTION
## Summary
- add `print_declarations` entry in driver menu and navigation
- implement simple `PrintDeclarationsScreen` to list availability declarations
- provide English/Greek strings for the new option

## Testing
- `./gradlew test` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_68910cd021988328a56282c54a71c314