### PR TITLE
Χρήση Firebase BoM και ενημέρωση plugins

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -84,11 +84,11 @@ dependencies {
     implementation(platform("com.google.firebase:firebase-bom:34.1.0"))
 
     // Firebase Auth
-    implementation("com.google.firebase:firebase-auth-ktx:24.0.1")
+    implementation("com.google.firebase:firebase-auth-ktx")
 
     // Firebase Firestore
-    implementation("com.google.firebase:firebase-firestore-ktx:26.0.0")
-    implementation("com.google.firebase:firebase-dynamic-links-ktx:22.1.0")
+    implementation("com.google.firebase:firebase-firestore-ktx")
+    implementation("com.google.firebase:firebase-dynamic-links-ktx")
     // Android core
     implementation("androidx.core:core-ktx:1.17.0")
     implementation("androidx.appcompat:appcompat:1.7.1")

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -1,14 +1,14 @@
 // Top-level build file where you can add configuration options common to all sub-projects/modules.
 
 plugins {
-    id("com.android.application") version "8.9.3" apply false
+    id("com.android.application") version "8.5.2" apply false
     // Το plugin Compose απαιτείται σε Kotlin 2.x για να ενεργοποιηθεί ο
     // compiler του Jetpack Compose.
     id("org.jetbrains.kotlin.plugin.compose") version "2.1.21" apply false
     kotlin("kapt") version "2.1.21" apply false
 
     id("org.jetbrains.kotlin.android") version "2.1.21" apply false
-    id("com.google.gms.google-services") version "4.4.2" apply false
+    id("com.google.gms.google-services") version "4.4.3" apply false
 }
 
 


### PR DESCRIPTION
## Περίληψη
- Ενημέρωση έκδοσης plugin `com.android.application` σε 8.5.2
- Αναβάθμιση `google-services` plugin σε 4.4.3
- Χρήση Firebase BoM 34.1.0 και αφαίρεση εκδόσεων από Auth/Firestore/Dynamic Links

## Δοκιμές
- `./gradlew build` *(αποτυχία: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_68aa0b201a4883289da5360c3222c367