### PR TITLE
Απλοποίηση ανέβασματος φωτογραφίας προφίλ

### DIFF
--- a/app/src/main/java/com/ioannapergamali/mysmartroute/view/ui/screens/ProfileScreen.kt
+++ b/app/src/main/java/com/ioannapergamali/mysmartroute/view/ui/screens/ProfileScreen.kt
@@ -1,5 +1,8 @@
 package com.ioannapergamali.mysmartroute.view.ui.screens
 
+import android.util.Log
+import androidx.activity.compose.rememberLauncherForActivityResult
+import androidx.activity.result.contract.ActivityResultContracts
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
@@ -14,90 +17,47 @@ import androidx.compose.runtime.remember
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
+import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.unit.dp
 import androidx.navigation.NavController
-import android.util.Log
-import com.ioannapergamali.mysmartroute.view.ui.components.ScreenContainer
-import com.ioannapergamali.mysmartroute.view.ui.components.TopBar
-import androidx.compose.ui.res.stringResource
-import com.ioannapergamali.mysmartroute.R
+import coil.compose.AsyncImage
 import com.google.firebase.auth.FirebaseAuth
 import com.google.firebase.firestore.FirebaseFirestore
-
-
 import com.google.firebase.storage.FirebaseStorage
-import androidx.activity.compose.rememberLauncherForActivityResult
-import androidx.activity.result.contract.ActivityResultContracts
-import coil.compose.AsyncImage
+import com.ioannapergamali.mysmartroute.R
+import com.ioannapergamali.mysmartroute.view.ui.components.ScreenContainer
+import com.ioannapergamali.mysmartroute.view.ui.components.TopBar
 
