### PR TITLE
Εμφάνιση ώρας στις διαθέσιμες μεταφορές

### DIFF
--- a/app/src/main/java/com/ioannapergamali/mysmartroute/view/ui/screens/AvailableTransportsScreen.kt
+++ b/app/src/main/java/com/ioannapergamali/mysmartroute/view/ui/screens/AvailableTransportsScreen.kt
@@ -33,6 +33,7 @@ import kotlinx.coroutines.launch
 import kotlin.math.max
 import java.time.Instant
 import java.time.ZoneId
+import java.time.LocalTime
 import java.time.format.DateTimeFormatter
 
 
@@ -50,6 +51,7 @@ private fun HeaderRow() {
         Text(stringResource(R.string.cost), modifier = Modifier.weight(1f))
         Text(stringResource(R.string.seats_label), modifier = Modifier.weight(1f))
         Text(stringResource(R.string.date), modifier = Modifier.weight(1f))
+        Text(stringResource(R.string.time), modifier = Modifier.weight(1f))
     }
     Divider()
 }
@@ -139,6 +141,7 @@ fun AvailableTransportsScreen(
                 Text(stringResource(R.string.no_transports_found))
             } else {
                 val formatter = remember { DateTimeFormatter.ofPattern("dd/MM/yyyy") }
+                val timeFormatter = remember { DateTimeFormatter.ofPattern("HH:mm") }
 
 
                 LazyColumn {
@@ -157,6 +160,8 @@ fun AvailableTransportsScreen(
                             .atZone(ZoneId.systemDefault())
                             .toLocalDate()
                             .format(formatter)
+                        val timeText = LocalTime.ofSecondOfDay(decl.startTime / 1000)
+                            .format(timeFormatter)
 
                         val reserved = reservationCounts[decl.id] ?: 0
                         val availableSeats = max(0, decl.seats - reserved)
@@ -186,6 +191,7 @@ fun AvailableTransportsScreen(
                                 Text(decl.cost.toString(), modifier = Modifier.weight(1f))
                                 Text(availableSeats.toString(), modifier = Modifier.weight(1f))
                                 Text(dateText, modifier = Modifier.weight(1f))
+                                Text(timeText, modifier = Modifier.weight(1f))
                             }
                             Spacer(Modifier.height(4.dp))
                             Button(

--- a/app/src/main/res/values-el/strings.xml
+++ b/app/src/main/res/values-el/strings.xml
@@ -113,6 +113,7 @@
     <string name="cost">Κόστος</string>
     <string name="duration">Διάρκεια</string>
     <string name="date">Ημερομηνία</string>
+    <string name="time">Ώρα</string>
     <string name="announce">Αποστολή</string>
     <string name="duration_format">Διάρκεια: %1$d λεπτά</string>
     <string name="app_language">Γλώσσα εφαρμογής</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -112,6 +112,7 @@
     <string name="cost">Cost</string>
     <string name="duration">Duration</string>
     <string name="date">Date</string>
+    <string name="time">Time</string>
     <string name="announce">Announce</string>
     <string name="duration_format">Duration: %1$d min</string>
     <string name="app_language">App Language</string>


### PR DESCRIPTION
## Περιγραφή
- Προστέθηκε στήλη ώρας στη λίστα διαθέσιμων μεταφορών
- Προστέθηκαν νέες μεταφράσεις για το πεδίο ώρα

## Έλεγχοι
- `./gradlew test` (απέτυχε: SDK location not found)


------
https://chatgpt.com/codex/tasks/task_e_68989f7362888328a421bf88c65f1635