### PR TITLE
Προσθήκη string πόρων για διαδρομές πεζοπορίας

### DIFF
--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -207,6 +207,9 @@
     <string name="no_notifications">No notifications</string>
     <string name="no_scheduled_transports">No scheduled transports</string>
 
+    <string name="walking_routes">Walking routes</string>
+    <string name="no_walking_routes">No walking routes</string>
+
     <!-- Notification text -->
     <string name="app_started_notification">App started successfully</string>
     <string name="driver_offer_notification">Ο οδηγός %1$s προσφέρθηκε να σας μεταφέρει. Αίτημα αριθμός %2$d</string>


### PR DESCRIPTION
## Σύνοψη
- Προστέθηκαν string πόροι `walking_routes` και `no_walking_routes` για την οθόνη WalkingRoutesScreen ώστε να αποφεύγεται το σφάλμα "Unresolved reference"

## Δοκιμές
- `./gradlew test` (απέτυχε να ολοκληρωθεί: το αρχείο καταγραφής έδειξε μόνο την εκκίνηση του Gradle Daemon)

------
https://chatgpt.com/codex/tasks/task_e_689a7e6d086483288300be5e5c5e665c