### PR TITLE
Κεντρική διαχείριση repositories και χρήση Firebase BoM

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -9,11 +9,6 @@ plugins {
     id("com.google.gms.google-services")
 }
 
-repositories {
-    google()
-    mavenCentral()
-}
-
 // Διαβάζουμε τα API keys από το local.properties ή από μεταβλητή περιβάλλοντος
 
 val localProps = Properties()

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -7,6 +7,7 @@ pluginManagement {
 }
 
 dependencyResolutionManagement {
+    repositoriesMode.set(RepositoriesMode.FAIL_ON_PROJECT_REPOS)
     repositories {
         google()
         mavenCentral()


### PR DESCRIPTION
## Περίληψη
- Ενεργοποίηση `repositoriesMode.set(RepositoriesMode.FAIL_ON_PROJECT_REPOS)` για ενιαία διαχείριση αποθετηρίων.
- Καθαρισμός module `app` από τοπικό `repositories` block, ώστε να χρησιμοποιεί τις κεντρικές ρυθμίσεις.
- Διατήρηση των εξαρτήσεων Firebase μέσω BoM.

## Έλεγχοι
- `./gradlew help`


------
https://chatgpt.com/codex/tasks/task_e_68aa34c6cfc483289c0d4101c22e0e1e