### PR TITLE
Εμφάνιση μηνύματος κατά την κράτηση θέσης

### DIFF
--- a/app/src/main/java/com/ioannapergamali/mysmartroute/viewmodel/VehicleRequestViewModel.kt
+++ b/app/src/main/java/com/ioannapergamali/mysmartroute/viewmodel/VehicleRequestViewModel.kt
@@ -265,9 +265,12 @@ class VehicleRequestViewModel : ViewModel() {
                         declarationId = current.id
                     )
                     result.fold(
-                        onSuccess = { },
+                        onSuccess = {
+                            Toast.makeText(context, R.string.seat_booked, Toast.LENGTH_SHORT).show()
+                        },
                         onFailure = {
-           return@launch
+                            Toast.makeText(context, R.string.seat_unavailable, Toast.LENGTH_SHORT).show()
+                            return@launch
                         }
                     )
                 }


### PR DESCRIPTION
## Σύνοψη
- Προσθήκη ενημερωτικών Toast μηνυμάτων όταν ο επιβάτης αποδέχεται προσφορά.
- Ενημέρωση χειρισμού αποτυχίας κράτησης για άμεση επιστροφή από τη ροή.

## Δοκιμές
- `./gradlew test` *(αποτυχία: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_6899cb72e33483289eaeb9789ff5c428