### PR TITLE
Καθαρισμός δεδομένων κατά την υποβίβαση οδηγού

### DIFF
--- a/app/src/main/java/com/ioannapergamali/mysmartroute/data/local/TransferRequestDao.kt
+++ b/app/src/main/java/com/ioannapergamali/mysmartroute/data/local/TransferRequestDao.kt
@@ -30,6 +30,6 @@ interface TransferRequestDao {
     @Query("SELECT * FROM transfer_requests WHERE driverId = :driverId")
     fun getRequestsForDriver(driverId: String): Flow<List<TransferRequestEntity>>
 
-    @Query("DELETE FROM transfer_requests WHERE driverId = :userId OR passengerId = :userId")
-    suspend fun deleteAllForUser(userId: String)
+    @Query("DELETE FROM transfer_requests WHERE driverId = :driverId")
+    suspend fun deleteForDriver(driverId: String)
 }

--- a/app/src/main/java/com/ioannapergamali/mysmartroute/viewmodel/UserViewModel.kt
+++ b/app/src/main/java/com/ioannapergamali/mysmartroute/viewmodel/UserViewModel.kt
@@ -146,6 +146,28 @@ class UserViewModel : ViewModel() {
         val firestore = FirebaseFirestore.getInstance()
 
         vehicleDao.deleteForUser(driverId)
+        runCatching {
+            firestore.collection("vehicles")
+                .whereEqualTo("userId", driverId)
+                .get()
+                .await()
+                .documents
+                .forEach { doc ->
+                    firestore.collection("vehicles").document(doc.id).delete().await()
+                }
+        }
+
+        transferDao.deleteForDriver(driverId)
+        runCatching {
+            firestore.collection("transfer_requests")
+                .whereEqualTo("driverId", driverId)
+                .get()
+                .await()
+                .documents
+                .forEach { doc ->
+                    firestore.collection("transfer_requests").document(doc.id).delete().await()
+                }
+        }
 
         // Ανακτούμε όλες τις δηλώσεις μεταφοράς του οδηγού από το Firestore
         val declarations = runCatching {


### PR DESCRIPTION
## Περίληψη
- Διαγραφή δηλωμένων οχημάτων από το Firestore όταν οδηγός υποβιβάζεται σε επιβάτη
- Αφαίρεση αιτημάτων μεταφοράς για τον οδηγό τόσο τοπικά όσο και στο Firestore

## Έλεγχοι
- `./gradlew test --dry-run` (απέτυχε: SDK location not found)


------
https://chatgpt.com/codex/tasks/task_e_68a4844c58748328b0a1a87f4e915c8e