### PR TITLE
Fix missing DAO initialization in TransferRequestViewModel

### DIFF
--- a/app/src/main/java/com/ioannapergamali/mysmartroute/viewmodel/TransferRequestViewModel.kt
+++ b/app/src/main/java/com/ioannapergamali/mysmartroute/viewmodel/TransferRequestViewModel.kt
@@ -39,7 +39,7 @@ class TransferRequestViewModel : ViewModel() {
             status = RequestStatus.PENDING
         )
         viewModelScope.launch(Dispatchers.IO) {
-
+            val dao = MySmartRouteDatabase.getInstance(context).transferRequestDao()
             val id = dao.insert(entity)
             val saved = entity.copy(requestNumber = id.toInt())
             try {


### PR DESCRIPTION
## Summary
- Initialize local DAO in TransferRequestViewModel.submitRequest

## Testing
- `./gradlew test` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_68980ef398e08328bc068387c1649845