### PR TITLE
Ενημέρωση Gradle wrapper και Firebase εξαρτήσεων

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -80,7 +80,6 @@ dependencies {
     implementation("com.google.firebase:firebase-auth-ktx")
     implementation("com.google.firebase:firebase-firestore-ktx")
     implementation("com.google.firebase:firebase-dynamic-links-ktx")
-    implementation("com.google.firebase:firebase-common-ktx")
 
     // Android core
     implementation(libs.androidx.core.ktx)

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -1,7 +1,7 @@
 // Top-level build file where you can add configuration options common to all sub-projects/modules.
 
 plugins {
-    id("com.android.application") version "8.6.0" apply false
+    id("com.android.application") version "8.12.1" apply false
     // Το plugin Compose απαιτείται σε Kotlin 2.x για να ενεργοποιηθεί ο
     // compiler του Jetpack Compose.
     id("org.jetbrains.kotlin.plugin.compose") version "2.1.21" apply false

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
 #Sun May 25 18:53:14 EEST 2025
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-8.11.1-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.13-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists


### PR DESCRIPTION
## Περίληψη
- Αναβάθμιση του Android Gradle Plugin στην έκδοση 8.12.1 και του Gradle wrapper σε 8.13
- Χρήση Firebase BoM 34.1.0 με καθαρότερο μπλοκ εξαρτήσεων

## Δοκιμές
- ⚠️ `./gradlew :app:checkDebugAarMetadata` (απέτυχε: SDK location not found)

------
https://chatgpt.com/codex/tasks/task_e_68aa3b6d53948328871946a57babc821