### PR TITLE
Ενημέρωση μενού και ειδοποιήσεων κατά την υποβίβαση οδηγού

### DIFF
--- a/app/src/main/java/com/ioannapergamali/mysmartroute/view/ui/screens/EditPrivilegesScreen.kt
+++ b/app/src/main/java/com/ioannapergamali/mysmartroute/view/ui/screens/EditPrivilegesScreen.kt
@@ -19,10 +19,12 @@ import com.ioannapergamali.mysmartroute.model.enumerations.localizedName
 import com.ioannapergamali.mysmartroute.view.ui.components.ScreenContainer
 import com.ioannapergamali.mysmartroute.view.ui.components.TopBar
 import com.ioannapergamali.mysmartroute.viewmodel.UserViewModel
+import com.ioannapergamali.mysmartroute.viewmodel.AuthenticationViewModel
 
 @Composable
 fun EditPrivilegesScreen(navController: NavController, openDrawer: () -> Unit) {
     val viewModel: UserViewModel = viewModel()
+    val authViewModel: AuthenticationViewModel = viewModel()
     val context = LocalContext.current
     val users by viewModel.users.collectAsState()
 
@@ -47,7 +49,7 @@ fun EditPrivilegesScreen(navController: NavController, openDrawer: () -> Unit) {
                 LazyColumn {
                     items(users) { user ->
                         UserRoleRow(user = user) { role ->
-                            viewModel.changeUserRole(context, user.id, role)
+                            viewModel.changeUserRole(context, user.id, role, authViewModel)
                         }
                         Divider(color = MaterialTheme.colorScheme.outline)
                     }


### PR DESCRIPTION
## Περίληψη
- Η μέθοδος `loadCurrentUserRole` ελέγχει πλέον πάντα το Firestore ώστε να ανανεώνονται τα μενού μετά από αλλαγή ρόλου
- Κατά την υποβίβαση οδηγού διαγράφονται δηλώσεις/κρατήσεις από το Firestore και αποστέλλεται ειδοποίηση ακύρωσης στους επιβάτες

## Έλεγχοι
- `./gradlew test` *(απέτυχε: η διαδικασία σταμάτησε πριν ολοκληρωθεί το build)*

------
https://chatgpt.com/codex/tasks/task_e_68a46dd8e424832883d75e31a8536538