### PR TITLE
Fix password reset actionCodeSettings builder usage

### DIFF
--- a/app/src/main/java/com/ioannapergamali/mysmartroute/viewmodel/AuthenticationViewModel.kt
+++ b/app/src/main/java/com/ioannapergamali/mysmartroute/viewmodel/AuthenticationViewModel.kt
@@ -215,7 +215,11 @@ class AuthenticationViewModel : ViewModel() {
             val actionCodeSettings = actionCodeSettings {
                 url = "https://$domain/reset"
                 handleCodeInApp = true
-                androidPackageName(BuildConfig.APPLICATION_ID, true, null)
+                setAndroidPackageName(
+                    BuildConfig.APPLICATION_ID,
+                    true,
+                    null
+                )
                 dynamicLinkDomain = domain
             }
             auth.sendPasswordResetEmail(email, actionCodeSettings)


### PR DESCRIPTION
## Summary
- fix password reset builder by replacing deprecated `androidPackageName` with `setAndroidPackageName`

## Testing
- `./gradlew test` *(fails: Starting a Gradle Daemon, 1 busy Daemon could not be reused)*

------
https://chatgpt.com/codex/tasks/task_e_68a9eb13b3008328b27e08934e55ea8d