### PR TITLE
Use icons for request sorting

### DIFF
--- a/app/src/main/java/com/ioannapergamali/mysmartroute/view/ui/screens/ViewRequestsScreen.kt
+++ b/app/src/main/java/com/ioannapergamali/mysmartroute/view/ui/screens/ViewRequestsScreen.kt
@@ -11,6 +11,11 @@ import androidx.compose.material3.Divider
 import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.Scaffold
 import androidx.compose.material3.Text
+import androidx.compose.material3.Icon
+import androidx.compose.material3.IconButton
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.AttachMoney
+import androidx.compose.material.icons.filled.CalendarMonth
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.collectAsState
@@ -101,12 +106,18 @@ fun ViewRequestsScreen(
                 Text(stringResource(R.string.no_requests))
             } else {
                 Row {
-                    Button(onClick = { sortOption.value = SortOption.COST }) {
-                        Text(stringResource(R.string.sort_by_cost))
+                    IconButton(onClick = { sortOption.value = SortOption.COST }) {
+                        Icon(
+                            imageVector = Icons.Filled.AttachMoney,
+                            contentDescription = stringResource(R.string.sort_by_cost)
+                        )
                     }
                     Spacer(modifier = Modifier.width(8.dp))
-                    Button(onClick = { sortOption.value = SortOption.DATE }) {
-                        Text(stringResource(R.string.sort_by_date))
+                    IconButton(onClick = { sortOption.value = SortOption.DATE }) {
+                        Icon(
+                            imageVector = Icons.Filled.CalendarMonth,
+                            contentDescription = stringResource(R.string.sort_by_date)
+                        )
                     }
                 }
                 Spacer(modifier = Modifier.height(8.dp))


### PR DESCRIPTION
## Summary
- Replace text sort buttons with icon buttons for cost and date filters in request list

## Testing
- `./gradlew test` *(fails: process did not complete; see log)*

------
https://chatgpt.com/codex/tasks/task_e_6899e86c8f8083288971ec5d2ee9b781