### PR TITLE
Αποφυγή διπλής ολοκλήρωσης διαδρομής

### DIFF
--- a/app/src/main/java/com/ioannapergamali/mysmartroute/data/local/MovingDao.kt
+++ b/app/src/main/java/com/ioannapergamali/mysmartroute/data/local/MovingDao.kt
@@ -18,4 +18,7 @@ interface MovingDao {
 
     @Query("DELETE FROM movings WHERE id IN (:ids)")
     suspend fun deleteByIds(ids: List<String>)
+
+    @Query("SELECT COUNT(*) FROM movings WHERE routeId = :routeId AND date = :date")
+    suspend fun countForRoute(routeId: String, date: Long): Int
 }

--- a/app/src/main/java/com/ioannapergamali/mysmartroute/view/ui/screens/PrepareCompleteRouteScreen.kt
+++ b/app/src/main/java/com/ioannapergamali/mysmartroute/view/ui/screens/PrepareCompleteRouteScreen.kt
@@ -398,8 +398,10 @@ fun PrepareCompleteRouteScreen(navController: NavController, openDrawer: () -> U
                             selectedDate!!,
                             updatedDecl.startTime,
                             updatedDecl
-                        )
-                        Toast.makeText(context, R.string.route_completed, Toast.LENGTH_SHORT).show()
+                        ) { completed ->
+                            val msg = if (completed) R.string.route_completed else R.string.route_already_completed
+                            Toast.makeText(context, msg, Toast.LENGTH_SHORT).show()
+                        }
                     }
                 }) {
                     Text(stringResource(R.string.complete_route))

--- a/app/src/main/res/values-el/strings.xml
+++ b/app/src/main/res/values-el/strings.xml
@@ -88,6 +88,7 @@
     <string name="prepare_complete_route">Προετοιμασία ολοκλήρωσης διαδρομής</string>
     <string name="complete_route">Ολοκλήρωση</string>
     <string name="route_completed">Η διαδρομή ολοκληρώθηκε</string>
+    <string name="route_already_completed">Η διαδρομή έχει ήδη ολοκληρωθεί</string>
     <string name="init_system">Αρχικοποίηση συστήματος</string>
     <string name="create_user">Δημιουργία λογαριασμού χρήστη</string>
     <string name="edit_privileges">Αλλαγή δικαιωμάτων χρήστη</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -86,6 +86,7 @@
     <string name="prepare_complete_route">Prepare Route Completion</string>
     <string name="complete_route">Complete Route</string>
     <string name="route_completed">Route marked as completed</string>
+    <string name="route_already_completed">Route has already been completed</string>
     <string name="init_system">Initialize System</string>
     <string name="create_user">Create User Account</string>
     <string name="edit_privileges">Promote or Demote User</string>


### PR DESCRIPTION
## Περίληψη
- Προσθήκη ελέγχου στη βάση για να μην καταχωρείται ολοκλήρωση διαδρομής δύο φορές
- Επιστροφή αποτελέσματος από το `completeRoute` και εμφάνιση κατάλληλου μηνύματος
- Νέα μεταφρασμένη συμβολοσειρά για ήδη ολοκληρωμένη διαδρομή

## Δοκιμές
- `./gradlew test` *(αποτυχία: λείπει το Android SDK)*

------
https://chatgpt.com/codex/tasks/task_e_689a0da836a88328be7df1cb16dfb0d8