### PR TITLE
Απλούστευση ρύθμισης αποθετηρίων Gradle

### DIFF
--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -7,7 +7,6 @@ pluginManagement {
 }
 
 dependencyResolutionManagement {
-    repositoriesMode.set(RepositoriesMode.FAIL_ON_PROJECT_REPOS)
     repositories {
         google()
         mavenCentral()


### PR DESCRIPTION
## Περίληψη
- Αφαίρεση του `repositoriesMode.set(RepositoriesMode.FAIL_ON_PROJECT_REPOS)` για να γίνεται απλούστερα η επίλυση των αποθετηρίων σε όλο το project.

## Έλεγχοι
- `./gradlew build` *(αποτυχία: λείπει το Android SDK στο περιβάλλον)*

------
https://chatgpt.com/codex/tasks/task_e_68a9ae667250832899e312c7332ebb19