### PR TITLE
Remove duplicate saveEditedRouteIfChanged function

### DIFF
--- a/app/src/main/java/com/ioannapergamali/mysmartroute/view/ui/screens/BookSeatScreen.kt
+++ b/app/src/main/java/com/ioannapergamali/mysmartroute/view/ui/screens/BookSeatScreen.kt
@@ -151,16 +151,6 @@ fun BookSeatScreen(
     val apiKey = MapsUtils.getApiKey(context)
     val isKeyMissing = apiKey.isBlank()
 
-    suspend fun saveEditedRouteIfChanged(): String {
-        val routeId = selectedRouteId ?: return ""
-        if (poiIds != originalPoiIds) {
-            routeViewModel.updateRoute(context, routeId, poiIds)
-            originalPoiIds.clear()
-            originalPoiIds.addAll(poiIds)
-        }
-        return routeId
-    }
-
     fun refreshRoute() {
         val currentPois = poiIds.mapNotNull { id -> allPois.find { it.id == id } }
         if (currentPois.size >= 2) {


### PR DESCRIPTION
## Summary
- remove first `saveEditedRouteIfChanged` to resolve conflicting overloads
- keep single implementation that saves a new route when POI list changes

## Testing
- `./gradlew test` *(fails: Gradle build did not complete in allotted time)*

------
https://chatgpt.com/codex/tasks/task_e_68a306e5d8888328b018bea05cd743af