### PR TITLE
Διόρθωση έκδοσης AGP σε 8.11.0 και αναβάθμιση Gradle wrapper σε 8.13

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -1,7 +1,7 @@
 // Top-level build file where you can add configuration options common to all sub-projects/modules.
 
 plugins {
-    id("com.android.application") version "8.12.1" apply false
+    id("com.android.application") version "8.11.0" apply false
     // Το plugin Compose απαιτείται σε Kotlin 2.x για να ενεργοποιηθεί ο
     // compiler του Jetpack Compose.
     id("org.jetbrains.kotlin.plugin.compose") version "2.1.21" apply false


### PR DESCRIPTION
## Περίληψη
- Χρήση του Android Gradle Plugin 8.11.0 για συμβατότητα με το έργο
- Ενημέρωση του Gradle wrapper στην έκδοση 8.13

## Δοκιμές
- `./gradlew --version`
- `./gradlew test` *(απέτυχε: δεν βρέθηκε Android SDK στο περιβάλλον)*

------
https://chatgpt.com/codex/tasks/task_e_68aa3eabec6c83289d01fed6220ab8d3