### PR TITLE
Βελτίωση κράτησης θέσεων με suspend και χειρισμό αποτελέσματος

### DIFF
--- a/app/src/main/java/com/ioannapergamali/mysmartroute/viewmodel/BookingViewModel.kt
+++ b/app/src/main/java/com/ioannapergamali/mysmartroute/viewmodel/BookingViewModel.kt
@@ -1,8 +1,8 @@
 package com.ioannapergamali.mysmartroute.viewmodel
 
 import android.content.Context
+import android.util.Log
 import androidx.lifecycle.ViewModel
-import androidx.lifecycle.viewModelScope
 import com.google.firebase.auth.FirebaseAuth
 import com.google.firebase.firestore.FirebaseFirestore
 import com.ioannapergamali.mysmartroute.data.local.RouteEntity
@@ -12,8 +12,8 @@ import com.ioannapergamali.mysmartroute.utils.toFirestoreMap
 import com.ioannapergamali.mysmartroute.utils.toRouteWithPoints
 import com.ioannapergamali.mysmartroute.utils.toTransportDeclarationEntity
 import kotlinx.coroutines.tasks.await
-import kotlinx.coroutines.runBlocking
-import kotlinx.coroutines.launch
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.withContext
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.first
@@ -22,6 +22,10 @@ import java.util.UUID
 class BookingViewModel : ViewModel() {
     private val db = FirebaseFirestore.getInstance()
     private val auth = FirebaseAuth.getInstance()
+
+    companion object {
+        private const val TAG = "BookingVM"
+    }
 
     private val _availableRoutes = MutableStateFlow<List<RouteEntity>>(emptyList())
     val availableRoutes: StateFlow<List<RouteEntity>> = _availableRoutes
@@ -37,88 +41,100 @@ class BookingViewModel : ViewModel() {
         }
     }
 
