### PR TITLE
Handle empty declaration id in ReservationViewModel

### DIFF
--- a/app/src/main/java/com/ioannapergamali/mysmartroute/viewmodel/ReservationViewModel.kt
+++ b/app/src/main/java/com/ioannapergamali/mysmartroute/viewmodel/ReservationViewModel.kt
@@ -24,6 +24,11 @@ class ReservationViewModel : ViewModel() {
 
     fun loadReservations(context: Context, routeId: String, date: Long, declarationId: String) {
         viewModelScope.launch {
+            if (declarationId.isBlank()) {
+                _reservations.value = emptyList()
+                return@launch
+            }
+
             val dao = MySmartRouteDatabase.getInstance(context).seatReservationDao()
             _reservations.value = dao.getReservationsForDeclaration(declarationId).first()
 
@@ -47,6 +52,8 @@ class ReservationViewModel : ViewModel() {
 
     /** Επιστρέφει τον αριθμό κρατήσεων για μια δήλωση μεταφοράς. */
     suspend fun getReservationCount(context: Context, declarationId: String): Int {
+        if (declarationId.isBlank()) return 0
+
         val dao = MySmartRouteDatabase.getInstance(context).seatReservationDao()
 
         val localCount = withContext(Dispatchers.IO) {


### PR DESCRIPTION
## Summary
- avoid Firestore crash when `declarationId` is empty by returning early in `loadReservations`
- skip fetching counts when `declarationId` is blank

## Testing
- `./gradlew test` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_689153a71208832898d9731449dd286c