### PR TITLE
Use auto-generated ID for transfer requests

### DIFF
--- a/app/src/main/java/com/ioannapergamali/mysmartroute/data/local/TransferRequestDao.kt
+++ b/app/src/main/java/com/ioannapergamali/mysmartroute/data/local/TransferRequestDao.kt
@@ -10,7 +10,7 @@ import com.ioannapergamali.mysmartroute.model.enumerations.RequestStatus
 @Dao
 interface TransferRequestDao {
     @Insert(onConflict = OnConflictStrategy.REPLACE)
-    suspend fun insert(request: TransferRequestEntity)
+    suspend fun insert(request: TransferRequestEntity): Long
 
     @Query("UPDATE transfer_requests SET status = :status WHERE requestNumber = :requestNumber")
     suspend fun updateStatus(requestNumber: Int, status: RequestStatus)

--- a/app/src/main/java/com/ioannapergamali/mysmartroute/utils/FirestoreMappers.kt
+++ b/app/src/main/java/com/ioannapergamali/mysmartroute/utils/FirestoreMappers.kt
@@ -451,7 +451,9 @@ fun DocumentSnapshot.toFavoriteEntity(): FavoriteEntity? {
 
 fun TransferRequestEntity.toFirestoreMap(): Map<String, Any> = mapOf(
     "requestNumber" to requestNumber,
-
+    "routeId" to routeId,
+    "passengerId" to passengerId,
+    "driverId" to driverId,
     "date" to date,
     "cost" to cost,
     "status" to status.name


### PR DESCRIPTION
## Summary
- Save transfer requests with Room auto-generated IDs and propagate to Firestore
- Include passenger, driver and route identifiers when serialising transfer requests

## Testing
- `./gradlew test` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_689807ab824483289bce34c50869711b