### PR TITLE
Προβολή ειδοποιήσεων ακυρωμένων κρατήσεων

### DIFF
--- a/app/src/main/java/com/ioannapergamali/mysmartroute/viewmodel/UserViewModel.kt
+++ b/app/src/main/java/com/ioannapergamali/mysmartroute/viewmodel/UserViewModel.kt
@@ -88,6 +88,20 @@ class UserViewModel : ViewModel() {
     fun getNotifications(context: Context, userId: String) =
         MySmartRouteDatabase.getInstance(context).notificationDao().getForUser(userId)
 
+    /** Διαγράφει τις ειδοποιήσεις του χρήστη αφού διαβαστούν. */
+    fun markNotificationsRead(context: Context, userId: String) {
+        viewModelScope.launch {
+            val dao = MySmartRouteDatabase.getInstance(context).notificationDao()
+            val notifications = dao.getForUser(userId).first()
+            notifications.forEach { notif ->
+                dao.deleteById(notif.id)
+                runCatching {
+                    db.collection("notifications").document(notif.id).delete().await()
+                }
+            }
+        }
+    }
+
     fun changeUserRole(context: Context, userId: String, newRole: UserRole) {
         viewModelScope.launch {
             val dbInstance = MySmartRouteDatabase.getInstance(context)


### PR DESCRIPTION
## Περίληψη
- Προσθήκη `markNotificationsRead` στο `UserViewModel` για καθαρισμό ειδοποιήσεων μετά την ανάγνωση.
- Ενημέρωση `NotificationsScreen` ώστε να εμφανίζει τις ειδοποιήσεις συστήματος και να τις διαγράφει αφού προβληθούν.

## Δοκιμές
- `./gradlew test` (αποτυχία: SDK location not found)


------
https://chatgpt.com/codex/tasks/task_e_68a46a1b7f148328a7849e5f5e3cc9c3