### PR TITLE
Avoid writing blank photoUrl to Firestore

### DIFF
--- a/app/src/main/java/com/ioannapergamali/mysmartroute/utils/FirestoreMappers.kt
+++ b/app/src/main/java/com/ioannapergamali/mysmartroute/utils/FirestoreMappers.kt
@@ -24,24 +24,26 @@ import com.ioannapergamali.mysmartroute.model.enumerations.RequestStatus
 
 /** Βοηθητικά extensions για μετατροπή οντοτήτων σε δομές κατάλληλες για το Firestore. */
 /** Μετατροπή ενός [UserEntity] σε Map. */
-fun UserEntity.toFirestoreMap(): Map<String, Any> = mapOf(
-    "id" to FirebaseFirestore.getInstance()
-        .collection("Authedication")
-        .document(id),
-    "name" to name,
-    "surname" to surname,
-    "username" to username,
-    "email" to email,
-    "phoneNum" to phoneNum,
-    "photoUrl" to (photoUrl ?: ""),
-    "password" to password,
-    "role" to role,
-    "roleId" to roleId,
-    "city" to city,
-    "streetName" to streetName,
-    "streetNum" to streetNum,
-    "postalCode" to postalCode
-)
+fun UserEntity.toFirestoreMap(): Map<String, Any> = buildMap {
+    put(
+        "id", FirebaseFirestore.getInstance()
+            .collection("Authedication")
+            .document(id)
+    )
+    put("name", name)
+    put("surname", surname)
+    put("username", username)
+    put("email", email)
+    put("phoneNum", phoneNum)
+    photoUrl?.takeIf { it.isNotBlank() }?.let { put("photoUrl", it) }
+    put("password", password)
+    put("role", role)
+    put("roleId", roleId)
+    put("city", city)
+    put("streetName", streetName)
+    put("streetNum", streetNum)
+    put("postalCode", postalCode)
+}
 
 /** Μετατροπή [VehicleEntity] σε Map. */
 fun VehicleEntity.toFirestoreMap(): Map<String, Any> = mapOf(


### PR DESCRIPTION
## Summary
- Skip storing an empty `photoUrl` when converting `UserEntity` to Firestore data

## Testing
- `./gradlew test` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b019eb3b908328b0fc939cf93af7d4