### PR TITLE
Προσθήκη φίλτρων ώρας και οχήματος στην προετοιμασία διαδρομής

### DIFF
--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -162,6 +162,8 @@
     <string name="select_route">Select route</string>
     <string name="add_poi_option">Add POI</string>
     <string name="select_date">Select date</string>
+    <string name="select_time">Select time</string>
+    <string name="select_vehicle">Select vehicle</string>
     <string name="select_pois_screen_title">Select Route POIs</string>
     <string name="choose_pois">Choose points of interest</string>
     <string name="confirm_poi_selection">Confirm selection</string>


### PR DESCRIPTION
## Περίληψη
- Προσθήκη κατάστασης `selectedVehicleName` ώστε να αποθηκεύεται το όνομα του οχήματος αντί για την περιγραφή
- Χρήση του `selectedVehicleName` στη φόρτωση δηλώσεων και κρατήσεων για σωστή διασταύρωση
- Ενημέρωση του dropdown επιλογής τύπου οχήματος να καταγράφει το `name`

## Δοκιμές
- `./gradlew app:test` *(απέτυχε: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_6899ca9ada0c8328bb0d99974cdb8522