### PR TITLE
Υποστήριξη αποθήκευσης αιτημάτων μεταφοράς

### DIFF
--- a/app/src/main/java/com/ioannapergamali/mysmartroute/data/local/MySmartRouteDatabase.kt
+++ b/app/src/main/java/com/ioannapergamali/mysmartroute/data/local/MySmartRouteDatabase.kt
@@ -641,7 +641,7 @@ abstract class MySmartRouteDatabase : RoomDatabase() {
                         "`requestNumber` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL, " +
                         "`routeId` TEXT NOT NULL, " +
                         "`passengerId` TEXT NOT NULL, " +
-
+                        "`driverId` TEXT NOT NULL, " +
                         "`date` INTEGER NOT NULL, " +
                         "`cost` REAL NOT NULL, " +
                         "`status` TEXT NOT NULL" +

--- a/app/src/main/java/com/ioannapergamali/mysmartroute/data/local/TransferRequestDao.kt
+++ b/app/src/main/java/com/ioannapergamali/mysmartroute/data/local/TransferRequestDao.kt
@@ -15,6 +15,9 @@ interface TransferRequestDao {
     @Query("UPDATE transfer_requests SET status = :status WHERE requestNumber = :requestNumber")
     suspend fun updateStatus(requestNumber: Int, status: RequestStatus)
 
+    @Query("UPDATE transfer_requests SET driverId = :driverId, status = :status WHERE requestNumber = :requestNumber")
+    suspend fun assignDriver(requestNumber: Int, driverId: String, status: RequestStatus)
+
     @Query("SELECT * FROM transfer_requests WHERE passengerId = :passengerId")
     fun getRequestsForPassenger(passengerId: String): Flow<List<TransferRequestEntity>>
 

--- a/app/src/main/java/com/ioannapergamali/mysmartroute/model/classes/transports/TransferRequest.kt
+++ b/app/src/main/java/com/ioannapergamali/mysmartroute/model/classes/transports/TransferRequest.kt
@@ -7,7 +7,7 @@ data class TransferRequest(
     val requestNumber: Int,
     val routeId: String,
     val passengerId: String,
-
+    val driverId: String,
     val date: Long,
     val cost: Double,
     val status: RequestStatus

--- a/app/src/main/java/com/ioannapergamali/mysmartroute/utils/FirestoreMappers.kt
+++ b/app/src/main/java/com/ioannapergamali/mysmartroute/utils/FirestoreMappers.kt
@@ -449,6 +449,16 @@ fun DocumentSnapshot.toFavoriteEntity(): FavoriteEntity? {
     return FavoriteEntity(favId, userId, type, preferred)
 }
 
+fun TransferRequestEntity.toFirestoreMap(): Map<String, Any> = mapOf(
+    "requestNumber" to requestNumber,
+    "routeId" to FirebaseFirestore.getInstance().collection("routes").document(routeId),
+    "passengerId" to FirebaseFirestore.getInstance().collection("users").document(passengerId),
+    "driverId" to FirebaseFirestore.getInstance().collection("users").document(driverId),
+    "date" to date,
+    "cost" to cost,
+    "status" to status.name
+)
+
 
 fun DocumentSnapshot.toTransferRequestEntity(): TransferRequestEntity? {
     val number = (getLong("requestNumber") ?: return null).toInt()

--- a/app/src/main/java/com/ioannapergamali/mysmartroute/viewmodel/TransferRequestViewModel.kt
+++ b/app/src/main/java/com/ioannapergamali/mysmartroute/viewmodel/TransferRequestViewModel.kt
@@ -1,0 +1,98 @@
+package com.ioannapergamali.mysmartroute.viewmodel
+
+import android.content.Context
+import android.util.Log
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.viewModelScope
+import com.google.firebase.auth.FirebaseAuth
+import com.google.firebase.firestore.FirebaseFirestore
+import com.ioannapergamali.mysmartroute.data.local.MySmartRouteDatabase
+import com.ioannapergamali.mysmartroute.data.local.TransferRequestEntity
+import com.ioannapergamali.mysmartroute.model.enumerations.RequestStatus
+import com.ioannapergamali.mysmartroute.utils.toFirestoreMap
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.tasks.await
+
+class TransferRequestViewModel : ViewModel() {
+    private val db = FirebaseFirestore.getInstance()
+    private val auth = FirebaseAuth.getInstance()
+
+    companion object {
+        private const val TAG = "TransferRequestVM"
+    }
+
+    private fun getNextRequestNumber(context: Context): Int {
+        val prefs = context.getSharedPreferences("transfer_requests", Context.MODE_PRIVATE)
+        val next = prefs.getInt("next_request_number", 1)
+        prefs.edit().putInt("next_request_number", next + 1).apply()
+        return next
+    }
+
+    fun submitRequest(
+        context: Context,
+        routeId: String,
+        driverId: String,
+        cost: Double,
+        date: Long
+    ) {
+        viewModelScope.launch(Dispatchers.IO) {
+            val passengerId = auth.currentUser?.uid ?: return@launch
+            val number = getNextRequestNumber(context)
+            val entity = TransferRequestEntity(
+                requestNumber = number,
+                routeId = routeId,
+                passengerId = passengerId,
+                driverId = driverId,
+                date = date,
+                cost = cost,
+                status = RequestStatus.PENDING
+            )
+            val dao = MySmartRouteDatabase.getInstance(context).transferRequestDao()
+            dao.insert(entity)
+            try {
+                db.collection("transfer_requests")
+                    .document(number.toString())
+                    .set(entity.toFirestoreMap())
+                    .await()
+            } catch (e: Exception) {
+                Log.e(TAG, "Αποτυχία αποθήκευσης αιτήματος", e)
+            }
+        }
+    }
+
+    fun notifyDriver(context: Context, requestNumber: Int, driverId: String) {
+        viewModelScope.launch(Dispatchers.IO) {
+            val dao = MySmartRouteDatabase.getInstance(context).transferRequestDao()
+            dao.assignDriver(requestNumber, driverId, RequestStatus.PENDING)
+            try {
+                db.collection("transfer_requests")
+                    .document(requestNumber.toString())
+                    .update(
+                        mapOf(
+                            "driverId" to db.collection("users").document(driverId),
+                            "status" to RequestStatus.PENDING.name
+                        )
+                    )
+                    .await()
+            } catch (e: Exception) {
+                Log.e(TAG, "Αποτυχία ενημέρωσης οδηγού", e)
+            }
+        }
+    }
+
+    fun updateStatus(context: Context, requestNumber: Int, status: RequestStatus) {
+        viewModelScope.launch(Dispatchers.IO) {
+            val dao = MySmartRouteDatabase.getInstance(context).transferRequestDao()
+            dao.updateStatus(requestNumber, status)
+            try {
+                db.collection("transfer_requests")
+                    .document(requestNumber.toString())
+                    .update("status", status.name)
+                    .await()
+            } catch (e: Exception) {
+                Log.e(TAG, "Αποτυχία ενημέρωσης κατάστασης", e)
+            }
+        }
+    }
+}


### PR DESCRIPTION
## Περίληψη
- Προστέθηκε στήλη driverId και migration για τον πίνακα transfer_requests
- Δημιουργήθηκε TransferRequestViewModel για αποθήκευση/ενημέρωση σε Room και Firestore
- Εμπλουτίστηκε το FirestoreMappers με toFirestoreMap για TransferRequestEntity

## Έλεγχοι
- `./gradlew test` (αποτυχία: SDK location not found)


------
https://chatgpt.com/codex/tasks/task_e_6897fa8a16a08328b8622b661b8c4a2c