### PR TITLE
Fix duration calculation for multi-POI transport availability

### DIFF
--- a/app/src/main/java/com/ioannapergamali/mysmartroute/view/ui/screens/AnnounceTransportScreen.kt
+++ b/app/src/main/java/com/ioannapergamali/mysmartroute/view/ui/screens/AnnounceTransportScreen.kt
@@ -124,10 +124,10 @@ fun AnnounceTransportScreen(navController: NavController, openDrawer: () -> Unit
         if (rId != null && vehicle != null) {
             scope.launch {
                 calculating = true
-                val (dur, path) = routeViewModel.getRouteDirections(context, rId, vehicle)
-                duration = dur
+                val (_, path) = routeViewModel.getRouteDirections(context, rId, vehicle)
                 pathPoints = path
                 pois = routeViewModel.getRoutePois(context, rId)
+                duration = routeViewModel.getRouteDuration(context, rId, vehicle)
                 path.firstOrNull()?.let { first ->
                     cameraPositionState.move(CameraUpdateFactory.newLatLngZoom(first, 13f))
                 }


### PR DESCRIPTION
## Summary
- Ensure total duration is computed for routes with multiple POIs when announcing transport availability

## Testing
- `./gradlew test` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a9e0bf367c832882285388eef74bab