### PR TITLE
Σύνδεση αιτημάτων με μενού επιβάτη και οδηγού

### DIFF
--- a/app/src/main/java/com/ioannapergamali/mysmartroute/view/ui/screens/BookSeatScreen.kt
+++ b/app/src/main/java/com/ioannapergamali/mysmartroute/view/ui/screens/BookSeatScreen.kt
@@ -63,6 +63,7 @@ import com.ioannapergamali.mysmartroute.viewmodel.RouteViewModel
 import com.ioannapergamali.mysmartroute.viewmodel.PoIViewModel
 import com.ioannapergamali.mysmartroute.viewmodel.TransportDeclarationViewModel
 import com.ioannapergamali.mysmartroute.viewmodel.VehicleRequestViewModel
+import com.ioannapergamali.mysmartroute.viewmodel.TransferRequestViewModel
 import kotlinx.coroutines.launch
 import java.time.Instant
 import java.time.ZoneId
@@ -87,6 +88,7 @@ fun BookSeatScreen(
     val poiViewModel: PoIViewModel = viewModel()
     val declarationViewModel: TransportDeclarationViewModel = viewModel()
     val requestViewModel: VehicleRequestViewModel = viewModel()
+    val transferRequestViewModel: TransferRequestViewModel = viewModel()
     val routes by viewModel.availableRoutes.collectAsState()
     val allPois by poiViewModel.pois.collectAsState()
     val declarations by declarationViewModel.declarations.collectAsState()
@@ -552,6 +554,12 @@ fun BookSeatScreen(
                             endId,
                             Double.MAX_VALUE,
                             dateMillis
+                        )
+                        transferRequestViewModel.submitRequest(
+                            context,
+                            r.id,
+                            dateMillis,
+                            Double.MAX_VALUE
                         )
                         message = context.getString(R.string.request_sent)
                     }

--- a/app/src/main/java/com/ioannapergamali/mysmartroute/view/ui/screens/FindVehicleScreen.kt
+++ b/app/src/main/java/com/ioannapergamali/mysmartroute/view/ui/screens/FindVehicleScreen.kt
@@ -39,6 +39,7 @@ import com.ioannapergamali.mysmartroute.R
 import com.ioannapergamali.mysmartroute.view.ui.components.ScreenContainer
 import com.ioannapergamali.mysmartroute.view.ui.components.TopBar
 import com.ioannapergamali.mysmartroute.viewmodel.VehicleRequestViewModel
+import com.ioannapergamali.mysmartroute.viewmodel.TransferRequestViewModel
 import com.ioannapergamali.mysmartroute.viewmodel.RouteViewModel
 import com.ioannapergamali.mysmartroute.viewmodel.PoIViewModel
 import com.ioannapergamali.mysmartroute.model.enumerations.VehicleType
