### PR TITLE
Fix PasswordResetUtils syntax and add reset link helper

### DIFF
--- a/app/src/main/java/com/ioannapergamali/mysmartroute/utils/PasswordResetUtils.kt
+++ b/app/src/main/java/com/ioannapergamali/mysmartroute/utils/PasswordResetUtils.kt
@@ -9,6 +9,14 @@ import android.net.Uri
  * Βοηθητικές συναρτήσεις για χειρισμό του συνδέσμου επαναφοράς κωδικού.
  */
 object PasswordResetUtils {
-
+    /**
+     * Ανοίγει τον σύνδεσμο επαναφοράς κωδικού στον προεπιλεγμένο περιηγητή.
+     *
+     * @param context Το context από όπου γίνεται η κλήση.
+     * @param url Ο σύνδεσμος επαναφοράς που θα ανοιχτεί.
+     */
+    fun openResetLink(context: Context, url: String) {
+        val intent = Intent(Intent.ACTION_VIEW, Uri.parse(url))
+        context.startActivity(intent)
     }
 }


### PR DESCRIPTION
## Summary
- fix syntax error in PasswordResetUtils
- add helper to open password reset link

## Testing
- `./gradlew test` (fails: SDK location not found)


------
https://chatgpt.com/codex/tasks/task_e_68a9db6d98f08328bf48de6191ecd7e2