### PR TITLE
Initialize Google Maps before moving camera

### DIFF
--- a/app/src/main/java/com/ioannapergamali/mysmartroute/view/ui/screens/SelectRoutePoisScreen.kt
+++ b/app/src/main/java/com/ioannapergamali/mysmartroute/view/ui/screens/SelectRoutePoisScreen.kt
@@ -14,6 +14,7 @@ import androidx.compose.ui.unit.dp
 import androidx.lifecycle.viewmodel.compose.viewModel
 import androidx.navigation.NavController
 import com.google.android.gms.maps.CameraUpdateFactory
+import com.google.android.gms.maps.MapsInitializer
 import com.google.android.gms.maps.model.LatLng
 import com.google.firebase.auth.FirebaseAuth
 import com.google.firebase.firestore.FirebaseFirestore
@@ -106,6 +107,7 @@ fun SelectRoutePoisScreen(navController: NavController, openDrawer: () -> Unit) 
                                     originalPoiIds.clear()
                                     originalPoiIds.addAll(selectedPoiIds)
                                     path.firstOrNull()?.let {
+                                        MapsInitializer.initialize(context)
                                         cameraPositionState.move(
                                             CameraUpdateFactory.newLatLngZoom(it, 13f)
                                         )


### PR DESCRIPTION
## Summary
- Initialize Google Maps SDK before invoking `CameraUpdateFactory`
- Avoid crash in `SelectRoutePoisScreen` when loading POIs and adjusting camera

## Testing
- `./gradlew test` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a9da9441188328bd083f49af036f58