### PR TITLE
Προσθήκη logs για αποθήκευση photoUrl

### DIFF
--- a/app/src/main/java/com/ioannapergamali/mysmartroute/utils/FirestoreMappers.kt
+++ b/app/src/main/java/com/ioannapergamali/mysmartroute/utils/FirestoreMappers.kt
@@ -1,4 +1,6 @@
 package com.ioannapergamali.mysmartroute.utils
+
+import android.util.Log
 import com.google.firebase.firestore.DocumentSnapshot
 import com.google.firebase.firestore.FirebaseFirestore
 import com.ioannapergamali.mysmartroute.data.local.SettingsEntity
@@ -25,6 +27,7 @@ import com.ioannapergamali.mysmartroute.model.enumerations.RequestStatus
 /** Βοηθητικά extensions για μετατροπή οντοτήτων σε δομές κατάλληλες για το Firestore. */
 /** Μετατροπή ενός [UserEntity] σε Map. */
 fun UserEntity.toFirestoreMap(): Map<String, Any> = buildMap {
+    Log.d("FirestoreMappers", "Αποθήκευση χρήστη $id με photoUrl=$photoUrl")
     put(
         "id", FirebaseFirestore.getInstance()
             .collection("Authedication")
@@ -35,7 +38,12 @@ fun UserEntity.toFirestoreMap(): Map<String, Any> = buildMap {
     put("username", username)
     put("email", email)
     put("phoneNum", phoneNum)
-    photoUrl?.takeIf { it.isNotBlank() }?.let { put("photoUrl", it) }
+    if (!photoUrl.isNullOrBlank()) {
+        put("photoUrl", photoUrl!!)
+        Log.d("FirestoreMappers", "photoUrl προστέθηκε: $photoUrl")
+    } else {
+        Log.d("FirestoreMappers", "photoUrl κενό - δεν προστέθηκε")
+    }
     put("password", password)
     put("role", role)
     put("roleId", roleId)
@@ -123,6 +131,8 @@ fun DocumentSnapshot.toUserEntity(): UserEntity? {
         is String -> rawId
         else -> getString("id")
     } ?: return null
+    val photo = getString("photoUrl")
+    Log.d("FirestoreMappers", "Φόρτωση χρήστη $id με photoUrl=$photo")
     return UserEntity(
         id = id,
         name = getString("name") ?: "",
@@ -130,7 +140,7 @@ fun DocumentSnapshot.toUserEntity(): UserEntity? {
         username = getString("username") ?: "",
         email = getString("email") ?: "",
         phoneNum = getString("phoneNum") ?: "",
-        photoUrl = getString("photoUrl"),
+        photoUrl = photo,
         password = getString("password") ?: "",
         role = getString("role") ?: "",
         roleId = when (val rawRole = get("roleId")) {

--- a/app/src/main/java/com/ioannapergamali/mysmartroute/view/ui/screens/ProfileScreen.kt
+++ b/app/src/main/java/com/ioannapergamali/mysmartroute/view/ui/screens/ProfileScreen.kt
@@ -59,6 +59,12 @@ fun ProfileScreen(navController: NavController, openDrawer: () -> Unit) {
                 docRef.set(mapOf("photoUrl" to url), SetOptions.merge())
                     .addOnSuccessListener {
                         Log.d("ProfileScreen", "photoUrl αποθηκεύτηκε επιτυχώς")
+                        docRef.get().addOnSuccessListener { refreshed ->
+                            Log.d(
+                                "ProfileScreen",
+                                "photoUrl μετά την αποθήκευση: ${refreshed.getString("photoUrl")}"
+                            )
+                        }
                     }
                     .addOnFailureListener { e ->
                         Log.e("ProfileScreen", "Αποτυχία αποθήκευσης photoUrl", e)


### PR DESCRIPTION
## Περίληψη
- Προστέθηκαν αναλυτικά logs στο `FirestoreMappers` για να φαίνεται αν και πότε αποθηκεύεται/φορτώνεται το `photoUrl`.
- Ενισχύθηκαν τα logs στο `ProfileScreen` ώστε να διαβάζεται άμεσα το `photoUrl` μετά την αποθήκευση.

## Δοκιμές
- `./gradlew test` *(αποτυχία: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b01bdb01c483289c1a5c15a4b2392a