### PR TITLE
Add trip rating screen with Room and Firestore support

### DIFF
--- a/app/src/main/java/com/ioannapergamali/mysmartroute/data/local/MySmartRouteDatabase.kt
+++ b/app/src/main/java/com/ioannapergamali/mysmartroute/data/local/MySmartRouteDatabase.kt
@@ -29,6 +29,8 @@ import com.ioannapergamali.mysmartroute.data.local.TransferRequestEntity
 import com.ioannapergamali.mysmartroute.data.local.TransferRequestDao
 import androidx.room.TypeConverters
 import com.ioannapergamali.mysmartroute.data.local.Converters
+import com.ioannapergamali.mysmartroute.data.local.TripRatingEntity
+import com.ioannapergamali.mysmartroute.data.local.TripRatingDao
 
 @Database(
     entities = [
@@ -48,9 +50,10 @@ import com.ioannapergamali.mysmartroute.data.local.Converters
         AvailabilityEntity::class,
         SeatReservationEntity::class,
         FavoriteEntity::class,
-        TransferRequestEntity::class
+        TransferRequestEntity::class,
+        TripRatingEntity::class
     ],
-    version = 49
+    version = 50
 )
 @TypeConverters(Converters::class)
 abstract class MySmartRouteDatabase : RoomDatabase() {
@@ -71,6 +74,7 @@ abstract class MySmartRouteDatabase : RoomDatabase() {
     abstract fun seatReservationDao(): SeatReservationDao
     abstract fun favoriteDao(): FavoriteDao
     abstract fun transferRequestDao(): TransferRequestDao
+    abstract fun tripRatingDao(): TripRatingDao
 
     companion object {
         @Volatile
@@ -657,6 +661,18 @@ abstract class MySmartRouteDatabase : RoomDatabase() {
             }
         }
 
+        private val MIGRATION_49_50 = object : Migration(49, 50) {
+            override fun migrate(database: SupportSQLiteDatabase) {
+                database.execSQL(
+                    "CREATE TABLE IF NOT EXISTS `trip_ratings` (" +
+                        "`movingId` TEXT NOT NULL, " +
+                        "`rating` INTEGER NOT NULL, " +
+                        "`comment` TEXT NOT NULL, " +
+                        "PRIMARY KEY(`movingId`))"
+                )
+            }
+        }
+
         private fun prepopulate(db: SupportSQLiteDatabase) {
             Log.d(TAG, "Prepopulating database")
             db.execSQL(
@@ -784,7 +800,8 @@ abstract class MySmartRouteDatabase : RoomDatabase() {
                     MIGRATION_45_46,
                     MIGRATION_46_47,
                     MIGRATION_47_48,
-                    MIGRATION_48_49
+                    MIGRATION_48_49,
+                    MIGRATION_49_50
                 )
                     .addCallback(object : RoomDatabase.Callback() {
                         override fun onCreate(db: SupportSQLiteDatabase) {

--- a/app/src/main/java/com/ioannapergamali/mysmartroute/data/local/TripRatingDao.kt
+++ b/app/src/main/java/com/ioannapergamali/mysmartroute/data/local/TripRatingDao.kt
@@ -1,0 +1,16 @@
+package com.ioannapergamali.mysmartroute.data.local
+
+import androidx.room.Dao
+import androidx.room.Insert
+import androidx.room.OnConflictStrategy
+import androidx.room.Query
+import kotlinx.coroutines.flow.Flow
+
+@Dao
+interface TripRatingDao {
+    @Query("SELECT * FROM trip_ratings")
+    fun getAll(): Flow<List<TripRatingEntity>>
+
+    @Insert(onConflict = OnConflictStrategy.REPLACE)
+    suspend fun upsert(rating: TripRatingEntity)
+}

--- a/app/src/main/java/com/ioannapergamali/mysmartroute/data/local/TripRatingEntity.kt
+++ b/app/src/main/java/com/ioannapergamali/mysmartroute/data/local/TripRatingEntity.kt
@@ -1,0 +1,15 @@
+package com.ioannapergamali.mysmartroute.data.local
+
+import androidx.room.Entity
+import androidx.room.PrimaryKey
+
+/**
+ * Πίνακας που αποθηκεύει τη βαθμολογία και το σχόλιο για ολοκληρωμένες μετακινήσεις.
+ * Το movingId αντιστοιχεί στο {@link MovingEntity#id}.
+ */
+@Entity(tableName = "trip_ratings")
+data class TripRatingEntity(
+    @PrimaryKey val movingId: String,
+    val rating: Int = 0,
+    val comment: String = ""
+)

--- a/app/src/main/java/com/ioannapergamali/mysmartroute/model/classes/transports/TripWithRating.kt
+++ b/app/src/main/java/com/ioannapergamali/mysmartroute/model/classes/transports/TripWithRating.kt
@@ -1,0 +1,12 @@
+package com.ioannapergamali.mysmartroute.model.classes.transports
+
+import com.ioannapergamali.mysmartroute.data.local.MovingEntity
+
+/**
+ * Συνδυάζει μια ολοκληρωμένη μετακίνηση με τη βαθμολογία και το σχόλιό της.
+ */
+data class TripWithRating(
+    val moving: MovingEntity,
+    val rating: Int = 0,
+    val comment: String = ""
+)

--- a/app/src/main/java/com/ioannapergamali/mysmartroute/model/navigation/NavigationHost.kt
+++ b/app/src/main/java/com/ioannapergamali/mysmartroute/model/navigation/NavigationHost.kt
@@ -47,6 +47,7 @@ import com.ioannapergamali.mysmartroute.view.ui.screens.SelectRoutePoisScreen
 import com.ioannapergamali.mysmartroute.view.ui.screens.AvailableTransportsScreen
 import com.ioannapergamali.mysmartroute.view.ui.screens.NotificationsScreen
 import com.ioannapergamali.mysmartroute.view.ui.screens.ReservationDetailsScreen
+import com.ioannapergamali.mysmartroute.view.ui.screens.RankTransportsScreen
 import com.ioannapergamali.mysmartroute.R
 
 
@@ -249,6 +250,10 @@ fun NavigationHost(
 
         composable("viewMovings") {
             PassengerMovingsScreen(navController = navController, openDrawer = openDrawer)
+        }
+
+        composable("rankTransports") {
+            RankTransportsScreen(navController = navController, openDrawer = openDrawer)
         }
 
         composable("printTicket") {

--- a/app/src/main/java/com/ioannapergamali/mysmartroute/view/ui/screens/RankTransportsScreen.kt
+++ b/app/src/main/java/com/ioannapergamali/mysmartroute/view/ui/screens/RankTransportsScreen.kt
@@ -1,0 +1,103 @@
+package com.ioannapergamali.mysmartroute.view.ui.screens
+
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.PaddingValues
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.lazy.items
+import androidx.compose.material3.Divider
+import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.OutlinedTextField
+import androidx.compose.material3.Scaffold
+import androidx.compose.material3.Slider
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.collectAsState
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.unit.dp
+import androidx.lifecycle.viewmodel.compose.viewModel
+import androidx.navigation.NavController
+import com.ioannapergamali.mysmartroute.R
+import com.ioannapergamali.mysmartroute.model.classes.transports.TripWithRating
+import com.ioannapergamali.mysmartroute.view.ui.components.ScreenContainer
+import com.ioannapergamali.mysmartroute.view.ui.components.TopBar
+import com.ioannapergamali.mysmartroute.viewmodel.TripRatingViewModel
+
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+fun RankTransportsScreen(navController: NavController, openDrawer: () -> Unit) {
+    val context = LocalContext.current
+    val viewModel: TripRatingViewModel = viewModel()
+    val trips by viewModel.trips.collectAsState()
+
+    LaunchedEffect(Unit) { viewModel.loadTrips(context) }
+
+    Scaffold(
+        topBar = {
+            TopBar(
+                title = stringResource(R.string.rank_transports),
+                navController = navController,
+                showMenu = true,
+                onMenuClick = openDrawer
+            )
+        }
+    ) { padding ->
+        ScreenContainer(modifier = Modifier.padding(padding)) {
+            if (trips.isEmpty()) {
+                Text(stringResource(R.string.no_completed_transports))
+            } else {
+                LazyColumn(
+                    modifier = Modifier.fillMaxSize(),
+                    contentPadding = PaddingValues(16.dp)
+                ) {
+                    items(trips) { trip ->
+                        TripRatingItem(trip) { rating, comment ->
+                            viewModel.updateRating(context, trip.moving, rating, comment)
+                        }
+                        Divider()
+                    }
+                }
+            }
+        }
+    }
+}
+
+@Composable
+private fun TripRatingItem(
+    trip: TripWithRating,
+    onSave: (Int, String) -> Unit
+) {
+    var rating by remember { mutableStateOf(trip.rating.toFloat()) }
+    var comment by remember { mutableStateOf(trip.comment) }
+
+    Column(modifier = Modifier.fillMaxWidth()) {
+        Text(text = trip.moving.routeName, style = MaterialTheme.typography.titleMedium)
+        Slider(
+            value = rating,
+            onValueChange = {
+                rating = it
+                onSave(it.toInt(), comment)
+            },
+            valueRange = 0f..100f
+        )
+        Text(stringResource(R.string.rating_label, rating.toInt()))
+        OutlinedTextField(
+            value = comment,
+            onValueChange = {
+                comment = it
+                onSave(rating.toInt(), comment)
+            },
+            label = { Text(stringResource(R.string.comment_label)) },
+            modifier = Modifier.fillMaxWidth()
+        )
+    }
+}

--- a/app/src/main/java/com/ioannapergamali/mysmartroute/viewmodel/TripRatingViewModel.kt
+++ b/app/src/main/java/com/ioannapergamali/mysmartroute/viewmodel/TripRatingViewModel.kt
@@ -1,0 +1,55 @@
+package com.ioannapergamali.mysmartroute.viewmodel
+
+import android.content.Context
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.viewModelScope
+import com.google.firebase.firestore.FirebaseFirestore
+import com.ioannapergamali.mysmartroute.data.local.MovingEntity
+import com.ioannapergamali.mysmartroute.data.local.MySmartRouteDatabase
+import com.ioannapergamali.mysmartroute.data.local.TripRatingEntity
+import com.ioannapergamali.mysmartroute.model.classes.transports.TripWithRating
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.combine
+import kotlinx.coroutines.launch
+
+/**
+ * ViewModel για προβολή και αποθήκευση βαθμολογιών μετακινήσεων.
+ */
+class TripRatingViewModel : ViewModel() {
+    private val firestore = FirebaseFirestore.getInstance()
+
+    private val _trips = MutableStateFlow<List<TripWithRating>>(emptyList())
+    val trips: StateFlow<List<TripWithRating>> = _trips
+
+    fun loadTrips(context: Context) {
+        viewModelScope.launch {
+            val db = MySmartRouteDatabase.getInstance(context)
+            val movingFlow = db.movingDao().getAll()
+            val ratingFlow = db.tripRatingDao().getAll()
+            combine(movingFlow, ratingFlow) { movings, ratings ->
+                val ratingMap = ratings.associateBy { it.movingId }
+                movings.filter { it.status == "completed" }.map { m ->
+                    val r = ratingMap[m.id]
+                    TripWithRating(m, r?.rating ?: 0, r?.comment ?: "")
+                }
+            }.collect { _trips.value = it }
+        }
+    }
+
+    fun updateRating(context: Context, moving: MovingEntity, rating: Int, comment: String) {
+        viewModelScope.launch {
+            val db = MySmartRouteDatabase.getInstance(context)
+            db.tripRatingDao().upsert(
+                TripRatingEntity(moving.id, rating, comment)
+            )
+            val data = hashMapOf(
+                "movingId" to moving.id,
+                "userId" to moving.userId,
+                "rating" to rating,
+                "comment" to comment
+            )
+            firestore.collection("trip_ratings").document(moving.id).set(data)
+        }
+    }
+}

--- a/app/src/main/res/values-el/strings.xml
+++ b/app/src/main/res/values-el/strings.xml
@@ -195,6 +195,9 @@
     <string name="driver_offer_notification">Ο οδηγός %1$s προσφέρθηκε να σας μεταφέρει. Αίτημα αριθμός %2$d</string>
     <string name="available_transports">Διαθέσιμες μεταφορές</string>
     <string name="no_transports_found">Δεν βρέθηκαν μεταφορές</string>
+    <string name="rating_label">Βαθμολογία: %1$d</string>
+    <string name="comment_label">Σχόλιο</string>
+    <string name="no_completed_transports">Δεν υπάρχουν ολοκληρωμένες μεταφορές</string>
     <string name="find_now">Εύρεση τώρα</string>
     <string name="save_request">Αποθήκευση αιτήματος</string>
     <string name="departure_date">Επιθυμητή ημερομηνία</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -220,6 +220,9 @@
     <string name="save_request">Save request</string>
     <string name="available_transports">Available transports</string>
     <string name="no_transports_found">No transports found</string>
+    <string name="rating_label">Rating: %1$d</string>
+    <string name="comment_label">Comment</string>
+    <string name="no_completed_transports">No completed transports</string>
     <string name="view_details">View details</string>
     <string name="reservation_details">Reservation details</string>
     <string name="no_reservation_found">No reservation found</string>


### PR DESCRIPTION
## Summary
- add TripRating entity, DAO and Room migration
- create ViewModel and UI to rank completed transports
- expose navigation route and string resources

## Testing
- `./gradlew assembleDebug` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_689890bbb8088328a6957c857c049529