### PR TITLE
Προσθήκη κουμπιού αποθήκευσης ως FAB στην οθόνη περπατήματος

### DIFF
--- a/app/src/main/java/com/ioannapergamali/mysmartroute/view/ui/screens/WalkingScreen.kt
+++ b/app/src/main/java/com/ioannapergamali/mysmartroute/view/ui/screens/WalkingScreen.kt
@@ -193,25 +193,24 @@ fun WalkingScreen(navController: NavController, openDrawer: () -> Unit) {
             )
         },
         floatingActionButton = {
-            if (selectedRouteId != null && startIndex != null && endIndex != null) {
-                ExtendedFloatingActionButton(
-                    onClick = {
-                        val rId = selectedRouteId ?: return@ExtendedFloatingActionButton
-                        val start = startIndex?.let { routePois[it].id } ?: return@ExtendedFloatingActionButton
-                        val end = endIndex?.let { routePois[it].id } ?: return@ExtendedFloatingActionButton
-                        val timestamp = System.currentTimeMillis()
-                        vehicleRequestViewModel.saveWalkingRoute(
-                            context,
-                            rId,
-                            start,
-                            end,
-                            timestamp
-                        )
-                    },
-                    icon = { Icon(Icons.Default.Save, contentDescription = null) },
-                    text = { Text(stringResource(R.string.save)) }
-                )
-            }
+            ExtendedFloatingActionButton(
+                onClick = {
+                    val rId = selectedRouteId ?: return@ExtendedFloatingActionButton
+                    val start = startIndex?.let { routePois[it].id } ?: return@ExtendedFloatingActionButton
+                    val end = endIndex?.let { routePois[it].id } ?: return@ExtendedFloatingActionButton
+                    val timestamp = System.currentTimeMillis()
+                    vehicleRequestViewModel.saveWalkingRoute(
+                        context,
+                        rId,
+                        start,
+                        end,
+                        timestamp
+                    )
+                },
+                icon = { Icon(Icons.Default.Save, contentDescription = null) },
+                text = { Text(stringResource(R.string.save)) },
+                enabled = selectedRouteId != null && startIndex != null && endIndex != null
+            )
         }
     ) { padding ->
         ScreenContainer(modifier = Modifier.padding(padding)) {
@@ -394,29 +393,6 @@ fun WalkingScreen(navController: NavController, openDrawer: () -> Unit) {
                     .fillMaxWidth()
                     .clickable { showTimePicker = true }
             )
-
-            Spacer(Modifier.height(16.dp))
-
-            Button(
-                onClick = {
-                    val rId = selectedRouteId ?: return@Button
-                    val start = startIndex?.let { routePois[it].id } ?: return@Button
-                    val end = endIndex?.let { routePois[it].id } ?: return@Button
-                    val timestamp = System.currentTimeMillis()
-                    vehicleRequestViewModel.saveWalkingRoute(
-                        context,
-                        rId,
-                        start,
-                        end,
-                        timestamp
-                    )
-                },
-                enabled = selectedRouteId != null && startIndex != null && endIndex != null
-            ) {
-                Text(stringResource(R.string.save))
-            }
-
-            Spacer(Modifier.height(16.dp))
         }
     }
 }

--- a/app/src/main/res/values-el/strings.xml
+++ b/app/src/main/res/values-el/strings.xml
@@ -236,6 +236,7 @@
     <string name="no_transports_found">Δεν βρέθηκαν μεταφορές</string>
     <string name="rating_label">Βαθμολογία: %1$d</string>
     <string name="comment_label">Σχόλιο</string>
+    <!-- Save button -->
     <string name="save">Αποθήκευση</string>
     <string name="no_completed_transports">Δεν υπάρχουν ολοκληρωμένες μεταφορές</string>
     <string name="find_now">Εύρεση τώρα</string>


### PR DESCRIPTION
## Περίληψη
- Το κουμπί αποθήκευσης εμφανίζεται πλέον ως `ExtendedFloatingActionButton` στην οθόνη περπατήματος, ακόμη κι όταν δεν έχουν οριστεί στάση εκκίνησης και αποβίβασης, παραμένοντας απενεργοποιημένο μέχρι να συμπληρωθούν όλα τα απαιτούμενα πεδία.
- Χρησιμοποιείται η ελληνική ετικέτα "Αποθήκευση".

## Δοκιμές
- `./gradlew test` *(κόλλησε: παρέμεινε στο στάδιο CONFIGURING, πιθανώς λόγω μη διαθέσιμου Android SDK)*

------
https://chatgpt.com/codex/tasks/task_e_68b03bda8b748328b04c3ca983a7b1ee