### PR TITLE
Fix vehicle loading for availability query

### DIFF
--- a/app/src/main/java/com/ioannapergamali/mysmartroute/viewmodel/VehicleViewModel.kt
+++ b/app/src/main/java/com/ioannapergamali/mysmartroute/viewmodel/VehicleViewModel.kt
@@ -120,7 +120,10 @@ class VehicleViewModel : ViewModel() {
                 val query = when {
                     includeAll -> db.collection("vehicles")
                     targetUser != null ->
-                        db.collection("vehicles").whereEqualTo("userId", targetUser)
+                        db.collection("vehicles").whereEqualTo(
+                            "userId",
+                            db.collection("users").document(targetUser)
+                        )
                     else -> null
                 }
                 query?.get()?.await()?.documents?.mapNotNull { it.toVehicleEntity() }


### PR DESCRIPTION
## Summary
- Correct Firestore query to load driver's vehicles in availability declaration

## Testing
- `./gradlew test` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a492a9835c83288e76417bd03afc50