### PR TITLE
Προσθήκη βοηθητικής συνάρτησης Firebase

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -75,7 +75,7 @@ kotlin {
 }
 
 dependencies {
-    // Firebase βιβλιοθήκες
+    // Firebase βιβλιοθήκες (BoM για συγχρονισμένες εκδόσεις)
     implementation(platform("com.google.firebase:firebase-bom:34.1.0"))
     implementation("com.google.firebase:firebase-auth-ktx")
     implementation("com.google.firebase:firebase-firestore-ktx")

--- a/app/src/main/java/com/ioannapergamali/mysmartroute/utils/FirebaseAuthUtils.kt
+++ b/app/src/main/java/com/ioannapergamali/mysmartroute/utils/FirebaseAuthUtils.kt
@@ -1,0 +1,17 @@
+package com.ioannapergamali.mysmartroute.utils
+
+import com.google.firebase.auth.ktx.auth
+import com.google.firebase.ktx.Firebase
+
+/**
+ * Απλή συνάρτηση ελέγχου σύνδεσης χρήστη στο Firebase Authentication.
+ */
+fun checkLogin() {
+    val auth = Firebase.auth
+    val user = auth.currentUser
+    if (user != null) {
+        println("Συνδεδεμένος χρήστης: ${'$'}{user.uid}")
+    } else {
+        println("Κανένας χρήστης δεν είναι συνδεδεμένος")
+    }
+}


### PR DESCRIPTION
## Περίληψη
- Επεξηγηματικό σχόλιο στο `build.gradle.kts` για τον Firebase BoM.
- Προσθήκη της `FirebaseAuthUtils.kt` με απλή συνάρτηση ελέγχου σύνδεσης.

## Δοκιμές
- `./gradlew help` *(απέτυχε: το περιβάλλον δεν ολοκλήρωσε την εκτέλεση)*

------
https://chatgpt.com/codex/tasks/task_e_68aa4a42a6d48328bf054ee8c21d5b0d