### PR TITLE
Add walking string resource

### DIFF
--- a/app/src/main/res/values-el/strings.xml
+++ b/app/src/main/res/values-el/strings.xml
@@ -206,6 +206,7 @@
     <string name="view_details">Προβολή λεπτομερειών</string>
     <string name="reservation_details">Λεπτομέρειες κράτησης</string>
     <string name="no_reservation_found">Δεν βρέθηκε η κράτηση</string>
+    <string name="walking">Περπάτημα</string>
     <string name="walking_routes">Διαδρομές πεζών</string>
     <string name="no_walking_routes">Δεν βρέθηκαν διαδρομές πεζών</string>
 

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -207,6 +207,7 @@
     <string name="no_notifications">No notifications</string>
     <string name="no_scheduled_transports">No scheduled transports</string>
 
+    <string name="walking">Walking</string>
     <string name="walking_routes">Walking routes</string>
     <string name="no_walking_routes">No walking routes</string>
 


### PR DESCRIPTION
## Summary
- Add missing `walking` string resource for Walking screen in both English and Greek

## Testing
- `./gradlew test` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_689a899a7e1483289347458afb8e1de4