### PR TITLE
feat: add password reset screen

### DIFF
--- a/app/src/main/java/com/ioannapergamali/mysmartroute/model/navigation/NavigationHost.kt
+++ b/app/src/main/java/com/ioannapergamali/mysmartroute/model/navigation/NavigationHost.kt
@@ -6,6 +6,7 @@ import androidx.navigation.compose.NavHost
 import androidx.navigation.compose.composable
 import androidx.navigation.navArgument
 import com.ioannapergamali.mysmartroute.view.ui.screens.HomeScreen
+import com.ioannapergamali.mysmartroute.view.ui.screens.ResetPasswordScreen
 import com.ioannapergamali.mysmartroute.view.ui.screens.SignUpScreen
 import com.ioannapergamali.mysmartroute.view.ui.screens.MenuScreen
 import com.ioannapergamali.mysmartroute.view.ui.screens.RegisterVehicleScreen
@@ -77,8 +78,9 @@ fun NavigationHost(
                 openDrawer = openDrawer
             )
         }
-
-
+        composable("resetPassword") {
+            ResetPasswordScreen(navController = navController, openDrawer = openDrawer)
+        }
 
         composable("Signup") {
             SignUpScreen(

--- a/app/src/main/java/com/ioannapergamali/mysmartroute/view/ui/screens/HomeScreen.kt
+++ b/app/src/main/java/com/ioannapergamali/mysmartroute/view/ui/screens/HomeScreen.kt
@@ -83,6 +83,7 @@ fun HomeScreen(
                         uiState = uiState,
                         onLogin = { viewModel.login(context, email, password) },
                         onNavigateToSignUp = onNavigateToSignUp,
+                        onForgotPassword = { navController.navigate("resetPassword") },
                         onLogout = { viewModel.signOut() },
                         modifier = Modifier.weight(1f)
                     )
@@ -105,6 +106,7 @@ fun HomeScreen(
                         uiState = uiState,
                         onLogin = { viewModel.login(context, email, password) },
                         onNavigateToSignUp = onNavigateToSignUp,
+                        onForgotPassword = { navController.navigate("resetPassword") },
                         onLogout = { viewModel.signOut() }
                     )
                 }
@@ -145,6 +147,7 @@ private fun HomeContent(
     uiState: AuthenticationViewModel.LoginState,
     onLogin: () -> Unit,
     onNavigateToSignUp: () -> Unit,
+    onForgotPassword: () -> Unit,
     onLogout: () -> Unit = {},
     modifier: Modifier = Modifier
 ) {
@@ -220,6 +223,14 @@ private fun HomeContent(
             Button(onClick = onLogin) {
                 Text(stringResource(R.string.login))
             }
+
+            Spacer(modifier = Modifier.height(8.dp))
+
+            Text(
+                text = stringResource(R.string.forgot_password),
+                color = MaterialTheme.colorScheme.primary,
+                modifier = Modifier.clickable { onForgotPassword() }
+            )
 
             Spacer(modifier = Modifier.height(8.dp))
 

--- a/app/src/main/java/com/ioannapergamali/mysmartroute/view/ui/screens/ResetPasswordScreen.kt
+++ b/app/src/main/java/com/ioannapergamali/mysmartroute/view/ui/screens/ResetPasswordScreen.kt
@@ -1,0 +1,86 @@
+package com.ioannapergamali.mysmartroute.view.ui.screens
+
+import androidx.compose.foundation.layout.*
+import androidx.compose.material3.*
+import androidx.compose.runtime.*
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.unit.dp
+import androidx.lifecycle.viewmodel.compose.viewModel
+import androidx.navigation.NavController
+import com.ioannapergamali.mysmartroute.R
+import com.ioannapergamali.mysmartroute.view.ui.components.ScreenContainer
+import com.ioannapergamali.mysmartroute.view.ui.components.TopBar
+import com.ioannapergamali.mysmartroute.viewmodel.AuthenticationViewModel
+import com.ioannapergamali.mysmartroute.view.ui.util.LocalKeyboardBubbleState
+import com.ioannapergamali.mysmartroute.view.ui.util.observeBubble
+
+@Composable
+fun ResetPasswordScreen(navController: NavController, openDrawer: () -> Unit) {
+    val viewModel: AuthenticationViewModel = viewModel()
+    val uiState by viewModel.resetPasswordState.collectAsState()
+    var email by remember { mutableStateOf("") }
+    val bubbleState = LocalKeyboardBubbleState.current!!
+
+    Scaffold(
+        topBar = {
+            TopBar(
+                title = stringResource(R.string.reset_password),
+                navController = navController,
+                showMenu = false,
+                showHomeIcon = false,
+                showLanguageToggle = false,
+                showNotifications = false
+            )
+        }
+    ) { padding ->
+        ScreenContainer(modifier = Modifier.padding(padding)) {
+            Column(
+                modifier = Modifier.fillMaxWidth(),
+                horizontalAlignment = Alignment.CenterHorizontally
+            ) {
+                OutlinedTextField(
+                    value = email,
+                    onValueChange = { email = it },
+                    label = { Text(stringResource(R.string.email)) },
+                    modifier = Modifier
+                        .fillMaxWidth()
+                        .observeBubble(bubbleState, 0) { email }
+                )
+                Spacer(modifier = Modifier.height(16.dp))
+                Button(onClick = { viewModel.resetPassword(email) }) {
+                    Text(stringResource(R.string.send_reset_email))
+                }
+                when (uiState) {
+                    is AuthenticationViewModel.ResetPasswordState.Loading -> {
+                        Spacer(modifier = Modifier.height(16.dp))
+                        CircularProgressIndicator()
+                    }
+                    is AuthenticationViewModel.ResetPasswordState.Success -> {
+                        Spacer(modifier = Modifier.height(16.dp))
+                        Text(stringResource(R.string.password_reset_email_sent))
+                        Spacer(modifier = Modifier.height(8.dp))
+                        Button(onClick = {
+                            viewModel.clearResetPasswordState()
+                            navController.navigate("home") {
+                                popUpTo("home") { inclusive = true }
+                            }
+                        }) {
+                            Text(stringResource(R.string.back_to_login))
+                        }
+                    }
+                    is AuthenticationViewModel.ResetPasswordState.Error -> {
+                        Spacer(modifier = Modifier.height(8.dp))
+                        Text(
+                            (uiState as AuthenticationViewModel.ResetPasswordState.Error).message,
+                            color = MaterialTheme.colorScheme.error
+                        )
+                    }
+                    else -> {}
+                }
+            }
+        }
+    }
+}
+

--- a/app/src/main/res/values-el/strings.xml
+++ b/app/src/main/res/values-el/strings.xml
@@ -30,6 +30,11 @@
     <string name="password">Κωδικός</string>
     <string name="no_account">Αν δεν έχετε λογαριασμό</string>
     <string name="sign_up">Εγγραφή</string>
+    <string name="forgot_password">Ξέχασα τον κωδικό;</string>
+    <string name="reset_password">Επαναφορά κωδικού</string>
+    <string name="send_reset_email">Αποστολή email επαναφοράς</string>
+    <string name="back_to_login">Επιστροφή στη σύνδεση</string>
+    <string name="password_reset_email_sent">Στάλθηκε email επαναφοράς κωδικού</string>
     <string name="first_name">Όνομα</string>
     <string name="last_name">Επώνυμο</string>
     <string name="username">Όνομα χρήστη</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -28,6 +28,11 @@
     <string name="password">Password</string>
     <string name="no_account">If you don\'t have an account</string>
     <string name="sign_up">Sign Up</string>
+    <string name="forgot_password">Forgot Password?</string>
+    <string name="reset_password">Reset Password</string>
+    <string name="send_reset_email">Send reset email</string>
+    <string name="back_to_login">Back to login</string>
+    <string name="password_reset_email_sent">Password reset email sent</string>
     <string name="first_name">Name</string>
     <string name="last_name">Surname</string>
     <string name="username">Username</string>


### PR DESCRIPTION
## Summary
- add reset password screen with Firebase integration
- wire reset screen into navigation and home login
- provide localized strings for new screen

## Testing
- `./gradlew test` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_68aab13311948328a517277968c289e9