### PR TITLE
Group movings by status

### DIFF
--- a/app/src/main/java/com/ioannapergamali/mysmartroute/data/local/MovingStatus.kt
+++ b/app/src/main/java/com/ioannapergamali/mysmartroute/data/local/MovingStatus.kt
@@ -1,0 +1,15 @@
+package com.ioannapergamali.mysmartroute.data.local
+
+enum class MovingStatus {
+    ACTIVE,
+    PENDING,
+    UNSUCCESSFUL,
+    COMPLETED
+}
+
+fun MovingEntity.movingStatus(now: Long = System.currentTimeMillis()): MovingStatus = when {
+    status == "accepted" && date > now -> MovingStatus.ACTIVE
+    status == "accepted" && date <= now -> MovingStatus.COMPLETED
+    status != "accepted" && date > now -> MovingStatus.PENDING
+    else -> MovingStatus.UNSUCCESSFUL
+}

--- a/app/src/main/java/com/ioannapergamali/mysmartroute/view/ui/screens/PassengerMovingsScreen.kt
+++ b/app/src/main/java/com/ioannapergamali/mysmartroute/view/ui/screens/PassengerMovingsScreen.kt
@@ -20,6 +20,8 @@ import androidx.lifecycle.viewmodel.compose.viewModel
 import androidx.navigation.NavController
 import com.ioannapergamali.mysmartroute.R
 import com.ioannapergamali.mysmartroute.data.local.MovingEntity
+import com.ioannapergamali.mysmartroute.data.local.MovingStatus
+import com.ioannapergamali.mysmartroute.data.local.movingStatus
 import com.ioannapergamali.mysmartroute.view.ui.components.ScreenContainer
 import com.ioannapergamali.mysmartroute.view.ui.components.TopBar
 import com.ioannapergamali.mysmartroute.viewmodel.VehicleRequestViewModel
@@ -37,10 +39,7 @@ fun PassengerMovingsScreen(navController: NavController, openDrawer: () -> Unit)
     }
 
     val now = System.currentTimeMillis()
-    val active = movings.filter { it.status == "accepted" && it.date > now }
-    val pending = movings.filter { it.status != "accepted" && it.date > now }
-    val unsuccessful = movings.filter { it.status != "accepted" && it.date <= now }
-    val completed = movings.filter { it.status == "accepted" && it.date <= now }
+    val grouped = movings.groupBy { it.movingStatus(now) }
 
     Scaffold(
         topBar = {
@@ -56,10 +55,22 @@ fun PassengerMovingsScreen(navController: NavController, openDrawer: () -> Unit)
             if (movings.isEmpty()) {
                 Text(stringResource(R.string.no_movings))
             } else {
-                MovingCategory(stringResource(R.string.active_movings), active)
-                MovingCategory(stringResource(R.string.pending_movings), pending)
-                MovingCategory(stringResource(R.string.unsuccessful_movings), unsuccessful)
-                MovingCategory(stringResource(R.string.completed_movings), completed)
+                MovingCategory(
+                    stringResource(R.string.active_movings),
+                    grouped[MovingStatus.ACTIVE].orEmpty()
+                )
+                MovingCategory(
+                    stringResource(R.string.pending_movings),
+                    grouped[MovingStatus.PENDING].orEmpty()
+                )
+                MovingCategory(
+                    stringResource(R.string.unsuccessful_movings),
+                    grouped[MovingStatus.UNSUCCESSFUL].orEmpty()
+                )
+                MovingCategory(
+                    stringResource(R.string.completed_movings),
+                    grouped[MovingStatus.COMPLETED].orEmpty()
+                )
             }
         }
     }


### PR DESCRIPTION
## Summary
- classify movings with a new MovingStatus enum
- group PassengerMovingsScreen listings by computed status

## Testing
- `./gradlew test` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_6898404263a48328837acf1c2759f44f