### PR TITLE
Fix missing driverId branch in Firestore mapper

### DIFF
--- a/app/src/main/java/com/ioannapergamali/mysmartroute/utils/FirestoreMappers.kt
+++ b/app/src/main/java/com/ioannapergamali/mysmartroute/utils/FirestoreMappers.kt
@@ -465,7 +465,9 @@ fun DocumentSnapshot.toTransferRequestEntity(): TransferRequestEntity? {
     val driverId = when (val d = get("driverId")) {
         is DocumentReference -> d.id
         is String -> d
+        else -> getString("driverId")
 
+    } ?: return null
     val dateVal = getLong("date") ?: 0L
     val costVal = getDouble("cost") ?: 0.0
     val statusStr = getString("status") ?: RequestStatus.PENDING.name


### PR DESCRIPTION
## Summary
- handle optional `driverId` when mapping transfer requests from Firestore

## Testing
- `./gradlew test` *(fails: Android SDK/Gradle setup could not finish in this environment)*

------
https://chatgpt.com/codex/tasks/task_e_6897f76d12088328980f58175678f588