### PR TITLE
Improve password reset handling and update Firebase BOM

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -81,7 +81,7 @@ kotlin {
 
 dependencies {
     // Firebase BoM (χωρίς έκδοση για κάθε βιβλιοθήκη)
-    implementation(platform("com.google.firebase:firebase-bom:33.2.0"))
+    implementation(platform("com.google.firebase:firebase-bom:34.1.0"))
 
     // Firebase Auth
     implementation("com.google.firebase:firebase-auth-ktx")

--- a/app/src/main/java/com/ioannapergamali/mysmartroute/viewmodel/AuthenticationViewModel.kt
+++ b/app/src/main/java/com/ioannapergamali/mysmartroute/viewmodel/AuthenticationViewModel.kt
@@ -6,6 +6,7 @@ import android.util.Log
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import com.google.firebase.auth.FirebaseAuth
+import com.google.firebase.auth.FirebaseAuthInvalidCredentialsException
 import com.google.firebase.auth.ktx.actionCodeSettings
 import com.google.firebase.firestore.FirebaseFirestore
 import com.google.firebase.firestore.DocumentReference
@@ -252,9 +253,12 @@ class AuthenticationViewModel : ViewModel() {
                         }
                 }
                 .addOnFailureListener { e ->
-                    _resetPasswordState.value = ResetPasswordState.Error(
-                        e.localizedMessage ?: "Invalid or expired reset link",
-                    )
+                    val message = if (e is FirebaseAuthInvalidCredentialsException) {
+                        "Ο σύνδεσμος επαναφοράς δεν είναι έγκυρος ή έχει λήξει"
+                    } else {
+                        e.localizedMessage ?: "Invalid or expired reset link"
+                    }
+                    _resetPasswordState.value = ResetPasswordState.Error(message)
                 }
         }
     }


### PR DESCRIPTION
## Summary
- add friendlier error message for invalid password reset links
- upgrade Firebase BOM to v34.1.0

## Testing
- `./gradlew test` *(fails: Starting a Gradle Daemon, 1 busy Daemon could not be reused)*

------
https://chatgpt.com/codex/tasks/task_e_68aa04daa0288328aba59e94532e6ba0