### PR TITLE
Store driver and route as Firestore references

### DIFF
--- a/app/src/main/java/com/ioannapergamali/mysmartroute/utils/FirestoreMappers.kt
+++ b/app/src/main/java/com/ioannapergamali/mysmartroute/utils/FirestoreMappers.kt
@@ -302,9 +302,9 @@ fun DocumentSnapshot.toMovingEntity(): MovingEntity? {
 
 fun TransportDeclarationEntity.toFirestoreMap(): Map<String, Any> = mapOf(
     "id" to id,
-    // Αποθηκεύουμε απλά τα ids για ευκολότερη αναζήτηση
-    "routeId" to routeId,
-    "driverId" to driverId,
+    // Χρησιμοποιούμε αναφορές εγγράφων για οδηγό και διαδρομή
+    "routeId" to FirebaseFirestore.getInstance().collection("routes").document(routeId),
+    "driverId" to FirebaseFirestore.getInstance().collection("users").document(driverId),
     "vehicleId" to vehicleId,
     "vehicleType" to vehicleType,
     "cost" to cost,


### PR DESCRIPTION
## Summary
- use Firestore document references for driver and route ids in transport declarations

## Testing
- `./gradlew test` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_68911d075fbc8328aebf87e90fabb17c