### PR TITLE
Ορισμός εκδόσεων για Firebase εξαρτήσεις

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -75,10 +75,9 @@ kotlin {
 }
 
 dependencies {
-    // Firebase BoM – διαχειρίζεται όλες τις εκδόσεις Firebase
-    implementation(platform("com.google.firebase:firebase-bom:34.1.0"))
-    implementation("com.google.firebase:firebase-auth-ktx")
-    implementation("com.google.firebase:firebase-firestore-ktx")
+    // Firebase
+    implementation("com.google.firebase:firebase-auth-ktx:23.2.1")
+    implementation("com.google.firebase:firebase-firestore-ktx:25.1.4")
 
     // Android core
     implementation("androidx.core:core-ktx:1.12.0")


### PR DESCRIPTION
## Περίληψη
- Ορίστηκαν ρητές εκδόσεις για τα `firebase-auth-ktx` και `firebase-firestore-ktx` ώστε να επιλυθούν σωστά τα artifacts.

## Δοκιμές
- `./gradlew :app:assembleDebug` *(αποτυχία: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a9b8615d948328ab4bb997a8aa8cc8