### PR TITLE
Προσθήκη ελληνικών μεταφράσεων για διαδρομές πεζών

### DIFF
--- a/app/src/main/res/values-el/strings.xml
+++ b/app/src/main/res/values-el/strings.xml
@@ -206,5 +206,7 @@
     <string name="view_details">Προβολή λεπτομερειών</string>
     <string name="reservation_details">Λεπτομέρειες κράτησης</string>
     <string name="no_reservation_found">Δεν βρέθηκε η κράτηση</string>
+    <string name="walking_routes">Διαδρομές πεζών</string>
+    <string name="no_walking_routes">Δεν βρέθηκαν διαδρομές πεζών</string>
 
 </resources>


### PR DESCRIPTION
## Περίληψη
- Προστέθηκαν τα κλειδιά `walking_routes` και `no_walking_routes` στο ελληνικό `strings.xml` για να αναγνωρίζονται σωστά τα νέα μηνύματα της οθόνης διαδρομών πεζών.

## Έλεγχοι
- `./gradlew :app:compileDebugKotlin` *(αποτυχία: λείπει Android SDK)*

------
https://chatgpt.com/codex/tasks/task_e_689a80a82d4c8328b30d6030192c0840