### PR TITLE
Προσθήκη Firebase Analytics KTX

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -79,6 +79,7 @@ dependencies {
     implementation(platform("com.google.firebase:firebase-bom:34.1.0"))
     implementation("com.google.firebase:firebase-auth-ktx")
     implementation("com.google.firebase:firebase-firestore-ktx")
+    implementation("com.google.firebase:firebase-analytics-ktx")
 
     // Το Dynamic Links δεν περιλαμβάνεται στο BoM, δηλώνουμε ρητά την έκδοση
     implementation("com.google.firebase:firebase-dynamic-links:22.1.0")


### PR DESCRIPTION
## Περίληψη
- Προσθήκη `com.google.firebase:firebase-analytics-ktx` στο `app/build.gradle.kts` για σωστή επίλυση των εξαρτήσεων Firebase

## Έλεγχοι
- `./gradlew assembleDebug` *(αποτυχία: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_68aa7a9aaab08328b1fadac5b1c39fbc