### PR TITLE
Χρήση προεπιλεγμένου domain Firebase για επαναφορά κωδικού

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -39,7 +39,11 @@ android {
         versionName = "2.10"
         testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"
         buildConfigField("String", "MAPS_API_KEY", "\"$MAPS_API_KEY\"")
-        buildConfigField("String", "PASSWORD_RESET_DOMAIN", "\"reset.mysmartroute.com\"")
+        buildConfigField(
+            "String",
+            "PASSWORD_RESET_DOMAIN",
+            "\"mysmartroute-26a64.firebaseapp.com\""
+        )
         manifestPlaceholders["MAPS_API_KEY"] = MAPS_API_KEY
     }
 

--- a/app/src/main/java/com/ioannapergamali/mysmartroute/viewmodel/AuthenticationViewModel.kt
+++ b/app/src/main/java/com/ioannapergamali/mysmartroute/viewmodel/AuthenticationViewModel.kt
@@ -222,7 +222,6 @@ class AuthenticationViewModel : ViewModel() {
                     true,
                     null
                 )
-                dynamicLinkDomain = domain
             }
             auth.sendPasswordResetEmail(email, actionCodeSettings)
                 .addOnSuccessListener {


### PR DESCRIPTION
## Σύνοψη
- Ρύθμιση του BuildConfig ώστε να χρησιμοποιείται το προεπιλεγμένο domain του Firebase για συνδέσμους επαναφοράς κωδικού.
- Αφαίρεση της ιδιότητας `dynamicLinkDomain` από το ActionCodeSettings για απλούστερη διαχείριση του reset link.

## Δοκιμές
- `./gradlew test` *(κόλλησε στο ξεκίνημα· δεν ολοκληρώθηκε)*


------
https://chatgpt.com/codex/tasks/task_e_68a9fd1edcac832897622a34195673ea