### PR TITLE
Use auto-generated ID for transfer requests

### DIFF
--- a/app/src/main/java/com/ioannapergamali/mysmartroute/data/local/TransferRequestDao.kt
+++ b/app/src/main/java/com/ioannapergamali/mysmartroute/data/local/TransferRequestDao.kt
@@ -10,7 +10,7 @@ import com.ioannapergamali.mysmartroute.model.enumerations.RequestStatus
 @Dao
 interface TransferRequestDao {
     @Insert(onConflict = OnConflictStrategy.REPLACE)
-    suspend fun insert(request: TransferRequestEntity)
+    suspend fun insert(request: TransferRequestEntity): Long
 
     @Query("UPDATE transfer_requests SET status = :status WHERE requestNumber = :requestNumber")
     suspend fun updateStatus(requestNumber: Int, status: RequestStatus)

--- a/app/src/main/java/com/ioannapergamali/mysmartroute/utils/FirestoreMappers.kt
+++ b/app/src/main/java/com/ioannapergamali/mysmartroute/utils/FirestoreMappers.kt
@@ -451,7 +451,15 @@ fun DocumentSnapshot.toFavoriteEntity(): FavoriteEntity? {
 
 fun TransferRequestEntity.toFirestoreMap(): Map<String, Any> = mapOf(
     "requestNumber" to requestNumber,
-
+    "routeId" to FirebaseFirestore.getInstance()
+        .collection("routes")
+        .document(routeId),
+    "passengerId" to FirebaseFirestore.getInstance()
+        .collection("users")
+        .document(passengerId),
+    "driverId" to FirebaseFirestore.getInstance()
+        .collection("users")
+        .document(driverId),
     "date" to date,
     "cost" to cost,
     "status" to status.name

--- a/app/src/main/java/com/ioannapergamali/mysmartroute/viewmodel/TransferRequestViewModel.kt
+++ b/app/src/main/java/com/ioannapergamali/mysmartroute/viewmodel/TransferRequestViewModel.kt
@@ -22,13 +22,6 @@ class TransferRequestViewModel : ViewModel() {
         private const val TAG = "TransferRequestVM"
     }
 
-    private fun getNextRequestNumber(context: Context): Int {
-        val prefs = context.getSharedPreferences("transfer_requests", Context.MODE_PRIVATE)
-        val next = prefs.getInt("next_request_number", 1)
-        prefs.edit().putInt("next_request_number", next + 1).apply()
-        return next
-    }
-
     fun submitRequest(
         context: Context,
         routeId: String,
@@ -37,9 +30,7 @@ class TransferRequestViewModel : ViewModel() {
         date: Long,
         cost: Double,
     ) {
-        val number = getNextRequestNumber(context)
         val entity = TransferRequestEntity(
-            requestNumber = number,
             routeId = routeId,
             passengerId = passengerId,
             driverId = driverId,
@@ -48,12 +39,15 @@ class TransferRequestViewModel : ViewModel() {
             status = RequestStatus.PENDING
         )
         viewModelScope.launch(Dispatchers.IO) {
-            val dao = MySmartRouteDatabase.getInstance(context).transferRequestDao()
-            dao.insert(entity)
+            val dao = MySmartRouteDatabase
+                .getInstance(context.applicationContext)
+                .transferRequestDao()
+            val id = dao.insert(entity)
+            val saved = entity.copy(requestNumber = id.toInt())
             try {
                 db.collection("transfer_requests")
-                    .document(number.toString())
-                    .set(entity.toFirestoreMap())
+                    .document(id.toString())
+                    .set(saved.toFirestoreMap())
                     .await()
             } catch (e: Exception) {
                 Log.e(TAG, "Αποτυχία υποβολής αιτήματος", e)


### PR DESCRIPTION
## Summary
- Represent transfer request links with Firestore DocumentReferences
- Use application context when accessing Room database

## Testing
- `./gradlew test` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_689807ab824483289bce34c50869711b