### PR TITLE
Create seat reservation after passenger accepts offer

### DIFF
--- a/app/src/main/java/com/ioannapergamali/mysmartroute/viewmodel/VehicleRequestViewModel.kt
+++ b/app/src/main/java/com/ioannapergamali/mysmartroute/viewmodel/VehicleRequestViewModel.kt
@@ -253,7 +253,24 @@ class VehicleRequestViewModel : ViewModel() {
                 val current = list[index]
 
                 if (accept) {
-
+                    val resDao = MySmartRouteDatabase.getInstance(context).seatReservationDao()
+                    val reservation = SeatReservationEntity(
+                        id = UUID.randomUUID().toString(),
+                        routeId = current.routeId,
+                        userId = current.userId,
+                        date = current.date,
+                        startPoiId = current.startPoiId,
+                        endPoiId = current.endPoiId
+                    )
+                    resDao.insert(reservation)
+                    try {
+                        db.collection("seat_reservations")
+                            .document(reservation.id)
+                            .set(reservation.toFirestoreMap())
+                            .await()
+                    } catch (e: Exception) {
+                        Log.e(TAG, "Failed to create seat reservation", e)
+                    }
                 }
 
                 val status = if (accept) "accepted" else "rejected"


### PR DESCRIPTION
## Summary
- Create a seat reservation entry when a passenger accepts a driver's offer

## Testing
- `./gradlew test` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_6899e9554fb083289645dba46fca60cf