### PR TITLE
Μεταφορά προβολής POI στο μενού διαχειριστή

### DIFF
--- a/app/src/main/assets/menus.json
+++ b/app/src/main/assets/menus.json
@@ -5,23 +5,74 @@
       {
         "titleKey": "passenger_menu_title",
         "options": [
-          {"titleKey": "sign_out", "route": "signOut"},
-          {"titleKey": "manage_favorites", "route": "manageFavorites"},
-          {"titleKey": "route_mode", "route": "routeMode"},
-          {"titleKey": "find_vehicle", "route": "findVehicle"},
-          {"titleKey": "find_way", "route": "findWay"},
-          {"titleKey": "book_seat", "route": "bookSeat"},
-          {"titleKey": "view_routes", "route": "viewRoutes"},
-          {"titleKey": "select_pois_screen_title", "route": "selectRoutePois"},
-          {"titleKey": "view_transports", "route": "viewTransports"},
-          {"titleKey": "view_requests", "route": "viewRequests"},
-          {"titleKey": "view_movings", "route": "viewMovings"},
-          {"titleKey": "walking", "route": "walking"},
-          {"titleKey": "walking_routes", "route": "walkingRoutes"},
-          {"titleKey": "print_ticket", "route": "printTicket"},
-          {"titleKey": "cancel_seat", "route": "cancelSeat"},
-          {"titleKey": "rank_transports", "route": "rankTransports"},
-          {"titleKey": "shutdown", "route": "shutdown"}
+          {
+            "titleKey": "sign_out",
+            "route": "signOut"
+          },
+          {
+            "titleKey": "manage_favorites",
+            "route": "manageFavorites"
+          },
+          {
+            "titleKey": "route_mode",
+            "route": "routeMode"
+          },
+          {
+            "titleKey": "find_vehicle",
+            "route": "findVehicle"
+          },
+          {
+            "titleKey": "find_way",
+            "route": "findWay"
+          },
+          {
+            "titleKey": "book_seat",
+            "route": "bookSeat"
+          },
+          {
+            "titleKey": "view_routes",
+            "route": "viewRoutes"
+          },
+          {
+            "titleKey": "select_pois_screen_title",
+            "route": "selectRoutePois"
+          },
+          {
+            "titleKey": "view_transports",
+            "route": "viewTransports"
+          },
+          {
+            "titleKey": "view_requests",
+            "route": "viewRequests"
+          },
+          {
+            "titleKey": "view_movings",
+            "route": "viewMovings"
+          },
+          {
+            "titleKey": "walking",
+            "route": "walking"
+          },
+          {
+            "titleKey": "walking_routes",
+            "route": "walkingRoutes"
+          },
+          {
+            "titleKey": "print_ticket",
+            "route": "printTicket"
+          },
+          {
+            "titleKey": "cancel_seat",
+            "route": "cancelSeat"
+          },
+          {
+            "titleKey": "rank_transports",
+            "route": "rankTransports"
+          },
+          {
+            "titleKey": "shutdown",
+            "route": "shutdown"
+          }
         ]
       }
     ]
@@ -32,16 +83,46 @@
       {
         "titleKey": "driver_menu_title",
         "options": [
-          {"titleKey": "register_vehicle", "route": "registerVehicle"},
-          {"titleKey": "declare_route", "route": "declareRoute"},
-          {"titleKey": "announce_availability", "route": "announceAvailability"},
-          {"titleKey": "print_declarations", "route": "printDeclarations"},
-          {"titleKey": "find_passengers", "route": "findPassengers"},
-          {"titleKey": "print_list", "route": "printList"},
-          {"titleKey": "print_scheduled", "route": "printScheduled"},
-          {"titleKey": "print_completed", "route": "printCompleted"},
-          {"titleKey": "prepare_complete_route", "route": "prepareCompleteRoute"},
-          {"titleKey": "view_transport_requests", "route": "viewTransportRequests"}
+          {
+            "titleKey": "register_vehicle",
+            "route": "registerVehicle"
+          },
+          {
+            "titleKey": "declare_route",
+            "route": "declareRoute"
+          },
+          {
+            "titleKey": "announce_availability",
+            "route": "announceAvailability"
+          },
+          {
+            "titleKey": "print_declarations",
+            "route": "printDeclarations"
+          },
+          {
+            "titleKey": "find_passengers",
+            "route": "findPassengers"
+          },
+          {
+            "titleKey": "print_list",
+            "route": "printList"
+          },
+          {
+            "titleKey": "print_scheduled",
+            "route": "printScheduled"
+          },
+          {
+            "titleKey": "print_completed",
+            "route": "printCompleted"
+          },
+          {
+            "titleKey": "prepare_complete_route",
+            "route": "prepareCompleteRoute"
+          },
+          {
+            "titleKey": "view_transport_requests",
+            "route": "viewTransportRequests"
+          }
         ]
       }
     ]
