### PR TITLE
Configure Firebase repositories and sample usage

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -75,12 +75,12 @@ kotlin {
 }
 
 dependencies {
-    // Firebase βιβλιοθήκες (BoM για συγχρονισμένες εκδόσεις)
+    // Firebase (BoM για αυτόματες εκδόσεις όλων των modules)
     implementation(platform("com.google.firebase:firebase-bom:34.1.0"))
     implementation("com.google.firebase:firebase-auth-ktx")
     implementation("com.google.firebase:firebase-firestore-ktx")
 
-    // Το Dynamic Links δεν περιλαμβάνεται στο BoM, δηλώνουμε ρητά την έκδοση
+    // Το Dynamic Links δεν καλύπτεται από το BoM, δηλώνουμε ρητά την έκδοση
     implementation("com.google.firebase:firebase-dynamic-links:22.1.0")
 
 

--- a/app/src/main/java/com/ioannapergamali/mysmartroute/viewmodel/MainActivity.kt
+++ b/app/src/main/java/com/ioannapergamali/mysmartroute/viewmodel/MainActivity.kt
@@ -37,6 +37,9 @@ import kotlinx.coroutines.runBlocking
 import kotlinx.coroutines.launch
 import com.ioannapergamali.mysmartroute.model.interfaces.ThemeOption
 import android.view.WindowManager
+import com.google.firebase.auth.ktx.auth
+import com.google.firebase.firestore.ktx.firestore
+import com.google.firebase.ktx.Firebase
 
 
 
@@ -66,6 +69,12 @@ class MainActivity : ComponentActivity() {
         // Συγχρονισμός ρυθμίσεων από τη βάση
         settingsViewModel.syncSettings(this)
         requestViewModel.loadRequests(this)
+        // Απλό παράδειγμα χρήσης Firebase Auth & Firestore
+        val auth = Firebase.auth
+        val db = Firebase.firestore
+        auth.signInAnonymously()
+            .addOnFailureListener { e -> Log.e("Auth", "Αποτυχία σύνδεσης", e) }
+        db.collection("debug").add(mapOf("ts" to System.currentTimeMillis()))
         // Έλεγχος φόρτωσης του Maps API key
         val apiKey = MapsUtils.getApiKey(this)
         Log.d("Maps", "API key loaded? ${apiKey.isNotEmpty()}")

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -10,12 +10,3 @@ plugins {
     id("org.jetbrains.kotlin.android") version "2.0.20" apply false
     id("com.google.gms.google-services") version "4.4.3" apply false
 }
-
-allprojects {
-    repositories {
-        google()
-        mavenCentral()
-    }
-}
-
-

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -1,3 +1,5 @@
+import org.gradle.api.initialization.resolve.RepositoriesMode
+
 pluginManagement {
     repositories {
         google()
@@ -7,6 +9,7 @@ pluginManagement {
 }
 
 dependencyResolutionManagement {
+    repositoriesMode.set(RepositoriesMode.FAIL_ON_PROJECT_REPOS)
     repositories {
         google()
         mavenCentral()


### PR DESCRIPTION
## Summary
- centralize repository setup to google() and mavenCentral() with RepositoriesMode
- clarify Firebase BOM usage and add sample Auth/Firestore snippet
- remove legacy allprojects repository block

## Testing
- `./gradlew tasks`

------
https://chatgpt.com/codex/tasks/task_e_68aa9b8ef980832897ebf8a1c8954b2e