### PR TITLE
Ρύθμιση dynamic link για επαναφορά κωδικού

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -39,6 +39,7 @@ android {
         versionName = "2.10"
         testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"
         buildConfigField("String", "MAPS_API_KEY", "\"$MAPS_API_KEY\"")
+        buildConfigField("String", "PASSWORD_RESET_DOMAIN", "\"reset.mysmartroute.com\"")
         manifestPlaceholders["MAPS_API_KEY"] = MAPS_API_KEY
     }
 
@@ -83,6 +84,7 @@ dependencies {
 
     // Firebase Firestore
     implementation("com.google.firebase:firebase-firestore-ktx")
+    implementation("com.google.firebase:firebase-dynamic-links-ktx")
     // Android core
     implementation("androidx.core:core-ktx:1.17.0")
     implementation("androidx.appcompat:appcompat:1.7.1")

--- a/app/src/main/java/com/ioannapergamali/mysmartroute/viewmodel/AuthenticationViewModel.kt
+++ b/app/src/main/java/com/ioannapergamali/mysmartroute/viewmodel/AuthenticationViewModel.kt
@@ -6,6 +6,7 @@ import android.util.Log
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import com.google.firebase.auth.FirebaseAuth
+import com.google.firebase.auth.ktx.actionCodeSettings
 import com.google.firebase.firestore.FirebaseFirestore
 import com.google.firebase.firestore.DocumentReference
 import com.google.gson.Gson
@@ -25,6 +26,7 @@ import com.ioannapergamali.mysmartroute.model.enumerations.UserRole
 import com.ioannapergamali.mysmartroute.utils.NetworkUtils
 import com.ioannapergamali.mysmartroute.model.menus.MenuConfig
 import com.ioannapergamali.mysmartroute.model.menus.RoleMenuConfig
+import com.ioannapergamali.mysmartroute.BuildConfig
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.launch
@@ -209,7 +211,14 @@ class AuthenticationViewModel : ViewModel() {
                 _resetPasswordState.value = ResetPasswordState.Error("Email is required")
                 return@launch
             }
-            auth.sendPasswordResetEmail(email)
+            val domain = BuildConfig.PASSWORD_RESET_DOMAIN
+            val actionCodeSettings = actionCodeSettings {
+                url = "https://$domain/reset"
+                handleCodeInApp = true
+                androidPackageName(BuildConfig.APPLICATION_ID, true, null)
+                dynamicLinkDomain = domain
+            }
+            auth.sendPasswordResetEmail(email, actionCodeSettings)
                 .addOnSuccessListener {
                     _resetPasswordState.value = ResetPasswordState.Success
                 }


### PR DESCRIPTION
## Summary
- Προστέθηκε BuildConfig πεδίο για το domain επαναφοράς κωδικού
- Ενεργοποιήθηκε αποστολή email reset μέσω ActionCodeSettings με dynamic link
- Προστέθηκε εξάρτηση για Firebase Dynamic Links

## Testing
- `./gradlew test` *(απέτυχε: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a9de08f44483289265205c9b512cd2