### PR TITLE
Διαχείριση ονομάτων σημείων για διαχειριστές

### DIFF
--- a/app/src/main/java/com/ioannapergamali/mysmartroute/data/local/RoutePointDao.kt
+++ b/app/src/main/java/com/ioannapergamali/mysmartroute/data/local/RoutePointDao.kt
@@ -16,6 +16,9 @@ interface RoutePointDao {
     @Query("DELETE FROM route_points WHERE routeId = :routeId")
     suspend fun deletePointsForRoute(routeId: String)
 
+    @Query("UPDATE route_points SET poiId = :newId WHERE poiId = :oldId")
+    suspend fun updatePoiReferences(oldId: String, newId: String)
+
     @Query("SELECT * FROM route_points")
     fun getAll(): kotlinx.coroutines.flow.Flow<List<RoutePointEntity>>
 }

--- a/app/src/main/java/com/ioannapergamali/mysmartroute/view/ui/components/NavigationDrawer.kt
+++ b/app/src/main/java/com/ioannapergamali/mysmartroute/view/ui/components/NavigationDrawer.kt
@@ -11,6 +11,7 @@ import androidx.compose.material.icons.filled.Person
 import androidx.compose.material.icons.filled.Login
 import androidx.compose.material.icons.filled.Settings
 import androidx.compose.material.icons.filled.Menu
+import androidx.compose.material.icons.filled.LocationOn
 import com.google.firebase.auth.FirebaseAuth
 import androidx.compose.material3.*
 import androidx.compose.material3.MaterialTheme
