### PR TITLE
Διόρθωση ορισμού submitRequest στο TransferRequestViewModel

### DIFF
--- a/app/src/main/java/com/ioannapergamali/mysmartroute/viewmodel/TransferRequestViewModel.kt
+++ b/app/src/main/java/com/ioannapergamali/mysmartroute/viewmodel/TransferRequestViewModel.kt
@@ -32,28 +32,30 @@ class TransferRequestViewModel : ViewModel() {
     fun submitRequest(
         context: Context,
         routeId: String,
+        passengerId: String,
         driverId: String,
+        date: Long,
         cost: Double,
-
-            val number = getNextRequestNumber(context)
-            val entity = TransferRequestEntity(
-                requestNumber = number,
-                routeId = routeId,
-                passengerId = passengerId,
-                driverId = driverId,
-                date = date,
-                cost = cost,
-                status = RequestStatus.PENDING
-            )
-            val dao = MySmartRouteDatabase.getInstance(context).transferRequestDao()
-            dao.insert(entity)
-            try {
-                db.collection("transfer_requests")
-                    .document(number.toString())
-                    .set(entity.toFirestoreMap())
-                    .await()
-
-            }
+    ) {
+        val number = getNextRequestNumber(context)
+        val entity = TransferRequestEntity(
+            requestNumber = number,
+            routeId = routeId,
+            passengerId = passengerId,
+            driverId = driverId,
+            date = date,
+            cost = cost,
+            status = RequestStatus.PENDING
+        )
+        val dao = MySmartRouteDatabase.getInstance(context).transferRequestDao()
+        dao.insert(entity)
+        try {
+            db.collection("transfer_requests")
+                .document(number.toString())
+                .set(entity.toFirestoreMap())
+                .await()
+        } catch (e: Exception) {
+            Log.e(TAG, "Αποτυχία υποβολής αιτήματος", e)
         }
     }
 


### PR DESCRIPTION
## Περιγραφή
- Επιδιόρθωση της συνάρτησης `submitRequest` στο `TransferRequestViewModel` ώστε να κλείνει σωστά η λίστα παραμέτρων και να χειρίζεται εξαίρεση.

## Έλεγχοι
- `./gradlew test` *(αποτυχία: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_6897fff3ffb08328a0c822e7e633e960