### PR TITLE
Αποφυγή άκυρου DocumentReference στις κρατήσεις

### DIFF
--- a/app/src/main/java/com/ioannapergamali/mysmartroute/utils/FirestoreMappers.kt
+++ b/app/src/main/java/com/ioannapergamali/mysmartroute/utils/FirestoreMappers.kt
@@ -376,15 +376,22 @@ fun DocumentSnapshot.toAvailabilityEntity(): AvailabilityEntity? {
     return AvailabilityEntity(availId, userId, dateVal, fromVal, toVal)
 }
 
-fun SeatReservationEntity.toFirestoreMap(): Map<String, Any> = mapOf(
-    "id" to id,
-    "declarationId" to FirebaseFirestore.getInstance().collection("transport_declarations").document(declarationId),
-    "routeId" to FirebaseFirestore.getInstance().collection("routes").document(routeId),
-    "userId" to FirebaseFirestore.getInstance().collection("users").document(userId),
-    "date" to date,
-    "startPoiId" to FirebaseFirestore.getInstance().collection("pois").document(startPoiId),
-    "endPoiId" to FirebaseFirestore.getInstance().collection("pois").document(endPoiId)
-)
+fun SeatReservationEntity.toFirestoreMap(): Map<String, Any> {
+    val map = mutableMapOf<String, Any>(
+        "id" to id,
+        "routeId" to FirebaseFirestore.getInstance().collection("routes").document(routeId),
+        "userId" to FirebaseFirestore.getInstance().collection("users").document(userId),
+        "date" to date,
+        "startPoiId" to FirebaseFirestore.getInstance().collection("pois").document(startPoiId),
+        "endPoiId" to FirebaseFirestore.getInstance().collection("pois").document(endPoiId)
+    )
+    if (declarationId.isNotBlank()) {
+        map["declarationId"] = FirebaseFirestore.getInstance()
+            .collection("transport_declarations")
+            .document(declarationId)
+    }
+    return map
+}
 
 fun DocumentSnapshot.toSeatReservationEntity(): SeatReservationEntity? {
     val resId = getString("id") ?: id

--- a/app/src/main/java/com/ioannapergamali/mysmartroute/view/ui/screens/AvailableTransportsScreen.kt
+++ b/app/src/main/java/com/ioannapergamali/mysmartroute/view/ui/screens/AvailableTransportsScreen.kt
@@ -191,13 +191,14 @@ fun AvailableTransportsScreen(
                             Button(
                                 onClick = {
                                     scope.launch {
-                                        val result = bookingViewModel.reserveSeat(
-                                            context,
-                                            decl.routeId,
-                                            decl.date,
-                                            startId ?: "",
-                                            endId ?: ""
-                                        )
+                                          val result = bookingViewModel.reserveSeat(
+                                              context = context,
+                                              routeId = decl.routeId,
+                                              date = decl.date,
+                                              startPoiId = startId ?: "",
+                                              endPoiId = endId ?: "",
+                                              declarationId = decl.id
+                                          )
                                         message = result.fold(
                                             onSuccess = {
                                                 reservationCounts[decl.id] = reserved + 1

--- a/app/src/main/java/com/ioannapergamali/mysmartroute/viewmodel/BookingViewModel.kt
+++ b/app/src/main/java/com/ioannapergamali/mysmartroute/viewmodel/BookingViewModel.kt
@@ -43,7 +43,8 @@ class BookingViewModel : ViewModel() {
         routeId: String,
         date: Long,
         startPoiId: String,
-        endPoiId: String
+        endPoiId: String,
+        declarationId: String = ""
     ): Result<Unit> = withContext(Dispatchers.IO) {
         val userId = auth.currentUser?.uid
             ?: return@withContext Result.failure(Exception("Απαιτείται σύνδεση"))
@@ -58,6 +59,7 @@ class BookingViewModel : ViewModel() {
 
         val reservation = SeatReservationEntity(
             id = UUID.randomUUID().toString(),
+            declarationId = declarationId,
             routeId = routeId,
             userId = userId,
             date = date,

--- a/app/src/main/java/com/ioannapergamali/mysmartroute/viewmodel/VehicleRequestViewModel.kt
+++ b/app/src/main/java/com/ioannapergamali/mysmartroute/viewmodel/VehicleRequestViewModel.kt
@@ -203,11 +203,12 @@ class VehicleRequestViewModel : ViewModel() {
                 if (accept) {
 
                     val result = bookingViewModel.reserveSeat(
-                        context,
-                        current.routeId,
-                        current.date,
-                        current.startPoiId,
-                        current.endPoiId
+                        context = context,
+                        routeId = current.routeId,
+                        date = current.date,
+                        startPoiId = current.startPoiId,
+                        endPoiId = current.endPoiId,
+                        declarationId = current.id
                     )
                     result.fold(
                         onSuccess = { },


### PR DESCRIPTION
## Περίληψη
- Προστέθηκε `declarationId` στο `reserveSeat` και ενημερώθηκαν οι κλήσεις
- Προσαρμόστηκε ο mapper ώστε το `declarationId` να αποστέλλεται μόνο όταν υπάρχει

## Έλεγχοι
- `./gradlew test` *(αποτυχία: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_6897cff402b48328bc361f42e869b8d4