### PR TITLE
feat: show summary details for all users

### DIFF
--- a/app/src/main/java/com/ioannapergamali/mysmartroute/view/ui/screens/ViewUsersScreen.kt
+++ b/app/src/main/java/com/ioannapergamali/mysmartroute/view/ui/screens/ViewUsersScreen.kt
@@ -82,9 +82,11 @@ private fun UserSummaryItem(summary: UserSummary) {
         summary.completedMovings.forEach { m ->
             Text("- ${m.routeName}")
         }
-        Text(stringResource(R.string.total_cost_label, summary.totalCost))
-        Text(stringResource(R.string.average_rating_label, summary.passengerAverageRating))
+    } else {
+        Text(stringResource(R.string.no_completed_movings))
     }
+    Text(stringResource(R.string.total_cost_label, summary.totalCost))
+    Text(stringResource(R.string.average_rating_label, summary.passengerAverageRating))
     if (role == UserRole.DRIVER || role == UserRole.ADMIN) {
         if (summary.vehicles.isNotEmpty()) {
             Text(stringResource(R.string.vehicles_label), style = MaterialTheme.typography.labelLarge)

--- a/app/src/main/res/values-el/strings.xml
+++ b/app/src/main/res/values-el/strings.xml
@@ -122,6 +122,7 @@
     <string name="total_cost_label">Συνολικό κόστος: %1$.2f€</string>
     <string name="vehicles_label">Οχήματα</string>
     <string name="passenger_avg_rating_label">Ικανοποίηση επιβατών: %1$.1f/5</string>
+    <string name="no_completed_movings">Δεν υπάρχουν ολοκληρωμένες μετακινήσεις</string>
     <string name="advance_date">Μεταφορά ημερομηνίας</string>
     <string name="declare_route">Δήλωση διαδρομής</string>
     <string name="announce_transport">Δήλωση μεταφοράς</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -120,6 +120,7 @@
     <string name="total_cost_label">Total cost: %1$.2f€</string>
     <string name="vehicles_label">Vehicles</string>
     <string name="passenger_avg_rating_label">Passenger satisfaction: %1$.1f/5</string>
+    <string name="no_completed_movings">No completed movings</string>
     <string name="advance_date">Advance Date</string>
     <string name="declare_route">Declare Route</string>
     <string name="announce_transport">Announce Transport</string>


### PR DESCRIPTION
## Summary
- show empty message when user has no completed movings and always display cost and rating
- add missing string resources for "no completed movings" in English and Greek

## Testing
- `./gradlew test` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_68aaac94cdd083289935a899ea2e8d50