### PR TITLE
Καθαρισμός build script για Firebase εξαρτήσεις

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -13,7 +13,6 @@ repositories {
     google()
     mavenCentral()
 }
-
 // Διαβάζουμε τα API keys από το local.properties ή από μεταβλητή περιβάλλοντος
 
 val localProps = Properties()
@@ -77,11 +76,6 @@ android {
 
 kotlin {
     jvmToolchain(21)
-}
-
-repositories {
-    google()
-    mavenCentral()
 }
 
 dependencies {


### PR DESCRIPTION
## Περίληψη
- Αφαίρεση περιττών `repositories` από το `app/build.gradle.kts`
- Επιβεβαίωση χρήσης Firebase BoM και του plugin Google Services
- Επαναφορά της ρητής δήλωσης `repositories` στο module `app`

## Έλεγχοι
- `./gradlew :app:dependencies --configuration debugRuntimeClasspath --console=plain | tail -n 20`


------
https://chatgpt.com/codex/tasks/task_e_68aa5cbab65483288d27a39be3c3d7c0