### PR TITLE
Opt in to experimental Material3 API

### DIFF
--- a/app/src/main/java/com/ioannapergamali/mysmartroute/view/ui/screens/WalkingScreen.kt
+++ b/app/src/main/java/com/ioannapergamali/mysmartroute/view/ui/screens/WalkingScreen.kt
@@ -1,6 +1,8 @@
+@file:OptIn(ExperimentalMaterial3Api::class)
 package com.ioannapergamali.mysmartroute.view.ui.screens
 
 import androidx.compose.foundation.layout.*
+import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.*
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.AccessTime


### PR DESCRIPTION
## Summary
- opt in to ExperimentalMaterial3Api in WalkingScreen

## Testing
- `./gradlew test` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_689a998b07948328a87453d57be06f01