### PR TITLE
Προσθήκη logs για αποθήκευση αιτήματος μεταφοράς

### DIFF
--- a/app/src/main/java/com/ioannapergamali/mysmartroute/viewmodel/TransferRequestViewModel.kt
+++ b/app/src/main/java/com/ioannapergamali/mysmartroute/viewmodel/TransferRequestViewModel.kt
@@ -40,13 +40,16 @@ class TransferRequestViewModel : ViewModel() {
         )
         viewModelScope.launch(Dispatchers.IO) {
             val dao = MySmartRouteDatabase.getInstance(context).transferRequestDao()
-            val id = dao.insert(entity)
-            val saved = entity.copy(requestNumber = id.toInt())
             try {
+                Log.d(TAG, "Εισαγωγή αιτήματος: $entity")
+                val id = dao.insert(entity)
+                Log.d(TAG, "Το αίτημα αποθηκεύτηκε τοπικά με id=$id")
+                val saved = entity.copy(requestNumber = id.toInt())
                 db.collection("transfer_requests")
                     .document(id.toString())
                     .set(saved.toFirestoreMap())
                     .await()
+                Log.d(TAG, "Το αίτημα αποθηκεύτηκε στο Firestore με id=$id")
             } catch (e: Exception) {
                 Log.e(TAG, "Αποτυχία υποβολής αιτήματος", e)
             }


### PR DESCRIPTION
## Περίληψη
- Προστέθηκαν διαγνωστικά μηνύματα κατά την αποθήκευση αιτήματος μεταφοράς ώστε να εντοπίζεται τοπική και απομακρυσμένη αποθήκευση.

## Έλεγχοι
- `./gradlew test` *(αποτυχία: απαιτούνται Android SDK components και αποδοχή αδειών)*

------
https://chatgpt.com/codex/tasks/task_e_689812694ca48328bb3509cdc3310246