### PR TITLE
Προσθήκη ViewModel για διαχείριση σημείων

### DIFF
--- a/app/src/main/java/com/ioannapergamali/mysmartroute/repository/PointRepository.kt
+++ b/app/src/main/java/com/ioannapergamali/mysmartroute/repository/PointRepository.kt
@@ -21,6 +21,9 @@ class PointRepository {
     /** Επιστροφή όλων των ονομάτων σημείων */
     fun getAllPointNames(): List<String> = points.values.map { it.name }
 
+    /** Επιστροφή όλων των σημείων */
+    fun getAllPoints(): List<Point> = points.values.toList()
+
     /** Ενημέρωση στοιχείων ενός σημείου */
     fun updatePoint(pointId: String, newName: String, newDetails: String) {
         points[pointId]?.apply {

--- a/app/src/main/java/com/ioannapergamali/mysmartroute/viewmodel/UserPointViewModel.kt
+++ b/app/src/main/java/com/ioannapergamali/mysmartroute/viewmodel/UserPointViewModel.kt
@@ -1,0 +1,53 @@
+package com.ioannapergamali.mysmartroute.viewmodel
+
+import androidx.lifecycle.ViewModel
+import com.ioannapergamali.mysmartroute.repository.Point
+import com.ioannapergamali.mysmartroute.repository.PointRepository
+import com.ioannapergamali.mysmartroute.repository.Route
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+
+/**
+ * Απλό ViewModel για παρουσίαση και διαχείριση των σημείων που
+ * έχουν προσθέσει οι χρήστες. Παρέχει λειτουργίες ενημέρωσης και
+ * ομαδοποίησης ονομάτων.
+ */
+class UserPointViewModel(
+    private val repository: PointRepository = PointRepository()
+) : ViewModel() {
+
+    private val _points = MutableStateFlow<List<Point>>(emptyList())
+    val points: StateFlow<List<Point>> = _points
+
+    init {
+        refreshPoints()
+    }
+
+    /** Φόρτωση όλων των σημείων για προβολή στον χρήστη. */
+    fun refreshPoints() {
+        _points.value = repository.getAllPoints()
+    }
+
+    /** Προσθήκη νέου σημείου. */
+    fun addPoint(point: Point) {
+        repository.addPoint(point)
+        refreshPoints()
+    }
+
+    /** Ενημέρωση στοιχείων υπάρχοντος σημείου. */
+    fun updatePoint(id: String, name: String, details: String) {
+        repository.updatePoint(id, name, details)
+        refreshPoints()
+    }
+
+    /** Ομαδοποίηση δύο σημείων με διατήρηση του πρώτου. */
+    fun mergePoints(keepId: String, removeId: String) {
+        repository.mergePoints(keepId, removeId)
+        refreshPoints()
+    }
+
+    /** Προσθήκη διαδρομής για τις δοκιμές. */
+    fun addRoute(route: Route) {
+        repository.addRoute(route)
+    }
+}

--- a/app/src/test/java/com/ioannapergamali/mysmartroute/repository/PointRepositoryTest.kt
+++ b/app/src/test/java/com/ioannapergamali/mysmartroute/repository/PointRepositoryTest.kt
@@ -6,6 +6,17 @@ import org.junit.Test
 class PointRepositoryTest {
 
     @Test
+    fun getAllPoints_returnsAllPoints() {
+        val repo = PointRepository()
+        val p1 = Point("1", "Σημείο Α", "")
+        val p2 = Point("2", "Σημείο Β", "")
+        repo.addPoint(p1)
+        repo.addPoint(p2)
+
+        assertEquals(listOf(p1, p2), repo.getAllPoints())
+    }
+
+    @Test
     fun getAllPointNames_returnsAll() {
         val repo = PointRepository()
         repo.addPoint(Point("1", "Σημείο Α", ""))


### PR DESCRIPTION
## Περίληψη
- Προστέθηκε μέθοδος `getAllPoints` στο `PointRepository` για εύκολη επισκόπηση όλων των σημείων.
- Δημιουργήθηκε το `UserPointViewModel` που προσφέρει προβολή, ενημέρωση και ομαδοποίηση σημείων.
- Επεκτάθηκαν τα unit tests του `PointRepository` για να καλύπτουν την νέα μέθοδο.

## Έλεγχοι
- `./gradlew test` *(αποτυχία: SDK location not found)*


------
https://chatgpt.com/codex/tasks/task_e_68aa17c63c4c83288b6727f39792e116