### PR TITLE
Εμφάνιση διαθέσιμων οχημάτων ανά τύπο

### DIFF
--- a/app/src/main/java/com/ioannapergamali/mysmartroute/view/ui/screens/PrepareCompleteRouteScreen.kt
+++ b/app/src/main/java/com/ioannapergamali/mysmartroute/view/ui/screens/PrepareCompleteRouteScreen.kt
@@ -220,11 +220,17 @@ fun PrepareCompleteRouteScreen(navController: NavController, openDrawer: () -> U
                 Spacer(Modifier.height(16.dp))
             }
 
-            Box {
-                Button(onClick = { expanded = true }) {
-                    Text(selectedRoute?.name ?: stringResource(R.string.select_route))
-                }
-                DropdownMenu(expanded = expanded, onDismissRequest = { expanded = false }) {
+            ExposedDropdownMenuBox(expanded = expanded, onExpandedChange = { expanded = !expanded }) {
+                OutlinedTextField(
+                    value = selectedRoute?.name ?: "",
+                    onValueChange = {},
+                    label = { Text(stringResource(R.string.route_name)) },
+                    placeholder = { Text(stringResource(R.string.select_route)) },
+                    trailingIcon = { ExposedDropdownMenuDefaults.TrailingIcon(expanded = expanded) },
+                    modifier = Modifier.menuAnchor().fillMaxWidth(),
+                    readOnly = true
+                )
+                ExposedDropdownMenu(expanded = expanded, onDismissRequest = { expanded = false }) {
                     displayRoutes.forEach { route ->
                         DropdownMenuItem(text = { Text(route.name) }, onClick = {
                             selectedRoute = route
@@ -289,7 +295,12 @@ fun PrepareCompleteRouteScreen(navController: NavController, openDrawer: () -> U
                 Row {
                     VehicleType.values().forEach { type ->
                         Column(horizontalAlignment = Alignment.CenterHorizontally) {
-                            IconButton(onClick = { selectedVehicle = type }) {
+                            IconButton(onClick = {
+                                selectedVehicle = type
+                                vehicleName = ""
+                                selectedVehicleId = ""
+                                selectedVehicleDescription = ""
+                            }) {
                                 Icon(
                                     imageVector = iconForVehicle(type),
                                     contentDescription = labelForVehicle(type),
@@ -311,15 +322,20 @@ fun PrepareCompleteRouteScreen(navController: NavController, openDrawer: () -> U
                         readOnly = true
                     )
                     ExposedDropdownMenu(expanded = expandedVehicle, onDismissRequest = { expandedVehicle = false }) {
-                        vehicles.filter { it.userId == selectedDriverId }.forEach { vehicle ->
-                            DropdownMenuItem(text = { Text(vehicle.name) }, onClick = {
-                                vehicleName = vehicle.name
-                                selectedVehicle = runCatching { VehicleType.valueOf(vehicle.type) }.getOrNull()
-                                selectedVehicleId = vehicle.id
-                                selectedVehicleDescription = vehicle.description
-                                expandedVehicle = false
-                            })
-                        }
+                        vehicles
+                            .filter {
+                                it.userId == selectedDriverId &&
+                                    (selectedVehicle == null || runCatching { VehicleType.valueOf(it.type) }.getOrNull() == selectedVehicle)
+                            }
+                            .forEach { vehicle ->
+                                DropdownMenuItem(text = { Text(vehicle.name) }, onClick = {
+                                    vehicleName = vehicle.name
+                                    selectedVehicle = runCatching { VehicleType.valueOf(vehicle.type) }.getOrNull()
+                                    selectedVehicleId = vehicle.id
+                                    selectedVehicleDescription = vehicle.description
+                                    expandedVehicle = false
+                                })
+                            }
                     }
                 }
                 if (selectedVehicleDescription.isNotEmpty()) {


### PR DESCRIPTION
## Σκοπός
- Φιλτράρισμα οχημάτων στο βήμα ολοκλήρωσης διαδρομής βάσει του επιλεγμένου τύπου.
- Προβολή του ονόματος της διαδρομής στο πεδίο επιλογής.

## Αλλαγές
- Καθαρισμός τρέχουσας επιλογής οχήματος όταν αλλάζει ο τύπος.
- Φιλτράρισμα της λίστας οχημάτων ώστε να εμφανίζονται μόνο όσα ταιριάζουν με τον επιλεγμένο τύπο.
- Χρήση `OutlinedTextField` με `ExposedDropdownMenuBox` για την επιλογή διαδρομής και εμφάνιση του ονόματος της.

## Έλεγχοι
- `./gradlew test` *(αποτυχία: λείπει το Android SDK)*


------
https://chatgpt.com/codex/tasks/task_e_689a1c305b308328971e3e299c75a414