### PR TITLE
Χρήση time picker στο πεδίο ώρας της οθόνης Περπάτημα

### DIFF
--- a/app/src/main/java/com/ioannapergamali/mysmartroute/view/ui/screens/WalkingScreen.kt
+++ b/app/src/main/java/com/ioannapergamali/mysmartroute/view/ui/screens/WalkingScreen.kt
@@ -2,6 +2,7 @@
 package com.ioannapergamali.mysmartroute.view.ui.screens
 
 import androidx.compose.foundation.layout.*
+import androidx.compose.foundation.clickable
 import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.*
 import androidx.compose.material.icons.Icons
@@ -365,7 +366,9 @@ fun WalkingScreen(navController: NavController, openDrawer: () -> Unit) {
                         Icon(Icons.Default.AccessTime, contentDescription = stringResource(R.string.time))
                     }
                 },
-                modifier = Modifier.fillMaxWidth()
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .clickable { showTimePicker = true }
             )
 
             Spacer(Modifier.height(16.dp))


### PR DESCRIPTION
## Σύνοψη
- Επιτρέπει την επιλογή ώρας πατώντας στο πεδίο ώρας στην οθόνη Περπάτημα

## Δοκιμές
- `./gradlew test` *(απέτυχε: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b0355b68fc83288d9f1c174cb7dfa1