### PR TITLE
Προσθήκη υπολογισμού χρόνου περπατήματος

### DIFF
--- a/app/src/main/java/com/ioannapergamali/mysmartroute/utils/WalkingUtils.kt
+++ b/app/src/main/java/com/ioannapergamali/mysmartroute/utils/WalkingUtils.kt
@@ -1,0 +1,24 @@
+package com.ioannapergamali.mysmartroute.utils
+
+import kotlin.time.Duration
+import kotlin.time.DurationUnit
+import kotlin.time.toDuration
+
+/**
+ * Χρηστικές συναρτήσεις για τον υπολογισμό χρόνου περπατήματος.
+ */
+object WalkingUtils {
+    private const val DEFAULT_WALKING_SPEED_MPS = 1.4
+
+    /**
+     * Επιστρέφει την εκτιμώμενη διάρκεια περπατήματος για την απόσταση [distanceMeters].
+     */
+    fun walkingDuration(
+        distanceMeters: Double,
+        speedMps: Double = DEFAULT_WALKING_SPEED_MPS
+    ): Duration {
+        val seconds = distanceMeters / speedMps
+        return seconds.toDuration(DurationUnit.SECONDS)
+    }
+}
+

--- a/app/src/test/java/com/ioannapergamali/mysmartroute/utils/WalkingUtilsTest.kt
+++ b/app/src/test/java/com/ioannapergamali/mysmartroute/utils/WalkingUtilsTest.kt
@@ -1,0 +1,13 @@
+package com.ioannapergamali.mysmartroute.utils
+
+import kotlin.test.Test
+import kotlin.test.assertEquals
+
+class WalkingUtilsTest {
+    @Test
+    fun walkingDuration_returnsSeconds() {
+        val duration = WalkingUtils.walkingDuration(2800.0)
+        assertEquals(2000, duration.inWholeSeconds)
+    }
+}
+


### PR DESCRIPTION
## Περίληψη
- Δημιουργία βοηθητικού `WalkingUtils` για εκτίμηση χρόνου περπατήματος με χρήση `kotlin.time`.
- Προσθήκη unit test που επιβεβαιώνει τη διάρκεια για 2.8 km.

## Δοκιμές
- `./gradlew test` *(απέτυχε λόγω περιορισμών περιβάλλοντος: Starting a Gradle Daemon, 1 busy Daemon could not be reused, use --status for details)*


------
https://chatgpt.com/codex/tasks/task_e_68b02db38e688328ad1f0518e00f1f28