### PR TITLE
Set completed status when finishing route

### DIFF
--- a/app/src/main/java/com/ioannapergamali/mysmartroute/viewmodel/ReservationViewModel.kt
+++ b/app/src/main/java/com/ioannapergamali/mysmartroute/viewmodel/ReservationViewModel.kt
@@ -105,7 +105,7 @@ class ReservationViewModel : ViewModel() {
                     startPoiId = res.startPoiId,
                     endPoiId = res.endPoiId,
                     driverId = declaration.driverId,
-                    status = "accepted"
+                    status = "completed"
                 )
                 movingDao.insert(moving)
                 if (NetworkUtils.isInternetAvailable(context)) {


### PR DESCRIPTION
## Summary
- Set generated movings to completed when driver finalizes a route so they appear for rating.

## Testing
- `./gradlew test` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_6898a1d304148328926f7f7af90d63e0