### PR TITLE
chore: update coroutines

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -122,10 +122,10 @@ dependencies {
     implementation("com.google.android.gms:play-services-location:21.3.0")
     implementation("com.google.android.libraries.places:places:3.4.0")
 
-    // Coroutines
-    implementation("org.jetbrains.kotlinx:kotlinx-coroutines-core:1.9.0")
-    implementation("org.jetbrains.kotlinx:kotlinx-coroutines-android:1.9.0")
-    implementation("org.jetbrains.kotlinx:kotlinx-coroutines-play-services:1.9.0")
+    // Coroutines (νεότερη σταθερή έκδοση)
+    implementation("org.jetbrains.kotlinx:kotlinx-coroutines-core:1.10.2")
+    implementation("org.jetbrains.kotlinx:kotlinx-coroutines-android:1.10.2")
+    implementation("org.jetbrains.kotlinx:kotlinx-coroutines-play-services:1.10.2")
 
     // HTTP Networking
     implementation("com.squareup.okhttp3:okhttp:4.12.0")


### PR DESCRIPTION
## Summary
- update Kotlin coroutines dependencies to 1.10.2

## Testing
- `./gradlew assembleDebug` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_68aa954a0b8083288274f9fcd6e22e6f