### PR TITLE
Αφαίρεση παρωχημένων Firebase KTX εξαρτήσεων

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -77,9 +77,10 @@ kotlin {
 dependencies {
     // Firebase βιβλιοθήκες (BoM για συγχρονισμένες εκδόσεις)
     implementation(platform("com.google.firebase:firebase-bom:34.1.0"))
-    implementation("com.google.firebase:firebase-auth-ktx")
-    implementation("com.google.firebase:firebase-firestore-ktx")
-    implementation("com.google.firebase:firebase-dynamic-links-ktx")
+    implementation("com.google.firebase:firebase-auth")
+    implementation("com.google.firebase:firebase-firestore")
+    // Το Dynamic Links δεν περιλαμβάνεται στο BoM, δηλώνουμε ρητά την έκδοση
+    implementation("com.google.firebase:firebase-dynamic-links:22.1.0")
 
     // Android core
     implementation(libs.androidx.core.ktx)


### PR DESCRIPTION
## Περιγραφή
- Αντικατάσταση `firebase-*-ktx` με τις κύριες βιβλιοθήκες μέσω Firebase BoM
- Ρητή δήλωση `firebase-dynamic-links:22.1.0` που δεν καλύπτεται από το BoM

## Έλεγχοι
- `./gradlew build` *(απέτυχε: λείπει το Android SDK στο περιβάλλον εκτέλεσης)*

------
https://chatgpt.com/codex/tasks/task_e_68aa6ac859bc8328ba84f6e2989d3f15