### PR TITLE
Απλούστευση ρύθμισης αποθετηρίων Gradle

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -10,3 +10,10 @@ plugins {
     id("org.jetbrains.kotlin.android") version "2.1.21" apply false
     id("com.google.gms.google-services") version "4.4.2" apply false
 }
+
+allprojects {
+    repositories {
+        google()
+        mavenCentral()
+    }
+}

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -7,7 +7,6 @@ pluginManagement {
 }
 
 dependencyResolutionManagement {
-    repositoriesMode.set(RepositoriesMode.FAIL_ON_PROJECT_REPOS)
     repositories {
         google()
         mavenCentral()


### PR DESCRIPTION
## Περίληψη
- Αφαίρεση του `repositoriesMode.set(RepositoriesMode.FAIL_ON_PROJECT_REPOS)` για να γίνεται απλούστερα η επίλυση των αποθετηρίων σε όλο το project.
- Προστέθηκε ενότητα `allprojects { repositories { google() mavenCentral() } }` στο `build.gradle.kts` ώστε τα modules να βρίσκουν τις βιβλιοθήκες Firebase.

## Έλεγχοι
- `./gradlew build` *(διεκόπη: παρατεταμένος χρόνος εκτέλεσης σε περιβάλλον χωρίς Android SDK)*

------
https://chatgpt.com/codex/tasks/task_e_68a9ae667250832899e312c7332ebb19