### PR TITLE
Προσθήκη οθόνης ορισμού χρόνου περπατήματος στο μενού διαχειριστή

### DIFF
--- a/app/src/main/java/com/ioannapergamali/mysmartroute/model/navigation/NavigationHost.kt
+++ b/app/src/main/java/com/ioannapergamali/mysmartroute/model/navigation/NavigationHost.kt
@@ -15,6 +15,7 @@ import com.ioannapergamali.mysmartroute.view.ui.screens.DeclareRouteScreen
 import com.ioannapergamali.mysmartroute.view.ui.screens.DirectionsMapScreen
 import com.ioannapergamali.mysmartroute.view.ui.screens.PoIListScreen
 import com.ioannapergamali.mysmartroute.view.ui.screens.DefinePoiScreen
+import com.ioannapergamali.mysmartroute.view.ui.screens.DefineDurationScreen
 import com.ioannapergamali.mysmartroute.view.ui.screens.SettingsScreen
 import com.ioannapergamali.mysmartroute.view.ui.screens.AboutScreen
 import com.ioannapergamali.mysmartroute.view.ui.screens.SupportScreen
@@ -140,6 +141,10 @@ fun NavigationHost(
                 routeId = routeIdArg
             )
         }
+        composable("defineDuration") {
+            DefineDurationScreen(navController = navController, openDrawer = openDrawer)
+        }
+
 
 
 

--- a/app/src/main/java/com/ioannapergamali/mysmartroute/utils/WalkingUtils.kt
+++ b/app/src/main/java/com/ioannapergamali/mysmartroute/utils/WalkingUtils.kt
@@ -1,0 +1,24 @@
+package com.ioannapergamali.mysmartroute.utils
+
+import kotlin.time.Duration
+import kotlin.time.DurationUnit
+import kotlin.time.toDuration
+
+/**
+ * Χρηστικές συναρτήσεις για τον υπολογισμό χρόνου περπατήματος.
+ */
+object WalkingUtils {
+    private const val DEFAULT_WALKING_SPEED_MPS = 1.4
+
+    /**
+     * Επιστρέφει την εκτιμώμενη διάρκεια περπατήματος για την απόσταση [distanceMeters].
+     */
+    fun walkingDuration(
+        distanceMeters: Double,
+        speedMps: Double = DEFAULT_WALKING_SPEED_MPS
+    ): Duration {
+        val seconds = distanceMeters / speedMps
+        return seconds.toDuration(DurationUnit.SECONDS)
+    }
+}
+

--- a/app/src/main/java/com/ioannapergamali/mysmartroute/view/ui/screens/DefineDurationScreen.kt
+++ b/app/src/main/java/com/ioannapergamali/mysmartroute/view/ui/screens/DefineDurationScreen.kt
@@ -1,0 +1,60 @@
+package com.ioannapergamali.mysmartroute.view.ui.screens
+
+import androidx.compose.foundation.layout.*
+import androidx.compose.material3.*
+import androidx.compose.runtime.*
+import androidx.compose.runtime.saveable.rememberSaveable
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.text.input.KeyboardOptions
+import androidx.compose.ui.text.input.KeyboardType
+import androidx.compose.ui.unit.dp
+import androidx.navigation.NavController
+import com.ioannapergamali.mysmartroute.R
+import com.ioannapergamali.mysmartroute.utils.WalkingUtils
+import com.ioannapergamali.mysmartroute.view.ui.components.ScreenContainer
+import com.ioannapergamali.mysmartroute.view.ui.components.TopBar
+import kotlin.time.Duration
+
+@Composable
+fun DefineDurationScreen(navController: NavController, openDrawer: () -> Unit) {
+    var distanceText by rememberSaveable { mutableStateOf("") }
+    var duration: Duration? by remember { mutableStateOf(null) }
+
+    Scaffold(
+        topBar = {
+            TopBar(
+                title = stringResource(R.string.define_duration),
+                navController = navController,
+                showMenu = true,
+                onMenuClick = openDrawer
+            )
+        }
+    ) { padding ->
+        ScreenContainer(modifier = Modifier.padding(padding)) {
+            OutlinedTextField(
+                value = distanceText,
+                onValueChange = { distanceText = it },
+                label = { Text(stringResource(R.string.distance_meters)) },
+                keyboardOptions = KeyboardOptions(keyboardType = KeyboardType.Number),
+                modifier = Modifier.fillMaxWidth()
+            )
+
+            Spacer(Modifier.height(16.dp))
+
+            Button(onClick = {
+                distanceText.toDoubleOrNull()?.let {
+                    duration = WalkingUtils.walkingDuration(it)
+                }
+            }) {
+                Text(stringResource(R.string.calculate))
+            }
+
+            duration?.let {
+                Spacer(Modifier.height(16.dp))
+                Text(stringResource(R.string.walking_duration_result, it.toString()))
+            }
+        }
+    }
+}
+

--- a/app/src/main/res/values-el/strings.xml
+++ b/app/src/main/res/values-el/strings.xml
@@ -248,4 +248,8 @@
     <string name="walking_routes">Διαδρομές πεζών</string>
     <string name="no_walking_routes">Δεν βρέθηκαν διαδρομές πεζών</string>
 
+    <string name="distance_meters">Απόσταση (μ)</string>
+    <string name="calculate">Υπολογισμός</string>
+    <string name="walking_duration_result">Διάρκεια: %1$s</string>
+
 </resources>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -245,6 +245,10 @@
     <string name="walking_routes">Walking routes</string>
     <string name="no_walking_routes">No walking routes</string>
 
+    <string name="distance_meters">Distance (m)</string>
+    <string name="calculate">Calculate</string>
+    <string name="walking_duration_result">Duration: %1$s</string>
+
     <!-- Notification text -->
     <string name="app_started_notification">App started successfully</string>
     <string name="driver_offer_notification">Ο οδηγός %1$s προσφέρθηκε να σας μεταφέρει. Αίτημα αριθμός %2$d</string>

--- a/app/src/test/java/com/ioannapergamali/mysmartroute/utils/WalkingUtilsTest.kt
+++ b/app/src/test/java/com/ioannapergamali/mysmartroute/utils/WalkingUtilsTest.kt
@@ -1,0 +1,13 @@
+package com.ioannapergamali.mysmartroute.utils
+
+import kotlin.test.Test
+import kotlin.test.assertEquals
+
+class WalkingUtilsTest {
+    @Test
+    fun walkingDuration_returnsSeconds() {
+        val duration = WalkingUtils.walkingDuration(2800.0)
+        assertEquals(2000, duration.inWholeSeconds)
+    }
+}
+


### PR DESCRIPTION
## Περίληψη
- Δημιουργία οθόνης `DefineDurationScreen` για υπολογισμό διάρκειας περπατήματος.
- Σύνδεση της νέας οθόνης στο `NavigationHost` ώστε να είναι διαθέσιμη από το μενού διαχειριστή.
- Προσθήκη μεταφράσεων στα αρχεία `strings`.

## Δοκιμές
- `./gradlew test` *(απέτυχε: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b02db38e688328ad1f0518e00f1f28