### PR TITLE
feat: add walking route save

### DIFF
--- a/app/src/main/java/com/ioannapergamali/mysmartroute/view/ui/screens/WalkingScreen.kt
+++ b/app/src/main/java/com/ioannapergamali/mysmartroute/view/ui/screens/WalkingScreen.kt
@@ -8,6 +8,7 @@ import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.AccessTime
 import androidx.compose.material.icons.filled.Delete
 import androidx.compose.material.icons.filled.Refresh
+import androidx.compose.material.icons.filled.Save
 import androidx.compose.material3.menuAnchor
 import androidx.compose.runtime.*
 import androidx.compose.runtime.saveable.rememberSaveable
@@ -40,6 +41,7 @@ import com.ioannapergamali.mysmartroute.view.ui.components.ScreenContainer
 import com.ioannapergamali.mysmartroute.view.ui.components.TopBar
 import com.ioannapergamali.mysmartroute.viewmodel.RouteViewModel
 import com.ioannapergamali.mysmartroute.viewmodel.PoIViewModel
+import com.ioannapergamali.mysmartroute.viewmodel.VehicleRequestViewModel
 import com.ioannapergamali.mysmartroute.model.enumerations.VehicleType
 import com.ioannapergamali.mysmartroute.utils.MapsUtils
 import android.app.TimePickerDialog
@@ -50,6 +52,7 @@ fun WalkingScreen(navController: NavController, openDrawer: () -> Unit) {
     val context = LocalContext.current
     val routeViewModel: RouteViewModel = viewModel()
     val poiViewModel: PoIViewModel = viewModel()
+    val vehicleRequestViewModel: VehicleRequestViewModel = viewModel()
     val routes by routeViewModel.routes.collectAsState()
     val allPois by poiViewModel.pois.collectAsState()
 
@@ -187,6 +190,27 @@ fun WalkingScreen(navController: NavController, openDrawer: () -> Unit) {
                 showMenu = true,
                 onMenuClick = openDrawer
             )
+        },
+        floatingActionButton = {
+            if (selectedRouteId != null && startIndex != null && endIndex != null) {
+                ExtendedFloatingActionButton(
+                    onClick = {
+                        val rId = selectedRouteId ?: return@ExtendedFloatingActionButton
+                        val start = startIndex?.let { routePois[it].id } ?: return@ExtendedFloatingActionButton
+                        val end = endIndex?.let { routePois[it].id } ?: return@ExtendedFloatingActionButton
+                        val timestamp = System.currentTimeMillis()
+                        vehicleRequestViewModel.saveWalkingRoute(
+                            context,
+                            rId,
+                            start,
+                            end,
+                            timestamp
+                        )
+                    },
+                    icon = { Icon(Icons.Default.Save, contentDescription = null) },
+                    text = { Text(stringResource(R.string.save)) }
+                )
+            }
         }
     ) { padding ->
         ScreenContainer(modifier = Modifier.padding(padding)) {
@@ -370,4 +394,5 @@ fun WalkingScreen(navController: NavController, openDrawer: () -> Unit) {
 
             Spacer(Modifier.height(16.dp))
         }
-    } }
+    }
+}

--- a/app/src/main/java/com/ioannapergamali/mysmartroute/viewmodel/VehicleRequestViewModel.kt
+++ b/app/src/main/java/com/ioannapergamali/mysmartroute/viewmodel/VehicleRequestViewModel.kt
@@ -152,6 +152,37 @@ class VehicleRequestViewModel : ViewModel() {
         }
     }
 
+    fun saveWalkingRoute(
+        context: Context,
+        routeId: String,
+        fromPoiId: String,
+        toPoiId: String,
+        dateTime: Long
+    ) {
+        viewModelScope.launch {
+            val userId = FirebaseAuth.getInstance().currentUser?.uid ?: return@launch
+            val id = UUID.randomUUID().toString()
+            val data = mapOf(
+                "routeId" to routeId,
+                "fromPoiId" to fromPoiId,
+                "toPoiId" to toPoiId,
+                "date" to dateTime
+            )
+            try {
+                db.collection("users")
+                    .document(userId)
+                    .collection("walking")
+                    .document(id)
+                    .set(data)
+                    .await()
+                Toast.makeText(context, R.string.route_saved, Toast.LENGTH_SHORT).show()
+            } catch (e: Exception) {
+                Log.e(TAG, "Failed to save walking route", e)
+                Toast.makeText(context, R.string.route_save_failed, Toast.LENGTH_SHORT).show()
+            }
+        }
+    }
+
     fun markNotificationsRead(allUsers: Boolean) {
         val userId = FirebaseAuth.getInstance().currentUser?.uid
         val notifications = if (allUsers) {

--- a/app/src/main/res/values-el/strings.xml
+++ b/app/src/main/res/values-el/strings.xml
@@ -236,7 +236,7 @@
     <string name="no_transports_found">Δεν βρέθηκαν μεταφορές</string>
     <string name="rating_label">Βαθμολογία: %1$d</string>
     <string name="comment_label">Σχόλιο</string>
-    <string name="save">Καταχώρηση</string>
+    <string name="save">Αποθήκευση</string>
     <string name="no_completed_transports">Δεν υπάρχουν ολοκληρωμένες μεταφορές</string>
     <string name="find_now">Εύρεση τώρα</string>
     <string name="save_request">Αποθήκευση αιτήματος</string>


### PR DESCRIPTION
## Summary
- show save button in walking screen to store routes
- persist walking routes under user subcollection in Firestore
- update Greek translation for save label

## Testing
- `CI=true ./gradlew test --console=plain` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b0364629548328a052c04e767a1342