### PR TITLE
Κλείσιμο θέσης με ειδοποίηση κατά την αποδοχή αιτήματος

### DIFF
--- a/app/src/main/java/com/ioannapergamali/mysmartroute/viewmodel/VehicleRequestViewModel.kt
+++ b/app/src/main/java/com/ioannapergamali/mysmartroute/viewmodel/VehicleRequestViewModel.kt
@@ -12,6 +12,8 @@ import kotlinx.coroutines.Dispatchers
 import com.ioannapergamali.mysmartroute.utils.toFirestoreMap
 import com.ioannapergamali.mysmartroute.utils.toMovingEntity
 import com.ioannapergamali.mysmartroute.utils.NetworkUtils
+import com.ioannapergamali.mysmartroute.utils.NotificationUtils
+import com.ioannapergamali.mysmartroute.R
 
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
@@ -150,8 +152,29 @@ class VehicleRequestViewModel : ViewModel() {
             val list = _requests.value.toMutableList()
             val index = list.indexOfFirst { it.id == requestId }
             if (index != -1) {
+                val current = list[index]
+
+                if (accept) {
+                    val booked = BookingViewModel().reserveSeat(
+                        context,
+                        current.routeId,
+                        current.date,
+                        current.startPoiId,
+                        current.endPoiId
+                    )
+                    if (!booked) {
+                        Log.e(TAG, "Seat reservation failed")
+                        return@launch
+                    }
+                    NotificationUtils.showNotification(
+                        context,
+                        context.getString(R.string.reserve_seat_title),
+                        context.getString(R.string.seat_booked)
+                    )
+                }
+
                 val status = if (accept) "accepted" else "rejected"
-                val updated = list[index].copy(status = status, driverId = if (accept) list[index].driverId else "")
+                val updated = current.copy(status = status, driverId = if (accept) current.driverId else "")
                 list[index] = updated
                 _requests.value = list
                 dao.insert(updated)


### PR DESCRIPTION
## Περίληψη
- Προσθήκη ειδοποίησης όταν ο επιβάτης αποδέχεται αίτημα και γίνεται επιτυχής κράτηση θέσης.

## Δοκιμές
- `./gradlew test` απέτυχε: SDK location not found.


------
https://chatgpt.com/codex/tasks/task_e_689132ec52a483288644ead2e3bd7667