### PR TITLE
Προσθήκη τεκμηρίωσης κατάστασης μετακινήσεων

### DIFF
--- a/app/src/main/java/com/ioannapergamali/mysmartroute/data/local/MovingStatus.kt
+++ b/app/src/main/java/com/ioannapergamali/mysmartroute/data/local/MovingStatus.kt
@@ -1,5 +1,13 @@
 package com.ioannapergamali.mysmartroute.data.local
 
+/**
+ * Περιγράφει την κατάσταση μιας μετακίνησης όπως εμφανίζεται στην εφαρμογή.
+ *
+ * - [ACTIVE]    Μετακινήσεις "accepted" που είναι προγραμματισμένες για το μέλλον.
+ * - [PENDING]   Μετακινήσεις "open" που ακόμη δεν έχει παρέλθει η προγραμματισμένη ώρα.
+ * - [UNSUCCESSFUL] Μετακινήσεις "open" των οποίων έχει λήξει ο χρόνος χωρίς να γίνουν αποδεκτές.
+ * - [COMPLETED] Μετακινήσεις "accepted" με ημερομηνία στο παρελθόν.
+ */
 enum class MovingStatus {
     ACTIVE,
     PENDING,
@@ -7,6 +15,10 @@ enum class MovingStatus {
     COMPLETED
 }
 
+/**
+ * Υπολογίζει την [MovingStatus] μιας [MovingEntity] με βάση την κατάσταση αποδοχής
+ * και τη χρονική στιγμή της μετακίνησης.
+ */
 fun MovingEntity.movingStatus(now: Long = System.currentTimeMillis()): MovingStatus = when {
     status == "accepted" && date > now -> MovingStatus.ACTIVE
     status == "accepted" && date <= now -> MovingStatus.COMPLETED


### PR DESCRIPTION
## Περίληψη
- Προσθήκη ελληνικής τεκμηρίωσης για τις καταστάσεις μετακινήσεων και τη συνάρτηση υπολογισμού τους.

## Έλεγχοι
- `./gradlew test` (απέτυχε: SDK location not found)


------
https://chatgpt.com/codex/tasks/task_e_689844c873b88328bf3f171ff7f3f84d