+/**
+ * Εμφανίζει τα στοιχεία του χρήστη και επιτρέπει την αλλαγή της φωτογραφίας προφίλ.
+ * Η φωτογραφία ανεβαίνει στο Firebase Storage και το URL αποθηκεύεται στο Firestore.
+ */
 @Composable
 fun ProfileScreen(navController: NavController, openDrawer: () -> Unit) {
     val user = FirebaseAuth.getInstance().currentUser
     val username = remember { mutableStateOf<String?>(null) }
     val photoUrl = remember { mutableStateOf<String?>(null) }
 
-    val imagePicker = rememberLauncherForActivityResult(
-        contract = ActivityResultContracts.GetContent()
-    ) { uri ->
-        val uid = user?.uid
-        Log.d("ProfileScreen", "Ελήφθη uri=$uri για uid=$uid")
-        if (uid == null || uri == null) {
-            Log.w("ProfileScreen", "uid ή uri κενό - διακοπή διαδικασίας")
-            return@rememberLauncherForActivityResult
-        }
-        val ref = FirebaseStorage.getInstance()
-            .reference.child("profile_photos/$uid.jpg")
-        Log.d("ProfileScreen", "Ξεκινάει ανέβασμα εικόνας για $uid")
-        ref.putFile(uri)
+    val imagePicker = rememberLauncherForActivityResult(ActivityResultContracts.GetContent()) { uri ->
+        val uid = user?.uid ?: return@rememberLauncherForActivityResult
+        uri ?: return@rememberLauncherForActivityResult
+
+        val storageRef = FirebaseStorage.getInstance().reference
+            .child("profileImages/$uid.jpg")
+
+        storageRef.putFile(uri)
             .addOnSuccessListener {
-                Log.d("ProfileScreen", "Το ανέβασμα ολοκληρώθηκε, ανακτώ URL")
-                ref.downloadUrl
+                storageRef.downloadUrl.addOnSuccessListener { downloadUri ->
+                    val url = downloadUri.toString()
+                    photoUrl.value = url
 
-                    .addOnSuccessListener { downloadUri ->
-                        val url = downloadUri.toString()
-                        photoUrl.value = url
-                        Log.d("ProfileScreen", "Λήφθηκε URL: $url")
-                        val docRef = FirebaseFirestore.getInstance()
-                            .collection("users")
-                            .document(uid)
-                        Log.d("ProfileScreen", "Αποθήκευση photoUrl στο Firestore για $uid")
-                        docRef.update("photoUrl", url)
-                            .addOnSuccessListener {
-                                Log.d("ProfileScreen", "photoUrl αποθηκεύτηκε επιτυχώς")
-                                docRef.get().addOnSuccessListener { refreshed ->
-                                    Log.d(
-                                        "ProfileScreen",
-                                        "photoUrl μετά την αποθήκευση: ${refreshed.getString("photoUrl")}"
-                                    )
-                                }
-                            }
-                            .addOnFailureListener { e ->
-                                Log.e("ProfileScreen", "Αποτυχία αποθήκευσης photoUrl", e)
-                            }
+                    val docRef = FirebaseFirestore.getInstance()
+                        .collection("users")
+                        .document(uid)
 
-            }.addOnSuccessListener { downloadUri ->
-                val url = downloadUri.toString()
-                photoUrl.value = url
-                val docRef = FirebaseFirestore.getInstance()
-                    .collection("users")
-                    .document(uid)
-
-                Log.d("ProfileScreen", "photoUrl προς αποθήκευση: $url")
-
-                docRef.set(mapOf("photoUrl" to url), SetOptions.merge())
-                    .addOnSuccessListener {
-                        Log.d("ProfileScreen", "photoUrl αποθηκεύτηκε επιτυχώς")
-                        docRef.get().addOnSuccessListener { refreshed ->
-                            Log.d(
-                                "ProfileScreen",
-                                "photoUrl μετά την αποθήκευση: ${refreshed.getString("photoUrl")}"
-                            )
-                        }
-
-                    }
-                    .addOnFailureListener { e ->
-                        Log.e("ProfileScreen", "Αποτυχία λήψης URL", e)
-                    }
+                    docRef.update("photoUrl", url)
+                        .addOnFailureListener { docRef.set(mapOf("photoUrl" to url)) }
+                }
             }
             .addOnFailureListener { e ->
                 Log.e("ProfileScreen", "Αποτυχία ανεβάσματος εικόνας", e)
@@ -105,15 +65,13 @@ fun ProfileScreen(navController: NavController, openDrawer: () -> Unit) {
     }
 
     LaunchedEffect(user) {
-        val uid = user?.uid
-        if (uid != null) {
+        user?.uid?.let { uid ->
             FirebaseFirestore.getInstance().collection("users")
                 .document(uid)
                 .get()
                 .addOnSuccessListener { doc ->
                     username.value = doc.getString("username")
                     photoUrl.value = doc.getString("photoUrl")
-                    Log.d("ProfileScreen", "photoUrl από τη βάση: ${photoUrl.value}")
                 }
                 .addOnFailureListener { e ->
                     Log.e("ProfileScreen", "Αποτυχία φόρτωσης photoUrl", e)
@@ -145,12 +103,15 @@ fun ProfileScreen(navController: NavController, openDrawer: () -> Unit) {
                             .clip(CircleShape)
                     )
                 }
+
                 Button(onClick = { imagePicker.launch("image/*") }) {
                     Text(text = stringResource(id = R.string.upload_photo))
                 }
+
                 Text(text = "Email: ${user?.email ?: ""}")
                 username.value?.let { Text(text = "Username: $it") }
             }
         }
     }
 }
+


### PR DESCRIPTION
## Περίληψη
- Απλοποίηση της `ProfileScreen` ώστε η φωτογραφία προφίλ να ανεβαίνει στο Firebase Storage και να αποθηκεύεται το URL στο Firestore.
- Φόρτωση της αποθηκευμένης φωτογραφίας και των στοιχείων χρήστη με το άνοιγμα της οθόνης.

## Έλεγχοι
- `./gradlew test` *(αποτυχία: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b02ff749b08328939569f333ef50ca