### PR TITLE
Προσθήκη ώρας 24ωρου στις προβολές αιτημάτων

### DIFF
--- a/app/src/main/java/com/ioannapergamali/mysmartroute/view/ui/screens/ViewRequestsScreen.kt
+++ b/app/src/main/java/com/ioannapergamali/mysmartroute/view/ui/screens/ViewRequestsScreen.kt
@@ -138,8 +138,11 @@ fun ViewRequestsScreen(
                             val toName = poiNames[req.endPoiId] ?: ""
                             val routeName = if (fromName.isNotBlank() && toName.isNotBlank())
                                 "$fromName → $toName" else ""
-                            val dateText = if (req.date > 0L) {
-                                DateFormat.getDateFormat(context).format(Date(req.date))
+                            val dateTimeText = if (req.date > 0L) {
+                                val date = Date(req.date)
+                                val dateStr = DateFormat.getDateFormat(context).format(date)
+                                val timeStr = DateFormat.format("HH:mm", date).toString()
+                                "$dateStr $timeStr"
                             } else ""
                             val costText = if (req.cost == Double.MAX_VALUE) "-" else req.cost.toString()
                             Row(
@@ -149,7 +152,7 @@ fun ViewRequestsScreen(
                                 Text(req.requestNumber.toString(), modifier = Modifier.width(columnWidth))
                                 Text(routeName, modifier = Modifier.width(columnWidth))
                                 Text(costText, modifier = Modifier.width(columnWidth))
-                                Text(dateText, modifier = Modifier.width(columnWidth))
+                                Text(dateTimeText, modifier = Modifier.width(columnWidth))
                                 if (req.status == "pending") {
                                     val dName = driverNames[req.driverId] ?: ""
                                     Text(dName, modifier = Modifier.width(columnWidth))

--- a/app/src/main/java/com/ioannapergamali/mysmartroute/view/ui/screens/ViewTransportRequestsScreen.kt
+++ b/app/src/main/java/com/ioannapergamali/mysmartroute/view/ui/screens/ViewTransportRequestsScreen.kt
@@ -153,8 +153,11 @@ fun ViewTransportRequestsScreen(
                             val routeName = if (fromName.isNotBlank() && toName.isNotBlank()) "$fromName - $toName" else ""
                             val userName = userNames[req.userId] ?: ""
                             val isChecked = selectedRequests[req.id] ?: false
-                            val dateText = if (req.date > 0L) {
-                                DateFormat.getDateFormat(context).format(Date(req.date))
+                            val dateTimeText = if (req.date > 0L) {
+                                val date = Date(req.date)
+                                val dateStr = DateFormat.getDateFormat(context).format(date)
+                                val timeStr = DateFormat.format("HH:mm", date).toString()
+                                "$dateStr $timeStr"
                             } else ""
                             Row(
                                 modifier = Modifier.padding(vertical = 8.dp),
@@ -175,7 +178,7 @@ fun ViewTransportRequestsScreen(
                                 Text(routeName, modifier = Modifier.width(columnWidth))
                                 val costText = if (req.cost == Double.MAX_VALUE) "∞" else req.cost.toString()
                                 Text(costText, modifier = Modifier.width(columnWidth))
-                                Text(dateText, modifier = Modifier.width(columnWidth))
+                                Text(dateTimeText, modifier = Modifier.width(columnWidth))
                                 Text(req.requestNumber.toString(), modifier = Modifier.width(columnWidth))
                                 if (req.status == "open") {
                                     Button(


### PR DESCRIPTION
## Περίληψη
- Προσθήκη εμφάνισης της ώρας (24ωρη μορφή) στην οθόνη προβολής αιτημάτων επιβάτη.
- Προσθήκη εμφάνισης της ώρας (24ωρη μορφή) στην οθόνη προβολής αιτημάτων μεταφοράς οδηγού.

## Δοκιμές
- `./gradlew test` (αποτυχία: SDK location not found)


------
https://chatgpt.com/codex/tasks/task_e_6898a060ee0c8328b7fd357877e740cb