### PR TITLE
Show accepted requests in scheduled print

### DIFF
--- a/app/src/main/java/com/ioannapergamali/mysmartroute/view/ui/screens/PrintScheduledScreen.kt
+++ b/app/src/main/java/com/ioannapergamali/mysmartroute/view/ui/screens/PrintScheduledScreen.kt
@@ -1,18 +1,44 @@
 package com.ioannapergamali.mysmartroute.view.ui.screens
 
 import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.lazy.items
+import androidx.compose.material3.Divider
 import androidx.compose.material3.Scaffold
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.collectAsState
+import androidx.compose.runtime.getValue
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.res.stringResource
 import androidx.navigation.NavController
+import androidx.lifecycle.viewmodel.compose.viewModel
+import com.google.firebase.auth.FirebaseAuth
 import com.ioannapergamali.mysmartroute.R
 import com.ioannapergamali.mysmartroute.view.ui.components.ScreenContainer
 import com.ioannapergamali.mysmartroute.view.ui.components.TopBar
+import com.ioannapergamali.mysmartroute.viewmodel.PoIViewModel
+import com.ioannapergamali.mysmartroute.viewmodel.VehicleRequestViewModel
 
 @Composable
 fun PrintScheduledScreen(navController: NavController, openDrawer: () -> Unit) {
+    val context = LocalContext.current
+    val requestViewModel: VehicleRequestViewModel = viewModel()
+    val poiViewModel: PoIViewModel = viewModel()
+    val requests by requestViewModel.requests.collectAsState()
+    val pois by poiViewModel.pois.collectAsState()
+
+    LaunchedEffect(Unit) {
+        poiViewModel.loadPois(context)
+        requestViewModel.loadRequests(context, allUsers = true)
+    }
+
+    val currentDriver = FirebaseAuth.getInstance().currentUser?.uid
+    val scheduled = requests.filter { it.status == "accepted" && it.driverId == currentDriver }
+    val poiNames = pois.associate { it.id to it.name }
+
     Scaffold(
         topBar = {
             TopBar(
@@ -24,7 +50,18 @@ fun PrintScheduledScreen(navController: NavController, openDrawer: () -> Unit) {
         }
     ) { paddingValues ->
         ScreenContainer(modifier = Modifier.padding(paddingValues)) {
-            Text(text = stringResource(R.string.not_implemented))
+            if (scheduled.isEmpty()) {
+                Text(text = stringResource(R.string.no_scheduled_transports))
+            } else {
+                LazyColumn {
+                    items(scheduled) { req ->
+                        val fromName = poiNames[req.startPoiId] ?: ""
+                        val toName = poiNames[req.endPoiId] ?: ""
+                        Text("$fromName → $toName")
+                        Divider()
+                    }
+                }
+            }
         }
     }
 }

--- a/app/src/main/res/values-el/strings.xml
+++ b/app/src/main/res/values-el/strings.xml
@@ -178,6 +178,7 @@
     <string name="accept_offer">Αποδοχή</string>
     <string name="reject_offer">Απόρριψη</string>
     <string name="no_notifications">Καμία ειδοποίηση</string>
+    <string name="no_scheduled_transports">Δεν βρέθηκαν προγραμματισμένες μεταφορές</string>
     <!-- Notification text -->
     <string name="app_started_notification">Η εφαρμογή ξεκίνησε</string>
     <string name="available_transports">Διαθέσιμες μεταφορές</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -190,6 +190,7 @@
     <string name="accept_offer">Accept</string>
     <string name="reject_offer">Reject</string>
     <string name="no_notifications">No notifications</string>
+    <string name="no_scheduled_transports">No scheduled transports</string>
 
     <!-- Notification text -->
     <string name="app_started_notification">App started successfully</string>


### PR DESCRIPTION
## Summary
- display accepted transport requests in PrintScheduled screen
- add missing string resources for scheduled transport message

## Testing
- `./gradlew test --no-daemon --console=plain` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_689721a41c1483289efdeba74bf366c2