### PR TITLE
Αποφυγή σφάλματος διπλής κύλισης σε RankTransportsScreen

### DIFF
--- a/app/src/main/java/com/ioannapergamali/mysmartroute/view/ui/screens/RankTransportsScreen.kt
+++ b/app/src/main/java/com/ioannapergamali/mysmartroute/view/ui/screens/RankTransportsScreen.kt
@@ -52,7 +52,7 @@ fun RankTransportsScreen(navController: NavController, openDrawer: () -> Unit) {
             )
         }
     ) { padding ->
-        ScreenContainer(modifier = Modifier.padding(padding)) {
+        ScreenContainer(modifier = Modifier.padding(padding), scrollable = false) {
             if (trips.isEmpty()) {
                 Text(stringResource(R.string.no_completed_transports))
             } else {


### PR DESCRIPTION
## Περίληψη
- Απενεργοποίηση της κύλισης στο `ScreenContainer` του `RankTransportsScreen` ώστε να μην εμφανίζεται `IllegalStateException` λόγω εμφωλευμένων scrollable στοιχείων.

## Έλεγχοι
- `./gradlew test` *(αποτυχία: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_6898d6b432948328a885210f9c0ed566