### PR TITLE
Remove destructive migration fallback from Room database

### DIFF
--- a/app/src/main/java/com/ioannapergamali/mysmartroute/data/local/MySmartRouteDatabase.kt
+++ b/app/src/main/java/com/ioannapergamali/mysmartroute/data/local/MySmartRouteDatabase.kt
@@ -821,7 +821,6 @@ abstract class MySmartRouteDatabase : RoomDatabase() {
                             prepopulate(db)
                         }
                     })
-                    .fallbackToDestructiveMigration()
                     .build().also { INSTANCE = it }
             }
         }


### PR DESCRIPTION
## Summary
- Αφαιρέθηκε το `fallbackToDestructiveMigration()` από τον `Room.databaseBuilder` ώστε να διατηρούνται τα τοπικά δεδομένα κατά τις αναβαθμίσεις της βάσης.

## Testing
- `./gradlew test --no-daemon` *(απέτυχε: η διαδικασία σταμάτησε μετά το μήνυμα για single-use Daemon, χωρίς να ολοκληρωθεί η εκτέλεση)*

------
https://chatgpt.com/codex/tasks/task_e_68a494d0f1508328a4df3e9d3b9f2bb3