### PR TITLE
fix: add explicit firebase ktx dependencies

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -80,15 +80,10 @@ kotlin {
 }
 
 dependencies {
-    // Firebase BoM (χωρίς έκδοση για κάθε βιβλιοθήκη)
-    implementation(platform("com.google.firebase:firebase-bom:34.1.0"))
-
-    // Firebase Auth
-    implementation("com.google.firebase:firebase-auth-ktx")
-
-    // Firebase Firestore
-    implementation("com.google.firebase:firebase-firestore-ktx")
-    implementation("com.google.firebase:firebase-dynamic-links-ktx")
+    // Firebase βιβλιοθήκες
+    implementation(libs.firebase.auth.ktx)
+    implementation(libs.firebase.firestore.ktx)
+    implementation(libs.firebase.dynamic.links.ktx)
     // Android core
     implementation("androidx.core:core-ktx:1.17.0")
     implementation("androidx.appcompat:appcompat:1.7.1")

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -13,6 +13,7 @@ constraintlayout = "2.1.4"
 material3Android = "1.3.2"
 firebaseFirestoreKtx = "25.1.4"
 firebaseAuthKtx = "22.3.1"
+firebaseDynamicLinksKtx = "22.1.0"
 room = "2.7.1"
 
 [libraries]
@@ -20,6 +21,7 @@ androidx-core-ktx = { group = "androidx.core", name = "core-ktx", version.ref = 
 firebase-bom = { module = "com.google.firebase:firebase-bom", version.ref = "firebaseBom" }
 google-firebase-auth-ktx = { module = "com.google.firebase:firebase-auth-ktx" }
 google-firebase-firestore-ktx = { module = "com.google.firebase:firebase-firestore-ktx" }
+firebase-dynamic-links-ktx = { group = "com.google.firebase", name = "firebase-dynamic-links-ktx", version.ref = "firebaseDynamicLinksKtx" }
 junit = { group = "junit", name = "junit", version.ref = "junit" }
 androidx-junit = { group = "androidx.test.ext", name = "junit", version.ref = "junitVersion" }
 androidx-espresso-core = { group = "androidx.test.espresso", name = "espresso-core", version.ref = "espressoCore" }


### PR DESCRIPTION
## Summary
- add firebase-dynamic-links-ktx version to version catalog
- depend on firebase auth, firestore and dynamic links via version catalog

## Testing
- `./gradlew test` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_68aa0f067f288328a38013a8e9ce44ba