### PR TITLE
Log password reset messages

### DIFF
--- a/app/src/main/java/com/ioannapergamali/mysmartroute/view/ui/screens/HomeScreen.kt
+++ b/app/src/main/java/com/ioannapergamali/mysmartroute/view/ui/screens/HomeScreen.kt
@@ -22,6 +22,7 @@ import com.ioannapergamali.mysmartroute.view.ui.animation.rememberBreathingAnima
 import com.ioannapergamali.mysmartroute.view.ui.animation.rememberSlideFadeInAnimation
 import androidx.compose.ui.platform.LocalContext
 import android.widget.Toast
+import android.util.Log
 import androidx.lifecycle.viewmodel.compose.viewModel
 import com.ioannapergamali.mysmartroute.viewmodel.AuthenticationViewModel
 import androidx.compose.ui.text.input.PasswordVisualTransformation
@@ -29,6 +30,8 @@ import com.ioannapergamali.mysmartroute.view.ui.components.ScreenContainer
 import com.google.firebase.auth.FirebaseAuth
 import com.ioannapergamali.mysmartroute.view.ui.util.observeBubble
 import com.ioannapergamali.mysmartroute.view.ui.util.LocalKeyboardBubbleState
+
+private const val TAG = "HomeScreen"
 
 @Composable
 fun HomeScreen(
@@ -135,15 +138,18 @@ fun HomeScreen(
         LaunchedEffect(resetState) {
             when (resetState) {
                 is AuthenticationViewModel.ResetPasswordState.Success -> {
+                    val msg = context.getString(R.string.reset_email_sent)
+                    Log.i(TAG, msg)
                     Toast.makeText(
                         context,
-                        context.getString(R.string.reset_email_sent),
+                        msg,
                         Toast.LENGTH_SHORT
                     ).show()
                     viewModel.clearResetPasswordState()
                 }
                 is AuthenticationViewModel.ResetPasswordState.Error -> {
                     val message = (resetState as AuthenticationViewModel.ResetPasswordState.Error).message
+                    Log.e(TAG, message)
                     Toast.makeText(context, message, Toast.LENGTH_SHORT).show()
                     viewModel.clearResetPasswordState()
                 }

--- a/app/src/main/java/com/ioannapergamali/mysmartroute/viewmodel/AuthenticationViewModel.kt
+++ b/app/src/main/java/com/ioannapergamali/mysmartroute/viewmodel/AuthenticationViewModel.kt
@@ -208,7 +208,9 @@ class AuthenticationViewModel : ViewModel() {
         viewModelScope.launch {
             _resetPasswordState.value = ResetPasswordState.Loading
             if (email.isBlank()) {
-                _resetPasswordState.value = ResetPasswordState.Error("Email is required")
+                val message = "Email is required"
+                Log.w(TAG, message)
+                _resetPasswordState.value = ResetPasswordState.Error(message)
                 return@launch
             }
             val domain = BuildConfig.PASSWORD_RESET_DOMAIN
@@ -224,12 +226,13 @@ class AuthenticationViewModel : ViewModel() {
             }
             auth.sendPasswordResetEmail(email, actionCodeSettings)
                 .addOnSuccessListener {
+                    Log.i(TAG, "Password reset email sent to $email")
                     _resetPasswordState.value = ResetPasswordState.Success
                 }
                 .addOnFailureListener { e ->
-                    _resetPasswordState.value = ResetPasswordState.Error(
-                        e.localizedMessage ?: "Failed to send reset email"
-                    )
+                    val msg = e.localizedMessage ?: "Failed to send reset email"
+                    Log.e(TAG, msg, e)
+                    _resetPasswordState.value = ResetPasswordState.Error(msg)
                 }
         }
     }


### PR DESCRIPTION
## Summary
- Log reset password workflow in `AuthenticationViewModel`
- Report reset password results in `HomeScreen`

## Testing
- `./gradlew test` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a9f63bf9648328abeea06a92b84732