### PR TITLE
Εμφάνιση εικονιδίου ειδοποιήσεων μόνο όταν ο χρήστης είναι συνδεδεμένος

### DIFF
--- a/app/src/main/java/com/ioannapergamali/mysmartroute/view/ui/components/TopBar.kt
+++ b/app/src/main/java/com/ioannapergamali/mysmartroute/view/ui/components/TopBar.kt
@@ -81,6 +81,7 @@ fun TopBar(
     }
 
     val userId = FirebaseAuth.getInstance().currentUser?.uid
+    val isLoggedIn = userId != null
     val hasNotifications = remember(role, requests) {
         when (role) {
             UserRole.DRIVER -> requests.any {
@@ -141,7 +142,7 @@ fun TopBar(
             }
         },
         actions = {
-            if (showNotifications) {
+            if (showNotifications && isLoggedIn) {
                 IconButton(onClick = { navController.navigate("notifications") }) {
                     BadgedBox(badge = {
                         if (hasNotifications) {


### PR DESCRIPTION
## Περίληψη
- Προστέθηκε έλεγχος `isLoggedIn` στο TopBar.
- Το εικονίδιο ειδοποιήσεων εμφανίζεται μόνο για συνδεδεμένους χρήστες.

## Δοκιμές
- `./gradlew test` (αποτυχία: SDK location not found)


------
https://chatgpt.com/codex/tasks/task_e_6897e70958bc8328aafa9bcd7a175ebf