### PR TITLE
Εμφάνιση λεπτομερειών στη λίστα δηλώσεων

### DIFF
--- a/app/src/main/java/com/ioannapergamali/mysmartroute/view/ui/screens/PrintDeclarationsScreen.kt
+++ b/app/src/main/java/com/ioannapergamali/mysmartroute/view/ui/screens/PrintDeclarationsScreen.kt
@@ -2,14 +2,17 @@ package com.ioannapergamali.mysmartroute.view.ui.screens
 
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.items
 import androidx.compose.material3.Card
 import androidx.compose.material3.CardDefaults
+import androidx.compose.material3.Icon
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Scaffold
 import androidx.compose.material3.Text
@@ -17,14 +20,25 @@ import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.Alignment
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.unit.dp
 import androidx.lifecycle.viewmodel.compose.viewModel
 import androidx.navigation.NavController
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.DirectionsBike
+import androidx.compose.material.icons.filled.DirectionsBus
+import androidx.compose.material.icons.filled.DirectionsCar
+import androidx.compose.material.icons.filled.TwoWheeler
 import com.ioannapergamali.mysmartroute.R
+import com.ioannapergamali.mysmartroute.data.local.MySmartRouteDatabase
 import com.ioannapergamali.mysmartroute.data.local.TransportDeclarationEntity
+import com.ioannapergamali.mysmartroute.model.enumerations.VehicleType
 import com.ioannapergamali.mysmartroute.view.ui.components.TopBar
 import com.ioannapergamali.mysmartroute.viewmodel.TransportDeclarationViewModel
 import java.text.SimpleDateFormat
@@ -73,8 +87,29 @@ fun PrintDeclarationsScreen(navController: NavController, openDrawer: () -> Unit
 
 @Composable
 private fun DeclarationItem(declaration: TransportDeclarationEntity) {
+    val context = LocalContext.current
+    var routeName by remember { mutableStateOf("") }
+    var driverName by remember { mutableStateOf("") }
+    var vehicleName by remember { mutableStateOf("") }
+
+    LaunchedEffect(declaration) {
+        val db = MySmartRouteDatabase.getInstance(context)
+        routeName = db.routeDao().findById(declaration.routeId)?.name.orEmpty()
+        val driver = db.userDao().getUser(declaration.driverId)
+        driverName = listOfNotNull(driver?.name, driver?.surname).joinToString(" ").trim()
+        vehicleName = db.vehicleDao().getVehicle(declaration.vehicleId)?.name.orEmpty()
+    }
+
+    val vehicleIcon = when (VehicleType.valueOf(declaration.vehicleType)) {
+        VehicleType.CAR, VehicleType.TAXI -> Icons.Filled.DirectionsCar
+        VehicleType.BIGBUS, VehicleType.SMALLBUS -> Icons.Filled.DirectionsBus
+        VehicleType.BICYCLE -> Icons.Filled.DirectionsBike
+        VehicleType.MOTORBIKE -> Icons.Filled.TwoWheeler
+    }
+
     val formatter = SimpleDateFormat("dd/MM/yyyy", Locale.getDefault())
     val dateText = formatter.format(Date(declaration.date))
+
     Card(
         modifier = Modifier.fillMaxWidth(),
         colors = CardDefaults.cardColors(containerColor = MaterialTheme.colorScheme.surface),
@@ -86,8 +121,13 @@ private fun DeclarationItem(declaration: TransportDeclarationEntity) {
                 .padding(16.dp),
             verticalArrangement = Arrangement.spacedBy(4.dp)
         ) {
-            Text(text = "${stringResource(R.string.route)}: ${declaration.routeId}")
-            Text(text = "${stringResource(R.string.vehicle_type)}: ${declaration.vehicleType}")
+            Text(text = "${stringResource(R.string.route)}: ${routeName.ifBlank { declaration.routeId }}")
+            Text(text = "${stringResource(R.string.driver)}: ${driverName.ifBlank { declaration.driverId }}")
+            Row(verticalAlignment = Alignment.CenterVertically) {
+                Icon(vehicleIcon, contentDescription = stringResource(R.string.vehicle))
+                Spacer(modifier = Modifier.width(4.dp))
+                Text(text = vehicleName.ifBlank { declaration.vehicleType })
+            }
             Text(text = "${stringResource(R.string.date)}: $dateText")
         }
     }


### PR DESCRIPTION
## Περίληψη
- Εμφάνιση ονόματος διαδρομής και οδηγού στις δηλώσεις μεταφοράς
- Προσθήκη εικονιδίου οχήματος και ονόματος οχήματος στη λίστα

## Έλεγχοι
- `./gradlew test` *(αποτυχία: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_689110bf16b08328b7a90e2425a4dcdf