### PR TITLE
Fix missing request acceptance string

### DIFF
--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -196,6 +196,7 @@
     <string name="app_started_notification">App started successfully</string>
     <string name="driver_offer_notification">Ο οδηγός %1$s προσφέρθηκε να σας μεταφέρει</string>
     <string name="request_accepted">Request accepted</string>
+    <string name="request_accept_failed">Αποτυχία αποδοχής αιτήματος</string>
     <string name="request_accepted_notification">The request was accepted</string>
 
     


### PR DESCRIPTION
## Summary
- add `request_accept_failed` string resource for seat reservation failures

## Testing
- `./gradlew test` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_68975e8aa7708328a0eb2ccad55ad44c