### PR TITLE
Αναζήτηση οχήματος βάσει κόστους χωρίς ημερομηνία

### DIFF
--- a/app/src/main/java/com/ioannapergamali/mysmartroute/view/ui/screens/AvailableTransportsScreen.kt
+++ b/app/src/main/java/com/ioannapergamali/mysmartroute/view/ui/screens/AvailableTransportsScreen.kt
@@ -111,7 +111,7 @@ fun AvailableTransportsScreen(
         if (decl.routeId != routeId) return@filter false
         if (startIndex < 0 || endIndex < 0 || startIndex >= endIndex) return@filter false
         if (maxCost != null && decl.cost > maxCost) return@filter false
-        if (date != null && decl.date != date) return@filter false
+        if (date != null && date > 0 && decl.date != date) return@filter false
         if (!decl.matchesFavorites(preferred, nonPreferred)) return@filter false
         true
     }

--- a/app/src/main/java/com/ioannapergamali/mysmartroute/view/ui/screens/FindVehicleScreen.kt
+++ b/app/src/main/java/com/ioannapergamali/mysmartroute/view/ui/screens/FindVehicleScreen.kt
@@ -414,7 +414,7 @@ fun FindVehicleScreen(navController: NavController, openDrawer: () -> Unit) {
                         val toId = routePois[toIdx].id
                         val cost = maxCostText.toDoubleOrNull() ?: Double.MAX_VALUE
                         val routeId = selectedRouteId ?: return@Button
-                        val dateMillis = System.currentTimeMillis()
+                        val dateMillis = 0L
                         requestViewModel.requestTransport(context, routeId, fromId, toId, cost, dateMillis)
                         navController.navigate(
                             "availableTransports?routeId=" +
@@ -442,7 +442,7 @@ fun FindVehicleScreen(navController: NavController, openDrawer: () -> Unit) {
                             val toId = routePois[toIdx].id
                             val cost = maxCostText.toDoubleOrNull() ?: Double.MAX_VALUE
                             val routeId = saveEditedRouteAsNewRoute()
-                            val dateMillis = System.currentTimeMillis()
+                            val dateMillis = 0L
                             requestViewModel.requestTransport(context, routeId, fromId, toId, cost, dateMillis)
                             transferRequestViewModel.submitRequest(context, routeId, dateMillis, cost)
                             message = context.getString(R.string.request_sent)


### PR DESCRIPTION
## Περίληψη
- Παραλείπεται η ημερομηνία κατά την αναζήτηση οχήματος, χρησιμοποιώντας μόνο το κόστος
- Προσαρμόστηκε η λίστα διαθέσιμων μεταφορών ώστε να αγνοεί την ημερομηνία όταν δεν ορίζεται

## Δοκιμές
- `./gradlew test --console=plain` (αποτυχία: δεν βρέθηκε το Android SDK)


------
https://chatgpt.com/codex/tasks/task_e_68a4dc27778c83288f5cc62408e0081f