### PR TITLE
Εμφάνιση αριθμού αιτήματος σε λίστες και ειδοποιήσεις

### DIFF
--- a/app/src/main/java/com/ioannapergamali/mysmartroute/view/ui/screens/NotificationsScreen.kt
+++ b/app/src/main/java/com/ioannapergamali/mysmartroute/view/ui/screens/NotificationsScreen.kt
@@ -79,7 +79,8 @@ fun NotificationsScreen(navController: NavController, openDrawer: () -> Unit) {
                             UserRole.DRIVER -> when {
                                 req.driverId.isBlank() -> stringResource(
                                     R.string.passenger_request_notification,
-                                    req.createdByName
+                                    req.createdByName,
+                                    req.requestNumber
                                 )
 
                                 req.status == "accepted" -> stringResource(
@@ -88,7 +89,8 @@ fun NotificationsScreen(navController: NavController, openDrawer: () -> Unit) {
                                 )
 
                                 req.status == "rejected" -> stringResource(
-                                    R.string.request_rejected_notification
+                                    R.string.request_rejected_notification,
+                                    req.requestNumber
                                 )
 
                                 else -> ""
@@ -96,7 +98,8 @@ fun NotificationsScreen(navController: NavController, openDrawer: () -> Unit) {
 
                             UserRole.PASSENGER -> stringResource(
                                 R.string.driver_offer_notification,
-                                req.driverName
+                                req.driverName,
+                                req.requestNumber
                             )
 
                             else -> ""

--- a/app/src/main/java/com/ioannapergamali/mysmartroute/view/ui/screens/ViewRequestsScreen.kt
+++ b/app/src/main/java/com/ioannapergamali/mysmartroute/view/ui/screens/ViewRequestsScreen.kt
@@ -100,6 +100,10 @@ fun ViewRequestsScreen(navController: NavController, openDrawer: () -> Unit) {
                         item {
                             Row(verticalAlignment = Alignment.CenterVertically) {
                                 Text(
+                                    stringResource(R.string.request_number),
+                                    modifier = Modifier.width(columnWidth)
+                                )
+                                Text(
                                     stringResource(R.string.route_name),
                                     modifier = Modifier.width(columnWidth)
                                 )
@@ -127,6 +131,7 @@ fun ViewRequestsScreen(navController: NavController, openDrawer: () -> Unit) {
                                 modifier = Modifier.padding(vertical = 8.dp),
                                 verticalAlignment = Alignment.CenterVertically,
                             ) {
+                                Text(req.requestNumber.toString(), modifier = Modifier.width(columnWidth))
                                 Text(routeName, modifier = Modifier.width(columnWidth))
                                 Text(costText, modifier = Modifier.width(columnWidth))
                                 Text(dateText, modifier = Modifier.width(columnWidth))

--- a/app/src/main/java/com/ioannapergamali/mysmartroute/view/ui/screens/ViewTransportRequestsScreen.kt
+++ b/app/src/main/java/com/ioannapergamali/mysmartroute/view/ui/screens/ViewTransportRequestsScreen.kt
@@ -127,6 +127,11 @@ fun ViewTransportRequestsScreen(navController: NavController, openDrawer: () -> 
                                     modifier = Modifier.width(columnWidth),
                                     style = MaterialTheme.typography.labelMedium
                                 )
+                                Text(
+                                    stringResource(R.string.request_number),
+                                    modifier = Modifier.width(columnWidth),
+                                    style = MaterialTheme.typography.labelMedium
+                                )
                             }
                             Divider()
                         }
@@ -159,6 +164,7 @@ fun ViewTransportRequestsScreen(navController: NavController, openDrawer: () -> 
                                 val costText = if (req.cost == Double.MAX_VALUE) "∞" else req.cost.toString()
                                 Text(costText, modifier = Modifier.width(columnWidth))
                                 Text(dateText, modifier = Modifier.width(columnWidth))
+                                Text(req.requestNumber.toString(), modifier = Modifier.width(columnWidth))
                                 if (req.status == "open") {
                                     Button(
                                         onClick = {

--- a/app/src/main/java/com/ioannapergamali/mysmartroute/viewmodel/VehicleRequestViewModel.kt
+++ b/app/src/main/java/com/ioannapergamali/mysmartroute/viewmodel/VehicleRequestViewModel.kt
@@ -285,7 +285,11 @@ class VehicleRequestViewModel : ViewModel() {
                 NotificationUtils.showNotification(
                     context,
                     context.getString(R.string.notifications),
-                    context.getString(R.string.passenger_request_notification, passengerName),
+                    context.getString(
+                        R.string.passenger_request_notification,
+                        passengerName,
+                        req.requestNumber
+                    ),
                     req.id.hashCode()
                 )
                 notifiedRequests.add(req.id)
@@ -302,7 +306,11 @@ class VehicleRequestViewModel : ViewModel() {
             NotificationUtils.showNotification(
                 context,
                 context.getString(R.string.notifications),
-                context.getString(R.string.driver_offer_notification, driverName),
+                context.getString(
+                    R.string.driver_offer_notification,
+                    driverName,
+                    req.requestNumber
+                ),
                 req.id.hashCode()
             )
             notifiedRequests.add(req.id)
@@ -330,7 +338,10 @@ class VehicleRequestViewModel : ViewModel() {
                 NotificationUtils.showNotification(
                     context,
                     context.getString(R.string.notifications),
-                    context.getString(R.string.request_rejected_notification),
+                    context.getString(
+                        R.string.request_rejected_notification,
+                        req.requestNumber
+                    ),
                     req.id.hashCode()
                 )
                 notifiedRequests.add(req.id)

--- a/app/src/main/res/values-el/strings.xml
+++ b/app/src/main/res/values-el/strings.xml
@@ -180,16 +180,17 @@
     <string name="reject_offer">Απόρριψη</string>
     <string name="no_notifications">Καμία ειδοποίηση</string>
     <string name="no_scheduled_transports">Δεν βρέθηκαν προγραμματισμένες μεταφορές</string>
+    <string name="request_number">Αριθμός αιτήματος</string>
     <!-- Notification text -->
     <string name="app_started_notification">Η εφαρμογή ξεκίνησε</string>
     <string name="request_accepted">Το αίτημα έγινε αποδεκτό</string>
 
-    <string name="request_rejected_notification">Το αίτημά σας δεν έγινε αποδεκτό</string>
+    <string name="request_rejected_notification">Το αίτημά σας με αριθμό %1$d δεν έγινε αποδεκτό</string>
 
     <string name="request_accepted_notification">Το αίτημά σας με αριθμό %1$d έγινε αποδεκτό</string>
 
-    <string name="passenger_request_notification">Ο επιβάτης %1$s ζήτησε μεταφορά</string>
-    <string name="driver_offer_notification">Ο οδηγός %1$s προσφέρθηκε να σας μεταφέρει</string>
+    <string name="passenger_request_notification">Ο επιβάτης %1$s ζήτησε μεταφορά. Αίτημα αριθμός %2$d</string>
+    <string name="driver_offer_notification">Ο οδηγός %1$s προσφέρθηκε να σας μεταφέρει. Αίτημα αριθμός %2$d</string>
     <string name="available_transports">Διαθέσιμες μεταφορές</string>
     <string name="no_transports_found">Δεν βρέθηκαν μεταφορές</string>
     <string name="find_now">Εύρεση τώρα</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -187,6 +187,7 @@
     <string name="sort_by_cost">Sort by cost</string>
     <string name="sort_by_date">Sort by date</string>
     <string name="cancel_request">Cancel request</string>
+    <string name="request_number">Request number</string>
     <string name="notify_passenger">Notify passenger</string>
     <string name="accept_offer">Accept</string>
     <string name="reject_offer">Reject</string>
@@ -195,12 +196,12 @@
 
     <!-- Notification text -->
     <string name="app_started_notification">App started successfully</string>
-    <string name="driver_offer_notification">Ο οδηγός %1$s προσφέρθηκε να σας μεταφέρει</string>
-    <string name="passenger_request_notification">Ο επιβάτης %1$s ζήτησε μεταφορά</string>
+    <string name="driver_offer_notification">Ο οδηγός %1$s προσφέρθηκε να σας μεταφέρει. Αίτημα αριθμός %2$d</string>
+    <string name="passenger_request_notification">Ο επιβάτης %1$s ζήτησε μεταφορά. Αίτημα αριθμός %2$d</string>
     <string name="request_accepted">Request accepted</string>
     <string name="request_accept_failed">Αποτυχία αποδοχής αιτήματος</string>
 
-    <string name="request_rejected_notification">The request was rejected</string>
+    <string name="request_rejected_notification">Your request with number %1$d was rejected</string>
 
     <string name="request_accepted_notification">Your request with number %1$d was accepted</string>
 


### PR DESCRIPTION
## Περιγραφή
- Προστέθηκε στήλη με τον αριθμό αιτήματος στις οθόνες προβολής αιτημάτων
- Οι ειδοποιήσεις οδηγού και επιβάτη εμφανίζουν πλέον τον αριθμό αιτήματος
- Εμπλουτισμός πόρων κειμένου με μεταφράσεις για τον αριθμό αιτήματος

## Έλεγχοι
- `./gradlew test` (αποτυχία: SDK location not found)


------
https://chatgpt.com/codex/tasks/task_e_68982237978c8328978625eb66d6356c