### PR TITLE
Handle all driver notification cases

### DIFF
--- a/app/src/main/java/com/ioannapergamali/mysmartroute/view/ui/screens/NotificationsScreen.kt
+++ b/app/src/main/java/com/ioannapergamali/mysmartroute/view/ui/screens/NotificationsScreen.kt
@@ -82,6 +82,16 @@ fun NotificationsScreen(navController: NavController, openDrawer: () -> Unit) {
                                     req.createdByName
                                 )
 
+                                req.status == "accepted" -> stringResource(
+                                    R.string.request_accepted_notification,
+                                    req.requestNumber
+                                )
+
+                                req.status == "rejected" -> stringResource(
+                                    R.string.request_rejected_notification
+                                )
+
+                                else -> ""
                             }
 
                             UserRole.PASSENGER -> stringResource(


### PR DESCRIPTION
## Summary
- handle driver request accepted and rejected notifications
- make `when` in `NotificationsScreen` exhaustive

## Testing
- `./gradlew test` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_6897f4d5ae4c8328af3c5ae01648d98e