### PR TITLE
Προσθήκη συνδέσμου αιτήματος στις ειδοποιήσεις

### DIFF
--- a/app/src/main/java/com/ioannapergamali/mysmartroute/model/navigation/NavigationHost.kt
+++ b/app/src/main/java/com/ioannapergamali/mysmartroute/model/navigation/NavigationHost.kt
@@ -51,9 +51,13 @@ import com.ioannapergamali.mysmartroute.R
 
 
 @Composable
-fun NavigationHost(navController : NavHostController, openDrawer: () -> Unit) {
+fun NavigationHost(
+    navController: NavHostController,
+    openDrawer: () -> Unit,
+    startDestination: String = "home"
+) {
 
-    NavHost(navController = navController , startDestination = "home") {
+    NavHost(navController = navController, startDestination = startDestination) {
 
         composable("home") {
             HomeScreen(

--- a/app/src/main/java/com/ioannapergamali/mysmartroute/utils/NotificationUtils.kt
+++ b/app/src/main/java/com/ioannapergamali/mysmartroute/utils/NotificationUtils.kt
@@ -2,6 +2,7 @@ package com.ioannapergamali.mysmartroute.utils
 
 import android.app.NotificationChannel
 import android.app.NotificationManager
+import android.app.PendingIntent
 import android.content.Context
 import android.os.Build
 import androidx.core.app.NotificationCompat
@@ -11,7 +12,13 @@ import com.ioannapergamali.mysmartroute.R
 object NotificationUtils {
     private const val CHANNEL_ID = "default_channel"
 
-    fun showNotification(context: Context, title: String, text: String, id: Int = 0) {
+    fun showNotification(
+        context: Context,
+        title: String,
+        text: String,
+        id: Int = 0,
+        pendingIntent: PendingIntent? = null
+    ) {
         // Δημιουργία καναλιού ειδοποίησης για Android 8+
         if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
             val channel = NotificationChannel(
@@ -23,12 +30,18 @@ object NotificationUtils {
                 .createNotificationChannel(channel)
         }
 
-        val notification = NotificationCompat.Builder(context, CHANNEL_ID)
+        val builder = NotificationCompat.Builder(context, CHANNEL_ID)
             .setSmallIcon(R.drawable.ic_notification)
             .setContentTitle(title)
             .setContentText(text)
             .setPriority(NotificationCompat.PRIORITY_DEFAULT)
-            .build()
+
+        pendingIntent?.let {
+            builder.setContentIntent(it)
+                .setAutoCancel(true)
+        }
+
+        val notification = builder.build()
 
         NotificationManagerCompat.from(context).notify(id, notification)
     }

--- a/app/src/main/java/com/ioannapergamali/mysmartroute/viewmodel/MainActivity.kt
+++ b/app/src/main/java/com/ioannapergamali/mysmartroute/viewmodel/MainActivity.kt
@@ -81,6 +81,8 @@ class MainActivity : ComponentActivity() {
             SoundManager.setVolume(volume)
             if (enabled) SoundManager.play()
         }
+        val startDestination = intent?.getStringExtra("startDestination") ?: "home"
+
         setContent {
             val context = LocalContext.current
             val theme by ThemePreferenceManager.themeFlow(context).collectAsState(initial = AppTheme.Ocean)
@@ -106,7 +108,11 @@ class MainActivity : ComponentActivity() {
             MysmartrouteTheme(theme = theme, darkTheme = dark, font = font.fontFamily) {
                 val navController = rememberNavController()
                 DrawerWrapper(navController = navController) { openDrawer ->
-                    NavigationHost(navController = navController, openDrawer = openDrawer)
+                    NavigationHost(
+                        navController = navController,
+                        openDrawer = openDrawer,
+                        startDestination = startDestination
+                    )
                 }
             }
         }

--- a/app/src/main/java/com/ioannapergamali/mysmartroute/viewmodel/VehicleRequestViewModel.kt
+++ b/app/src/main/java/com/ioannapergamali/mysmartroute/viewmodel/VehicleRequestViewModel.kt
@@ -1,6 +1,8 @@
 package com.ioannapergamali.mysmartroute.viewmodel
 
+import android.app.PendingIntent
 import android.content.Context
+import android.content.Intent
 import android.util.Log
 import android.widget.Toast
 import androidx.lifecycle.ViewModel
@@ -16,6 +18,7 @@ import com.ioannapergamali.mysmartroute.utils.NetworkUtils
 import com.ioannapergamali.mysmartroute.utils.NotificationUtils
 import com.ioannapergamali.mysmartroute.R
 import com.ioannapergamali.mysmartroute.viewmodel.BookingViewModel
+import com.ioannapergamali.mysmartroute.viewmodel.MainActivity
 
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
@@ -282,11 +285,21 @@ class VehicleRequestViewModel : ViewModel() {
         _requests.value.filter { it.driverId.isBlank() && it.status.isBlank() && it.id !in notifiedRequests }
             .forEach { req ->
                 val passengerName = UserViewModel().getUserName(context, req.userId)
+                val intent = Intent(context, MainActivity::class.java).apply {
+                    putExtra("startDestination", "viewTransportRequests")
+                }
+                val pending = PendingIntent.getActivity(
+                    context,
+                    req.id.hashCode(),
+                    intent,
+                    PendingIntent.FLAG_UPDATE_CURRENT or PendingIntent.FLAG_IMMUTABLE
+                )
                 NotificationUtils.showNotification(
                     context,
                     context.getString(R.string.notifications),
                     context.getString(R.string.passenger_request_notification, passengerName),
-                    req.id.hashCode()
+                    req.id.hashCode(),
+                    pending
                 )
                 notifiedRequests.add(req.id)
             }
@@ -299,11 +312,21 @@ class VehicleRequestViewModel : ViewModel() {
             } else {
                 UserViewModel().getUserName(context, req.driverId)
             }
+            val intent = Intent(context, MainActivity::class.java).apply {
+                putExtra("startDestination", "viewRequests")
+            }
+            val pending = PendingIntent.getActivity(
+                context,
+                req.id.hashCode(),
+                intent,
+                PendingIntent.FLAG_UPDATE_CURRENT or PendingIntent.FLAG_IMMUTABLE
+            )
             NotificationUtils.showNotification(
                 context,
                 context.getString(R.string.notifications),
                 context.getString(R.string.driver_offer_notification, driverName),
-                req.id.hashCode()
+                req.id.hashCode(),
+                pending
             )
             notifiedRequests.add(req.id)
         }
@@ -313,25 +336,45 @@ class VehicleRequestViewModel : ViewModel() {
         val userId = FirebaseAuth.getInstance().currentUser?.uid ?: return
         _requests.value.filter { it.status == "accepted" && it.driverId == userId && it.id !in notifiedRequests }
             .forEach { req ->
-            NotificationUtils.showNotification(
-                context,
-                context.getString(R.string.notifications),
-                context.getString(R.string.request_accepted_notification, req.requestNumber),
-                req.id.hashCode()
-            )
-            notifiedRequests.add(req.id)
-        }
+                val intent = Intent(context, MainActivity::class.java).apply {
+                    putExtra("startDestination", "viewTransportRequests")
+                }
+                val pending = PendingIntent.getActivity(
+                    context,
+                    req.id.hashCode(),
+                    intent,
+                    PendingIntent.FLAG_UPDATE_CURRENT or PendingIntent.FLAG_IMMUTABLE
+                )
+                NotificationUtils.showNotification(
+                    context,
+                    context.getString(R.string.notifications),
+                    context.getString(R.string.request_accepted_notification, req.requestNumber),
+                    req.id.hashCode(),
+                    pending
+                )
+                notifiedRequests.add(req.id)
+            }
     }
 
     private suspend fun showRejectedNotifications(context: Context) {
         val userId = FirebaseAuth.getInstance().currentUser?.uid ?: return
         _requests.value.filter { it.status == "rejected" && it.driverId == userId && it.id !in notifiedRequests }
             .forEach { req ->
+                val intent = Intent(context, MainActivity::class.java).apply {
+                    putExtra("startDestination", "viewTransportRequests")
+                }
+                val pending = PendingIntent.getActivity(
+                    context,
+                    req.id.hashCode(),
+                    intent,
+                    PendingIntent.FLAG_UPDATE_CURRENT or PendingIntent.FLAG_IMMUTABLE
+                )
                 NotificationUtils.showNotification(
                     context,
                     context.getString(R.string.notifications),
                     context.getString(R.string.request_rejected_notification),
-                    req.id.hashCode()
+                    req.id.hashCode(),
+                    pending
                 )
                 notifiedRequests.add(req.id)
             }


### PR DESCRIPTION
## Σύνοψη
- Προσθήκη δυνατότητας PendingIntent ώστε οι ειδοποιήσεις να ανοίγουν την εφαρμογή και να κατευθύνουν τον χρήστη στο κατάλληλο αίτημα
- Προσαρμογή του VehicleRequestViewModel για δημιουργία PendingIntent προς τις οθόνες αιτημάτων
- Υποστήριξη παραμέτρου αρχικής διαδρομής στο NavigationHost και χρήση της στο MainActivity

## Έλεγχοι
- `./gradlew test` (απέτυχε: SDK location not found)

------
https://chatgpt.com/codex/tasks/task_e_68982372d19083288cb23ca81139a792