### PR TITLE
Προσθήκη πεδίου κόστους στην αναζήτηση μέσου μεταφοράς

### DIFF
--- a/app/src/main/java/com/ioannapergamali/mysmartroute/model/navigation/NavigationHost.kt
+++ b/app/src/main/java/com/ioannapergamali/mysmartroute/model/navigation/NavigationHost.kt
@@ -40,6 +40,7 @@ import com.ioannapergamali.mysmartroute.view.ui.screens.ViewTransportRequestsScr
 import com.ioannapergamali.mysmartroute.view.ui.screens.ViewRequestsScreen
 import com.ioannapergamali.mysmartroute.view.ui.screens.BookSeatScreen
 import com.ioannapergamali.mysmartroute.view.ui.screens.FindVehicleScreen
+import com.ioannapergamali.mysmartroute.view.ui.screens.RouteModeScreen
 import com.ioannapergamali.mysmartroute.view.ui.screens.ViewRoutesScreen
 import com.ioannapergamali.mysmartroute.view.ui.screens.SelectRoutePoisScreen
 import com.ioannapergamali.mysmartroute.view.ui.screens.AvailableTransportsScreen
@@ -174,6 +175,15 @@ fun NavigationHost(navController : NavHostController, openDrawer: () -> Unit) {
 
         composable("findVehicle") {
             FindVehicleScreen(navController = navController, openDrawer = openDrawer)
+        }
+
+        composable("findWay") {
+            RouteModeScreen(
+                navController = navController,
+                openDrawer = openDrawer,
+                titleRes = R.string.find_way,
+                includeCost = true
+            )
         }
 
         composable(


### PR DESCRIPTION
## Περίληψη
- Υλοποίηση κοινής οθόνης αναζήτησης οχήματος με παραμετρικό τίτλο και προαιρετικό πεδίο κόστους.
- Σύνδεση της διαδρομής `findWay` με την οθόνη αναζήτησης ώστε να εμφανίζεται το πεδίο κόστους και ο σωστός τίτλος.
- Προσθήκη κουμπιών "Δήλωση διαδρομής" και "Αποθήκευση αιτήματος" για ευκολότερη διαχείριση των αιτημάτων μεταφοράς.

## Δοκιμές
- `./gradlew test` (αποτυχία: SDK location not found)


------
https://chatgpt.com/codex/tasks/task_e_689123d009e0832893af3621dc849048