### PR TITLE
Fix missing notification text parameters

### DIFF
--- a/app/src/main/java/com/ioannapergamali/mysmartroute/viewmodel/VehicleRequestViewModel.kt
+++ b/app/src/main/java/com/ioannapergamali/mysmartroute/viewmodel/VehicleRequestViewModel.kt
@@ -297,7 +297,13 @@ class VehicleRequestViewModel : ViewModel() {
                 NotificationUtils.showNotification(
                     context,
                     context.getString(R.string.notifications),
-
+                    context.getString(
+                        R.string.passenger_request_notification,
+                        passengerName,
+                        req.requestNumber
+                    ),
+                    req.id.hashCode(),
+                    pending
                 )
                 notifiedRequests.add(req.id)
             }
@@ -322,7 +328,13 @@ class VehicleRequestViewModel : ViewModel() {
             NotificationUtils.showNotification(
                 context,
                 context.getString(R.string.notifications),
-
+                context.getString(
+                    R.string.request_pending_notification,
+                    driverName,
+                    req.requestNumber
+                ),
+                req.id.hashCode(),
+                pending
             )
             notifiedRequests.add(req.id)
         }
@@ -368,7 +380,12 @@ class VehicleRequestViewModel : ViewModel() {
                 NotificationUtils.showNotification(
                     context,
                     context.getString(R.string.notifications),
-
+                    context.getString(
+                        R.string.request_rejected_notification,
+                        req.requestNumber
+                    ),
+                    req.id.hashCode(),
+                    pending
                 )
                 notifiedRequests.add(req.id)
             }

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -204,6 +204,7 @@
     <string name="app_started_notification">App started successfully</string>
     <string name="driver_offer_notification">Ο οδηγός %1$s προσφέρθηκε να σας μεταφέρει. Αίτημα αριθμός %2$d</string>
     <string name="passenger_request_notification">Ο επιβάτης %1$s ζήτησε μεταφορά. Αίτημα αριθμός %2$d</string>
+    <string name="request_pending_notification">Driver %1$s responded to your request. Request number %2$d</string>
     <string name="request_accepted">Request accepted</string>
     <string name="request_accept_failed">Αποτυχία αποδοχής αιτήματος</string>
 


### PR DESCRIPTION
## Summary
- Add text, id and intent parameters to notification calls
- Introduce `request_pending_notification` string resource

## Testing
- `./gradlew test` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_68982691ca1c83288b832b512a8b8c20