### PR TITLE
Ενημέρωση μενού και ειδοποιήσεων κατά την υποβίβαση οδηγού

### DIFF
--- a/app/src/main/java/com/ioannapergamali/mysmartroute/view/ui/screens/EditPrivilegesScreen.kt
+++ b/app/src/main/java/com/ioannapergamali/mysmartroute/view/ui/screens/EditPrivilegesScreen.kt
@@ -19,10 +19,12 @@ import com.ioannapergamali.mysmartroute.model.enumerations.localizedName
 import com.ioannapergamali.mysmartroute.view.ui.components.ScreenContainer
 import com.ioannapergamali.mysmartroute.view.ui.components.TopBar
 import com.ioannapergamali.mysmartroute.viewmodel.UserViewModel
+import com.ioannapergamali.mysmartroute.viewmodel.AuthenticationViewModel
 
 @Composable
 fun EditPrivilegesScreen(navController: NavController, openDrawer: () -> Unit) {
     val viewModel: UserViewModel = viewModel()
+    val authViewModel: AuthenticationViewModel = viewModel()
     val context = LocalContext.current
     val users by viewModel.users.collectAsState()
 
@@ -47,7 +49,7 @@ fun EditPrivilegesScreen(navController: NavController, openDrawer: () -> Unit) {
                 LazyColumn {
                     items(users) { user ->
                         UserRoleRow(user = user) { role ->
-                            viewModel.changeUserRole(context, user.id, role)
+                            viewModel.changeUserRole(context, user.id, role, authViewModel)
                         }
                         Divider(color = MaterialTheme.colorScheme.outline)
                     }


### PR DESCRIPTION
## Περίληψη
- Ανανεώνεται ο ρόλος και το μενού του χρήστη όταν υποβιβάζεται από οδηγό σε επιβάτη
- Καθαρίζονται παλιές ειδοποιήσεις επιβατών και αποστέλλεται μήνυμα ακύρωσης θέσης
- Οθόνη διαχείρισης δικαιωμάτων ενημερώνεται για να ανανεώνει τα μενού του τρέχοντος χρήστη

## Έλεγχοι
- `./gradlew test` *(απέτυχε: το build δεν ολοκληρώθηκε στο διαθέσιμο περιβάλλον)*

------
https://chatgpt.com/codex/tasks/task_e_68a46dd8e424832883d75e31a8536538