### PR TITLE
feat: add password reset

### DIFF
--- a/app/src/main/java/com/ioannapergamali/mysmartroute/view/ui/screens/HomeScreen.kt
+++ b/app/src/main/java/com/ioannapergamali/mysmartroute/view/ui/screens/HomeScreen.kt
@@ -56,6 +56,7 @@ fun HomeScreen(
 
         val viewModel: AuthenticationViewModel = viewModel()
         val uiState by viewModel.loginState.collectAsState()
+        val resetState by viewModel.resetPasswordState.collectAsState()
         val context = LocalContext.current
         var email by remember { mutableStateOf("") }
         var password by remember { mutableStateOf("") }
@@ -84,6 +85,7 @@ fun HomeScreen(
                         onLogin = { viewModel.login(context, email, password) },
                         onNavigateToSignUp = onNavigateToSignUp,
                         onLogout = { viewModel.signOut() },
+                        onResetPassword = { viewModel.resetPassword(email) },
                         modifier = Modifier.weight(1f)
                     )
                 }
@@ -105,7 +107,8 @@ fun HomeScreen(
                         uiState = uiState,
                         onLogin = { viewModel.login(context, email, password) },
                         onNavigateToSignUp = onNavigateToSignUp,
-                        onLogout = { viewModel.signOut() }
+                        onLogout = { viewModel.signOut() },
+                        onResetPassword = { viewModel.resetPassword(email) }
                     )
                 }
             }
@@ -128,6 +131,21 @@ fun HomeScreen(
                 else -> {}
             }
         }
+
+        LaunchedEffect(resetState) {
+            when (resetState) {
+                is AuthenticationViewModel.ResetPasswordState.Success -> {
+                    Toast.makeText(context, stringResource(R.string.reset_email_sent), Toast.LENGTH_SHORT).show()
+                    viewModel.clearResetPasswordState()
+                }
+                is AuthenticationViewModel.ResetPasswordState.Error -> {
+                    val message = (resetState as AuthenticationViewModel.ResetPasswordState.Error).message
+                    Toast.makeText(context, message, Toast.LENGTH_SHORT).show()
+                    viewModel.clearResetPasswordState()
+                }
+                else -> {}
+            }
+        }
     }
 }
 
@@ -145,6 +163,7 @@ private fun HomeContent(
     onLogin: () -> Unit,
     onNavigateToSignUp: () -> Unit,
     onLogout: () -> Unit = {},
+    onResetPassword: () -> Unit,
     modifier: Modifier = Modifier
 ) {
     val bubbleState = LocalKeyboardBubbleState.current!!
@@ -213,6 +232,14 @@ private fun HomeContent(
                     color = MaterialTheme.colorScheme.error
                 )
             }
+
+            Spacer(Modifier.height(8.dp))
+
+            Text(
+                text = stringResource(R.string.forgot_password),
+                color = MaterialTheme.colorScheme.primary,
+                modifier = Modifier.clickable { onResetPassword() }
+            )
 
             Spacer(Modifier.height(16.dp))
 

--- a/app/src/main/res/values-el/strings.xml
+++ b/app/src/main/res/values-el/strings.xml
@@ -28,6 +28,8 @@
     <string name="logout">Αποσύνδεση</string>
     <string name="email">Email</string>
     <string name="password">Κωδικός</string>
+    <string name="forgot_password">Ξεχάσατε τον κωδικό;</string>
+    <string name="reset_email_sent">Στάλθηκε email επαναφοράς κωδικού</string>
     <string name="no_account">Αν δεν έχετε λογαριασμό</string>
     <string name="sign_up">Εγγραφή</string>
     <string name="first_name">Όνομα</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -26,6 +26,8 @@
     <string name="logout">Logout</string>
     <string name="email">Email</string>
     <string name="password">Password</string>
+    <string name="forgot_password">Forgot password?</string>
+    <string name="reset_email_sent">Password reset email sent</string>
     <string name="no_account">If you don\'t have an account</string>
     <string name="sign_up">Sign Up</string>
     <string name="first_name">Name</string>


### PR DESCRIPTION
## Summary
- add state and methods to trigger Firebase password reset
- expose reset password UI link and feedback toast

## Testing
- `./gradlew test` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a98f50446483288fe825d68e63578d