### PR TITLE
feat: add walking route save

### DIFF
--- a/app/src/main/java/com/ioannapergamali/mysmartroute/view/ui/screens/WalkingScreen.kt
+++ b/app/src/main/java/com/ioannapergamali/mysmartroute/view/ui/screens/WalkingScreen.kt
@@ -40,6 +40,7 @@ import com.ioannapergamali.mysmartroute.view.ui.components.ScreenContainer
 import com.ioannapergamali.mysmartroute.view.ui.components.TopBar
 import com.ioannapergamali.mysmartroute.viewmodel.RouteViewModel
 import com.ioannapergamali.mysmartroute.viewmodel.PoIViewModel
+import com.ioannapergamali.mysmartroute.viewmodel.VehicleRequestViewModel
 import com.ioannapergamali.mysmartroute.model.enumerations.VehicleType
 import com.ioannapergamali.mysmartroute.utils.MapsUtils
 import android.app.TimePickerDialog
@@ -50,6 +51,7 @@ fun WalkingScreen(navController: NavController, openDrawer: () -> Unit) {
     val context = LocalContext.current
     val routeViewModel: RouteViewModel = viewModel()
     val poiViewModel: PoIViewModel = viewModel()
+    val vehicleRequestViewModel: VehicleRequestViewModel = viewModel()
     val routes by routeViewModel.routes.collectAsState()
     val allPois by poiViewModel.pois.collectAsState()
 
@@ -369,5 +371,27 @@ fun WalkingScreen(navController: NavController, openDrawer: () -> Unit) {
             )
 
             Spacer(Modifier.height(16.dp))
+
+            Button(
+                onClick = {
+                    val rId = selectedRouteId ?: return@Button
+                    val start = startIndex?.let { routePois[it].id } ?: return@Button
+                    val end = endIndex?.let { routePois[it].id } ?: return@Button
+                    val timestamp = System.currentTimeMillis()
+                    vehicleRequestViewModel.saveWalkingRoute(
+                        context,
+                        rId,
+                        start,
+                        end,
+                        timestamp
+                    )
+                },
+                enabled = selectedRouteId != null && startIndex != null && endIndex != null
+            ) {
+                Text(stringResource(R.string.save))
+            }
+
+            Spacer(Modifier.height(16.dp))
         }
-    } }
+    }
+}

--- a/app/src/main/java/com/ioannapergamali/mysmartroute/viewmodel/VehicleRequestViewModel.kt
+++ b/app/src/main/java/com/ioannapergamali/mysmartroute/viewmodel/VehicleRequestViewModel.kt
@@ -152,6 +152,37 @@ class VehicleRequestViewModel : ViewModel() {
         }
     }
 
+    fun saveWalkingRoute(
+        context: Context,
+        routeId: String,
+        fromPoiId: String,
+        toPoiId: String,
+        dateTime: Long
+    ) {
+        viewModelScope.launch {
+            val userId = FirebaseAuth.getInstance().currentUser?.uid ?: return@launch
+            val id = UUID.randomUUID().toString()
+            val data = mapOf(
+                "routeId" to routeId,
+                "fromPoiId" to fromPoiId,
+                "toPoiId" to toPoiId,
+                "date" to dateTime
+            )
+            try {
+                db.collection("users")
+                    .document(userId)
+                    .collection("walking")
+                    .document(id)
+                    .set(data)
+                    .await()
+                Toast.makeText(context, R.string.route_saved, Toast.LENGTH_SHORT).show()
+            } catch (e: Exception) {
+                Log.e(TAG, "Failed to save walking route", e)
+                Toast.makeText(context, R.string.route_save_failed, Toast.LENGTH_SHORT).show()
+            }
+        }
+    }
+
     fun markNotificationsRead(allUsers: Boolean) {
         val userId = FirebaseAuth.getInstance().currentUser?.uid
         val notifications = if (allUsers) {


### PR DESCRIPTION
## Summary
- add save button in walking screen to store routes
- persist walking routes under user subcollection in Firestore

## Testing
- `./gradlew test` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b0364629548328a052c04e767a1342