### PR TITLE
Use Firestore auto IDs for transfer requests

### DIFF
--- a/app/src/main/java/com/ioannapergamali/mysmartroute/data/local/MySmartRouteDatabase.kt
+++ b/app/src/main/java/com/ioannapergamali/mysmartroute/data/local/MySmartRouteDatabase.kt
@@ -50,7 +50,7 @@ import com.ioannapergamali.mysmartroute.data.local.Converters
         FavoriteEntity::class,
         TransferRequestEntity::class
     ],
-    version = 48
+    version = 49
 )
 @TypeConverters(Converters::class)
 abstract class MySmartRouteDatabase : RoomDatabase() {
@@ -651,6 +651,12 @@ abstract class MySmartRouteDatabase : RoomDatabase() {
             }
         }
 
+        private val MIGRATION_48_49 = object : Migration(48, 49) {
+            override fun migrate(database: SupportSQLiteDatabase) {
+                database.execSQL("ALTER TABLE `transfer_requests` ADD COLUMN `firebaseId` TEXT NOT NULL DEFAULT ''")
+            }
+        }
+
         private fun prepopulate(db: SupportSQLiteDatabase) {
             Log.d(TAG, "Prepopulating database")
             db.execSQL(
@@ -777,7 +783,8 @@ abstract class MySmartRouteDatabase : RoomDatabase() {
                     MIGRATION_44_45,
                     MIGRATION_45_46,
                     MIGRATION_46_47,
-                    MIGRATION_47_48
+                    MIGRATION_47_48,
+                    MIGRATION_48_49
                 )
                     .addCallback(object : RoomDatabase.Callback() {
                         override fun onCreate(db: SupportSQLiteDatabase) {

--- a/app/src/main/java/com/ioannapergamali/mysmartroute/data/local/TransferRequestDao.kt
+++ b/app/src/main/java/com/ioannapergamali/mysmartroute/data/local/TransferRequestDao.kt
@@ -18,6 +18,12 @@ interface TransferRequestDao {
     @Query("UPDATE transfer_requests SET driverId = :driverId, status = :status WHERE requestNumber = :requestNumber")
     suspend fun assignDriver(requestNumber: Int, driverId: String, status: RequestStatus)
 
+    @Query("UPDATE transfer_requests SET firebaseId = :firebaseId WHERE requestNumber = :requestNumber")
+    suspend fun setFirebaseId(requestNumber: Int, firebaseId: String)
+
+    @Query("SELECT * FROM transfer_requests WHERE requestNumber = :requestNumber")
+    suspend fun getRequestByNumber(requestNumber: Int): TransferRequestEntity?
+
     @Query("SELECT * FROM transfer_requests WHERE passengerId = :passengerId")
     fun getRequestsForPassenger(passengerId: String): Flow<List<TransferRequestEntity>>
 

--- a/app/src/main/java/com/ioannapergamali/mysmartroute/data/local/TransferRequestEntity.kt
+++ b/app/src/main/java/com/ioannapergamali/mysmartroute/data/local/TransferRequestEntity.kt
@@ -11,6 +11,7 @@ data class TransferRequestEntity(
     val routeId: String = "",
     val passengerId: String = "",
     val driverId: String = "",
+    val firebaseId: String = "",
 
     /** Ημερομηνία σε millis */
     val date: Long = 0L,

--- a/app/src/main/java/com/ioannapergamali/mysmartroute/utils/FirestoreMappers.kt
+++ b/app/src/main/java/com/ioannapergamali/mysmartroute/utils/FirestoreMappers.kt
@@ -490,5 +490,5 @@ fun DocumentSnapshot.toTransferRequestEntity(): TransferRequestEntity? {
     val dateVal = getLong("date") ?: 0L
     val costVal = getDouble("cost") ?: 0.0
     val statusStr = getString("status") ?: RequestStatus.PENDING.name
-    return TransferRequestEntity(number, routeId, passengerId, driverId, dateVal, costVal, enumValueOf(statusStr))
+    return TransferRequestEntity(number, routeId, passengerId, driverId, id, dateVal, costVal, enumValueOf(statusStr))
 }


### PR DESCRIPTION
## Summary
- Χρήση αυτόματων IDs του Firestore ώστε κάθε αίτημα να αποθηκεύεται με μοναδικό document
- Αποθήκευση του firebaseId στην τοπική βάση και ενημέρωση οδηγού/κατάστασης με αυτό το ID
- Προσθήκη πεδίου και migration για το firebaseId στη Room database

## Testing
- `./gradlew test` *(απέτυχε: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_689884694fa0832889539df0ec713ce9