### PR TITLE
Καθαρισμός αιτημάτων και κρατήσεων όταν επιβάτης γίνεται οδηγός

### DIFF
--- a/app/src/main/java/com/ioannapergamali/mysmartroute/data/local/SeatReservationDao.kt
+++ b/app/src/main/java/com/ioannapergamali/mysmartroute/data/local/SeatReservationDao.kt
@@ -17,6 +17,9 @@ interface SeatReservationDao {
     @Query("SELECT * FROM seat_reservations WHERE userId = :userId")
     fun getReservationsForUser(userId: String): Flow<List<SeatReservationEntity>>
 
+    @Query("DELETE FROM seat_reservations WHERE userId = :userId")
+    suspend fun deleteForUser(userId: String)
+
     @Query("SELECT * FROM seat_reservations WHERE routeId = :routeId")
     fun getReservationsForRoute(routeId: String): Flow<List<SeatReservationEntity>>
 

--- a/app/src/main/java/com/ioannapergamali/mysmartroute/data/local/TransferRequestDao.kt
+++ b/app/src/main/java/com/ioannapergamali/mysmartroute/data/local/TransferRequestDao.kt
@@ -32,4 +32,7 @@ interface TransferRequestDao {
 
     @Query("DELETE FROM transfer_requests WHERE driverId = :driverId")
     suspend fun deleteForDriver(driverId: String)
+
+    @Query("DELETE FROM transfer_requests WHERE passengerId = :passengerId")
+    suspend fun deleteForPassenger(passengerId: String)
 }

--- a/app/src/main/java/com/ioannapergamali/mysmartroute/viewmodel/UserViewModel.kt
+++ b/app/src/main/java/com/ioannapergamali/mysmartroute/viewmodel/UserViewModel.kt
@@ -132,6 +132,9 @@ class UserViewModel : ViewModel() {
             if (oldRole == UserRole.DRIVER && newRole == UserRole.PASSENGER) {
                 handleDriverDemotion(dbInstance, userId)
             }
+            if (oldRole == UserRole.PASSENGER && newRole == UserRole.DRIVER) {
+                handlePassengerPromotion(dbInstance, userId)
+            }
             if (FirebaseAuth.getInstance().currentUser?.uid == userId) {
                 authViewModel?.loadCurrentUserRole(context, loadMenus = true)
             }
@@ -182,5 +185,29 @@ class UserViewModel : ViewModel() {
 
         // Καθαρίζουμε τα δεδομένα του οδηγού από Room και Firestore
         demoteDriverToPassenger(dbInstance, firestore, driverId)
+    }
+
+    private suspend fun handlePassengerPromotion(dbInstance: MySmartRouteDatabase, passengerId: String) {
+        val transferDao = dbInstance.transferRequestDao()
+        val seatDao = dbInstance.seatReservationDao()
+        val firestore = FirebaseFirestore.getInstance()
+
+        transferDao.deleteForPassenger(passengerId)
+        seatDao.deleteForUser(passengerId)
+
+        runCatching {
+            val batch = firestore.batch()
+            firestore.collection("transfer_requests")
+                .whereEqualTo("passengerId", passengerId)
+                .get().await()
+                .forEach { batch.delete(it.reference) }
+
+            firestore.collection("seat_reservations")
+                .whereEqualTo("userId", passengerId)
+                .get().await()
+                .forEach { batch.delete(it.reference) }
+
+            batch.commit().await()
+        }
     }
 }


### PR DESCRIPTION
## Περίληψη
- Προστέθηκαν μέθοδοι για διαγραφή αιτημάτων μεταφοράς και κρατήσεων θέσεων με βάση το passengerId.
- Καθαρισμός σχετικών εγγραφών σε Room και Firestore κατά την προαγωγή επιβάτη σε οδηγό.

## Έλεγχοι
- `./gradlew test` *(απέτυχε: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a4b253f75083288ba0ce9b49804e8e