-    fun reserveSeat(
+    suspend fun reserveSeat(
         context: Context,
         routeId: String,
         date: Long,
         startPoiId: String,
         endPoiId: String
-    ): Boolean {
-        val userId = auth.currentUser?.uid ?: return false
-        val reservationId = UUID.randomUUID().toString()
-        return try {
-            runBlocking {
-                val declarations = db.collection("transport_declarations")
-                    .whereEqualTo("routeId", routeId)
-                    .whereEqualTo("date", date)
-                    .get().await()
-                    .documents.mapNotNull { it.toTransportDeclarationEntity() }
-                val declaration = declarations.firstOrNull() ?: return@runBlocking false
-
-                // Έλεγχος αν ο επιβάτης έχει ήδη κάνει κράτηση για τη συγκεκριμένη διαδρομή
-                val routeRef = db.collection("routes").document(routeId)
-                val userRef = db.collection("users").document(userId)
-                val existingUserReservation = db.collection("seat_reservations")
-                    .whereEqualTo("routeId", routeRef)
-                    .whereEqualTo("date", date)
-                    .whereEqualTo("userId", userRef)
-                    .get().await()
-                if (existingUserReservation.size() > 0) {
-                    return@runBlocking false
-                }
-
-                // Έλεγχος διαθεσιμότητας θέσεων
-                val existing = db.collection("seat_reservations")
-                    .whereEqualTo("routeId", routeRef)
-                    .whereEqualTo("date", date)
-                    .get().await()
-                if (existing.size() >= declaration.seats) {
-                    return@runBlocking false
-                }
-
-                // Έλεγχος σειράς σημείων επιβίβασης και αποβίβασης
-                val dbInstance = MySmartRouteDatabase.getInstance(context)
-                var points = dbInstance.routePointDao().getPointsForRoute(routeId).first()
-                if (points.isEmpty()) {
-                    val snap = FirebaseFirestore.getInstance()
-                        .collection("routes")
-                        .document(routeId)
-                        .get()
-                        .await()
-                    val (_, remotePoints) = snap.toRouteWithPoints() ?: return@runBlocking false
-                    remotePoints.forEach { dbInstance.routePointDao().insert(it) }
-                    points = remotePoints
-                }
-                val startIndex = points.indexOfFirst { it.poiId == startPoiId }
-                val endIndex = points.indexOfFirst { it.poiId == endPoiId }
-                if (startIndex == -1 || endIndex == -1 || startIndex >= endIndex) {
-                    return@runBlocking false
-                }
-
-                // Έλεγχος τοπικής βάσης για τυχόν υπάρχουσα κράτηση
-                val localExisting = dbInstance.seatReservationDao()
-                    .findUserReservation(userId, routeId, date)
-                if (localExisting != null) {
-                    return@runBlocking false
-                }
-                val reservation = SeatReservationEntity(
-                    reservationId,
-                    declaration.id,
-                    routeId,
-                    userId,
-                    date,
-                    startPoiId,
-                    endPoiId
-                )
-                db.collection("seat_reservations").document(reservationId)
-                    .set(reservation.toFirestoreMap()).await()
-                viewModelScope.launch {
-                    MySmartRouteDatabase.getInstance(context).seatReservationDao().insert(reservation)
-                }
-                true
+    ): Result<Unit> = withContext(Dispatchers.IO) {
+        val userId = auth.currentUser?.uid
+            ?: run {
+                Log.e(TAG, "Ο χρήστης δεν είναι συνδεδεμένος")
+                return@withContext Result.failure(Exception("Ο χρήστης δεν είναι συνδεδεμένος"))
             }
+
+        val reservationId = UUID.randomUUID().toString()
+        try {
+            val declarations = db.collection("transport_declarations")
+                .whereEqualTo("routeId", routeId)
+                .whereEqualTo("date", date)
+                .get().await()
+                .documents.mapNotNull { it.toTransportDeclarationEntity() }
+            val declaration = declarations.firstOrNull()
+                ?: run {
+                    Log.e(TAG, "Δεν βρέθηκε δήλωση μεταφοράς")
+                    return@withContext Result.failure(Exception("Δεν βρέθηκε δήλωση μεταφοράς"))
+                }
+
+            val routeRef = db.collection("routes").document(routeId)
+            val userRef = db.collection("users").document(userId)
+            val existingUserReservation = db.collection("seat_reservations")
+                .whereEqualTo("routeId", routeRef)
+                .whereEqualTo("date", date)
+                .whereEqualTo("userId", userRef)
+                .get().await()
+            if (existingUserReservation.size() > 0) {
+                Log.e(TAG, "Έχεις ήδη κράτηση")
+                return@withContext Result.failure(Exception("Έχεις ήδη κράτηση"))
+            }
+
+            val existing = db.collection("seat_reservations")
+                .whereEqualTo("routeId", routeRef)
+                .whereEqualTo("date", date)
+                .get().await()
+            if (existing.size() >= declaration.seats) {
+                Log.e(TAG, "Δεν υπάρχουν διαθέσιμες θέσεις")
+                return@withContext Result.failure(Exception("Δεν υπάρχουν διαθέσιμες θέσεις"))
+            }
+
+            val dbInstance = MySmartRouteDatabase.getInstance(context)
+            var points = dbInstance.routePointDao().getPointsForRoute(routeId).first()
+            if (points.isEmpty()) {
+                val snap = FirebaseFirestore.getInstance()
+                    .collection("routes")
+                    .document(routeId)
+                    .get()
+                    .await()
+                val (_, remotePoints) = snap.toRouteWithPoints()
+                    ?: run {
+                        Log.e(TAG, "Αδυναμία φόρτωσης σημείων")
+                        return@withContext Result.failure(Exception("Αδυναμία φόρτωσης σημείων"))
+                    }
+                remotePoints.forEach { dbInstance.routePointDao().insert(it) }
+                points = remotePoints
+            }
+            val startIndex = points.indexOfFirst { it.poiId == startPoiId }
+            val endIndex = points.indexOfFirst { it.poiId == endPoiId }
+            if (startIndex == -1 || endIndex == -1 || startIndex >= endIndex) {
+                Log.e(TAG, "Μη έγκυρα σημεία διαδρομής")
+                return@withContext Result.failure(Exception("Μη έγκυρα σημεία διαδρομής"))
+            }
+
+            val localExisting = dbInstance.seatReservationDao()
+                .findUserReservation(userId, routeId, date)
+            if (localExisting != null) {
+                Log.e(TAG, "Υπάρχει ήδη τοπική κράτηση")
+                return@withContext Result.failure(Exception("Υπάρχει ήδη τοπική κράτηση"))
+            }
+
+            val reservation = SeatReservationEntity(
+                reservationId,
+                declaration.id,
+                routeId,
+                userId,
+                date,
+                startPoiId,
+                endPoiId
+            )
+            db.collection("seat_reservations").document(reservationId)
+                .set(reservation.toFirestoreMap()).await()
+            dbInstance.seatReservationDao().insert(reservation)
+            Log.d(TAG, "Κράτηση ολοκληρώθηκε")
+            Result.success(Unit)
         } catch (e: Exception) {
-            false
+            Log.e(TAG, "Σφάλμα κατά την κράτηση", e)
+            Result.failure(e)
         }
     }
 }

--- a/app/src/main/java/com/ioannapergamali/mysmartroute/viewmodel/VehicleRequestViewModel.kt
+++ b/app/src/main/java/com/ioannapergamali/mysmartroute/viewmodel/VehicleRequestViewModel.kt
@@ -15,6 +15,7 @@ import com.ioannapergamali.mysmartroute.utils.toMovingEntity
 import com.ioannapergamali.mysmartroute.utils.NetworkUtils
 import com.ioannapergamali.mysmartroute.utils.NotificationUtils
 import com.ioannapergamali.mysmartroute.R
+import com.ioannapergamali.mysmartroute.viewmodel.BookingViewModel
 
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
@@ -33,6 +34,7 @@ data class PassengerRequest(
 
 class VehicleRequestViewModel : ViewModel() {
     private val db = FirebaseFirestore.getInstance()
+    private val bookingViewModel = BookingViewModel()
 
     private val _requests = MutableStateFlow<List<MovingEntity>>(emptyList())
     val requests: StateFlow<List<MovingEntity>> = _requests
@@ -199,22 +201,26 @@ class VehicleRequestViewModel : ViewModel() {
                 val current = list[index]
 
                 if (accept) {
-                    val booked = BookingViewModel().reserveSeat(
+                    Log.d(TAG, "Προσπάθεια κράτησης για αίτημα $requestId")
+                    val result = bookingViewModel.reserveSeat(
                         context,
                         current.routeId,
                         current.date,
                         current.startPoiId,
                         current.endPoiId
                     )
-                    if (!booked) {
-                        Toast.makeText(
-                            context,
-                            context.getString(R.string.request_accept_failed),
-                            Toast.LENGTH_SHORT
-                        ).show()
-                        Log.e(TAG, "Seat reservation failed")
-                        return@launch
-                    }
+                    result.fold(
+                        onSuccess = { },
+                        onFailure = {
+                            Toast.makeText(
+                                context,
+                                context.getString(R.string.request_accept_failed),
+                                Toast.LENGTH_SHORT
+                            ).show()
+                            Log.e(TAG, "Seat reservation failed: ${'$'}{it.message}", it)
+                            return@launch
+                        }
+                    )
                 }
 
                 val status = if (accept) "accepted" else "rejected"
@@ -231,10 +237,6 @@ class VehicleRequestViewModel : ViewModel() {
                     ).await()
                 } catch (e: Exception) {
                     Log.e(TAG, "Failed to respond to offer", e)
-                }
-
-                if (accept) {
-
                 }
             }
         }


### PR DESCRIPTION
## Περίληψη
- Μετατροπή της `reserveSeat` σε `suspend` με χρήση `Result` και ελέγχους στο IO context
- Προσθήκη `BookingViewModel` στο `VehicleRequestViewModel` και χειρισμός αποτυχίας κατά την αποδοχή προσφοράς
- Αναθεώρηση του `AvailableTransportsScreen` ώστε η κράτηση θέσης να γίνεται μέσα από coroutine scope
- Προσθήκη αναλυτικών logs για την `reserveSeat` και την αποδοχή αιτημάτων

## Έλεγχοι
- `./gradlew test` *(αποτυχία: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_6897705c4abc8328b3a4d6d720f3ca3a