### PR TITLE
Προσθήκη επιβεβαίωσης επαναφοράς κωδικού και ενημέρωση Firebase BOM

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -99,7 +99,7 @@ dependencies {
 
     // Firebase
     // Χρήση της πιο πρόσφατης έκδοσης BOM
-    implementation(platform("com.google.firebase:firebase-bom:33.16.0"))
+    implementation(platform("com.google.firebase:firebase-bom:34.1.0"))
     implementation("com.google.firebase:firebase-auth-ktx")
     implementation("com.google.firebase:firebase-firestore-ktx")
 

--- a/app/src/main/java/com/ioannapergamali/mysmartroute/viewmodel/AuthenticationViewModel.kt
+++ b/app/src/main/java/com/ioannapergamali/mysmartroute/viewmodel/AuthenticationViewModel.kt
@@ -221,6 +221,29 @@ class AuthenticationViewModel : ViewModel() {
         }
     }
 
+    fun confirmPasswordReset(oobCode: String, newPassword: String) {
+        viewModelScope.launch {
+            _resetPasswordState.value = ResetPasswordState.Loading
+            auth.verifyPasswordResetCode(oobCode)
+                .addOnSuccessListener {
+                    auth.confirmPasswordReset(oobCode, newPassword)
+                        .addOnSuccessListener {
+                            _resetPasswordState.value = ResetPasswordState.Success
+                        }
+                        .addOnFailureListener { e ->
+                            _resetPasswordState.value = ResetPasswordState.Error(
+                                e.localizedMessage ?: "Failed to reset password",
+                            )
+                        }
+                }
+                .addOnFailureListener { e ->
+                    _resetPasswordState.value = ResetPasswordState.Error(
+                        e.localizedMessage ?: "Invalid or expired reset link",
+                    )
+                }
+        }
+    }
+
     fun clearResetPasswordState() {
         _resetPasswordState.value = ResetPasswordState.Idle
     }


### PR DESCRIPTION
## Summary
- προσθήκη συνάρτησης επιβεβαίωσης επαναφοράς κωδικού με `verifyPasswordResetCode` και `confirmPasswordReset`
- αναβάθμιση εξάρτησης Firebase BOM στην έκδοση 34.1.0

## Testing
- `./gradlew test --dry-run` (απέτυχε: SDK location not found)

------
https://chatgpt.com/codex/tasks/task_e_68a9a1b781288328b4f713b7b97affc4