### PR TITLE
Καθαρισμός δεδομένων επιβάτη κατά την προαγωγή σε οδηγό

### DIFF
--- a/app/src/main/java/com/ioannapergamali/mysmartroute/viewmodel/UserViewModel.kt
+++ b/app/src/main/java/com/ioannapergamali/mysmartroute/viewmodel/UserViewModel.kt
@@ -10,6 +10,7 @@ import com.ioannapergamali.mysmartroute.data.local.MySmartRouteDatabase
 import com.ioannapergamali.mysmartroute.data.local.UserEntity
 import com.ioannapergamali.mysmartroute.data.local.NotificationEntity
 import com.ioannapergamali.mysmartroute.data.local.demoteDriverToPassenger
+import com.ioannapergamali.mysmartroute.data.local.promotePassengerToDriver
 import com.ioannapergamali.mysmartroute.utils.toFirestoreMap
 import com.ioannapergamali.mysmartroute.model.enumerations.UserRole
 import com.ioannapergamali.mysmartroute.utils.NetworkUtils
@@ -189,6 +190,7 @@ class UserViewModel : ViewModel() {
     }
 
     private suspend fun handlePassengerPromotion(dbInstance: MySmartRouteDatabase, userId: String) {
-
+        val firestore = FirebaseFirestore.getInstance()
+        promotePassengerToDriver(dbInstance, firestore, userId)
     }
 }


### PR DESCRIPTION
## Περίληψη
- προστέθηκε βοηθητική συνάρτηση `promotePassengerToDriver` που διαγράφει αιτήματα, μετακινήσεις και κρατήσεις ενός επιβάτη όταν γίνεται οδηγός
- κλήση της νέας συνάρτησης κατά την αλλαγή ρόλου στο `UserViewModel`

## Έλεγχοι
- `./gradlew test` *(αποτυχία: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a4d71954888328bd27b72a913f8c78