### PR TITLE
Χρήση βιβλιοθηκών Firebase KTX

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -77,8 +77,8 @@ kotlin {
 dependencies {
     // Firebase βιβλιοθήκες (BoM για συγχρονισμένες εκδόσεις)
     implementation(platform("com.google.firebase:firebase-bom:34.1.0"))
-    implementation("com.google.firebase:firebase-auth")
-    implementation("com.google.firebase:firebase-firestore")
+    implementation("com.google.firebase:firebase-auth-ktx")
+    implementation("com.google.firebase:firebase-firestore-ktx")
 
     // Το Dynamic Links δεν περιλαμβάνεται στο BoM, δηλώνουμε ρητά την έκδοση
     implementation("com.google.firebase:firebase-dynamic-links:22.1.0")


### PR DESCRIPTION
## Summary
- Αντικατάσταση των εξαρτήσεων firebase-auth και firebase-firestore με τις εκδόσεις KTX ώστε να αναγνωρίζεται το αντικείμενο `Firebase`

## Testing
- `./gradlew test` *(αποτυχία: δεν βρέθηκε το Android SDK)*

------
https://chatgpt.com/codex/tasks/task_e_68aa72356d10832895ee5d66a3822be7