### PR TITLE
fix: add explicit firebase ktx dependencies

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -80,17 +80,12 @@ kotlin {
 }
 
 dependencies {
-    // Firebase BoM (χωρίς έκδοση για κάθε βιβλιοθήκη)
-    implementation(platform("com.google.firebase:firebase-bom:34.1.0"))
-
-    // Firebase Auth
-    implementation("com.google.firebase:firebase-auth-ktx")
-
-    // Firebase Firestore
-    implementation("com.google.firebase:firebase-firestore-ktx")
-    implementation("com.google.firebase:firebase-dynamic-links-ktx")
+    // Firebase βιβλιοθήκες
+    implementation(libs.firebase.auth.ktx)
+    implementation(libs.firebase.firestore.ktx)
+    implementation(libs.firebase.dynamic.links.ktx)
     // Android core
-    implementation("androidx.core:core-ktx:1.17.0")
+    implementation(libs.androidx.core.ktx)
     implementation("androidx.appcompat:appcompat:1.7.1")
     implementation("com.google.android.material:material:1.12.0")
     implementation("androidx.activity:activity-ktx:1.10.1")

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -1,7 +1,7 @@
 // Top-level build file where you can add configuration options common to all sub-projects/modules.
 
 plugins {
-    id("com.android.application") version "8.5.2" apply false
+    id("com.android.application") version "8.6.0" apply false
     // Το plugin Compose απαιτείται σε Kotlin 2.x για να ενεργοποιηθεί ο
     // compiler του Jetpack Compose.
     id("org.jetbrains.kotlin.plugin.compose") version "2.1.21" apply false

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,5 +1,5 @@
 [versions]
-agp = "8.2.0"
+agp = "8.6.0"
 firebaseBom = "34.1.0"
 kotlin = "2.1.21"
 coreKtx = "1.12.0"
@@ -13,6 +13,7 @@ constraintlayout = "2.1.4"
 material3Android = "1.3.2"
 firebaseFirestoreKtx = "25.1.4"
 firebaseAuthKtx = "22.3.1"
+firebaseDynamicLinksKtx = "22.1.0"
 room = "2.7.1"
 
 [libraries]
@@ -20,6 +21,7 @@ androidx-core-ktx = { group = "androidx.core", name = "core-ktx", version.ref = 
 firebase-bom = { module = "com.google.firebase:firebase-bom", version.ref = "firebaseBom" }
 google-firebase-auth-ktx = { module = "com.google.firebase:firebase-auth-ktx" }
 google-firebase-firestore-ktx = { module = "com.google.firebase:firebase-firestore-ktx" }
+firebase-dynamic-links-ktx = { group = "com.google.firebase", name = "firebase-dynamic-links-ktx", version.ref = "firebaseDynamicLinksKtx" }
 junit = { group = "junit", name = "junit", version.ref = "junit" }
 androidx-junit = { group = "androidx.test.ext", name = "junit", version.ref = "junitVersion" }
 androidx-espresso-core = { group = "androidx.test.espresso", name = "espresso-core", version.ref = "espressoCore" }


### PR DESCRIPTION
## Summary
- add firebase-dynamic-links-ktx version to version catalog
- depend on firebase auth, firestore and dynamic links via version catalog
- upgrade Android Gradle plugin and align core dependency

## Testing
- `./gradlew test` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_68aa0f067f288328a38013a8e9ce44ba