### PR TITLE
Αναζήτηση οχήματος βάσει κόστους χωρίς χρήση ημερομηνίας

### DIFF
--- a/app/src/main/java/com/ioannapergamali/mysmartroute/view/ui/screens/FindVehicleScreen.kt
+++ b/app/src/main/java/com/ioannapergamali/mysmartroute/view/ui/screens/FindVehicleScreen.kt
@@ -47,6 +47,8 @@ import com.ioannapergamali.mysmartroute.utils.MapsUtils
 import com.google.firebase.auth.FirebaseAuth
 import com.google.firebase.firestore.FirebaseFirestore
 import kotlinx.coroutines.tasks.await
+import java.time.LocalDate
+import java.time.ZoneId
 
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable
@@ -81,6 +83,9 @@ fun FindVehicleScreen(navController: NavController, openDrawer: () -> Unit) {
     val coroutineScope = rememberCoroutineScope()
     val apiKey = MapsUtils.getApiKey(context)
     val isKeyMissing = apiKey.isBlank()
+    val dateMillis = remember {
+        LocalDate.now().atStartOfDay(ZoneId.systemDefault()).toInstant().toEpochMilli()
+    }
 
     suspend fun saveEditedRouteIfChanged(): String {
         val routeId = selectedRouteId ?: return ""
@@ -414,15 +419,13 @@ fun FindVehicleScreen(navController: NavController, openDrawer: () -> Unit) {
                         val toId = routePois[toIdx].id
                         val cost = maxCostText.toDoubleOrNull() ?: Double.MAX_VALUE
                         val routeId = selectedRouteId ?: return@Button
-                        val dateMillis = System.currentTimeMillis()
                         requestViewModel.requestTransport(context, routeId, fromId, toId, cost, dateMillis)
                         navController.navigate(
                             "availableTransports?routeId=" +
                                 routeId +
                                 "&startId=" + fromId +
                                 "&endId=" + toId +
-                                "&maxCost=" + cost +
-                                "&date=" + dateMillis
+                                "&maxCost=" + cost
                         )
                     },
                     enabled = selectedRouteId != null && startIndex != null && endIndex != null,
@@ -442,7 +445,6 @@ fun FindVehicleScreen(navController: NavController, openDrawer: () -> Unit) {
                             val toId = routePois[toIdx].id
                             val cost = maxCostText.toDoubleOrNull() ?: Double.MAX_VALUE
                             val routeId = saveEditedRouteAsNewRoute()
-                            val dateMillis = System.currentTimeMillis()
                             requestViewModel.requestTransport(context, routeId, fromId, toId, cost, dateMillis)
                             transferRequestViewModel.submitRequest(context, routeId, dateMillis, cost)
                             message = context.getString(R.string.request_sent)


### PR DESCRIPTION
## Περίληψη
- Υπολογισμός της σημερινής ημερομηνίας στην αρχή της ημέρας και χρήση της στα αιτήματα αναζήτησης και αποθήκευσης
- Αφαίρεση της παραμέτρου ημερομηνίας κατά την πλοήγηση ώστε οι διαθέσιμες μεταφορές να φιλτράρονται μόνο με βάση το κόστος

## Δοκιμές
- `./gradlew --no-daemon test --console=plain --stacktrace` (αποτυχία: SDK location not found. Define a valid SDK location with an ANDROID_HOME environment variable or by setting the sdk.dir path in your project's local properties file)


------
https://chatgpt.com/codex/tasks/task_e_68a4dc27778c83288f5cc62408e0081f