### PR TITLE
Προβολή 10 καλύτερων και χειρότερων οδηγών

### DIFF
--- a/app/src/main/java/com/ioannapergamali/mysmartroute/data/local/TripRatingDao.kt
+++ b/app/src/main/java/com/ioannapergamali/mysmartroute/data/local/TripRatingDao.kt
@@ -5,6 +5,7 @@ import androidx.room.Insert
 import androidx.room.OnConflictStrategy
 import androidx.room.Query
 import kotlinx.coroutines.flow.Flow
+import com.ioannapergamali.mysmartroute.model.classes.users.DriverRating
 
 @Dao
 interface TripRatingDao {
@@ -13,4 +14,32 @@ interface TripRatingDao {
 
     @Insert(onConflict = OnConflictStrategy.REPLACE)
     suspend fun upsert(rating: TripRatingEntity)
+
+    @Query(
+        """
+            SELECT u.id AS driverId, u.name AS name, u.surname AS surname, AVG(r.rating) AS averageRating
+            FROM trip_ratings r
+            INNER JOIN movings m ON m.id = r.movingId
+            INNER JOIN users u ON u.id = m.driverId
+            WHERE m.driverId <> ''
+            GROUP BY u.id
+            ORDER BY averageRating DESC
+            LIMIT 10
+        """
+    )
+    fun getTopDrivers(): Flow<List<DriverRating>>
+
+    @Query(
+        """
+            SELECT u.id AS driverId, u.name AS name, u.surname AS surname, AVG(r.rating) AS averageRating
+            FROM trip_ratings r
+            INNER JOIN movings m ON m.id = r.movingId
+            INNER JOIN users u ON u.id = m.driverId
+            WHERE m.driverId <> ''
+            GROUP BY u.id
+            ORDER BY averageRating ASC
+            LIMIT 10
+        """
+    )
+    fun getWorstDrivers(): Flow<List<DriverRating>>
 }

--- a/app/src/main/java/com/ioannapergamali/mysmartroute/model/classes/users/DriverRating.kt
+++ b/app/src/main/java/com/ioannapergamali/mysmartroute/model/classes/users/DriverRating.kt
@@ -1,0 +1,8 @@
+package com.ioannapergamali.mysmartroute.model.classes.users
+
+data class DriverRating(
+    val driverId: String,
+    val name: String,
+    val surname: String,
+    val averageRating: Double
+)

--- a/app/src/main/java/com/ioannapergamali/mysmartroute/model/navigation/NavigationHost.kt
+++ b/app/src/main/java/com/ioannapergamali/mysmartroute/model/navigation/NavigationHost.kt
@@ -52,6 +52,7 @@ import com.ioannapergamali.mysmartroute.view.ui.screens.AvailableTransportsScree
 import com.ioannapergamali.mysmartroute.view.ui.screens.NotificationsScreen
 import com.ioannapergamali.mysmartroute.view.ui.screens.ReservationDetailsScreen
 import com.ioannapergamali.mysmartroute.view.ui.screens.RankTransportsScreen
+import com.ioannapergamali.mysmartroute.view.ui.screens.RankDriversScreen
 import com.ioannapergamali.mysmartroute.R
 
 
@@ -270,6 +271,10 @@ fun NavigationHost(
 
         composable("rankTransports") {
             RankTransportsScreen(navController = navController, openDrawer = openDrawer)
+        }
+
+        composable("rankDrivers") {
+            RankDriversScreen(navController = navController, openDrawer = openDrawer)
         }
 
         composable("printTicket") {

--- a/app/src/main/java/com/ioannapergamali/mysmartroute/view/ui/screens/RankDriversScreen.kt
+++ b/app/src/main/java/com/ioannapergamali/mysmartroute/view/ui/screens/RankDriversScreen.kt
@@ -1,0 +1,63 @@
+package com.ioannapergamali.mysmartroute.view.ui.screens
+
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Scaffold
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.collectAsState
+import androidx.compose.runtime.getValue
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.unit.dp
+import androidx.lifecycle.viewmodel.compose.viewModel
+import androidx.navigation.NavController
+import com.ioannapergamali.mysmartroute.R
+import com.ioannapergamali.mysmartroute.view.ui.components.ScreenContainer
+import com.ioannapergamali.mysmartroute.view.ui.components.TopBar
+import com.ioannapergamali.mysmartroute.viewmodel.DriverRatingViewModel
+
+@Composable
+fun RankDriversScreen(navController: NavController, openDrawer: () -> Unit) {
+    val context = LocalContext.current
+    val viewModel: DriverRatingViewModel = viewModel()
+    val best by viewModel.bestDrivers.collectAsState()
+    val worst by viewModel.worstDrivers.collectAsState()
+
+    LaunchedEffect(Unit) { viewModel.loadRatings(context) }
+
+    Scaffold(
+        topBar = {
+            TopBar(
+                title = stringResource(R.string.rank_drivers),
+                navController = navController,
+                showMenu = true,
+                onMenuClick = openDrawer
+            )
+        }
+    ) { padding ->
+        ScreenContainer(modifier = Modifier.padding(padding)) {
+            Text(stringResource(R.string.top_drivers), style = MaterialTheme.typography.titleMedium)
+            if (best.isEmpty()) {
+                Text(stringResource(R.string.no_driver_ratings))
+            } else {
+                best.forEachIndexed { index, driver ->
+                    Text("${index + 1}. ${driver.name} ${driver.surname} - ${stringResource(R.string.average_rating_label, driver.averageRating)}")
+                }
+            }
+            Spacer(modifier = Modifier.height(16.dp))
+            Text(stringResource(R.string.worst_drivers), style = MaterialTheme.typography.titleMedium)
+            if (worst.isEmpty()) {
+                Text(stringResource(R.string.no_driver_ratings))
+            } else {
+                worst.forEachIndexed { index, driver ->
+                    Text("${index + 1}. ${driver.name} ${driver.surname} - ${stringResource(R.string.average_rating_label, driver.averageRating)}")
+                }
+            }
+        }
+    }
+}

--- a/app/src/main/java/com/ioannapergamali/mysmartroute/viewmodel/DriverRatingViewModel.kt
+++ b/app/src/main/java/com/ioannapergamali/mysmartroute/viewmodel/DriverRatingViewModel.kt
@@ -1,0 +1,28 @@
+package com.ioannapergamali.mysmartroute.viewmodel
+
+import android.content.Context
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.viewModelScope
+import com.ioannapergamali.mysmartroute.data.local.MySmartRouteDatabase
+import com.ioannapergamali.mysmartroute.model.classes.users.DriverRating
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.launch
+
+class DriverRatingViewModel : ViewModel() {
+    private val _bestDrivers = MutableStateFlow<List<DriverRating>>(emptyList())
+    val bestDrivers: StateFlow<List<DriverRating>> = _bestDrivers
+
+    private val _worstDrivers = MutableStateFlow<List<DriverRating>>(emptyList())
+    val worstDrivers: StateFlow<List<DriverRating>> = _worstDrivers
+
+    fun loadRatings(context: Context) {
+        val db = MySmartRouteDatabase.getInstance(context)
+        viewModelScope.launch {
+            db.tripRatingDao().getTopDrivers().collect { _bestDrivers.value = it }
+        }
+        viewModelScope.launch {
+            db.tripRatingDao().getWorstDrivers().collect { _worstDrivers.value = it }
+        }
+    }
+}

--- a/app/src/main/res/values-el/strings.xml
+++ b/app/src/main/res/values-el/strings.xml
@@ -109,6 +109,10 @@
     <string name="view_unassigned">Προβολή μη εκχωρημένων διαδρομών</string>
     <string name="review_poi">Έλεγχος ονομάτων σημείων ενδιαφέροντος</string>
     <string name="rank_drivers">Προβολή 10 καλύτερων και χειρότερων οδηγών</string>
+    <string name="top_drivers">Κορυφαίοι 10 οδηγοί</string>
+    <string name="worst_drivers">Χειρότεροι 10 οδηγοί</string>
+    <string name="no_driver_ratings">Δεν υπάρχουν βαθμολογίες οδηγών</string>
+    <string name="average_rating_label">Μέση βαθμολογία: %1$.1f/5</string>
     <string name="rank_passengers">Προβολή 10 πιο και λιγότερο ικανοποιημένων επιβατών</string>
     <string name="view_vehicles">Προβολή διαθέσιμων οχημάτων</string>
     <string name="vehicles_empty">Δεν βρέθηκαν οχήματα</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -107,6 +107,10 @@
     <string name="view_unassigned">View List of Unassigned Routes</string>
     <string name="review_poi">Review Point of Interest Names</string>
     <string name="rank_drivers">Show 10 Best and Worst Drivers</string>
+    <string name="top_drivers">Top 10 drivers</string>
+    <string name="worst_drivers">Bottom 10 drivers</string>
+    <string name="no_driver_ratings">No driver ratings found</string>
+    <string name="average_rating_label">Avg rating: %1$.1f/5</string>
     <string name="rank_passengers">View 10 Happiest/Least Happy Passengers</string>
     <string name="view_vehicles">View Available Vehicles</string>
     <string name="vehicles_empty">No vehicles found</string>


### PR DESCRIPTION
## Περίληψη
- Προστέθηκε κλάση `DriverRating` για την αποθήκευση μέσης βαθμολογίας οδηγών
- Επεκτάθηκε το `TripRatingDao` με ερωτήματα για τους 10 καλύτερους και χειρότερους οδηγούς
- Δημιουργήθηκαν `DriverRatingViewModel` και `RankDriversScreen` και προστέθηκε νέα διαδρομή πλοήγησης

## Δοκιμές
- `./gradlew test` *(αποτυχία: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a98fa97074832890fe5b4b3cec4c47