### PR TITLE
Απαίτηση κριτηρίων αναζήτησης πριν την εμφάνιση επιβατών

### DIFF
--- a/app/src/main/java/com/ioannapergamali/mysmartroute/view/ui/screens/FindPassengersScreen.kt
+++ b/app/src/main/java/com/ioannapergamali/mysmartroute/view/ui/screens/FindPassengersScreen.kt
@@ -79,15 +79,17 @@ fun FindPassengersScreen(
     val selectedDateText = selectedDateMillis?.let { dateFormatter.format(Date(it)) }
         ?: stringResource(R.string.select_date)
 
+    val hasCriteria = selectedDateMillis != null || selectedTimeMillis != null || selectedRouteId != null
+
     val filteredDeclarations = remember(declarations, selectedDateMillis, selectedTimeMillis, selectedRouteId) {
-        declarations.filter { decl ->
+        if (!hasCriteria) emptyList() else declarations.filter { decl ->
             (selectedDateMillis == null || decl.date == selectedDateMillis) &&
             (selectedTimeMillis == null || decl.startTime == selectedTimeMillis) &&
             (selectedRouteId == null || decl.routeId == selectedRouteId)
         }
     }
     val routeIds = filteredDeclarations.map { it.routeId }.toSet()
-    val filteredRequests = requests.filter { req ->
+    val filteredRequests = if (!hasCriteria) emptyList() else requests.filter { req ->
         routeIds.contains(req.routeId) &&
             (selectedDateMillis == null || req.date == selectedDateMillis)
     }
@@ -138,7 +140,9 @@ fun FindPassengersScreen(
                 }
                 Spacer(modifier = Modifier.height(8.dp))
             }
-            if (filteredRequests.isEmpty()) {
+            if (!hasCriteria) {
+                Text(stringResource(R.string.select_search_criteria))
+            } else if (filteredRequests.isEmpty()) {
                 Text(stringResource(R.string.no_requests))
             } else {
                 LazyColumn {

--- a/app/src/main/res/values-el/strings.xml
+++ b/app/src/main/res/values-el/strings.xml
@@ -175,6 +175,7 @@
     <string name="max_cost">Μέγιστο κόστος</string>
     <string name="request_sent">Το αίτημα καταχωρήθηκε</string>
     <string name="view_requests">Προβολή αιτημάτων</string>
+    <string name="select_search_criteria">Επιλέξτε κριτήρια αναζήτησης</string>
     <string name="view_transport_requests">Προβολή αιτημάτων μεταφοράς</string>
     <string name="sort_by_cost">Ταξινόμηση κατά κόστος</string>
     <string name="sort_by_date">Ταξινόμηση κατά ημερομηνία</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -190,6 +190,7 @@
     <string name="request_sent">Request saved</string>
     <string name="view_requests">View Requests</string>
     <string name="no_requests">No requests found</string>
+    <string name="select_search_criteria">Please select search criteria</string>
     <string name="view_movings">View Movings</string>
     <string name="no_movings">No movings found</string>
     <string name="active_movings">Active movings</string>


### PR DESCRIPTION
## Σύνοψη
- Προστέθηκε λογική που απαιτεί τουλάχιστον ένα κριτήριο (ημερομηνία, ώρα ή διαδρομή) για την εμφάνιση επιβατών στην οθόνη αναζήτησης.
- Εμφανίζεται μήνυμα προτροπής όταν δεν έχουν επιλεγεί κριτήρια.
- Προστέθηκαν αντίστοιχες συμβολοσειρές στα αγγλικά και ελληνικά.

## Έλεγχοι
- `./gradlew test` απέτυχε: SDK location not found.


------
https://chatgpt.com/codex/tasks/task_e_689a403062508328a2fef05f6753bacb