### PR TITLE
Αποθήκευση τροποποιημένων διαδρομών με μοναδικό όνομα

### DIFF
--- a/app/src/main/java/com/ioannapergamali/mysmartroute/view/ui/screens/SelectRoutePoisScreen.kt
+++ b/app/src/main/java/com/ioannapergamali/mysmartroute/view/ui/screens/SelectRoutePoisScreen.kt
@@ -156,12 +156,19 @@ fun SelectRoutePoisScreen(navController: NavController, openDrawer: () -> Unit) 
                     val route = selectedRoute
                     if (route != null && selectedPoiIds.size >= 2) {
                         scope.launch {
-                            routeViewModel.updateRoute(context, route.id, selectedPoiIds)
-                            Toast.makeText(
+                            val id = routeViewModel.addRouteWithUniqueName(
                                 context,
-                                context.getString(R.string.route_saved),
-                                Toast.LENGTH_SHORT
-                            ).show()
+                                selectedPoiIds,
+                                route.name
+                            )
+                            if (id != null) {
+                                routeViewModel.loadRoutes(context, includeAll = true)
+                                Toast.makeText(
+                                    context,
+                                    context.getString(R.string.route_saved),
+                                    Toast.LENGTH_SHORT
+                                ).show()
+                            }
                         }
                     }
                 }) {

--- a/app/src/main/java/com/ioannapergamali/mysmartroute/viewmodel/RouteViewModel.kt
+++ b/app/src/main/java/com/ioannapergamali/mysmartroute/viewmodel/RouteViewModel.kt
@@ -132,6 +132,23 @@ class RouteViewModel : ViewModel() {
         return id
     }
 
+    suspend fun addRouteWithUniqueName(
+        context: Context,
+        poiIds: List<String>,
+        baseName: String
+    ): String? {
+        if (poiIds.size < 2 || baseName.isBlank()) return null
+        val db = MySmartRouteDatabase.getInstance(context)
+        val routeDao = db.routeDao()
+        var name = baseName
+        var counter = 1
+        while (routeDao.findByName(name) != null) {
+            name = "$baseName ($counter)"
+            counter++
+        }
+        return addRoute(context, poiIds, name)
+    }
+
     suspend fun updateRoute(context: Context, routeId: String, poiIds: List<String>) {
         if (routeId.isBlank() || poiIds.size < 2) return
         val db = MySmartRouteDatabase.getInstance(context)


### PR DESCRIPTION
## Περίληψη
- Προσθήκη `addRouteWithUniqueName` στο `RouteViewModel` για δημιουργία νέων διαδρομών με μοναδικά ονόματα.
- Ενημέρωση `SelectRoutePoisScreen` ώστε οι αλλαγές στα POI να αποθηκεύονται ως νέα διαδρομή.

## Έλεγχοι
- `./gradlew test` (απέτυχε: SDK location not found)


------
https://chatgpt.com/codex/tasks/task_e_68a2675df40c8328b73b24b01edee43c