### PR TITLE
Καθαρισμός μετακινήσεων κατά την υποβίβαση οδηγού

### DIFF
--- a/app/src/main/java/com/ioannapergamali/mysmartroute/data/local/MovingDao.kt
+++ b/app/src/main/java/com/ioannapergamali/mysmartroute/data/local/MovingDao.kt
@@ -19,6 +19,9 @@ interface MovingDao {
     @Query("DELETE FROM movings WHERE id IN (:ids)")
     suspend fun deleteByIds(ids: List<String>)
 
+    @Query("DELETE FROM movings WHERE driverId = :driverId")
+    suspend fun deleteForDriver(driverId: String)
+
     @Query("SELECT COUNT(*) FROM movings WHERE routeId = :routeId AND date = :date")
     suspend fun countForRoute(routeId: String, date: Long): Int
 

--- a/app/src/main/java/com/ioannapergamali/mysmartroute/viewmodel/UserViewModel.kt
+++ b/app/src/main/java/com/ioannapergamali/mysmartroute/viewmodel/UserViewModel.kt
@@ -143,6 +143,7 @@ class UserViewModel : ViewModel() {
         val notifDao = dbInstance.notificationDao()
         val vehicleDao = dbInstance.vehicleDao()
         val transferDao = dbInstance.transferRequestDao()
+        val movingDao = dbInstance.movingDao()
         val firestore = FirebaseFirestore.getInstance()
 
         vehicleDao.deleteForUser(driverId)
@@ -166,6 +167,18 @@ class UserViewModel : ViewModel() {
                 .documents
                 .forEach { doc ->
                     firestore.collection("transfer_requests").document(doc.id).delete().await()
+                }
+        }
+
+        movingDao.deleteForDriver(driverId)
+        runCatching {
+            firestore.collection("movings")
+                .whereEqualTo("driverId", driverId)
+                .get()
+                .await()
+                .documents
+                .forEach { doc ->
+                    firestore.collection("movings").document(doc.id).delete().await()
                 }
         }
 


### PR DESCRIPTION
## Σύντομη περίληψη
- Διαγραφή movings του οδηγού από τη Room και το Firestore κατά την υποβίβαση σε επιβάτη.
- Προσθήκη μεθόδου DAO για διαγραφή movings ανά οδηγό.

## Έλεγχοι
- `./gradlew test` (απέτυχε: SDK location not found)


------
https://chatgpt.com/codex/tasks/task_e_68a48d808ee4832882930b8ee587d448