### PR TITLE
Ενημέρωση roleId κατά την αλλαγή δικαιωμάτων

### DIFF
--- a/app/src/main/java/com/ioannapergamali/mysmartroute/viewmodel/UserViewModel.kt
+++ b/app/src/main/java/com/ioannapergamali/mysmartroute/viewmodel/UserViewModel.kt
@@ -116,8 +116,18 @@ class UserViewModel : ViewModel() {
             val oldRole = runCatching { UserRole.valueOf(user.role) }.getOrNull() ?: UserRole.PASSENGER
             if (oldRole == newRole) return@launch
             user.role = newRole.name
+            val newRoleId = when (newRole) {
+                UserRole.PASSENGER -> "role_passenger"
+                UserRole.DRIVER -> "role_driver"
+                UserRole.ADMIN -> "role_admin"
+            }
+            user.roleId = newRoleId
             userDao.insert(user)
-            runCatching { db.collection("users").document(userId).update("role", newRole.name).await() }
+            runCatching {
+                db.collection("users").document(userId)
+                    .update("role", newRole.name, "roleId", newRoleId)
+                    .await()
+            }
             if (oldRole == UserRole.DRIVER && newRole == UserRole.PASSENGER) {
                 handleDriverDemotion(dbInstance, userId)
             }


### PR DESCRIPTION
## Περίληψη
- Ενημερώνεται το `roleId` τόσο στην τοπική βάση όσο και στο Firestore όταν αλλάζει ο ρόλος ενός χρήστη.

## Δοκιμές
- `./gradlew test` (η λήψη Gradle ξεκίνησε, αλλά η διαδικασία διακόπηκε στο περιβάλλον εκτέλεσης)


------
https://chatgpt.com/codex/tasks/task_e_68a4784462fc8328a280bc238725bfe5