### PR TITLE
Add request deep links for notifications

### DIFF
--- a/app/src/main/java/com/ioannapergamali/mysmartroute/model/navigation/NavigationHost.kt
+++ b/app/src/main/java/com/ioannapergamali/mysmartroute/model/navigation/NavigationHost.kt
@@ -55,7 +55,8 @@ import com.ioannapergamali.mysmartroute.R
 fun NavigationHost(
     navController: NavHostController,
     openDrawer: () -> Unit,
-    startDestination: String = "home"
+    startDestination: String = "home",
+    requestId: String? = null
 ) {
 
     NavHost(navController = navController, startDestination = startDestination) {
@@ -239,7 +240,11 @@ fun NavigationHost(
         }
 
         composable("viewRequests") {
-            ViewRequestsScreen(navController = navController, openDrawer = openDrawer)
+            ViewRequestsScreen(
+                navController = navController,
+                openDrawer = openDrawer,
+                initialRequestId = requestId
+            )
         }
 
         composable("viewMovings") {
@@ -279,7 +284,11 @@ fun NavigationHost(
         }
 
         composable("viewTransportRequests") {
-            ViewTransportRequestsScreen(navController = navController, openDrawer = openDrawer)
+            ViewTransportRequestsScreen(
+                navController = navController,
+                openDrawer = openDrawer,
+                initialRequestId = requestId
+            )
         }
 
         composable("viewVehicles") {

--- a/app/src/main/java/com/ioannapergamali/mysmartroute/view/ui/screens/ViewTransportRequestsScreen.kt
+++ b/app/src/main/java/com/ioannapergamali/mysmartroute/view/ui/screens/ViewTransportRequestsScreen.kt
@@ -4,6 +4,7 @@ import androidx.compose.foundation.horizontalScroll
 import androidx.compose.foundation.layout.*
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.items
+import androidx.compose.foundation.lazy.rememberLazyListState
 import androidx.compose.foundation.rememberScrollState
 import androidx.compose.material3.Button
 import androidx.compose.material3.Checkbox
@@ -37,7 +38,11 @@ import java.util.Date
 
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable
-fun ViewTransportRequestsScreen(navController: NavController, openDrawer: () -> Unit) {
+fun ViewTransportRequestsScreen(
+    navController: NavController,
+    openDrawer: () -> Unit,
+    initialRequestId: String? = null
+) {
     val context = LocalContext.current
     val viewModel: VehicleRequestViewModel = viewModel()
     val transferViewModel: TransferRequestViewModel = viewModel()
@@ -48,6 +53,7 @@ fun ViewTransportRequestsScreen(navController: NavController, openDrawer: () -> 
     val userNames = remember { mutableStateMapOf<String, String>() }
     val selectedRequests = remember { mutableStateMapOf<String, Boolean>() }
     val scrollState = rememberScrollState()
+    val listState = rememberLazyListState()
     val columnWidth = 150.dp
 
     LaunchedEffect(Unit) {
@@ -59,6 +65,12 @@ fun ViewTransportRequestsScreen(navController: NavController, openDrawer: () -> 
         requests.forEach { req ->
             if (req.userId.isNotBlank() && userNames[req.userId] == null) {
                 userNames[req.userId] = userViewModel.getUserName(context, req.userId)
+            }
+        }
+        initialRequestId?.let { id ->
+            val index = requests.indexOfFirst { it.id == id }
+            if (index >= 0) {
+                listState.animateScrollToItem(index + 1)
             }
         }
     }
@@ -93,7 +105,7 @@ fun ViewTransportRequestsScreen(navController: NavController, openDrawer: () -> 
                 }
                 Spacer(modifier = Modifier.height(8.dp))
                 Row(modifier = Modifier.horizontalScroll(scrollState)) {
-                    LazyColumn {
+                    LazyColumn(state = listState) {
                         item {
                             Row(verticalAlignment = Alignment.CenterVertically) {
                                 Checkbox(

--- a/app/src/main/java/com/ioannapergamali/mysmartroute/viewmodel/MainActivity.kt
+++ b/app/src/main/java/com/ioannapergamali/mysmartroute/viewmodel/MainActivity.kt
@@ -82,6 +82,7 @@ class MainActivity : ComponentActivity() {
             if (enabled) SoundManager.play()
         }
         val startDestination = intent?.getStringExtra("startDestination") ?: "home"
+        val requestId = intent?.getStringExtra("requestId")
 
         setContent {
             val context = LocalContext.current
@@ -111,7 +112,8 @@ class MainActivity : ComponentActivity() {
                     NavigationHost(
                         navController = navController,
                         openDrawer = openDrawer,
-                        startDestination = startDestination
+                        startDestination = startDestination,
+                        requestId = requestId
                     )
                 }
             }

--- a/app/src/main/java/com/ioannapergamali/mysmartroute/viewmodel/VehicleRequestViewModel.kt
+++ b/app/src/main/java/com/ioannapergamali/mysmartroute/viewmodel/VehicleRequestViewModel.kt
@@ -289,6 +289,7 @@ class VehicleRequestViewModel : ViewModel() {
                 val passengerName = UserViewModel().getUserName(context, req.userId)
                 val intent = Intent(context, MainActivity::class.java).apply {
                     putExtra("startDestination", "viewTransportRequests")
+                    putExtra("requestId", req.id)
                 }
                 val pending = PendingIntent.getActivity(
                     context,
@@ -320,6 +321,7 @@ class VehicleRequestViewModel : ViewModel() {
             }
             val intent = Intent(context, MainActivity::class.java).apply {
                 putExtra("startDestination", "viewRequests")
+                putExtra("requestId", req.id)
             }
             val pending = PendingIntent.getActivity(
                 context,
@@ -348,6 +350,7 @@ class VehicleRequestViewModel : ViewModel() {
             .forEach { req ->
                 val intent = Intent(context, MainActivity::class.java).apply {
                     putExtra("startDestination", "viewTransportRequests")
+                    putExtra("requestId", req.id)
                 }
                 val pending = PendingIntent.getActivity(
                     context,
@@ -372,6 +375,7 @@ class VehicleRequestViewModel : ViewModel() {
             .forEach { req ->
                 val intent = Intent(context, MainActivity::class.java).apply {
                     putExtra("startDestination", "viewTransportRequests")
+                    putExtra("requestId", req.id)
                 }
                 val pending = PendingIntent.getActivity(
                     context,


### PR DESCRIPTION
## Summary
- Route notification taps directly to specific requests by attaching request IDs to intents
- Pass the request ID through MainActivity into NavigationHost for screen startup
- Scroll request listings to the targeted request when opened from a notification

## Testing
- `./gradlew test` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_689842892334832894662ff6f970ad5c