### PR TITLE
Εμφάνιση στοιχείων διαδρομής στη βαθμολόγηση

### DIFF
--- a/app/src/main/java/com/ioannapergamali/mysmartroute/view/ui/screens/RankTransportsScreen.kt
+++ b/app/src/main/java/com/ioannapergamali/mysmartroute/view/ui/screens/RankTransportsScreen.kt
@@ -32,6 +32,8 @@ import com.ioannapergamali.mysmartroute.model.classes.transports.TripWithRating
 import com.ioannapergamali.mysmartroute.view.ui.components.ScreenContainer
 import com.ioannapergamali.mysmartroute.view.ui.components.TopBar
 import com.ioannapergamali.mysmartroute.viewmodel.TripRatingViewModel
+import android.text.format.DateFormat
+import java.util.Date
 
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable
@@ -79,9 +81,20 @@ private fun TripRatingItem(
 ) {
     var rating by remember { mutableStateOf(trip.rating.toFloat()) }
     var comment by remember { mutableStateOf(trip.comment) }
+    val context = LocalContext.current
+    val dateText = if (trip.moving.date > 0L) {
+        DateFormat.getDateFormat(context).format(Date(trip.moving.date))
+    } else ""
+    val info = buildString {
+        append(trip.moving.routeName)
+        if (dateText.isNotBlank()) {
+            append(" - ")
+            append(dateText)
+        }
+    }
 
     Column(modifier = Modifier.fillMaxWidth()) {
-        Text(text = trip.moving.routeName, style = MaterialTheme.typography.titleMedium)
+        Text(text = info, style = MaterialTheme.typography.titleMedium)
         Slider(
             value = rating,
             onValueChange = {


### PR DESCRIPTION
## Περίληψη
- Εμφάνιση ονόματος και ημερομηνίας διαδρομής πριν από τη βαθμολογία κάθε μεταφοράς.

## Έλεγχοι
- `./gradlew test` *(απέτυχε: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_689a19172c488328916eb91604589eb2