### PR TITLE
Notify drivers when ride requests accepted

### DIFF
--- a/app/src/main/res/values-el/strings.xml
+++ b/app/src/main/res/values-el/strings.xml
@@ -181,6 +181,8 @@
     <string name="no_scheduled_transports">Δεν βρέθηκαν προγραμματισμένες μεταφορές</string>
     <!-- Notification text -->
     <string name="app_started_notification">Η εφαρμογή ξεκίνησε</string>
+    <string name="request_accepted">Το αίτημα έγινε αποδεκτό</string>
+    <string name="request_accepted_notification">Το αίτημά σας έγινε αποδεκτό</string>
     <string name="available_transports">Διαθέσιμες μεταφορές</string>
     <string name="no_transports_found">Δεν βρέθηκαν μεταφορές</string>
     <string name="find_now">Εύρεση τώρα</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -195,6 +195,8 @@
     <!-- Notification text -->
     <string name="app_started_notification">App started successfully</string>
     <string name="driver_offer_notification">Ο οδηγός %1$s προσφέρθηκε να σας μεταφέρει</string>
+    <string name="request_accepted">Request accepted</string>
+    <string name="request_accepted_notification">The request was accepted</string>
     
     <string name="find_now">Find now</string>
     <string name="save_request">Save request</string>


### PR DESCRIPTION
## Summary
- Show toast to passengers when accepting a ride offer
- Notify drivers locally when their offers are accepted
- Add string resources for acceptance messages in English and Greek

## Testing
- `./gradlew test` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_68974c43d0708328a5fda2bf0888e2d5