### PR TITLE
Handle completed movings via driver confirmation

### DIFF
--- a/app/src/main/java/com/ioannapergamali/mysmartroute/data/local/MovingEntity.kt
+++ b/app/src/main/java/com/ioannapergamali/mysmartroute/data/local/MovingEntity.kt
@@ -19,7 +19,7 @@ data class MovingEntity(
     val endPoiId: String = "",
     /** Ο οδηγός που ενδιαφέρεται να πραγματοποιήσει τη μεταφορά */
     val driverId: String = "",
-    /** Κατάσταση προσφοράς: open, pending, accepted, rejected */
+    /** Κατάσταση προσφοράς: open, pending, accepted, rejected, completed */
     val status: String = "open",
     /** Μοναδικός αριθμός αιτήματος */
     val requestNumber: Int = 0

--- a/app/src/main/java/com/ioannapergamali/mysmartroute/data/local/MovingStatus.kt
+++ b/app/src/main/java/com/ioannapergamali/mysmartroute/data/local/MovingStatus.kt
@@ -3,10 +3,10 @@ package com.ioannapergamali.mysmartroute.data.local
 /**
  * Περιγράφει την κατάσταση μιας μετακίνησης όπως εμφανίζεται στην εφαρμογή.
  *
- * - [ACTIVE]    Μετακινήσεις "accepted" που είναι προγραμματισμένες για το μέλλον.
+ * - [ACTIVE]    Μετακινήσεις "accepted" που δεν έχουν ολοκληρωθεί ακόμη.
  * - [PENDING]   Μετακινήσεις "open" που ακόμη δεν έχει παρέλθει η προγραμματισμένη ώρα.
  * - [UNSUCCESSFUL] Μετακινήσεις "open" των οποίων έχει λήξει ο χρόνος χωρίς να γίνουν αποδεκτές.
- * - [COMPLETED] Μετακινήσεις "accepted" με ημερομηνία στο παρελθόν.
+ * - [COMPLETED] Μετακινήσεις με status "completed", δηλαδή όταν ο οδηγός έχει πατήσει ολοκλήρωση.
  */
 enum class MovingStatus {
     ACTIVE,
@@ -20,8 +20,8 @@ enum class MovingStatus {
  * και τη χρονική στιγμή της μετακίνησης.
  */
 fun MovingEntity.movingStatus(now: Long = System.currentTimeMillis()): MovingStatus = when {
-    status == "accepted" && date > now -> MovingStatus.ACTIVE
-    status == "accepted" && date <= now -> MovingStatus.COMPLETED
+    status == "completed" -> MovingStatus.COMPLETED
+    status == "accepted" -> MovingStatus.ACTIVE
     status != "accepted" && date > now -> MovingStatus.PENDING
     else -> MovingStatus.UNSUCCESSFUL
 }


### PR DESCRIPTION
## Summary
- consider a moving completed only when its status is `completed`
- document new `completed` status in entity and status helper

## Testing
- `./gradlew test` *(fails: SDK location not found)*


------
https://chatgpt.com/codex/tasks/task_e_689869b1bfc8832880dc7511b2d4af35