### PR TITLE
Αφαίρεση διπλής δήλωσης dateMillis

### DIFF
--- a/app/src/main/java/com/ioannapergamali/mysmartroute/view/ui/screens/FindVehicleScreen.kt
+++ b/app/src/main/java/com/ioannapergamali/mysmartroute/view/ui/screens/FindVehicleScreen.kt
@@ -86,9 +86,6 @@ fun FindVehicleScreen(navController: NavController, openDrawer: () -> Unit) {
     val coroutineScope = rememberCoroutineScope()
     val apiKey = MapsUtils.getApiKey(context)
     val isKeyMissing = apiKey.isBlank()
-    val dateMillis = remember {
-        LocalDate.now().atStartOfDay(ZoneId.systemDefault()).toInstant().toEpochMilli()
-    }
 
     suspend fun saveEditedRouteIfChanged(): String {
         val routeId = selectedRouteId ?: return ""


### PR DESCRIPTION
## Περίληψη
- Αφαίρεση επαναλαμβανόμενης μεταβλητής `dateMillis` στο `FindVehicleScreen`.

## Δοκιμές
- `./gradlew test` *(απέτυχε: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a9936d5c2083288cd638aeb92ba8df