### PR TITLE
Αποθήκευση επεξεργασμένων διαδρομών με όνομα χρήστη

### DIFF
--- a/app/src/main/res/values-el/strings.xml
+++ b/app/src/main/res/values-el/strings.xml
@@ -159,6 +159,8 @@
     <string name="select_pois_screen_title">Επιλογή POI διαδρομής</string>
     <string name="choose_pois">Επιλογή σημείων ενδιαφέροντος</string>
     <string name="confirm_poi_selection">Επιβεβαίωση επιλογής</string>
+    <string name="route_saved">Η διαδρομή αποθηκεύτηκε</string>
+    <string name="route_save_failed">Η αποθήκευση διαδρομής απέτυχε</string>
     <string name="recalculate_route">Επανασχεδίαση διαδρομής</string>
     <string name="select_boarding">Επιλογή ως στάση επιβίβασης</string>
     <string name="select_dropoff">Επιλογή ως στάση αποβίβασης</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -170,6 +170,8 @@
     <string name="select_pois_screen_title">Select Route POIs</string>
     <string name="choose_pois">Choose points of interest</string>
     <string name="confirm_poi_selection">Confirm selection</string>
+    <string name="route_saved">Route saved</string>
+    <string name="route_save_failed">Unable to save route</string>
     <string name="recalculate_route">Recalculate route</string>
     <string name="departure_date">Departure date</string>
     <string name="no_departures">No scheduled departures</string>


### PR DESCRIPTION
## Περίληψη
- Αποθήκευση νέας διαδρομής όταν ο επιβάτης επεξεργάζεται τα POI με όνομα `edited_by_<username>`.
- Προσθήκη μηνυμάτων επιτυχίας/αποτυχίας κατά την αποθήκευση διαδρομής.

## Δοκιμές
- `./gradlew test` *(απέτυχε: έλειπαν εξαρτήσεις Android Gradle plugin)*

------
https://chatgpt.com/codex/tasks/task_e_68a20c69de2c83289cb6cd7269b18dce