### PR TITLE
Fix BookSeatScreen structure

### DIFF
--- a/app/src/main/java/com/ioannapergamali/mysmartroute/view/ui/screens/BookSeatScreen.kt
+++ b/app/src/main/java/com/ioannapergamali/mysmartroute/view/ui/screens/BookSeatScreen.kt
@@ -180,8 +180,6 @@ fun BookSeatScreen(
         }
     }
 
-    }
-
     val savedStateHandle = navController.currentBackStackEntry?.savedStateHandle
     val lifecycleOwner = LocalLifecycleOwner.current
     DisposableEffect(lifecycleOwner) {


### PR DESCRIPTION
## Summary
- Remove extra closing brace that prematurely ended `BookSeatScreen` composable

## Testing
- `./gradlew test` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a24e3fee848328be758e4a2cac8287