### PR TITLE
Εμφάνιση ονόματος διαδρομής στην αξιολόγηση μεταφορών

### DIFF
--- a/app/src/main/java/com/ioannapergamali/mysmartroute/view/ui/screens/RankTransportsScreen.kt
+++ b/app/src/main/java/com/ioannapergamali/mysmartroute/view/ui/screens/RankTransportsScreen.kt
@@ -85,11 +85,14 @@ private fun TripRatingItem(
     val dateText = if (trip.moving.date > 0L) {
         DateFormat.getDateFormat(context).format(Date(trip.moving.date))
     } else ""
+    val headerText = listOf(dateText, trip.moving.routeName)
+        .filter { it.isNotBlank() }
+        .joinToString(" - ")
 
     Column(modifier = Modifier.fillMaxWidth()) {
 
-        if (dateText.isNotBlank()) {
-            Text(text = dateText, style = MaterialTheme.typography.bodySmall)
+        if (headerText.isNotBlank()) {
+            Text(text = headerText, style = MaterialTheme.typography.bodySmall)
         }
         Slider(
             value = rating,


### PR DESCRIPTION
## Σύνοψη
- Προσθήκη εμφάνισης του ονόματος της διαδρομής δίπλα στην ημερομηνία στη λίστα αξιολόγησης μετακινήσεων

## Δοκιμές
- `./gradlew test` (απέτυχε: SDK location not found)

------
https://chatgpt.com/codex/tasks/task_e_689a2f3add408328a0b99d7d87715885