### PR TITLE
Add save button for transport ratings

### DIFF
--- a/app/src/main/java/com/ioannapergamali/mysmartroute/view/ui/screens/RankTransportsScreen.kt
+++ b/app/src/main/java/com/ioannapergamali/mysmartroute/view/ui/screens/RankTransportsScreen.kt
@@ -12,6 +12,7 @@ import androidx.compose.material3.Divider
 import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.Icon
 import androidx.compose.material3.IconButton
+import androidx.compose.material3.Button
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.OutlinedTextField
 import androidx.compose.material3.Scaffold
@@ -27,6 +28,7 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.unit.dp
+import androidx.compose.ui.Alignment
 import androidx.lifecycle.viewmodel.compose.viewModel
 import androidx.navigation.NavController
 import com.ioannapergamali.mysmartroute.R
@@ -104,7 +106,6 @@ private fun TripRatingItem(
             (1..5).forEach { index ->
                 IconButton(onClick = {
                     rating = index
-                    onSave(rating, comment)
                 }) {
                     Icon(
                         imageVector = if (index <= rating) Icons.Filled.Star else Icons.Outlined.Star,
@@ -119,10 +120,15 @@ private fun TripRatingItem(
             value = comment,
             onValueChange = {
                 comment = it
-                onSave(rating, comment)
             },
             label = { Text(stringResource(R.string.comment_label)) },
             modifier = Modifier.fillMaxWidth()
         )
+        Button(
+            onClick = { onSave(rating, comment) },
+            modifier = Modifier.align(Alignment.End)
+        ) {
+            Text(stringResource(R.string.save))
+        }
     }
 }

--- a/app/src/main/res/values-el/strings.xml
+++ b/app/src/main/res/values-el/strings.xml
@@ -236,6 +236,7 @@
     <string name="no_transports_found">Δεν βρέθηκαν μεταφορές</string>
     <string name="rating_label">Βαθμολογία: %1$d</string>
     <string name="comment_label">Σχόλιο</string>
+    <string name="save">Καταχώρηση</string>
     <string name="no_completed_transports">Δεν υπάρχουν ολοκληρωμένες μεταφορές</string>
     <string name="find_now">Εύρεση τώρα</string>
     <string name="save_request">Αποθήκευση αιτήματος</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -264,6 +264,7 @@
     <string name="no_transports_found">No transports found</string>
     <string name="rating_label">Rating: %1$d/5</string>
     <string name="comment_label">Comment</string>
+    <string name="save">Save</string>
     <string name="no_completed_transports">No completed transports</string>
     <string name="view_details">View details</string>
     <string name="reservation_details">Reservation details</string>


### PR DESCRIPTION
## Summary
- add explicit Save button when rating trips
- include "save" string resource and Greek translation

## Testing
- `./gradlew test --no-daemon` *(fails: Resolve dependencies stuck, process terminated)*

------
https://chatgpt.com/codex/tasks/task_e_68aace9ef38883289b8d8d8576eec498