### PR TITLE
Προσθήκη οθόνης επαναφοράς κωδικού με Firebase

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -81,7 +81,7 @@ kotlin {
 
 dependencies {
     // Firebase βιβλιοθήκες
-    implementation(platform("com.google.firebase:firebase-bom:33.4.0"))
+    implementation(platform("com.google.firebase:firebase-bom:34.1.0"))
     implementation("com.google.firebase:firebase-auth-ktx")
     implementation("com.google.firebase:firebase-firestore-ktx")
     implementation("com.google.firebase:firebase-dynamic-links-ktx")

--- a/app/src/main/java/com/ioannapergamali/mysmartroute/model/navigation/NavigationHost.kt
+++ b/app/src/main/java/com/ioannapergamali/mysmartroute/model/navigation/NavigationHost.kt
@@ -7,6 +7,7 @@ import androidx.navigation.compose.composable
 import androidx.navigation.navArgument
 import com.ioannapergamali.mysmartroute.view.ui.screens.HomeScreen
 import com.ioannapergamali.mysmartroute.view.ui.screens.SignUpScreen
+import com.ioannapergamali.mysmartroute.view.ui.screens.ForgotPasswordScreen
 import com.ioannapergamali.mysmartroute.view.ui.screens.MenuScreen
 import com.ioannapergamali.mysmartroute.view.ui.screens.RegisterVehicleScreen
 import com.ioannapergamali.mysmartroute.view.ui.screens.AnnounceTransportScreen
@@ -89,6 +90,9 @@ fun NavigationHost(
                 },
                 openDrawer = openDrawer
             )
+        }
+        composable("forgotPassword") {
+            ForgotPasswordScreen(navController = navController, openDrawer = openDrawer)
         }
         composable("menu") {
             MenuScreen(navController = navController, openDrawer = openDrawer)

--- a/app/src/main/java/com/ioannapergamali/mysmartroute/utils/PasswordResetUtils.kt
+++ b/app/src/main/java/com/ioannapergamali/mysmartroute/utils/PasswordResetUtils.kt
@@ -3,12 +3,42 @@ package com.ioannapergamali.mysmartroute.utils
 import android.content.Context
 import android.content.Intent
 import android.net.Uri
+import android.widget.Toast
+import com.google.firebase.auth.FirebaseAuth
+import com.ioannapergamali.mysmartroute.R
 
 
 /**
  * Βοηθητικές συναρτήσεις για χειρισμό του συνδέσμου επαναφοράς κωδικού.
  */
 object PasswordResetUtils {
+    private val auth: FirebaseAuth = FirebaseAuth.getInstance()
+
+    /**
+     * Στέλνει email επαναφοράς κωδικού μέσω Firebase Authentication.
+     */
+    fun sendPasswordResetEmail(email: String, context: Context) {
+        if (email.isBlank()) {
+            Toast.makeText(context, context.getString(R.string.email), Toast.LENGTH_SHORT).show()
+            return
+        }
+
+        auth.sendPasswordResetEmail(email)
+            .addOnSuccessListener {
+                Toast.makeText(
+                    context,
+                    context.getString(R.string.reset_email_sent),
+                    Toast.LENGTH_SHORT
+                ).show()
+            }
+            .addOnFailureListener { e ->
+                Toast.makeText(
+                    context,
+                    e.localizedMessage ?: "Αποτυχία",
+                    Toast.LENGTH_SHORT
+                ).show()
+            }
+    }
     /**
      * Ανοίγει τον σύνδεσμο επαναφοράς κωδικού στον προεπιλεγμένο περιηγητή.
      *

--- a/app/src/main/java/com/ioannapergamali/mysmartroute/view/ui/screens/ForgotPasswordScreen.kt
+++ b/app/src/main/java/com/ioannapergamali/mysmartroute/view/ui/screens/ForgotPasswordScreen.kt
@@ -1,0 +1,58 @@
+package com.ioannapergamali.mysmartroute.view.ui.screens
+
+import androidx.compose.foundation.layout.*
+import androidx.compose.material3.*
+import androidx.compose.runtime.*
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.unit.dp
+import androidx.navigation.NavController
+import com.ioannapergamali.mysmartroute.R
+import com.ioannapergamali.mysmartroute.utils.PasswordResetUtils
+import com.ioannapergamali.mysmartroute.view.ui.components.TopBar
+
+@Composable
+fun ForgotPasswordScreen(
+    navController: NavController,
+    openDrawer: () -> Unit
+) {
+    Scaffold(
+        topBar = {
+            TopBar(
+                title = stringResource(R.string.reset_password_title),
+                navController = navController,
+                showMenu = true,
+                showBack = true,
+                showHomeIcon = false,
+                onMenuClick = openDrawer
+            )
+        }
+    ) { padding ->
+        val context = LocalContext.current
+        var email by remember { mutableStateOf("") }
+
+        Column(
+            modifier = Modifier
+                .padding(padding)
+                .fillMaxSize(),
+            horizontalAlignment = Alignment.CenterHorizontally,
+            verticalArrangement = Arrangement.Center
+        ) {
+            OutlinedTextField(
+                value = email,
+                onValueChange = { email = it },
+                label = { Text(stringResource(R.string.email)) },
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .padding(horizontal = 16.dp)
+            )
+            Spacer(modifier = Modifier.height(16.dp))
+            Button(onClick = { PasswordResetUtils.sendPasswordResetEmail(email, context) }) {
+                Text(stringResource(R.string.send_reset_email))
+            }
+        }
+    }
+}
+

--- a/app/src/main/java/com/ioannapergamali/mysmartroute/view/ui/screens/HomeScreen.kt
+++ b/app/src/main/java/com/ioannapergamali/mysmartroute/view/ui/screens/HomeScreen.kt
@@ -22,7 +22,6 @@ import com.ioannapergamali.mysmartroute.view.ui.animation.rememberBreathingAnima
 import com.ioannapergamali.mysmartroute.view.ui.animation.rememberSlideFadeInAnimation
 import androidx.compose.ui.platform.LocalContext
 import android.widget.Toast
-import android.util.Log
 import androidx.lifecycle.viewmodel.compose.viewModel
 import com.ioannapergamali.mysmartroute.viewmodel.AuthenticationViewModel
 import androidx.compose.ui.text.input.PasswordVisualTransformation
@@ -30,8 +29,6 @@ import com.ioannapergamali.mysmartroute.view.ui.components.ScreenContainer
 import com.google.firebase.auth.FirebaseAuth
 import com.ioannapergamali.mysmartroute.view.ui.util.observeBubble
 import com.ioannapergamali.mysmartroute.view.ui.util.LocalKeyboardBubbleState
-
-private const val TAG = "HomeScreen"
 
 @Composable
 fun HomeScreen(
@@ -59,7 +56,6 @@ fun HomeScreen(
 
         val viewModel: AuthenticationViewModel = viewModel()
         val uiState by viewModel.loginState.collectAsState()
-        val resetState by viewModel.resetPasswordState.collectAsState()
         val context = LocalContext.current
         var email by remember { mutableStateOf("") }
         var password by remember { mutableStateOf("") }
@@ -88,7 +84,7 @@ fun HomeScreen(
                         onLogin = { viewModel.login(context, email, password) },
                         onNavigateToSignUp = onNavigateToSignUp,
                         onLogout = { viewModel.signOut() },
-                        onResetPassword = { viewModel.resetPassword(email) },
+                        onResetPassword = { navController.navigate("forgotPassword") },
                         modifier = Modifier.weight(1f)
                     )
                 }
@@ -111,7 +107,7 @@ fun HomeScreen(
                         onLogin = { viewModel.login(context, email, password) },
                         onNavigateToSignUp = onNavigateToSignUp,
                         onLogout = { viewModel.signOut() },
-                        onResetPassword = { viewModel.resetPassword(email) }
+                        onResetPassword = { navController.navigate("forgotPassword") }
                     )
                 }
             }
@@ -135,27 +131,6 @@ fun HomeScreen(
             }
         }
 
-        LaunchedEffect(resetState) {
-            when (resetState) {
-                is AuthenticationViewModel.ResetPasswordState.Success -> {
-                    val msg = context.getString(R.string.reset_email_sent)
-                    Log.i(TAG, msg)
-                    Toast.makeText(
-                        context,
-                        msg,
-                        Toast.LENGTH_SHORT
-                    ).show()
-                    viewModel.clearResetPasswordState()
-                }
-                is AuthenticationViewModel.ResetPasswordState.Error -> {
-                    val message = (resetState as AuthenticationViewModel.ResetPasswordState.Error).message
-                    Log.e(TAG, message)
-                    Toast.makeText(context, message, Toast.LENGTH_SHORT).show()
-                    viewModel.clearResetPasswordState()
-                }
-                else -> {}
-            }
-        }
     }
 }
 

--- a/app/src/main/res/values-el/strings.xml
+++ b/app/src/main/res/values-el/strings.xml
@@ -30,6 +30,8 @@
     <string name="password">Κωδικός</string>
     <string name="forgot_password">Ξεχάσατε τον κωδικό;</string>
     <string name="reset_email_sent">Στάλθηκε email επαναφοράς κωδικού</string>
+    <string name="reset_password_title">Επαναφορά κωδικού</string>
+    <string name="send_reset_email">Αποστολή email επαναφοράς</string>
     <string name="no_account">Αν δεν έχετε λογαριασμό</string>
     <string name="sign_up">Εγγραφή</string>
     <string name="first_name">Όνομα</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -28,6 +28,8 @@
     <string name="password">Password</string>
     <string name="forgot_password">Forgot password?</string>
     <string name="reset_email_sent">Password reset email sent</string>
+    <string name="reset_password_title">Reset Password</string>
+    <string name="send_reset_email">Send reset email</string>
     <string name="no_account">If you don\'t have an account</string>
     <string name="sign_up">Sign Up</string>
     <string name="first_name">Name</string>


### PR DESCRIPTION
## Σύνοψη
- Ενημέρωση του Firebase BOM στην έκδοση 34.1.0.
- Προσθήκη βοηθητικής συνάρτησης και οθόνης για αποστολή email επαναφοράς κωδικού.
- Προσαρμογή πλοήγησης και πόρων κειμένου για την υποστήριξη της νέας λειτουργίας.

## Έλεγχοι
- `./gradlew test` (απέτυχε: SDK location not found)


------
https://chatgpt.com/codex/tasks/task_e_68aa314d64fc8328a3586d98e2730004