### PR TITLE
Add passenger movings screen with categorized lists

### DIFF
--- a/app/src/main/assets/menus.json
+++ b/app/src/main/assets/menus.json
@@ -15,6 +15,7 @@
           {"titleKey": "select_pois_screen_title", "route": "selectRoutePois"},
           {"titleKey": "view_transports", "route": "viewTransports"},
           {"titleKey": "view_requests", "route": "viewRequests"},
+          {"titleKey": "view_movings", "route": "viewMovings"},
           {"titleKey": "print_ticket", "route": "printTicket"},
           {"titleKey": "cancel_seat", "route": "cancelSeat"},
           {"titleKey": "rank_transports", "route": "rankTransports"},

--- a/app/src/main/java/com/ioannapergamali/mysmartroute/data/local/MySmartRouteDatabase.kt
+++ b/app/src/main/java/com/ioannapergamali/mysmartroute/data/local/MySmartRouteDatabase.kt
@@ -249,6 +249,7 @@ abstract class MySmartRouteDatabase : RoomDatabase() {
                 insertOption("opt_passenger_10", passengerMenuId, "rank_transports", "rankTransports")
                 insertOption("opt_passenger_11", passengerMenuId, "shutdown", "shutdown")
                 insertOption("opt_passenger_12", passengerMenuId, "view_requests", "viewRequests")
+                insertOption("opt_passenger_13", passengerMenuId, "view_movings", "viewMovings")
 
                 val driverMenuId = "menu_driver_main"
                 insertMenu(driverMenuId, "role_driver", "driver_menu_title")
@@ -698,6 +699,7 @@ abstract class MySmartRouteDatabase : RoomDatabase() {
             insertOption("opt_passenger_10", passengerMenuId, "rank_transports", "rankTransports")
             insertOption("opt_passenger_11", passengerMenuId, "shutdown", "shutdown")
             insertOption("opt_passenger_12", passengerMenuId, "view_requests", "viewRequests")
+            insertOption("opt_passenger_13", passengerMenuId, "view_movings", "viewMovings")
 
             val driverMenuId = "menu_driver_main"
             insertMenu(driverMenuId, "role_driver", "driver_menu_title")

--- a/app/src/main/java/com/ioannapergamali/mysmartroute/model/navigation/NavigationHost.kt
+++ b/app/src/main/java/com/ioannapergamali/mysmartroute/model/navigation/NavigationHost.kt
@@ -38,6 +38,7 @@ import com.ioannapergamali.mysmartroute.view.ui.screens.PrepareCompleteRouteScre
 import com.ioannapergamali.mysmartroute.view.ui.screens.ViewVehiclesScreen
 import com.ioannapergamali.mysmartroute.view.ui.screens.ViewTransportRequestsScreen
 import com.ioannapergamali.mysmartroute.view.ui.screens.ViewRequestsScreen
+import com.ioannapergamali.mysmartroute.view.ui.screens.PassengerMovingsScreen
 import com.ioannapergamali.mysmartroute.view.ui.screens.BookSeatScreen
 import com.ioannapergamali.mysmartroute.view.ui.screens.FindVehicleScreen
 import com.ioannapergamali.mysmartroute.view.ui.screens.RouteModeScreen
@@ -235,6 +236,10 @@ fun NavigationHost(navController : NavHostController, openDrawer: () -> Unit) {
 
         composable("viewRequests") {
             ViewRequestsScreen(navController = navController, openDrawer = openDrawer)
+        }
+
+        composable("viewMovings") {
+            PassengerMovingsScreen(navController = navController, openDrawer = openDrawer)
         }
 
         composable("printTicket") {

--- a/app/src/main/java/com/ioannapergamali/mysmartroute/view/ui/screens/PassengerMovingsScreen.kt
+++ b/app/src/main/java/com/ioannapergamali/mysmartroute/view/ui/screens/PassengerMovingsScreen.kt
@@ -1,0 +1,80 @@
+package com.ioannapergamali.mysmartroute.view.ui.screens
+
+import android.text.format.DateFormat
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Scaffold
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.collectAsState
+import androidx.compose.runtime.getValue
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.unit.dp
+import androidx.lifecycle.viewmodel.compose.viewModel
+import androidx.navigation.NavController
+import com.ioannapergamali.mysmartroute.R
+import com.ioannapergamali.mysmartroute.data.local.MovingEntity
+import com.ioannapergamali.mysmartroute.view.ui.components.ScreenContainer
+import com.ioannapergamali.mysmartroute.view.ui.components.TopBar
+import com.ioannapergamali.mysmartroute.viewmodel.VehicleRequestViewModel
+import java.util.Date
+
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+fun PassengerMovingsScreen(navController: NavController, openDrawer: () -> Unit) {
+    val context = LocalContext.current
+    val viewModel: VehicleRequestViewModel = viewModel()
+    val movings by viewModel.requests.collectAsState()
+
+    LaunchedEffect(Unit) {
+        viewModel.loadRequests(context)
+    }
+
+    val now = System.currentTimeMillis()
+    val active = movings.filter { it.status == "accepted" && it.date > now }
+    val pending = movings.filter { it.status != "accepted" && it.date > now }
+    val unsuccessful = movings.filter { it.status != "accepted" && it.date <= now }
+    val completed = movings.filter { it.status == "accepted" && it.date <= now }
+
+    Scaffold(
+        topBar = {
+            TopBar(
+                title = stringResource(R.string.view_movings),
+                navController = navController,
+                showMenu = true,
+                onMenuClick = openDrawer
+            )
+        }
+    ) { padding ->
+        ScreenContainer(modifier = Modifier.padding(padding)) {
+            if (movings.isEmpty()) {
+                Text(stringResource(R.string.no_movings))
+            } else {
+                MovingCategory(stringResource(R.string.active_movings), active)
+                MovingCategory(stringResource(R.string.pending_movings), pending)
+                MovingCategory(stringResource(R.string.unsuccessful_movings), unsuccessful)
+                MovingCategory(stringResource(R.string.completed_movings), completed)
+            }
+        }
+    }
+}
+
+@Composable
+private fun MovingCategory(title: String, list: List<MovingEntity>) {
+    if (list.isNotEmpty()) {
+        Text(title, style = MaterialTheme.typography.titleMedium)
+        list.forEach { m ->
+            val dateText = if (m.date > 0L) {
+                DateFormat.getDateFormat(LocalContext.current).format(Date(m.date))
+            } else ""
+            Text("• $dateText")
+        }
+        Spacer(modifier = Modifier.height(16.dp))
+    }
+}

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -184,6 +184,12 @@
     <string name="request_sent">Request saved</string>
     <string name="view_requests">View Requests</string>
     <string name="no_requests">No requests found</string>
+    <string name="view_movings">View Movings</string>
+    <string name="no_movings">No movings found</string>
+    <string name="active_movings">Active movings</string>
+    <string name="pending_movings">Pending movings</string>
+    <string name="unsuccessful_movings">Unsuccessful movings</string>
+    <string name="completed_movings">Completed movings</string>
     <string name="sort_by_cost">Sort by cost</string>
     <string name="sort_by_date">Sort by date</string>
     <string name="cancel_request">Cancel request</string>


### PR DESCRIPTION
## Summary
- show passenger movings grouped as active, pending, unsuccessful and completed
- add navigation route for passenger movings screen
- provide string resources for moving categories
- expose passenger menu option to open movings screen

## Testing
- `./gradlew test` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_689824277c2c832897954605acdbbb0a