### PR TITLE
Αντικατάσταση Firebase.firestore με FirebaseFirestore.getInstance

### DIFF
--- a/app/src/main/java/com/ioannapergamali/mysmartroute/data/local/DriverOperations.kt
+++ b/app/src/main/java/com/ioannapergamali/mysmartroute/data/local/DriverOperations.kt
@@ -1,8 +1,6 @@
 package com.ioannapergamali.mysmartroute.data.local
 
-import com.google.firebase.ktx.Firebase
 import com.google.firebase.firestore.FirebaseFirestore
-import com.google.firebase.firestore.ktx.firestore
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.tasks.await
 import kotlinx.coroutines.withContext
@@ -12,7 +10,7 @@ import kotlinx.coroutines.withContext
  */
 suspend fun demoteDriverToPassenger(
     db: MySmartRouteDatabase,
-    firestore: FirebaseFirestore = Firebase.firestore,
+    firestore: FirebaseFirestore = FirebaseFirestore.getInstance(),
     driverId: String,
 ) = withContext(Dispatchers.IO) {
     // Τοπική βάση


### PR DESCRIPTION
## Περίληψη
- Αντικατάσταση του KTX `Firebase.firestore` με `FirebaseFirestore.getInstance()` για αποφυγή unresolved reference

## Έλεγχοι
- `./gradlew test` *(απέτυχε: Could not determine the dependencies of task ':app:testDebugUnitTest'. SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_68aa8e06db908328a44382e617e49715