@@ -50,6 +51,7 @@ fun FindVehicleScreen(navController: NavController, openDrawer: () -> Unit) {
     val context = LocalContext.current
     val routeViewModel: RouteViewModel = viewModel()
     val requestViewModel: VehicleRequestViewModel = viewModel()
+    val transferRequestViewModel: TransferRequestViewModel = viewModel()
     val poiViewModel: PoIViewModel = viewModel()
     val routes by routeViewModel.routes.collectAsState()
     val allPois by poiViewModel.pois.collectAsState()
@@ -398,6 +400,7 @@ fun FindVehicleScreen(navController: NavController, openDrawer: () -> Unit) {
                         val routeId = selectedRouteId ?: return@Button
                         val dateMillis = System.currentTimeMillis()
                         requestViewModel.requestTransport(context, routeId, fromId, toId, cost, dateMillis)
+                        transferRequestViewModel.submitRequest(context, routeId, dateMillis, cost)
                         message = context.getString(R.string.request_sent)
                     },
                     enabled = selectedRouteId != null && startIndex != null && endIndex != null,

--- a/app/src/main/java/com/ioannapergamali/mysmartroute/view/ui/screens/ViewRequestsScreen.kt
+++ b/app/src/main/java/com/ioannapergamali/mysmartroute/view/ui/screens/ViewRequestsScreen.kt
@@ -30,6 +30,8 @@ import com.ioannapergamali.mysmartroute.view.ui.components.TopBar
 import com.ioannapergamali.mysmartroute.viewmodel.PoIViewModel
 import com.ioannapergamali.mysmartroute.viewmodel.VehicleRequestViewModel
 import com.ioannapergamali.mysmartroute.viewmodel.UserViewModel
+import com.ioannapergamali.mysmartroute.viewmodel.TransferRequestViewModel
+import com.ioannapergamali.mysmartroute.model.enumerations.RequestStatus
 import android.text.format.DateFormat
 import java.util.Date
 
@@ -42,6 +44,7 @@ fun ViewRequestsScreen(navController: NavController, openDrawer: () -> Unit) {
     val viewModel: VehicleRequestViewModel = viewModel()
     val poiViewModel: PoIViewModel = viewModel()
     val userViewModel: UserViewModel = viewModel()
+    val transferViewModel: TransferRequestViewModel = viewModel()
     val requests by viewModel.requests.collectAsState()
     val pois by poiViewModel.pois.collectAsState()
     val driverNames = remember { mutableStateMapOf<String, String>() }
@@ -130,15 +133,36 @@ fun ViewRequestsScreen(navController: NavController, openDrawer: () -> Unit) {
                                 if (req.status == "pending") {
                                     val dName = driverNames[req.driverId] ?: ""
                                     Text(dName, modifier = Modifier.width(columnWidth))
-                                    Button(onClick = { viewModel.respondToOffer(context, req.id, true) }) {
+                                    Button(onClick = {
+                                        viewModel.respondToOffer(context, req.id, true)
+                                        transferViewModel.updateStatus(
+                                            context,
+                                            req.requestNumber,
+                                            RequestStatus.ACCEPTED
+                                        )
+                                    }) {
                                         Text(stringResource(R.string.accept_offer))
                                     }
                                     Spacer(modifier = Modifier.width(4.dp))
-                                    Button(onClick = { viewModel.respondToOffer(context, req.id, false) }) {
+                                    Button(onClick = {
+                                        viewModel.respondToOffer(context, req.id, false)
+                                        transferViewModel.updateStatus(
+                                            context,
+                                            req.requestNumber,
+                                            RequestStatus.REJECTED
+                                        )
+                                    }) {
                                         Text(stringResource(R.string.reject_offer))
                                     }
                                 }
-                                Button(onClick = { viewModel.deleteRequests(context, setOf(req.id)) }) {
+                                Button(onClick = {
+                                    transferViewModel.updateStatus(
+                                        context,
+                                        req.requestNumber,
+                                        RequestStatus.CANCELED
+                                    )
+                                    viewModel.deleteRequests(context, setOf(req.id))
+                                }) {
                                     Text(stringResource(R.string.cancel_request))
                                 }
                             }

--- a/app/src/main/java/com/ioannapergamali/mysmartroute/view/ui/screens/ViewTransportRequestsScreen.kt
+++ b/app/src/main/java/com/ioannapergamali/mysmartroute/view/ui/screens/ViewTransportRequestsScreen.kt
@@ -31,6 +31,7 @@ import com.ioannapergamali.mysmartroute.view.ui.components.TopBar
 import com.ioannapergamali.mysmartroute.viewmodel.PoIViewModel
 import com.ioannapergamali.mysmartroute.viewmodel.UserViewModel
 import com.ioannapergamali.mysmartroute.viewmodel.VehicleRequestViewModel
+import com.ioannapergamali.mysmartroute.viewmodel.TransferRequestViewModel
 import android.text.format.DateFormat
 import java.util.Date
 
@@ -39,6 +40,7 @@ import java.util.Date
 fun ViewTransportRequestsScreen(navController: NavController, openDrawer: () -> Unit) {
     val context = LocalContext.current
     val viewModel: VehicleRequestViewModel = viewModel()
+    val transferViewModel: TransferRequestViewModel = viewModel()
     val poiViewModel: PoIViewModel = viewModel()
     val userViewModel: UserViewModel = viewModel()
     val requests by viewModel.requests.collectAsState()
@@ -159,7 +161,10 @@ fun ViewTransportRequestsScreen(navController: NavController, openDrawer: () -> 
                                 Text(dateText, modifier = Modifier.width(columnWidth))
                                 if (req.status == "open") {
                                     Button(
-                                        onClick = { viewModel.notifyPassenger(context, req.id) },
+                                        onClick = {
+                                            viewModel.notifyPassenger(context, req.id)
+                                            transferViewModel.notifyDriver(context, req.requestNumber)
+                                        },
                                         modifier = Modifier.width(columnWidth)
                                     ) {
                                         Text(stringResource(R.string.notify_passenger))

--- a/app/src/main/java/com/ioannapergamali/mysmartroute/viewmodel/TransferRequestViewModel.kt
+++ b/app/src/main/java/com/ioannapergamali/mysmartroute/viewmodel/TransferRequestViewModel.kt
@@ -25,35 +25,38 @@ class TransferRequestViewModel : ViewModel() {
     fun submitRequest(
         context: Context,
         routeId: String,
-        passengerId: String,
-        driverId: String,
         date: Long,
         cost: Double,
     ) {
+        val passengerId = auth.currentUser?.uid ?: return
         val entity = TransferRequestEntity(
             routeId = routeId,
             passengerId = passengerId,
-            driverId = driverId,
+            driverId = "",
             date = date,
             cost = cost,
             status = RequestStatus.PENDING
         )
         viewModelScope.launch(Dispatchers.IO) {
             val dao = MySmartRouteDatabase.getInstance(context).transferRequestDao()
-            val id = dao.insert(entity)
-            val saved = entity.copy(requestNumber = id.toInt())
             try {
+                Log.d(TAG, "Εισαγωγή αιτήματος: $entity")
+                val id = dao.insert(entity)
+                Log.d(TAG, "Το αίτημα αποθηκεύτηκε τοπικά με id=$id")
+                val saved = entity.copy(requestNumber = id.toInt())
                 db.collection("transfer_requests")
                     .document(id.toString())
                     .set(saved.toFirestoreMap())
                     .await()
+                Log.d(TAG, "Το αίτημα αποθηκεύτηκε στο Firestore με id=$id")
             } catch (e: Exception) {
                 Log.e(TAG, "Αποτυχία υποβολής αιτήματος", e)
             }
         }
     }
 
-    fun notifyDriver(context: Context, requestNumber: Int, driverId: String) {
+    fun notifyDriver(context: Context, requestNumber: Int) {
+        val driverId = auth.currentUser?.uid ?: return
         viewModelScope.launch(Dispatchers.IO) {
             val dao = MySmartRouteDatabase.getInstance(context).transferRequestDao()
             dao.assignDriver(requestNumber, driverId, RequestStatus.PENDING)
@@ -62,7 +65,7 @@ class TransferRequestViewModel : ViewModel() {
                     .document(requestNumber.toString())
                     .update(
                         mapOf(
-
+                            "driverId" to driverId,
                             "status" to RequestStatus.PENDING.name
                         )
                     )


### PR DESCRIPTION
## Περίληψη
- Σύνδεση της αποθήκευσης αιτήματος των επιβατών με το νέο `TransferRequestViewModel`
- Ενημέρωση οδηγού και κατάστασης όταν ο οδηγός επιλέγει ειδοποίηση επιβάτη
- Συγχρονισμός κατάστασης αιτημάτων κατά την αποδοχή, απόρριψη ή ακύρωση από τον επιβάτη

## Έλεγχοι
- `./gradlew test` *(αποτυχία: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_689812694ca48328bb3509cdc3310246