### PR TITLE
Fix icon parameters in rating screen

### DIFF
--- a/app/src/main/java/com/ioannapergamali/mysmartroute/view/ui/screens/RankTransportsScreen.kt
+++ b/app/src/main/java/com/ioannapergamali/mysmartroute/view/ui/screens/RankTransportsScreen.kt
@@ -108,7 +108,8 @@ private fun TripRatingItem(
                 }) {
                     Icon(
                         imageVector = if (index <= rating) Icons.Filled.Star else Icons.Outlined.Star,
-
+                        contentDescription = null,
+                        tint = if (index <= rating) Color(0xFFFFD700) else Color.Gray
                     )
                 }
             }


### PR DESCRIPTION
## Summary
- ensure rating star icon specifies contentDescription and tint

## Testing
- `./gradlew test` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_689a36ca698c83288a86b0ec1619fc39