### PR TITLE
feat: implement user overview screen

### DIFF
--- a/app/src/main/java/com/ioannapergamali/mysmartroute/model/navigation/NavigationHost.kt
+++ b/app/src/main/java/com/ioannapergamali/mysmartroute/model/navigation/NavigationHost.kt
@@ -38,6 +38,7 @@ import com.ioannapergamali.mysmartroute.view.ui.screens.PrintDeclarationsScreen
 import com.ioannapergamali.mysmartroute.view.ui.screens.PrintTicketScreen
 import com.ioannapergamali.mysmartroute.view.ui.screens.PrepareCompleteRouteScreen
 import com.ioannapergamali.mysmartroute.view.ui.screens.ViewVehiclesScreen
+import com.ioannapergamali.mysmartroute.view.ui.screens.ViewUsersScreen
 import com.ioannapergamali.mysmartroute.view.ui.screens.ViewTransportRequestsScreen
 import com.ioannapergamali.mysmartroute.view.ui.screens.ViewRequestsScreen
 import com.ioannapergamali.mysmartroute.view.ui.screens.PassengerMovingsScreen
@@ -323,6 +324,10 @@ fun NavigationHost(
 
         composable("viewVehicles") {
             ViewVehiclesScreen(navController = navController, openDrawer = openDrawer)
+        }
+
+        composable("viewUsers") {
+            ViewUsersScreen(navController = navController, openDrawer = openDrawer)
         }
 
         composable("soundPicker") {

--- a/app/src/main/java/com/ioannapergamali/mysmartroute/view/ui/screens/ViewUsersScreen.kt
+++ b/app/src/main/java/com/ioannapergamali/mysmartroute/view/ui/screens/ViewUsersScreen.kt
@@ -1,0 +1,83 @@
+package com.ioannapergamali.mysmartroute.view.ui.screens
+
+import androidx.compose.foundation.layout.*
+import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.lazy.items
+import androidx.compose.material3.Divider
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Scaffold
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.collectAsState
+import androidx.compose.runtime.getValue
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.unit.dp
+import androidx.lifecycle.viewmodel.compose.viewModel
+import androidx.navigation.NavController
+import com.ioannapergamali.mysmartroute.R
+import com.ioannapergamali.mysmartroute.model.enumerations.UserRole
+import com.ioannapergamali.mysmartroute.view.ui.components.ScreenContainer
+import com.ioannapergamali.mysmartroute.view.ui.components.TopBar
+import com.ioannapergamali.mysmartroute.viewmodel.UserStatsViewModel
+import com.ioannapergamali.mysmartroute.viewmodel.UserSummary
+
+@Composable
+fun ViewUsersScreen(navController: NavController, openDrawer: () -> Unit) {
+    val viewModel: UserStatsViewModel = viewModel()
+    val context = LocalContext.current
+    val summaries by viewModel.userSummaries.collectAsState()
+
+    LaunchedEffect(Unit) {
+        viewModel.load(context)
+    }
+
+    Scaffold(
+        topBar = {
+            TopBar(
+                title = stringResource(R.string.view_users),
+                navController = navController,
+                showMenu = true,
+                onMenuClick = openDrawer
+            )
+        }
+    ) { padding ->
+        ScreenContainer(modifier = Modifier.padding(padding)) {
+            if (summaries.isEmpty()) {
+                Text(stringResource(R.string.no_users))
+            } else {
+                LazyColumn {
+                    items(summaries) { summary ->
+                        UserSummaryItem(summary)
+                        Divider(modifier = Modifier.padding(vertical = 8.dp))
+                    }
+                }
+            }
+        }
+    }
+}
+
+@Composable
+private fun UserSummaryItem(summary: UserSummary) {
+    val user = summary.user
+    Text("${user.name} ${user.surname}", style = MaterialTheme.typography.titleMedium)
+    val role = runCatching { UserRole.valueOf(user.role) }.getOrNull()
+    if (summary.completedMovings.isNotEmpty()) {
+        Text(stringResource(R.string.completed_movings), style = MaterialTheme.typography.labelLarge)
+        summary.completedMovings.forEach { m ->
+            Text("- ${m.routeName}")
+        }
+        Text(stringResource(R.string.total_cost_label, summary.totalCost))
+        Text(stringResource(R.string.average_rating_label, summary.passengerAverageRating))
+    }
+    if (role == UserRole.DRIVER || role == UserRole.ADMIN) {
+        if (summary.vehicles.isNotEmpty()) {
+            Text(stringResource(R.string.vehicles_label), style = MaterialTheme.typography.labelLarge)
+            summary.vehicles.forEach { v -> Text("- ${v.name}") }
+        }
+        Text(stringResource(R.string.passenger_avg_rating_label, summary.driverAverageRating))
+    }
+}
+

--- a/app/src/main/java/com/ioannapergamali/mysmartroute/viewmodel/UserStatsViewModel.kt
+++ b/app/src/main/java/com/ioannapergamali/mysmartroute/viewmodel/UserStatsViewModel.kt
@@ -1,0 +1,59 @@
+package com.ioannapergamali.mysmartroute.viewmodel
+
+import android.content.Context
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.viewModelScope
+import com.ioannapergamali.mysmartroute.data.local.MovingEntity
+import com.ioannapergamali.mysmartroute.data.local.MySmartRouteDatabase
+import com.ioannapergamali.mysmartroute.data.local.UserEntity
+import com.ioannapergamali.mysmartroute.data.local.VehicleEntity
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.combine
+import kotlinx.coroutines.launch
+
+data class UserSummary(
+    val user: UserEntity,
+    val completedMovings: List<MovingEntity>,
+    val totalCost: Double,
+    val passengerAverageRating: Double,
+    val vehicles: List<VehicleEntity>,
+    val driverAverageRating: Double
+)
+
+class UserStatsViewModel : ViewModel() {
+    private val _userSummaries = MutableStateFlow<List<UserSummary>>(emptyList())
+    val userSummaries: StateFlow<List<UserSummary>> = _userSummaries
+
+    fun load(context: Context) {
+        viewModelScope.launch {
+            val db = MySmartRouteDatabase.getInstance(context)
+            val userFlow = db.userDao().getAllUsers()
+            val movingFlow = db.movingDao().getAll()
+            val ratingFlow = db.tripRatingDao().getAll()
+            val vehicleFlow = db.vehicleDao().getAllVehicles()
+            val routeFlow = db.routeDao().getAll()
+
+            combine(userFlow, movingFlow, ratingFlow, vehicleFlow, routeFlow) { users, movings, ratings, vehicles, routes ->
+                val ratingMap = ratings.associateBy { it.movingId }
+                val routeMap = routes.associateBy { it.id }
+                val movingsByUser = movings.groupBy { it.userId }
+                val movingsByDriver = movings.groupBy { it.driverId }
+                val vehiclesByUser = vehicles.groupBy { it.userId }
+                users.map { user ->
+                    val userMovings = movingsByUser[user.id]?.filter { it.status == "completed" } ?: emptyList()
+                    userMovings.forEach { it.routeName = routeMap[it.routeId]?.name ?: "" }
+                    val totalCost = userMovings.sumOf { it.cost }
+                    val passengerRatings = userMovings.mapNotNull { ratingMap[it.id]?.rating }
+                    val passengerAvg = if (passengerRatings.isNotEmpty()) passengerRatings.average() else 0.0
+                    val userVehicles = vehiclesByUser[user.id] ?: emptyList()
+                    val driverMovings = movingsByDriver[user.id]?.filter { it.status == "completed" } ?: emptyList()
+                    val driverRatings = driverMovings.mapNotNull { ratingMap[it.id]?.rating }
+                    val driverAvg = if (driverRatings.isNotEmpty()) driverRatings.average() else 0.0
+                    UserSummary(user, userMovings, totalCost, passengerAvg, userVehicles, driverAvg)
+                }
+            }.collect { _userSummaries.value = it }
+        }
+    }
+}
+

--- a/app/src/main/res/values-el/strings.xml
+++ b/app/src/main/res/values-el/strings.xml
@@ -123,6 +123,9 @@
     <string name="view_pois">Προβολή σημείων ενδιαφέροντος</string>
     <string name="view_users">Προβολή χρηστών</string>
     <string name="no_users">Δεν βρέθηκαν χρήστες</string>
+    <string name="total_cost_label">Συνολικό κόστος: %1$.2f€</string>
+    <string name="vehicles_label">Οχήματα</string>
+    <string name="passenger_avg_rating_label">Ικανοποίηση επιβατών: %1$.1f/5</string>
     <string name="advance_date">Μεταφορά ημερομηνίας</string>
     <string name="declare_route">Δήλωση διαδρομής</string>
     <string name="announce_transport">Δήλωση μεταφοράς</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -121,6 +121,9 @@
     <string name="view_pois">View PoIs</string>
     <string name="view_users">View Users</string>
     <string name="no_users">No users found</string>
+    <string name="total_cost_label">Total cost: %1$.2f€</string>
+    <string name="vehicles_label">Vehicles</string>
+    <string name="passenger_avg_rating_label">Passenger satisfaction: %1$.1f/5</string>
     <string name="advance_date">Advance Date</string>
     <string name="declare_route">Declare Route</string>
     <string name="announce_transport">Announce Transport</string>


### PR DESCRIPTION
## Summary
- add screen to display users with role-specific details
- aggregate passenger costs, ratings and vehicles

## Testing
- `./gradlew test` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_68aa687734288328923a387ae2f36153