### PR TITLE
Καθαρισμός δεδομένων οδηγού κατά την υποβίβαση

### DIFF
--- a/app/src/main/java/com/ioannapergamali/mysmartroute/data/local/DriverOperations.kt
+++ b/app/src/main/java/com/ioannapergamali/mysmartroute/data/local/DriverOperations.kt
@@ -1,0 +1,46 @@
+package com.ioannapergamali.mysmartroute.data.local
+
+import com.google.firebase.firestore.FirebaseFirestore
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.tasks.await
+import kotlinx.coroutines.withContext
+
+/**
+ * Καθαρίζει όλα τα δεδομένα ενός οδηγού από τη βάση Room και το Firebase Firestore.
+ */
+suspend fun demoteDriverToPassenger(
+    db: MySmartRouteDatabase,
+    firestore: FirebaseFirestore = FirebaseFirestore.getInstance(),
+    driverId: String,
+) = withContext(Dispatchers.IO) {
+    // Τοπική βάση
+    db.vehicleDao().deleteForUser(driverId)
+    db.transportDeclarationDao().deleteForDriver(driverId)
+    db.transferRequestDao().deleteForDriver(driverId)
+    db.movingDao().deleteForDriver(driverId)
+
+    // Firebase
+    val batch = firestore.batch()
+
+    firestore.collection("vehicles")
+        .whereEqualTo("userId", driverId)
+        .get().await()
+        .forEach { batch.delete(it.reference) }
+
+    firestore.collection("transport_declarations")
+        .whereEqualTo("driverId", driverId)
+        .get().await()
+        .forEach { batch.delete(it.reference) }
+
+    firestore.collection("transfer_requests")
+        .whereEqualTo("driverId", driverId)
+        .get().await()
+        .forEach { batch.delete(it.reference) }
+
+    firestore.collection("movings")
+        .whereEqualTo("driverId", driverId)
+        .get().await()
+        .forEach { batch.delete(it.reference) }
+
+    batch.commit().await()
+}

--- a/app/src/main/java/com/ioannapergamali/mysmartroute/data/local/TransportDeclarationDao.kt
+++ b/app/src/main/java/com/ioannapergamali/mysmartroute/data/local/TransportDeclarationDao.kt
@@ -20,6 +20,9 @@ interface TransportDeclarationDao {
     @Query("SELECT * FROM transport_declarations WHERE id = :id LIMIT 1")
     suspend fun getById(id: String): TransportDeclarationEntity?
 
+    @Query("DELETE FROM transport_declarations WHERE driverId = :driverId")
+    suspend fun deleteForDriver(driverId: String)
+
     @Query("DELETE FROM transport_declarations WHERE id IN (:ids)")
     suspend fun deleteByIds(ids: List<String>)
 }


### PR DESCRIPTION
## Περίληψη
- Προσθήκη μεθόδου `deleteForDriver` στο `TransportDeclarationDao` για διαγραφή εγγραφών οδηγού.
- Νέα συνάρτηση `demoteDriverToPassenger` που καθαρίζει οχήματα, μετακινήσεις, δηλώσεις και αιτήματα από Room και Firestore.

## Έλεγχοι
- `./gradlew test` *(αποτυχία: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a49e94b9288328aaf066a1941aa6b4