### PR TITLE
Εμφάνιση ονόματος διαδρομής στις βαθμολογήσεις μεταφορών

### DIFF
--- a/app/src/main/java/com/ioannapergamali/mysmartroute/view/ui/screens/RankTransportsScreen.kt
+++ b/app/src/main/java/com/ioannapergamali/mysmartroute/view/ui/screens/RankTransportsScreen.kt
@@ -85,16 +85,12 @@ private fun TripRatingItem(
     val dateText = if (trip.moving.date > 0L) {
         DateFormat.getDateFormat(context).format(Date(trip.moving.date))
     } else ""
-    val info = buildString {
-        append(trip.moving.routeName)
-        if (dateText.isNotBlank()) {
-            append(" - ")
-            append(dateText)
-        }
-    }
 
     Column(modifier = Modifier.fillMaxWidth()) {
-        Text(text = info, style = MaterialTheme.typography.titleMedium)
+        Text(text = trip.moving.routeName, style = MaterialTheme.typography.titleMedium)
+        if (dateText.isNotBlank()) {
+            Text(text = dateText, style = MaterialTheme.typography.bodySmall)
+        }
         Slider(
             value = rating,
             onValueChange = {


### PR DESCRIPTION
## Περίληψη
- Προσθήκη εμφάνισης του ονόματος της διαδρομής πριν από τη βαθμολογία κάθε μεταφοράς.
- Εμφάνιση ημερομηνίας μεταφοράς σε ξεχωριστό πεδίο.

## Έλεγχοι
- `./gradlew test` (αποτυχία: SDK location not found)


------
https://chatgpt.com/codex/tasks/task_e_689a22efee688328a88f3764cb2fb665