### PR TITLE
Προσθήκη δοκιμών για διαχείριση σημείων

### DIFF
--- a/app/src/main/java/com/ioannapergamali/mysmartroute/repository/PointRepository.kt
+++ b/app/src/main/java/com/ioannapergamali/mysmartroute/repository/PointRepository.kt
@@ -52,5 +52,11 @@ class PointRepository {
     fun addRoute(route: Route) {
         routes[route.id] = route
     }
+
+    /** Επιστροφή σημείου */
+    fun getPoint(pointId: String): Point? = points[pointId]
+
+    /** Επιστροφή διαδρομής */
+    fun getRoute(routeId: String): Route? = routes[routeId]
 }
 

--- a/app/src/test/java/com/ioannapergamali/mysmartroute/repository/PointRepositoryTest.kt
+++ b/app/src/test/java/com/ioannapergamali/mysmartroute/repository/PointRepositoryTest.kt
@@ -1,0 +1,42 @@
+package com.ioannapergamali.mysmartroute.repository
+
+import org.junit.Assert.*
+import org.junit.Test
+
+class PointRepositoryTest {
+
+    @Test
+    fun getAllPointNames_returnsAll() {
+        val repo = PointRepository()
+        repo.addPoint(Point("1", "Σημείο Α", ""))
+        repo.addPoint(Point("2", "Σημείο Β", ""))
+
+        val names = repo.getAllPointNames()
+        assertEquals(listOf("Σημείο Α", "Σημείο Β"), names)
+    }
+
+    @Test
+    fun updatePoint_changesValues() {
+        val repo = PointRepository()
+        repo.addPoint(Point("1", "Παλαιό", "Περιγραφή"))
+
+        repo.updatePoint("1", "Νέο", "Νέα περιγραφή")
+        val point = repo.getPoint("1")
+        assertEquals("Νέο", point?.name)
+        assertEquals("Νέα περιγραφή", point?.details)
+    }
+
+    @Test
+    fun mergePoints_updatesRoutesAndRemovesMergedPoint() {
+        val repo = PointRepository()
+        repo.addPoint(Point("1", "Α", ""))
+        repo.addPoint(Point("2", "Β", ""))
+        repo.addRoute(Route("r", mutableListOf("1", "2")))
+
+        repo.mergePoints("1", "2")
+
+        assertNull(repo.getPoint("2"))
+        assertEquals("Α / Β", repo.getPoint("1")?.name)
+        assertEquals(listOf("1", "1"), repo.getRoute("r")?.pointIds)
+    }
+}


### PR DESCRIPTION
## Περιγραφή
- Προσθήκη μεθόδων ανάκτησης σημείων και διαδρομών στο `PointRepository`
- Δημιουργία unit tests για επισκόπηση, ενημέρωση και ομαδοποίηση σημείων

## Έλεγχοι
- `./gradlew test` *(αποτυχία: λείπουν Android SDK Build-Tools 35 και platform 35)*

------
https://chatgpt.com/codex/tasks/task_e_68aa055e44288328997860e515e9bc82