### PR TITLE
Μετονομασία συνάρτησης αποθήκευσης διαδρομής

### DIFF
--- a/app/src/main/java/com/ioannapergamali/mysmartroute/view/ui/screens/FindVehicleScreen.kt
+++ b/app/src/main/java/com/ioannapergamali/mysmartroute/view/ui/screens/FindVehicleScreen.kt
@@ -127,7 +127,7 @@ fun FindVehicleScreen(navController: NavController, openDrawer: () -> Unit) {
         }
     }
 
-    suspend fun saveEditedRouteIfChanged(): String {
+    suspend fun saveEditedRouteAsNewRoute(): String {
         if (routePoiIds == originalPoiIds) return selectedRouteId ?: ""
         val uid = FirebaseAuth.getInstance().currentUser?.uid ?: return selectedRouteId ?: ""
         val username = FirebaseFirestore.getInstance()
@@ -441,7 +441,7 @@ fun FindVehicleScreen(navController: NavController, openDrawer: () -> Unit) {
                             val fromId = routePois[fromIdx].id
                             val toId = routePois[toIdx].id
                             val cost = maxCostText.toDoubleOrNull() ?: Double.MAX_VALUE
-                            val routeId = saveEditedRouteIfChanged()
+                            val routeId = saveEditedRouteAsNewRoute()
                             val dateMillis = System.currentTimeMillis()
                             requestViewModel.requestTransport(context, routeId, fromId, toId, cost, dateMillis)
                             transferRequestViewModel.submitRequest(context, routeId, dateMillis, cost)


### PR DESCRIPTION
## Περίληψη
- Μετονομάστηκε η `saveEditedRouteIfChanged` που δημιουργούσε νέα διαδρομή σε `saveEditedRouteAsNewRoute` ώστε να αποφεύγονται τα conflicting overloads.
- Ενημερώθηκε η κλήση κατά την αποστολή αιτήματος μεταφοράς ώστε να χρησιμοποιεί τη νέα συνάρτηση.

## Έλεγχοι
- `./gradlew test` (αποτυχημένο: δεν βρέθηκε Android SDK)


------
https://chatgpt.com/codex/tasks/task_e_68a30b69467c832888f1ec9930bdd156