### PR TITLE
Προσθήκη οθόνης αναζήτησης επιβατών για οδηγούς

### DIFF
--- a/app/src/main/java/com/ioannapergamali/mysmartroute/model/navigation/NavigationHost.kt
+++ b/app/src/main/java/com/ioannapergamali/mysmartroute/model/navigation/NavigationHost.kt
@@ -41,6 +41,7 @@ import com.ioannapergamali.mysmartroute.view.ui.screens.ViewRequestsScreen
 import com.ioannapergamali.mysmartroute.view.ui.screens.PassengerMovingsScreen
 import com.ioannapergamali.mysmartroute.view.ui.screens.BookSeatScreen
 import com.ioannapergamali.mysmartroute.view.ui.screens.FindVehicleScreen
+import com.ioannapergamali.mysmartroute.view.ui.screens.FindPassengersScreen
 import com.ioannapergamali.mysmartroute.view.ui.screens.RouteModeScreen
 import com.ioannapergamali.mysmartroute.view.ui.screens.ViewRoutesScreen
 import com.ioannapergamali.mysmartroute.view.ui.screens.SelectRoutePoisScreen
@@ -191,6 +192,10 @@ fun NavigationHost(
                 titleRes = R.string.find_way,
                 includeCost = true
             )
+        }
+
+        composable("findPassengers") {
+            FindPassengersScreen(navController = navController, openDrawer = openDrawer)
         }
 
         composable(

--- a/app/src/main/java/com/ioannapergamali/mysmartroute/view/ui/screens/FindPassengersScreen.kt
+++ b/app/src/main/java/com/ioannapergamali/mysmartroute/view/ui/screens/FindPassengersScreen.kt
@@ -1,0 +1,156 @@
+package com.ioannapergamali.mysmartroute.view.ui.screens
+
+import androidx.compose.foundation.layout.*
+import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.lazy.items
+import androidx.compose.material3.*
+import androidx.compose.runtime.*
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.unit.dp
+import androidx.lifecycle.viewmodel.compose.viewModel
+import androidx.navigation.NavController
+import com.google.firebase.auth.FirebaseAuth
+import com.ioannapergamali.mysmartroute.R
+import com.ioannapergamali.mysmartroute.view.ui.components.ScreenContainer
+import com.ioannapergamali.mysmartroute.view.ui.components.TopBar
+import com.ioannapergamali.mysmartroute.viewmodel.*
+import java.util.Date
+import android.text.format.DateFormat
+
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+fun FindPassengersScreen(
+    navController: NavController,
+    openDrawer: () -> Unit
+) {
+    val context = LocalContext.current
+    val requestViewModel: VehicleRequestViewModel = viewModel()
+    val transferViewModel: TransferRequestViewModel = viewModel()
+    val declarationViewModel: TransportDeclarationViewModel = viewModel()
+    val userViewModel: UserViewModel = viewModel()
+    val poiViewModel: PoIViewModel = viewModel()
+
+    val requests by requestViewModel.requests.collectAsState()
+    val declarations by declarationViewModel.declarations.collectAsState()
+    val pois by poiViewModel.pois.collectAsState()
+    val userNames = remember { mutableStateMapOf<String, String>() }
+    val selectedRequests = remember { mutableStateMapOf<String, Boolean>() }
+    val driverId = FirebaseAuth.getInstance().currentUser?.uid
+
+    LaunchedEffect(Unit) {
+        requestViewModel.loadRequests(context, allUsers = true)
+        declarationViewModel.loadDeclarations(context, driverId)
+        poiViewModel.loadPois(context)
+    }
+
+    LaunchedEffect(requests) {
+        requests.forEach { req ->
+            if (userNames[req.userId] == null) {
+                userNames[req.userId] = userViewModel.getUserName(context, req.userId)
+            }
+        }
+    }
+
+    val datePickerState = rememberDatePickerState()
+    var showDatePicker by remember { mutableStateOf(false) }
+    val selectedDateMillis = datePickerState.selectedDateMillis
+    val dateFormatter = remember { DateFormat.getDateFormat(context) }
+    val selectedDateText = selectedDateMillis?.let { dateFormatter.format(Date(it)) }
+        ?: stringResource(R.string.select_date)
+
+    val filteredDeclarations = remember(declarations, selectedDateMillis) {
+        declarations.filter { decl ->
+            selectedDateMillis == null || decl.date == selectedDateMillis
+        }
+    }
+    val routeIds = filteredDeclarations.map { it.routeId }.toSet()
+    val filteredRequests = requests.filter { req ->
+        routeIds.contains(req.routeId) &&
+            (selectedDateMillis == null || req.date == selectedDateMillis)
+    }
+
+    val poiNames = pois.associate { it.id to it.name }
+    val hasSelection = selectedRequests.values.any { it }
+
+    Scaffold(
+        topBar = {
+            TopBar(
+                title = stringResource(R.string.find_passengers),
+                navController = navController,
+                showMenu = true,
+                onMenuClick = openDrawer
+            )
+        }
+    ) { padding ->
+        ScreenContainer(modifier = Modifier.padding(padding), scrollable = false) {
+            Button(onClick = { showDatePicker = true }) {
+                Text(selectedDateText)
+            }
+            Spacer(modifier = Modifier.height(8.dp))
+            if (filteredRequests.isEmpty()) {
+                Text(stringResource(R.string.no_requests))
+            } else {
+                LazyColumn {
+                    items(filteredRequests) { req ->
+                        val passengerName = userNames[req.userId] ?: ""
+                        val routeName = listOfNotNull(
+                            poiNames[req.startPoiId],
+                            poiNames[req.endPoiId]
+                        ).joinToString(" - ")
+                        val isChecked = selectedRequests[req.id] ?: false
+                        Row(
+                            verticalAlignment = Alignment.CenterVertically,
+                            modifier = Modifier.padding(vertical = 4.dp)
+                        ) {
+                            Checkbox(
+                                checked = isChecked,
+                                onCheckedChange = { checked ->
+                                    if (checked) selectedRequests[req.id] = true
+                                    else selectedRequests.remove(req.id)
+                                }
+                            )
+                            Column {
+                                Text(passengerName)
+                                Text(routeName, style = MaterialTheme.typography.bodySmall)
+                            }
+                        }
+                    }
+                }
+                Spacer(modifier = Modifier.height(8.dp))
+                Button(
+                    onClick = {
+                        val ids = selectedRequests.filterValues { it }.keys
+                        ids.forEach { id ->
+                            val req = filteredRequests.find { it.id == id }
+                            if (req != null) {
+                                requestViewModel.notifyPassenger(context, id)
+                                transferViewModel.notifyDriver(context, req.requestNumber)
+                            }
+                        }
+                        selectedRequests.clear()
+                    },
+                    enabled = hasSelection
+                ) {
+                    Text(stringResource(R.string.notify_selected))
+                }
+            }
+        }
+    }
+
+    if (showDatePicker) {
+        DatePickerDialog(
+            onDismissRequest = { showDatePicker = false },
+            confirmButton = {
+                TextButton(onClick = { showDatePicker = false }) {
+                    Text("OK")
+                }
+            }
+        ) {
+            DatePicker(state = datePickerState)
+        }
+    }
+}
+

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -201,6 +201,7 @@
     <string name="cancel_request">Cancel request</string>
     <string name="request_number">Request number</string>
     <string name="notify_passenger">Notify passenger</string>
+    <string name="notify_selected">Notify selected</string>
     <string name="accept_offer">Accept</string>
     <string name="reject_offer">Reject</string>
     <string name="no_notifications">No notifications</string>


### PR DESCRIPTION
## Περίληψη
- Νέα οθόνη FindPassengersScreen για αναζήτηση επιβατών με βάση διαδρομή και ημερομηνία
- Προσθήκη διαδρομής "findPassengers" στο NavigationHost
- Νέο string πόρου `notify_selected`

## Έλεγχοι
- `./gradlew test` απέτυχε (HTTP 503 κατά το κατέβασμα Gradle)

------
https://chatgpt.com/codex/tasks/task_e_689a3a193e8c8328a2555c5a46a00b30