### PR TITLE
Διόρθωση εξαρτήσεων Firebase

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -81,10 +81,10 @@ kotlin {
 
 dependencies {
     // Firebase βιβλιοθήκες
-
-    implementation(libs.firebase.auth.ktx)
-    implementation(libs.firebase.firestore.ktx)
-    implementation(libs.firebase.dynamic.links.ktx)
+    implementation(platform(libs.firebase.bom))
+    implementation("com.google.firebase:firebase-auth-ktx")
+    implementation("com.google.firebase:firebase-firestore-ktx")
+    implementation("com.google.firebase:firebase-dynamic-links-ktx")
     // Android core
     implementation(libs.androidx.core.ktx)
     implementation("androidx.appcompat:appcompat:1.7.1")


### PR DESCRIPTION
## Περίληψη
- Χρήση του Firebase BOM στο `build.gradle.kts`
- Αντικατάσταση των μη ορισμένων `libs.firebase.*` με άμεσες εξαρτήσεις

## Έλεγχοι
- `./gradlew test --dry-run` *(απέτυχε: δεν βρέθηκε Android SDK)*

------
https://chatgpt.com/codex/tasks/task_e_68aa21ed44e483289452c05ac3ac7b67