### PR TITLE
Διόρθωση αποθήκευσης αιτημάτων μεταφοράς

### DIFF
--- a/app/src/main/java/com/ioannapergamali/mysmartroute/viewmodel/TransferRequestViewModel.kt
+++ b/app/src/main/java/com/ioannapergamali/mysmartroute/viewmodel/TransferRequestViewModel.kt
@@ -39,7 +39,7 @@ class TransferRequestViewModel : ViewModel() {
             status = RequestStatus.PENDING
         )
         viewModelScope.launch(Dispatchers.IO) {
-
+            val dao = MySmartRouteDatabase.getInstance(context).transferRequestDao()
             val id = dao.insert(entity)
             val saved = entity.copy(requestNumber = id.toInt())
             try {


### PR DESCRIPTION
## Περιγραφή
- Αρχικοποιήθηκε σωστά το `TransferRequestDao` στο `TransferRequestViewModel` ώστε να καταχωρούνται οι αιτήσεις μεταφοράς

## Έλεγχοι
- `./gradlew test` *(αποτυχία: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_68980e4b7db88328be79d4ad789908a5