### PR TITLE
Προσθήκη πεδίου driverId στο TransferRequestEntity

### DIFF
--- a/app/src/main/java/com/ioannapergamali/mysmartroute/data/local/TransferRequestEntity.kt
+++ b/app/src/main/java/com/ioannapergamali/mysmartroute/data/local/TransferRequestEntity.kt
@@ -10,6 +10,7 @@ data class TransferRequestEntity(
     @PrimaryKey(autoGenerate = true) val requestNumber: Int = 0,
     val routeId: String = "",
     val passengerId: String = "",
+    val driverId: String = "",
 
     /** Ημερομηνία σε millis */
     val date: Long = 0L,


### PR DESCRIPTION
## Summary
- Προστέθηκε το πεδίο `driverId` στο `TransferRequestEntity` ώστε να υποστηρίζει ερωτήματα οδηγού.

## Testing
- `./gradlew test` *(απέτυχε: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_6897f60bceec832880fbab2372049987