### PR TITLE
Προσθήκη checkbox διαγραφής στην εκτύπωση κράτησης

### DIFF
--- a/app/src/main/java/com/ioannapergamali/mysmartroute/data/local/SeatReservationDao.kt
+++ b/app/src/main/java/com/ioannapergamali/mysmartroute/data/local/SeatReservationDao.kt
@@ -11,6 +11,9 @@ interface SeatReservationDao {
     @Insert(onConflict = OnConflictStrategy.REPLACE)
     suspend fun insert(reservation: SeatReservationEntity)
 
+    @Query("DELETE FROM seat_reservations WHERE id = :id")
+    suspend fun deleteById(id: String)
+
     @Query("SELECT * FROM seat_reservations WHERE userId = :userId")
     fun getReservationsForUser(userId: String): Flow<List<SeatReservationEntity>>
 

--- a/app/src/main/java/com/ioannapergamali/mysmartroute/view/ui/screens/PrintTicketScreen.kt
+++ b/app/src/main/java/com/ioannapergamali/mysmartroute/view/ui/screens/PrintTicketScreen.kt
@@ -1,6 +1,5 @@
 package com.ioannapergamali.mysmartroute.view.ui.screens
 
-import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxWidth
@@ -13,16 +12,15 @@ import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.Info
 import androidx.compose.material3.Card
 import androidx.compose.material3.CardDefaults
+import androidx.compose.material3.Checkbox
 import androidx.compose.material3.Icon
 import androidx.compose.material3.IconButton
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Scaffold
 import androidx.compose.material3.Text
-import androidx.compose.runtime.Composable
-import androidx.compose.runtime.LaunchedEffect
-import androidx.compose.runtime.collectAsState
-import androidx.compose.runtime.getValue
+import androidx.compose.runtime.*
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.Alignment
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.unit.dp
@@ -70,7 +68,7 @@ fun PrintTicketScreen(navController: NavController, openDrawer: () -> Unit) {
                     .padding(paddingValues)
             ) {
                 items(reservations) { res ->
-                    ReservationItem(res, navController)
+                    ReservationItem(res, navController) { viewModel.delete(context, it) }
                     Spacer(modifier = Modifier.height(8.dp))
                 }
             }
@@ -79,9 +77,14 @@ fun PrintTicketScreen(navController: NavController, openDrawer: () -> Unit) {
 }
 
 @Composable
-fun ReservationItem(reservation: SeatReservationEntity, navController: NavController) {
+fun ReservationItem(
+    reservation: SeatReservationEntity,
+    navController: NavController,
+    onDelete: (SeatReservationEntity) -> Unit
+) {
     val formatter = SimpleDateFormat("dd/MM/yyyy", Locale.getDefault())
     val dateText = formatter.format(Date(reservation.date))
+    var checked by remember { mutableStateOf(false) }
     Card(
         modifier = Modifier.fillMaxWidth(),
         colors = CardDefaults.cardColors(containerColor = MaterialTheme.colorScheme.surface),
@@ -91,8 +94,16 @@ fun ReservationItem(reservation: SeatReservationEntity, navController: NavContro
             modifier = Modifier
                 .fillMaxWidth()
                 .padding(16.dp),
-            horizontalArrangement = Arrangement.SpaceBetween
+            verticalAlignment = Alignment.CenterVertically
         ) {
+            Row(verticalAlignment = Alignment.CenterVertically) {
+                Checkbox(checked = checked, onCheckedChange = { isChecked ->
+                    checked = isChecked
+                    if (isChecked) onDelete(reservation)
+                })
+                Text(stringResource(R.string.delete_reservation))
+            }
+            Spacer(Modifier.weight(1f))
             Text(text = dateText)
             IconButton(onClick = {
                 val json = Uri.encode(Gson().toJson(reservation))

--- a/app/src/main/java/com/ioannapergamali/mysmartroute/viewmodel/UserReservationsViewModel.kt
+++ b/app/src/main/java/com/ioannapergamali/mysmartroute/viewmodel/UserReservationsViewModel.kt
@@ -45,5 +45,14 @@ class UserReservationsViewModel : ViewModel() {
             }
         }
     }
+
+    fun delete(context: Context, reservation: SeatReservationEntity) {
+        viewModelScope.launch {
+            val dao = MySmartRouteDatabase.getInstance(context).seatReservationDao()
+            dao.deleteById(reservation.id)
+            db.collection("seat_reservations").document(reservation.id).delete().await()
+            _reservations.value = _reservations.value.filterNot { it.id == reservation.id }
+        }
+    }
 }
 

--- a/app/src/main/res/values-el/strings.xml
+++ b/app/src/main/res/values-el/strings.xml
@@ -164,6 +164,7 @@
     <string name="add_favorite">Προσθήκη</string>
     <string name="delete_favorite">Αφαίρεση</string>
     <string name="delete_selected">Διαγραφή επιλεγμένων</string>
+    <string name="delete_reservation">Διαγραφή</string>
     <string name="clear_selection">Καθαρισμός επιλογής</string>
     <string name="no_reservations">Δεν βρέθηκαν κρατήσεις</string>
     <string name="no_declarations">Δεν βρέθηκαν δηλώσεις</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -177,6 +177,7 @@
     <string name="add_favorite">Add</string>
     <string name="delete_favorite">Delete</string>
     <string name="delete_selected">Delete selected</string>
+    <string name="delete_reservation">Delete</string>
     <string name="no_reservations">No reservations found</string>
     <string name="no_declarations">No declarations found</string>
     <string name="max_cost">Maximum cost</string>


### PR DESCRIPTION
## Περίληψη
- Προσθήκη δυνατότητας διαγραφής κράτησης από την οθόνη εκτύπωσης εισιτηρίου
- Υλοποίηση λογικής διαγραφής σε ViewModel και DAO
- Νέα συμβολοσειρά διεπαφής για τη διαγραφή κράτησης

## Έλεγχοι
- `./gradlew test` *(αποτυχία: Could not determine the dependencies of task ':app:testDebugUnitTest'. SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_6897d82117448328841f6d1c0cc014a4