### PR TITLE
feat: show summary details for all users

### DIFF
--- a/app/src/main/java/com/ioannapergamali/mysmartroute/data/local/MySmartRouteDatabase.kt
+++ b/app/src/main/java/com/ioannapergamali/mysmartroute/data/local/MySmartRouteDatabase.kt
@@ -54,7 +54,7 @@ import com.ioannapergamali.mysmartroute.data.local.TripRatingDao
         TripRatingEntity::class,
         NotificationEntity::class
     ],
-    version = 51
+    version = 52
 )
 @TypeConverters(Converters::class)
 abstract class MySmartRouteDatabase : RoomDatabase() {
@@ -682,6 +682,15 @@ abstract class MySmartRouteDatabase : RoomDatabase() {
             }
         }
 
+        private val MIGRATION_51_52 = object : Migration(51, 52) {
+            override fun migrate(database: SupportSQLiteDatabase) {
+                database.execSQL(
+                    "INSERT INTO `menu_options` (`id`, `menuId`, `titleResKey`, `route`) " +
+                        "VALUES ('opt_admin_11', 'menu_admin_main', 'view_users', 'viewUsers')"
+                )
+            }
+        }
+
         private fun prepopulate(db: SupportSQLiteDatabase) {
             Log.d(TAG, "Prepopulating database")
             db.execSQL(
@@ -812,7 +821,8 @@ abstract class MySmartRouteDatabase : RoomDatabase() {
                     MIGRATION_47_48,
                     MIGRATION_48_49,
                     MIGRATION_49_50,
-                    MIGRATION_50_51
+                    MIGRATION_50_51,
+                    MIGRATION_51_52
                 )
                     .addCallback(object : RoomDatabase.Callback() {
                         override fun onCreate(db: SupportSQLiteDatabase) {

--- a/app/src/main/java/com/ioannapergamali/mysmartroute/view/ui/screens/ViewUsersScreen.kt
+++ b/app/src/main/java/com/ioannapergamali/mysmartroute/view/ui/screens/ViewUsersScreen.kt
@@ -82,9 +82,11 @@ private fun UserSummaryItem(summary: UserSummary) {
         summary.completedMovings.forEach { m ->
             Text("- ${m.routeName}")
         }
-        Text(stringResource(R.string.total_cost_label, summary.totalCost))
-        Text(stringResource(R.string.average_rating_label, summary.passengerAverageRating))
+    } else {
+        Text(stringResource(R.string.no_completed_movings))
     }
+    Text(stringResource(R.string.total_cost_label, summary.totalCost))
+    Text(stringResource(R.string.average_rating_label, summary.passengerAverageRating))
     if (role == UserRole.DRIVER || role == UserRole.ADMIN) {
         if (summary.vehicles.isNotEmpty()) {
             Text(stringResource(R.string.vehicles_label), style = MaterialTheme.typography.labelLarge)

--- a/app/src/main/java/com/ioannapergamali/mysmartroute/viewmodel/UserStatsViewModel.kt
+++ b/app/src/main/java/com/ioannapergamali/mysmartroute/viewmodel/UserStatsViewModel.kt
@@ -9,7 +9,7 @@ import com.ioannapergamali.mysmartroute.data.local.UserEntity
 import com.ioannapergamali.mysmartroute.data.local.VehicleEntity
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
-import kotlinx.coroutines.flow.combine
+import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.launch
 
 data class UserSummary(
@@ -28,31 +28,30 @@ class UserStatsViewModel : ViewModel() {
     fun load(context: Context) {
         viewModelScope.launch {
             val db = MySmartRouteDatabase.getInstance(context)
-            val userFlow = db.userDao().getAllUsers()
-            val movingFlow = db.movingDao().getAll()
-            val ratingFlow = db.tripRatingDao().getAll()
-            val vehicleFlow = db.vehicleDao().getAllVehicles()
-            val routeFlow = db.routeDao().getAll()
+            val users = db.userDao().getAllUsers().first()
+            val movings = db.movingDao().getAll().first()
+            val ratings = db.tripRatingDao().getAll().first()
+            val vehicles = db.vehicleDao().getAllVehicles().first()
+            val routes = db.routeDao().getAll().first()
 
-            combine(userFlow, movingFlow, ratingFlow, vehicleFlow, routeFlow) { users, movings, ratings, vehicles, routes ->
-                val ratingMap = ratings.associateBy { it.movingId }
-                val routeMap = routes.associateBy { it.id }
-                val movingsByUser = movings.groupBy { it.userId }
-                val movingsByDriver = movings.groupBy { it.driverId }
-                val vehiclesByUser = vehicles.groupBy { it.userId }
-                users.map { user ->
-                    val userMovings = movingsByUser[user.id]?.filter { it.status == "completed" } ?: emptyList()
-                    userMovings.forEach { it.routeName = routeMap[it.routeId]?.name ?: "" }
-                    val totalCost = userMovings.sumOf { it.cost }
-                    val passengerRatings = userMovings.mapNotNull { ratingMap[it.id]?.rating }
-                    val passengerAvg = if (passengerRatings.isNotEmpty()) passengerRatings.average() else 0.0
-                    val userVehicles = vehiclesByUser[user.id] ?: emptyList()
-                    val driverMovings = movingsByDriver[user.id]?.filter { it.status == "completed" } ?: emptyList()
-                    val driverRatings = driverMovings.mapNotNull { ratingMap[it.id]?.rating }
-                    val driverAvg = if (driverRatings.isNotEmpty()) driverRatings.average() else 0.0
-                    UserSummary(user, userMovings, totalCost, passengerAvg, userVehicles, driverAvg)
-                }
-            }.collect { _userSummaries.value = it }
+            val ratingMap = ratings.associateBy { it.movingId }
+            val routeMap = routes.associateBy { it.id }
+            val movingsByUser = movings.groupBy { it.userId }
+            val movingsByDriver = movings.groupBy { it.driverId }
+            val vehiclesByUser = vehicles.groupBy { it.userId }
+
+            _userSummaries.value = users.map { user ->
+                val userMovings = movingsByUser[user.id]?.filter { it.status == "completed" } ?: emptyList()
+                userMovings.forEach { it.routeName = routeMap[it.routeId]?.name ?: "" }
+                val totalCost = userMovings.sumOf { it.cost }
+                val passengerRatings = userMovings.mapNotNull { ratingMap[it.id]?.rating }
+                val passengerAvg = if (passengerRatings.isNotEmpty()) passengerRatings.average() else 0.0
+                val userVehicles = vehiclesByUser[user.id] ?: emptyList()
+                val driverMovings = movingsByDriver[user.id]?.filter { it.status == "completed" } ?: emptyList()
+                val driverRatings = driverMovings.mapNotNull { ratingMap[it.id]?.rating }
+                val driverAvg = if (driverRatings.isNotEmpty()) driverRatings.average() else 0.0
+                UserSummary(user, userMovings, totalCost, passengerAvg, userVehicles, driverAvg)
+            }
         }
     }
 }

--- a/app/src/main/res/values-el/strings.xml
+++ b/app/src/main/res/values-el/strings.xml
@@ -122,6 +122,7 @@
     <string name="total_cost_label">Συνολικό κόστος: %1$.2f€</string>
     <string name="vehicles_label">Οχήματα</string>
     <string name="passenger_avg_rating_label">Ικανοποίηση επιβατών: %1$.1f/5</string>
+    <string name="no_completed_movings">Δεν υπάρχουν ολοκληρωμένες μετακινήσεις</string>
     <string name="advance_date">Μεταφορά ημερομηνίας</string>
     <string name="declare_route">Δήλωση διαδρομής</string>
     <string name="announce_transport">Δήλωση μεταφοράς</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -120,6 +120,7 @@
     <string name="total_cost_label">Total cost: %1$.2f€</string>
     <string name="vehicles_label">Vehicles</string>
     <string name="passenger_avg_rating_label">Passenger satisfaction: %1$.1f/5</string>
+    <string name="no_completed_movings">No completed movings</string>
     <string name="advance_date">Advance Date</string>
     <string name="declare_route">Declare Route</string>
     <string name="announce_transport">Announce Transport</string>


### PR DESCRIPTION
## Summary
- show empty message when user has no completed movings and always display cost and rating
- add missing string resources for "no completed movings" in English and Greek
- add migration to expose "view users" option in admin menu
- load user statistics once from the database so users appear in the list

## Testing
- `./gradlew test` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_68aaac94cdd083289935a899ea2e8d50