@@ -52,20 +133,58 @@
       {
         "titleKey": "admin_menu_title",
         "options": [
-          {"titleKey": "init_system", "route": "initSystem"},
-          {"titleKey": "create_user", "route": "createUser"},
-          {"titleKey": "edit_privileges", "route": "editPrivileges"},
-          {"titleKey": "define_poi", "route": "definePoi"},
-          {"titleKey": "edit_route", "route": "editRoute"},
-          {"titleKey": "define_duration", "route": "defineDuration"},
-          {"titleKey": "view_unassigned", "route": "viewUnassigned"},
-          {"titleKey": "review_poi", "route": "reviewPoi"},
-          {"titleKey": "rank_drivers", "route": "rankDrivers"},
-          {"titleKey": "rank_passengers", "route": "rankPassengers"},
-          {"titleKey": "view_vehicles", "route": "viewVehicles"},
-          {"titleKey": "view_pois", "route": "viewPois"},
-          {"titleKey": "view_users", "route": "viewUsers"},
-          {"titleKey": "advance_date", "route": "advanceDate"}
+          {
+            "titleKey": "init_system",
+            "route": "initSystem"
+          },
+          {
+            "titleKey": "create_user",
+            "route": "createUser"
+          },
+          {
+            "titleKey": "edit_privileges",
+            "route": "editPrivileges"
+          },
+          {
+            "titleKey": "define_poi",
+            "route": "definePoi"
+          },
+          {
+            "titleKey": "edit_route",
+            "route": "editRoute"
+          },
+          {
+            "titleKey": "define_duration",
+            "route": "defineDuration"
+          },
+          {
+            "titleKey": "view_unassigned",
+            "route": "viewUnassigned"
+          },
+          {
+            "titleKey": "review_poi",
+            "route": "reviewPoi"
+          },
+          {
+            "titleKey": "rank_drivers",
+            "route": "rankDrivers"
+          },
+          {
+            "titleKey": "rank_passengers",
+            "route": "rankPassengers"
+          },
+          {
+            "titleKey": "view_vehicles",
+            "route": "viewVehicles"
+          },
+          {
+            "titleKey": "view_users",
+            "route": "viewUsers"
+          },
+          {
+            "titleKey": "advance_date",
+            "route": "advanceDate"
+          }
         ]
       }
     ]

--- a/app/src/main/java/com/ioannapergamali/mysmartroute/data/local/MySmartRouteDatabase.kt
+++ b/app/src/main/java/com/ioannapergamali/mysmartroute/data/local/MySmartRouteDatabase.kt
@@ -282,9 +282,8 @@ abstract class MySmartRouteDatabase : RoomDatabase() {
                 insertOption("opt_admin_8", adminMenuId, "rank_drivers", "rankDrivers")
                 insertOption("opt_admin_9", adminMenuId, "rank_passengers", "rankPassengers")
                 insertOption("opt_admin_10", adminMenuId, "view_vehicles", "viewVehicles")
-                insertOption("opt_admin_11", adminMenuId, "view_pois", "viewPois")
-                insertOption("opt_admin_12", adminMenuId, "view_users", "viewUsers")
-                insertOption("opt_admin_13", adminMenuId, "advance_date", "advanceDate")
+                insertOption("opt_admin_11", adminMenuId, "view_users", "viewUsers")
+                insertOption("opt_admin_12", adminMenuId, "advance_date", "advanceDate")
             }
         }
 
@@ -759,9 +758,8 @@ abstract class MySmartRouteDatabase : RoomDatabase() {
             insertOption("opt_admin_8", adminMenuId, "rank_drivers", "rankDrivers")
             insertOption("opt_admin_9", adminMenuId, "rank_passengers", "rankPassengers")
             insertOption("opt_admin_10", adminMenuId, "view_vehicles", "viewVehicles")
-            insertOption("opt_admin_11", adminMenuId, "view_pois", "viewPois")
-            insertOption("opt_admin_12", adminMenuId, "view_users", "viewUsers")
-            insertOption("opt_admin_13", adminMenuId, "advance_date", "advanceDate")
+            insertOption("opt_admin_11", adminMenuId, "view_users", "viewUsers")
+            insertOption("opt_admin_12", adminMenuId, "advance_date", "advanceDate")
 
             Log.d(TAG, "Prepopulate complete")
             db.execSQL("INSERT INTO app_language (id, language) VALUES (1, 'el')")

--- a/app/src/main/java/com/ioannapergamali/mysmartroute/view/ui/components/NavigationDrawer.kt
+++ b/app/src/main/java/com/ioannapergamali/mysmartroute/view/ui/components/NavigationDrawer.kt
@@ -11,6 +11,7 @@ import androidx.compose.material.icons.filled.Person
 import androidx.compose.material.icons.filled.Login
 import androidx.compose.material.icons.filled.Settings
 import androidx.compose.material.icons.filled.Menu
+import androidx.compose.material.icons.filled.LocationOn
 import com.google.firebase.auth.FirebaseAuth
 import androidx.compose.material3.*
 import androidx.compose.material3.MaterialTheme
@@ -153,6 +154,18 @@ fun DrawerMenu(navController: NavController, closeDrawer: () -> Unit) {
                 },
                 icon = { Icon(Icons.Filled.Menu, contentDescription = null, tint = MaterialTheme.colorScheme.primary) }
             )
+
+            if (role.value == "ADMIN") {
+                NavigationDrawerItem(
+                    label = { Text(stringResource(R.string.view_pois)) },
+                    selected = false,
+                    onClick = {
+                        navController.navigate("viewPois")
+                        closeDrawer()
+                    },
+                    icon = { Icon(Icons.Filled.LocationOn, contentDescription = null, tint = MaterialTheme.colorScheme.primary) }
+                )
+            }
             NavigationDrawerItem(
                 label = { Text(stringResource(R.string.logout)) },
                 selected = false,


### PR DESCRIPTION
## Περίληψη
- Προστέθηκε νέα επιλογή "Προβολή σημείων ενδιαφέροντος" στο συρτάρι πλοήγησης για χρήστες με ρόλο διαχειριστή.
- Αφαιρέθηκε η επιλογή από τη δομή του βασικού μενού και ενημερώθηκε η αρχικοποίηση της βάσης.

## Έλεγχοι
- `./gradlew test` *(απέτυχε να ολοκληρωθεί λόγω περιορισμών περιβάλλοντος – τερματίστηκε μετά τη λήψη της διανομής του Gradle)*

------
https://chatgpt.com/codex/tasks/task_e_68aa681bf8888328a01591c6183767ed