### PR TITLE
Καθαρισμός build script για Firebase εξαρτήσεις

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -8,12 +8,6 @@ plugins {
     id("kotlin-kapt")
     id("com.google.gms.google-services")
 }
-
-repositories {
-    google()
-    mavenCentral()
-}
-
 // Διαβάζουμε τα API keys από το local.properties ή από μεταβλητή περιβάλλοντος
 
 val localProps = Properties()
@@ -77,11 +71,6 @@ android {
 
 kotlin {
     jvmToolchain(21)
-}
-
-repositories {
-    google()
-    mavenCentral()
 }
 
 dependencies {


### PR DESCRIPTION
## Περίληψη
- Αφαίρεση περιττών `repositories` από το `app/build.gradle.kts`
- Επιβεβαίωση χρήσης Firebase BoM και του plugin Google Services

## Έλεγχοι
- `./gradlew :app:dependencies`


------
https://chatgpt.com/codex/tasks/task_e_68aa5cbab65483288d27a39be3c3d7c0