### PR TITLE
Συγχρονισμός διαδρομών μετά τη συγχώνευση σημείων

### DIFF
--- a/app/src/main/java/com/ioannapergamali/mysmartroute/viewmodel/PoIViewModel.kt
+++ b/app/src/main/java/com/ioannapergamali/mysmartroute/viewmodel/PoIViewModel.kt
@@ -151,7 +151,11 @@ class PoIViewModel : ViewModel() {
                     tx.delete(removeRef)
                 }.await()
 
+                // Ενημέρωση των τοπικών διαδρομών ώστε να μην παραμένουν
+                // αναφορές στο παλιό σημείο που διαγράφεται.
                 routePointDao.updatePoiReferences(removeId, keepId)
+                routeDao.updatePoiReferences(removeId, keepId)
+
                 poiDao.deleteById(removeId)
                 _pois.value = _pois.value.filterNot { it.id == removeId }
             } catch (_: Exception) {


### PR DESCRIPTION
## Summary
- Ενημέρωση της `mergePois` ώστε να καλεί και `routeDao.updatePoiReferences`, διασφαλίζοντας ότι οι τοπικές διαδρομές δεν κρατούν παλιά αναφορά μετά τη συγχώνευση σημείων.

## Testing
- `./gradlew test` *(απέτυχε: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a9e80c9ee4832891d0bf9663db4025