### PR TITLE
Restrict drivers to their own declarations in print view

### DIFF
--- a/app/src/main/java/com/ioannapergamali/mysmartroute/data/local/TransportDeclarationDao.kt
+++ b/app/src/main/java/com/ioannapergamali/mysmartroute/data/local/TransportDeclarationDao.kt
@@ -14,6 +14,9 @@ interface TransportDeclarationDao {
     @Query("SELECT * FROM transport_declarations")
     fun getAll(): Flow<List<TransportDeclarationEntity>>
 
+    @Query("SELECT * FROM transport_declarations WHERE driverId = :driverId")
+    fun getForDriver(driverId: String): Flow<List<TransportDeclarationEntity>>
+
     @Query("SELECT * FROM transport_declarations WHERE id = :id LIMIT 1")
     suspend fun getById(id: String): TransportDeclarationEntity?
 

--- a/app/src/main/java/com/ioannapergamali/mysmartroute/view/ui/screens/PrintDeclarationsScreen.kt
+++ b/app/src/main/java/com/ioannapergamali/mysmartroute/view/ui/screens/PrintDeclarationsScreen.kt
@@ -44,6 +44,9 @@ import com.ioannapergamali.mysmartroute.data.local.TransportDeclarationEntity
 import com.ioannapergamali.mysmartroute.model.enumerations.VehicleType
 import com.ioannapergamali.mysmartroute.view.ui.components.TopBar
 import com.ioannapergamali.mysmartroute.viewmodel.TransportDeclarationViewModel
+import com.ioannapergamali.mysmartroute.viewmodel.AuthenticationViewModel
+import com.ioannapergamali.mysmartroute.model.enumerations.UserRole
+import com.google.firebase.auth.FirebaseAuth
 import java.text.SimpleDateFormat
 import java.util.Date
 import java.util.Locale
@@ -51,12 +54,23 @@ import java.util.Locale
 @Composable
 fun PrintDeclarationsScreen(navController: NavController, openDrawer: () -> Unit) {
     val viewModel: TransportDeclarationViewModel = viewModel()
+    val authViewModel: AuthenticationViewModel = viewModel()
     val declarations by viewModel.declarations.collectAsState()
+    val role by authViewModel.currentUserRole.collectAsState()
     val context = LocalContext.current
     val selected = remember { mutableStateMapOf<String, Boolean>() }
 
     LaunchedEffect(Unit) {
-        viewModel.loadDeclarations(context)
+        authViewModel.loadCurrentUserRole(context)
+    }
+
+    LaunchedEffect(role) {
+        val uid = FirebaseAuth.getInstance().currentUser?.uid
+        if (role == UserRole.ADMIN) {
+            viewModel.loadDeclarations(context)
+        } else if (role != null && uid != null) {
+            viewModel.loadDeclarations(context, uid)
+        }
     }
 
     Scaffold(

--- a/app/src/main/java/com/ioannapergamali/mysmartroute/viewmodel/TransportDeclarationViewModel.kt
+++ b/app/src/main/java/com/ioannapergamali/mysmartroute/viewmodel/TransportDeclarationViewModel.kt
@@ -25,10 +25,11 @@ class TransportDeclarationViewModel : ViewModel() {
         private const val TAG = "TransportDeclVM"
     }
 
-    fun loadDeclarations(context: Context) {
+    fun loadDeclarations(context: Context, driverId: String? = null) {
         viewModelScope.launch {
             val dao = MySmartRouteDatabase.getInstance(context).transportDeclarationDao()
-            dao.getAll().collect { list ->
+            val flow = if (driverId == null) dao.getAll() else dao.getForDriver(driverId)
+            flow.collect { list ->
                 _declarations.value = list
             }
         }


### PR DESCRIPTION
## Summary
- filter transport declarations by driver when not admin
- load user role in PrintDeclarationsScreen and show only own declarations

## Testing
- `./gradlew test --console=plain` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_68911c2b9cb8832895d62ec12803f1da