### PR TITLE
Update passenger request view to show status and disable repeated actions

### DIFF
--- a/app/src/main/java/com/ioannapergamali/mysmartroute/view/ui/screens/ViewRequestsScreen.kt
+++ b/app/src/main/java/com/ioannapergamali/mysmartroute/view/ui/screens/ViewRequestsScreen.kt
@@ -188,16 +188,19 @@ fun ViewRequestsScreen(
                                     }) {
                                         Text(stringResource(R.string.reject_offer))
                                     }
-                                }
-                                Button(onClick = {
-                                    transferViewModel.updateStatus(
-                                        context,
-                                        req.requestNumber,
-                                        RequestStatus.CANCELED
-                                    )
-                                    viewModel.deleteRequests(context, setOf(req.id))
-                                }) {
-                                    Text(stringResource(R.string.cancel_request))
+                                    Spacer(modifier = Modifier.width(4.dp))
+                                    Button(onClick = {
+                                        transferViewModel.updateStatus(
+                                            context,
+                                            req.requestNumber,
+                                            RequestStatus.CANCELED
+                                        )
+                                        viewModel.deleteRequests(context, setOf(req.id))
+                                    }) {
+                                        Text(stringResource(R.string.cancel_request))
+                                    }
+                                } else {
+                                    Text(req.status, modifier = Modifier.width(columnWidth))
                                 }
                             }
                             Divider()


### PR DESCRIPTION
## Summary
- Show request status after passenger accepts, rejects or cancels
- Hide action buttons once a decision is made

## Testing
- `./gradlew test` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_689a3667ccf88328a4e06d0b4d946a2f