### PR TITLE
Handle missing reset password message

### DIFF
--- a/app/src/main/java/com/ioannapergamali/mysmartroute/viewmodel/AuthenticationViewModel.kt
+++ b/app/src/main/java/com/ioannapergamali/mysmartroute/viewmodel/AuthenticationViewModel.kt
@@ -230,9 +230,9 @@ class AuthenticationViewModel : ViewModel() {
                     _resetPasswordState.value = ResetPasswordState.Success
                 }
                 .addOnFailureListener { e ->
-
-                    Log.e(TAG, msg, e)
-                    _resetPasswordState.value = ResetPasswordState.Error(msg)
+                    val message = e.localizedMessage ?: "Failed to send reset email"
+                    Log.e(TAG, message, e)
+                    _resetPasswordState.value = ResetPasswordState.Error(message)
                 }
         }
     }


### PR DESCRIPTION
## Summary
- define reset password error message instead of undefined msg

## Testing
- `./gradlew test` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_68aa01c9ff7c8328b032194d088abbfa