### PR TITLE
Διόρθωση σύνταξης στο PrepareCompleteRouteScreen

### DIFF
--- a/app/src/main/java/com/ioannapergamali/mysmartroute/view/ui/screens/PrepareCompleteRouteScreen.kt
+++ b/app/src/main/java/com/ioannapergamali/mysmartroute/view/ui/screens/PrepareCompleteRouteScreen.kt
@@ -302,14 +302,11 @@ fun PrepareCompleteRouteScreen(navController: NavController, openDrawer: () -> U
                 Text(stringResource(R.string.vehicle_type))
                 Row(horizontalArrangement = Arrangement.spacedBy(8.dp)) {
                     VehicleType.values().forEach { type ->
-                        val isSelected = selectedVehicle == type
                         Column(horizontalAlignment = Alignment.CenterHorizontally) {
-
-                                Icon(
-                                    imageVector = iconForVehicle(type),
-                                    contentDescription = labelForVehicle(type)
-                                )
-                            }
+                            Icon(
+                                imageVector = iconForVehicle(type),
+                                contentDescription = labelForVehicle(type)
+                            )
                             Text(labelForVehicle(type), style = MaterialTheme.typography.labelSmall)
                         }
                     }


### PR DESCRIPTION
## Περίληψη
- Διορθώθηκε η απεικόνιση τύπων οχημάτων αφαιρώντας πλεονάζουσα αγκύλη
- Αναδιοργανώθηκε το layout ώστε το εικονίδιο και το κείμενο να βρίσκονται στο ίδιο Column

## Δοκιμές
- `./gradlew test` (απέτυχε: SDK location not found)

------
https://chatgpt.com/codex/tasks/task_e_689a27226fa48328871ce03838e788ec