@@ -44,6 +45,7 @@ fun DrawerMenu(navController: NavController, closeDrawer: () -> Unit) {
     ) {
         val userState = remember { mutableStateOf(FirebaseAuth.getInstance().currentUser) }
         val username = remember { mutableStateOf<String?>(null) }
+        val role = remember { mutableStateOf<String?>(null) }
 
         DisposableEffect(Unit) {
             val auth = FirebaseAuth.getInstance()
@@ -56,6 +58,7 @@ fun DrawerMenu(navController: NavController, closeDrawer: () -> Unit) {
                         .get()
                         .addOnSuccessListener { doc ->
                             username.value = doc.getString("username")
+                            role.value = doc.getString("role")
                         }
                 } else {
                     username.value = null
@@ -123,6 +126,17 @@ fun DrawerMenu(navController: NavController, closeDrawer: () -> Unit) {
             },
             icon = { Icon(Icons.Filled.AdminPanelSettings, contentDescription = null, tint = MaterialTheme.colorScheme.primary) }
         )
+        if (role.value == "ADMIN") {
+            NavigationDrawerItem(
+                label = { Text(stringResource(R.string.view_pois)) },
+                selected = false,
+                onClick = {
+                    navController.navigate("poiList")
+                    closeDrawer()
+                },
+                icon = { Icon(Icons.Filled.LocationOn, contentDescription = null, tint = MaterialTheme.colorScheme.primary) }
+            )
+        }
         if (user != null) {
             NavigationDrawerItem(
                 label = { Text(stringResource(R.string.profile)) },

--- a/app/src/main/java/com/ioannapergamali/mysmartroute/view/ui/screens/PoIListScreen.kt
+++ b/app/src/main/java/com/ioannapergamali/mysmartroute/view/ui/screens/PoIListScreen.kt
@@ -3,17 +3,24 @@ package com.ioannapergamali.mysmartroute.view.ui.screens
 import androidx.compose.foundation.layout.*
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.items
+import androidx.compose.material3.AlertDialog
 import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.Icon
 import androidx.compose.material3.IconButton
 import androidx.compose.material3.Scaffold
 import androidx.compose.material3.Text
+import androidx.compose.material3.TextButton
+import androidx.compose.material3.TextField
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.Delete
+import androidx.compose.material.icons.filled.Edit
+import androidx.compose.material.icons.filled.Link
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.unit.dp
 import androidx.lifecycle.viewmodel.compose.viewModel
@@ -24,6 +31,7 @@ import androidx.compose.ui.res.stringResource
 import com.ioannapergamali.mysmartroute.R
 import com.ioannapergamali.mysmartroute.view.ui.components.ScreenContainer
 import com.ioannapergamali.mysmartroute.viewmodel.PoIViewModel
+import com.ioannapergamali.mysmartroute.data.local.PoIEntity
 
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable
@@ -31,6 +39,10 @@ fun PoIListScreen(navController: NavController, openDrawer: () -> Unit) {
     val viewModel: PoIViewModel = viewModel()
     val pois by viewModel.pois.collectAsState()
     val context = LocalContext.current
+
+    var editPoi by remember { mutableStateOf<PoIEntity?>(null) }
+    var editedName by remember { mutableStateOf("") }
+    var mergeKeepId by remember { mutableStateOf<String?>(null) }
 
     LaunchedEffect(Unit) { viewModel.loadPois(context) }
 
@@ -45,12 +57,56 @@ fun PoIListScreen(navController: NavController, openDrawer: () -> Unit) {
                         horizontalArrangement = Arrangement.SpaceBetween
                     ) {
                         Text(text = "${poi.name} (${poi.lat}, ${poi.lng})")
-                        IconButton(onClick = { viewModel.deletePoi(context, poi.id) }) {
-                            Icon(imageVector = Icons.Default.Delete, contentDescription = "Διαγραφή")
+                        Row {
+                            IconButton(onClick = {
+                                editPoi = poi
+                                editedName = poi.name
+                            }) {
+                                Icon(Icons.Default.Edit, contentDescription = "Επεξεργασία")
+                            }
+                            IconButton(onClick = {
+                                mergeKeepId?.let { keep ->
+                                    if (keep != poi.id) {
+                                        viewModel.mergePois(context, keep, poi.id)
+                                    }
+                                    mergeKeepId = null
+                                } ?: run {
+                                    mergeKeepId = poi.id
+                                }
+                            }) {
+                                Icon(
+                                    Icons.Default.Link,
+                                    contentDescription = "Συγχώνευση",
+                                    tint = if (mergeKeepId == poi.id)
+                                        androidx.compose.material3.MaterialTheme.colorScheme.primary else androidx.compose.material3.MaterialTheme.colorScheme.onSurface
+                                )
+                            }
+                            IconButton(onClick = { viewModel.deletePoi(context, poi.id) }) {
+                                Icon(imageVector = Icons.Default.Delete, contentDescription = "Διαγραφή")
+                            }
                         }
                     }
                 }
             }
         }
+    }
+
+    editPoi?.let { poi ->
+        AlertDialog(
+            onDismissRequest = { editPoi = null },
+            title = { Text(stringResource(R.string.poi_name)) },
+            text = {
+                TextField(value = editedName, onValueChange = { editedName = it })
+            },
+            confirmButton = {
+                TextButton(onClick = {
+                    viewModel.updatePoi(context, poi.copy(name = editedName))
+                    editPoi = null
+                }) { Text(stringResource(android.R.string.ok)) }
+            },
+            dismissButton = {
+                TextButton(onClick = { editPoi = null }) { Text(stringResource(android.R.string.cancel)) }
+            }
+        )
     }
 }


### PR DESCRIPTION
## Περίληψη
- Προστέθηκε δυνατότητα ενημέρωσης και συγχώνευσης PoI στο `PoIViewModel` και στο UI.
- Νέα επιλογή "View PoIs" στο συρτάρι πλοήγησης για ρόλο ADMIN.
- Επεκτάθηκε το `RoutePointDao` με ενημέρωση αναφορών σημείων διαδρομής.

## Έλεγχοι
- `./gradlew test` (αποτυχία: SDK location not found)


------
https://chatgpt.com/codex/tasks/task_e_68a9a311baa483288fbaf4a7e4091e3c