### PR TITLE
Fix syntax error in Gradle settings

### DIFF
--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -7,7 +7,6 @@ pluginManagement {
 }
 
 dependencyResolutionManagement {
-]
     repositories {
         google()
         mavenCentral()


### PR DESCRIPTION
## Summary
- remove stray bracket in settings.gradle.kts to fix `Expecting an element` error

## Testing
- `./gradlew test` *(fails: process stuck at Starting a Gradle Daemon, 1 busy Daemon could not be reused)*

------
https://chatgpt.com/codex/tasks/task_e_68aa5c0e823c8328a7b82198f097fc28