### PR TITLE
Αποτροπή ειδοποίησης επιβάτη για ληγμένα αιτήματα

### DIFF
--- a/app/src/main/java/com/ioannapergamali/mysmartroute/view/ui/screens/ViewTransportRequestsScreen.kt
+++ b/app/src/main/java/com/ioannapergamali/mysmartroute/view/ui/screens/ViewTransportRequestsScreen.kt
@@ -180,7 +180,8 @@ fun ViewTransportRequestsScreen(
                                 Text(costText, modifier = Modifier.width(columnWidth))
                                 Text(dateTimeText, modifier = Modifier.width(columnWidth))
                                 Text(req.requestNumber.toString(), modifier = Modifier.width(columnWidth))
-                                if (req.status == "open") {
+                                val isExpired = req.date > 0L && System.currentTimeMillis() > req.date
+                                if (req.status == "open" && !isExpired) {
                                     Button(
                                         onClick = {
                                             viewModel.notifyPassenger(context, req.id)
@@ -191,7 +192,8 @@ fun ViewTransportRequestsScreen(
                                         Text(stringResource(R.string.notify_passenger))
                                     }
                                 } else {
-                                    Text(req.status, modifier = Modifier.width(columnWidth))
+                                    val statusText = if (isExpired) stringResource(R.string.request_expired) else req.status
+                                    Text(statusText, modifier = Modifier.width(columnWidth))
                                 }
                             }
                             Divider()

--- a/app/src/main/java/com/ioannapergamali/mysmartroute/viewmodel/VehicleRequestViewModel.kt
+++ b/app/src/main/java/com/ioannapergamali/mysmartroute/viewmodel/VehicleRequestViewModel.kt
@@ -246,6 +246,11 @@ class VehicleRequestViewModel : ViewModel() {
             val dao = MySmartRouteDatabase.getInstance(context).movingDao()
             val driver = FirebaseAuth.getInstance().currentUser ?: return@launch
             val driverName = UserViewModel().getUserName(context, driver.uid)
+            val current = _requests.value.find { it.id == requestId } ?: return@launch
+            if (current.date > 0L && System.currentTimeMillis() > current.date) {
+                Toast.makeText(context, R.string.request_expired, Toast.LENGTH_SHORT).show()
+                return@launch
+            }
             val list = _requests.value.toMutableList()
             val index = list.indexOfFirst { it.id == requestId }
             if (index != -1) {

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -207,6 +207,7 @@
     <string name="request_number">Request number</string>
     <string name="notify_passenger">Notify passenger</string>
     <string name="notify_selected">Notify selected</string>
+    <string name="request_expired">Request expired</string>
     <string name="accept_offer">Accept</string>
     <string name="reject_offer">Reject</string>
     <string name="no_notifications">No notifications</string>


### PR DESCRIPTION
## Περίληψη
- Απενεργοποίηση ειδοποίησης επιβάτη σε αιτήματα με ημερομηνία παρελθόντος.
- Έλεγχος λήξης και ενημερωτικό μήνυμα στο ViewModel για αποφυγή ανεπιθύμητων κλήσεων.
- Προσθήκη πόρου κειμένου "Request expired" για την εμφάνιση κατάλληλου μηνύματος.

## Δοκιμές
- `./gradlew test` (αποτυχία: SDK location not found)


------
https://chatgpt.com/codex/tasks/task_e_68a4b5c298288328bd3c7e6c65282c08