### PR TITLE
Απόκρυψη ολοκληρωμένων μεταφορών από τις διαθέσιμες μεταφορές

### DIFF
--- a/app/src/main/java/com/ioannapergamali/mysmartroute/view/ui/screens/AvailableTransportsScreen.kt
+++ b/app/src/main/java/com/ioannapergamali/mysmartroute/view/ui/screens/AvailableTransportsScreen.kt
@@ -77,7 +77,7 @@ fun AvailableTransportsScreen(
     val bookingViewModel: BookingViewModel = viewModel()
     val scope = rememberCoroutineScope()
 
-    val declarations by declarationViewModel.declarations.collectAsState()
+    val declarations by declarationViewModel.pendingDeclarations.collectAsState()
     val drivers by userViewModel.drivers.collectAsState()
     val vehicles by vehicleViewModel.vehicles.collectAsState()
     val preferred by favoritesViewModel.preferredFlow(context).collectAsState(initial = emptySet())


### PR DESCRIPTION
## Περίληψη
- Φιλτράρονται οι ολοκληρωμένες δηλώσεις μεταφοράς ώστε να μην εμφανίζονται στη σελίδα διαθέσιμων μεταφορών.

## Έλεγχοι
- `./gradlew test` *(απέτυχε στο περιβάλλον: Starting a Gradle Daemon, 1 busy Daemon could not be reused)*

------
https://chatgpt.com/codex/tasks/task_e_68a4e8136fc483288259173af9cfd7fe