### PR TITLE
Προσθήκη βοηθητικής συνάρτησης Firebase και ρύθμιση αποθετηρίων

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -9,6 +9,11 @@ plugins {
     id("com.google.gms.google-services")
 }
 
+repositories {
+    google()
+    mavenCentral()
+}
+
 // Διαβάζουμε τα API keys από το local.properties ή από μεταβλητή περιβάλλοντος
 
 val localProps = Properties()
@@ -75,7 +80,7 @@ kotlin {
 }
 
 dependencies {
-    // Firebase βιβλιοθήκες
+    // Firebase βιβλιοθήκες (BoM για συγχρονισμένες εκδόσεις)
     implementation(platform("com.google.firebase:firebase-bom:34.1.0"))
     implementation("com.google.firebase:firebase-auth-ktx")
     implementation("com.google.firebase:firebase-firestore-ktx")

--- a/app/src/main/java/com/ioannapergamali/mysmartroute/utils/FirebaseAuthUtils.kt
+++ b/app/src/main/java/com/ioannapergamali/mysmartroute/utils/FirebaseAuthUtils.kt
@@ -1,0 +1,17 @@
+package com.ioannapergamali.mysmartroute.utils
+
+import com.google.firebase.auth.ktx.auth
+import com.google.firebase.ktx.Firebase
+
+/**
+ * Απλή συνάρτηση ελέγχου σύνδεσης χρήστη στο Firebase Authentication.
+ */
+fun checkLogin() {
+    val auth = Firebase.auth
+    val user = auth.currentUser
+    if (user != null) {
+        println("Συνδεδεμένος χρήστης: ${'$'}{user.uid}")
+    } else {
+        println("Κανένας χρήστης δεν είναι συνδεδεμένος")
+    }
+}

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -7,7 +7,6 @@ pluginManagement {
 }
 
 dependencyResolutionManagement {
-    repositoriesMode.set(RepositoriesMode.FAIL_ON_PROJECT_REPOS)
     repositories {
         google()
         mavenCentral()


### PR DESCRIPTION
## Περίληψη
- Επεξηγηματικό σχόλιο στο `build.gradle.kts` για τον Firebase BoM.
- Προσθήκη `FirebaseAuthUtils.kt` με απλή συνάρτηση ελέγχου σύνδεσης.
- Αφαίρεση του `RepositoriesMode.FAIL_ON_PROJECT_REPOS` και προσθήκη `repositories { google(); mavenCentral() }` στο module για επίλυση των βιβλιοθηκών Firebase.

## Δοκιμές
- `./gradlew help` *(ξεκίνησε η εκτέλεση και λήφθηκε το Gradle, αλλά η διαδικασία τερματίστηκε πρόωρα στο περιβάλλον δοκιμών)*

------
https://chatgpt.com/codex/tasks/task_e_68aa4a42a6d48328bf054ee8c21d5b0d