### PR TITLE
Αντικατάσταση μπάρας βαθμολογίας με επιλογή αστεριών

### DIFF
--- a/app/src/main/java/com/ioannapergamali/mysmartroute/view/ui/screens/RankTransportsScreen.kt
+++ b/app/src/main/java/com/ioannapergamali/mysmartroute/view/ui/screens/RankTransportsScreen.kt
@@ -2,6 +2,7 @@ package com.ioannapergamali.mysmartroute.view.ui.screens
 
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.PaddingValues
+import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
@@ -9,10 +10,11 @@ import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.items
 import androidx.compose.material3.Divider
 import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.Icon
+import androidx.compose.material3.IconButton
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.OutlinedTextField
 import androidx.compose.material3.Scaffold
-import androidx.compose.material3.Slider
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
@@ -32,6 +34,9 @@ import com.ioannapergamali.mysmartroute.model.classes.transports.TripWithRating
 import com.ioannapergamali.mysmartroute.view.ui.components.ScreenContainer
 import com.ioannapergamali.mysmartroute.view.ui.components.TopBar
 import com.ioannapergamali.mysmartroute.viewmodel.TripRatingViewModel
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.Star
+import androidx.compose.material.icons.outlined.Star
 import android.text.format.DateFormat
 import java.util.Date
 
@@ -79,7 +84,7 @@ private fun TripRatingItem(
     trip: TripWithRating,
     onSave: (Int, String) -> Unit
 ) {
-    var rating by remember { mutableStateOf(trip.rating.toFloat()) }
+    var rating by remember { mutableStateOf(trip.rating) }
     var comment by remember { mutableStateOf(trip.comment) }
     val context = LocalContext.current
     val dateText = if (trip.moving.date > 0L) {
@@ -94,20 +99,25 @@ private fun TripRatingItem(
         if (headerText.isNotBlank()) {
             Text(text = headerText, style = MaterialTheme.typography.bodySmall)
         }
-        Slider(
-            value = rating,
-            onValueChange = {
-                rating = it
-                onSave(it.toInt(), comment)
-            },
-            valueRange = 0f..100f
-        )
-        Text(stringResource(R.string.rating_label, rating.toInt()))
+        Row {
+            (1..5).forEach { index ->
+                IconButton(onClick = {
+                    rating = index
+                    onSave(rating, comment)
+                }) {
+                    Icon(
+                        imageVector = if (index <= rating) Icons.Filled.Star else Icons.Outlined.Star,
+                        contentDescription = null
+                    )
+                }
+            }
+        }
+        Text(stringResource(R.string.rating_label, rating))
         OutlinedTextField(
             value = comment,
             onValueChange = {
                 comment = it
-                onSave(rating.toInt(), comment)
+                onSave(rating, comment)
             },
             label = { Text(stringResource(R.string.comment_label)) },
             modifier = Modifier.fillMaxWidth()

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -224,7 +224,7 @@
     <string name="save_request">Save request</string>
     <string name="available_transports">Available transports</string>
     <string name="no_transports_found">No transports found</string>
-    <string name="rating_label">Rating: %1$d</string>
+    <string name="rating_label">Rating: %1$d/5</string>
     <string name="comment_label">Comment</string>
     <string name="no_completed_transports">No completed transports</string>
     <string name="view_details">View details</string>


### PR DESCRIPTION
## Τι άλλαξε
- Αντικατέστησα την μπάρα 0-100 με πέντε αστεράκια για τη βαθμολογία.
- Ενημέρωσα τη συμβολοσειρά εμφάνισης βαθμολογίας ώστε να δείχνει τιμή έως 5.

## Έλεγχοι
- `./gradlew test` (απέτυχε: SDK location not found)


------
https://chatgpt.com/codex/tasks/task_e_689a32c932e0832888bb0435af3cde95