### PR TITLE
Fix brace mismatch in FindVehicleScreen

### DIFF
--- a/app/src/main/java/com/ioannapergamali/mysmartroute/view/ui/screens/FindVehicleScreen.kt
+++ b/app/src/main/java/com/ioannapergamali/mysmartroute/view/ui/screens/FindVehicleScreen.kt
@@ -112,9 +112,6 @@ fun FindVehicleScreen(navController: NavController, openDrawer: () -> Unit) {
     }
 
 
-    }
-
-
     LaunchedEffect(Unit) {
         routeViewModel.loadRoutes(context, includeAll = true)
         poiViewModel.loadPois(context)
@@ -428,4 +425,5 @@ fun FindVehicleScreen(navController: NavController, openDrawer: () -> Unit) {
                 Text(message)
             }
         }
-    } }
+    }
+}


### PR DESCRIPTION
## Summary
- resolve extra closing brace that ended `FindVehicleScreen` prematurely
- ensure final closing brace wraps composable content correctly

## Testing
- `./gradlew test --quiet` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a2525fc3d88328b58686c73a604e61