### PR TITLE
Αποφυγή χρήσης stringResource σε LaunchedEffect

### DIFF
--- a/app/src/main/java/com/ioannapergamali/mysmartroute/view/ui/screens/HomeScreen.kt
+++ b/app/src/main/java/com/ioannapergamali/mysmartroute/view/ui/screens/HomeScreen.kt
@@ -135,7 +135,11 @@ fun HomeScreen(
         LaunchedEffect(resetState) {
             when (resetState) {
                 is AuthenticationViewModel.ResetPasswordState.Success -> {
-                    Toast.makeText(context, stringResource(R.string.reset_email_sent), Toast.LENGTH_SHORT).show()
+                    Toast.makeText(
+                        context,
+                        context.getString(R.string.reset_email_sent),
+                        Toast.LENGTH_SHORT
+                    ).show()
                     viewModel.clearResetPasswordState()
                 }
                 is AuthenticationViewModel.ResetPasswordState.Error -> {


### PR DESCRIPTION
## Περίληψη
- Αντικατάσταση του `stringResource` με `context.getString` μέσα στο `LaunchedEffect` στο `HomeScreen` για να αποφεύγεται η κλήση Composable από μη-Composable context.

## Έλεγχοι
- `./gradlew build` *(απέτυχε: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a9981237988328984edb0dc1d106df