### PR TITLE
Add walking route options for passengers

### DIFF
--- a/app/src/main/assets/menus.json
+++ b/app/src/main/assets/menus.json
@@ -16,6 +16,8 @@
           {"titleKey": "view_transports", "route": "viewTransports"},
           {"titleKey": "view_requests", "route": "viewRequests"},
           {"titleKey": "view_movings", "route": "viewMovings"},
+          {"titleKey": "walking", "route": "walking"},
+          {"titleKey": "walking_routes", "route": "walkingRoutes"},
           {"titleKey": "print_ticket", "route": "printTicket"},
           {"titleKey": "cancel_seat", "route": "cancelSeat"},
           {"titleKey": "rank_transports", "route": "rankTransports"},

--- a/app/src/main/java/com/ioannapergamali/mysmartroute/data/local/MySmartRouteDatabase.kt
+++ b/app/src/main/java/com/ioannapergamali/mysmartroute/data/local/MySmartRouteDatabase.kt
@@ -254,6 +254,8 @@ abstract class MySmartRouteDatabase : RoomDatabase() {
                 insertOption("opt_passenger_11", passengerMenuId, "shutdown", "shutdown")
                 insertOption("opt_passenger_12", passengerMenuId, "view_requests", "viewRequests")
                 insertOption("opt_passenger_13", passengerMenuId, "view_movings", "viewMovings")
+                insertOption("opt_passenger_14", passengerMenuId, "walking", "walking")
+                insertOption("opt_passenger_15", passengerMenuId, "walking_routes", "walkingRoutes")
 
                 val driverMenuId = "menu_driver_main"
                 insertMenu(driverMenuId, "role_driver", "driver_menu_title")
@@ -716,6 +718,8 @@ abstract class MySmartRouteDatabase : RoomDatabase() {
             insertOption("opt_passenger_11", passengerMenuId, "shutdown", "shutdown")
             insertOption("opt_passenger_12", passengerMenuId, "view_requests", "viewRequests")
             insertOption("opt_passenger_13", passengerMenuId, "view_movings", "viewMovings")
+            insertOption("opt_passenger_14", passengerMenuId, "walking", "walking")
+            insertOption("opt_passenger_15", passengerMenuId, "walking_routes", "walkingRoutes")
 
             val driverMenuId = "menu_driver_main"
             insertMenu(driverMenuId, "role_driver", "driver_menu_title")

--- a/app/src/main/java/com/ioannapergamali/mysmartroute/model/navigation/NavigationHost.kt
+++ b/app/src/main/java/com/ioannapergamali/mysmartroute/model/navigation/NavigationHost.kt
@@ -39,6 +39,8 @@ import com.ioannapergamali.mysmartroute.view.ui.screens.ViewVehiclesScreen
 import com.ioannapergamali.mysmartroute.view.ui.screens.ViewTransportRequestsScreen
 import com.ioannapergamali.mysmartroute.view.ui.screens.ViewRequestsScreen
 import com.ioannapergamali.mysmartroute.view.ui.screens.PassengerMovingsScreen
+import com.ioannapergamali.mysmartroute.view.ui.screens.WalkingScreen
+import com.ioannapergamali.mysmartroute.view.ui.screens.WalkingRoutesScreen
 import com.ioannapergamali.mysmartroute.view.ui.screens.BookSeatScreen
 import com.ioannapergamali.mysmartroute.view.ui.screens.FindVehicleScreen
 import com.ioannapergamali.mysmartroute.view.ui.screens.FindPassengersScreen
@@ -255,6 +257,14 @@ fun NavigationHost(
 
         composable("viewMovings") {
             PassengerMovingsScreen(navController = navController, openDrawer = openDrawer)
+        }
+
+        composable("walking") {
+            WalkingScreen(navController = navController, openDrawer = openDrawer)
+        }
+
+        composable("walkingRoutes") {
+            WalkingRoutesScreen(navController = navController, openDrawer = openDrawer)
         }
 
         composable("rankTransports") {

--- a/app/src/main/java/com/ioannapergamali/mysmartroute/view/ui/screens/WalkingRoutesScreen.kt
+++ b/app/src/main/java/com/ioannapergamali/mysmartroute/view/ui/screens/WalkingRoutesScreen.kt
@@ -1,0 +1,74 @@
+package com.ioannapergamali.mysmartroute.view.ui.screens
+
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.material3.*
+import androidx.compose.runtime.*
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.platform.LocalContext
+import androidx.lifecycle.viewmodel.compose.viewModel
+import androidx.navigation.NavController
+import com.ioannapergamali.mysmartroute.R
+import com.ioannapergamali.mysmartroute.view.ui.components.ScreenContainer
+import com.ioannapergamali.mysmartroute.view.ui.components.TopBar
+import com.ioannapergamali.mysmartroute.viewmodel.VehicleRequestViewModel
+import com.ioannapergamali.mysmartroute.data.local.MovingEntity
+
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+fun WalkingRoutesScreen(navController: NavController, openDrawer: () -> Unit) {
+    val viewModel: VehicleRequestViewModel = viewModel()
+    val context = LocalContext.current
+    val movings by viewModel.movings.collectAsState()
+
+    LaunchedEffect(Unit) {
+        viewModel.loadRequests(context)
+    }
+
+    val walkingMovings = movings.filter { it.vehicleId == VehicleRequestViewModel.WALKING_ID }
+
+    Scaffold(
+        topBar = {
+            TopBar(
+                title = stringResource(R.string.walking_routes),
+                navController = navController,
+                showMenu = true,
+                onMenuClick = openDrawer
+            )
+        }
+    ) { padding ->
+        ScreenContainer(modifier = Modifier.padding(padding)) {
+            if (walkingMovings.isEmpty()) {
+                Text(stringResource(R.string.no_walking_routes))
+            } else {
+                walkingMovings.forEach { m ->
+                    WalkingRow(m, onRespond = { accept ->
+                        viewModel.setWalkingStatus(context, m.id, accept)
+                    })
+                    Spacer(Modifier.height(8.dp))
+                }
+            }
+        }
+    }
+}
+
+@Composable
+private fun WalkingRow(m: MovingEntity, onRespond: (Boolean) -> Unit) {
+    Row(modifier = Modifier.fillMaxWidth(), horizontalArrangement = Arrangement.SpaceBetween) {
+        Text(m.routeName)
+        Row {
+            TextButton(onClick = { onRespond(true) }) {
+                Text(stringResource(R.string.accept_offer))
+            }
+            TextButton(onClick = { onRespond(false) }) {
+                Text(stringResource(R.string.reject_offer))
+            }
+        }
+    }
+}

--- a/app/src/main/java/com/ioannapergamali/mysmartroute/view/ui/screens/WalkingScreen.kt
+++ b/app/src/main/java/com/ioannapergamali/mysmartroute/view/ui/screens/WalkingScreen.kt
@@ -1,0 +1,67 @@
+package com.ioannapergamali.mysmartroute.view.ui.screens
+
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.DirectionsWalk
+import androidx.compose.material3.*
+import androidx.compose.runtime.*
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.platform.LocalContext
+import androidx.lifecycle.viewmodel.compose.viewModel
+import androidx.navigation.NavController
+import com.ioannapergamali.mysmartroute.R
+import com.ioannapergamali.mysmartroute.view.ui.components.ScreenContainer
+import com.ioannapergamali.mysmartroute.view.ui.components.TopBar
+import com.ioannapergamali.mysmartroute.viewmodel.VehicleRequestViewModel
+import java.text.SimpleDateFormat
+import java.util.Locale
+
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+fun WalkingScreen(navController: NavController, openDrawer: () -> Unit) {
+    val viewModel: VehicleRequestViewModel = viewModel()
+    val context = LocalContext.current
+    var dateText by remember { mutableStateOf("") }
+    var timeText by remember { mutableStateOf("") }
+
+    Scaffold(
+        topBar = {
+            TopBar(
+                title = stringResource(R.string.walking),
+                navController = navController,
+                showMenu = true,
+                onMenuClick = openDrawer
+            )
+        }
+    ) { padding ->
+        ScreenContainer(modifier = Modifier.padding(padding)) {
+            OutlinedTextField(
+                value = dateText,
+                onValueChange = { dateText = it },
+                label = { Text(stringResource(R.string.date)) },
+                modifier = Modifier.fillMaxWidth()
+            )
+            Spacer(Modifier.height(8.dp))
+            OutlinedTextField(
+                value = timeText,
+                onValueChange = { timeText = it },
+                label = { Text(stringResource(R.string.time)) },
+                modifier = Modifier.fillMaxWidth()
+            )
+            Spacer(Modifier.height(16.dp))
+            IconButton(onClick = {
+                val formatter = SimpleDateFormat("dd/MM/yyyy HH:mm", Locale.getDefault())
+                val timestamp = runCatching { formatter.parse("$dateText $timeText")?.time }
+                    .getOrNull() ?: System.currentTimeMillis()
+                viewModel.logWalking(context, timestamp)
+            }) {
+                Icon(Icons.Filled.DirectionsWalk, contentDescription = stringResource(R.string.walking))
+            }
+        }
+    }
+}

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -207,6 +207,9 @@
     <string name="reject_offer">Reject</string>
     <string name="no_notifications">No notifications</string>
     <string name="no_scheduled_transports">No scheduled transports</string>
+    <string name="walking">Walking</string>
+    <string name="walking_routes">Walking routes</string>
+    <string name="no_walking_routes">No walking routes found</string>
 
     <!-- Notification text -->
     <string name="app_started_notification">App started successfully</string>


### PR DESCRIPTION
## Summary
- Προσθήκη επιλογών **Walking** και **Walking routes** στο μενού του επιβάτη
- Νέα οθόνη καταγραφής διαδρομής περπατήματος
- Νέα οθόνη προβολής διαδρομών περπατήματος με αποδοχή/απόρριψη

## Testing
- `./gradlew test` *(αποτυχία: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_689a504903cc832891c49f4a5fe4de40