### PR TITLE
Add walking route persistence

### DIFF
--- a/app/src/main/java/com/ioannapergamali/mysmartroute/data/local/MySmartRouteDatabase.kt
+++ b/app/src/main/java/com/ioannapergamali/mysmartroute/data/local/MySmartRouteDatabase.kt
@@ -31,6 +31,8 @@ import androidx.room.TypeConverters
 import com.ioannapergamali.mysmartroute.data.local.Converters
 import com.ioannapergamali.mysmartroute.data.local.TripRatingEntity
 import com.ioannapergamali.mysmartroute.data.local.TripRatingDao
+import com.ioannapergamali.mysmartroute.data.local.WalkingRouteEntity
+import com.ioannapergamali.mysmartroute.data.local.WalkingDao
 
 @Database(
     entities = [
@@ -52,9 +54,10 @@ import com.ioannapergamali.mysmartroute.data.local.TripRatingDao
         FavoriteEntity::class,
         TransferRequestEntity::class,
         TripRatingEntity::class,
-        NotificationEntity::class
+        NotificationEntity::class,
+        WalkingRouteEntity::class
     ],
-    version = 53
+    version = 54
 )
 @TypeConverters(Converters::class)
 abstract class MySmartRouteDatabase : RoomDatabase() {
@@ -77,6 +80,7 @@ abstract class MySmartRouteDatabase : RoomDatabase() {
     abstract fun transferRequestDao(): TransferRequestDao
     abstract fun tripRatingDao(): TripRatingDao
     abstract fun notificationDao(): NotificationDao
+    abstract fun walkingDao(): WalkingDao
 
     companion object {
         @Volatile
@@ -697,6 +701,21 @@ abstract class MySmartRouteDatabase : RoomDatabase() {
             }
         }
 
+        private val MIGRATION_53_54 = object : Migration(53, 54) {
+            override fun migrate(database: SupportSQLiteDatabase) {
+                database.execSQL(
+                    "CREATE TABLE IF NOT EXISTS `walking` (" +
+                        "`id` TEXT NOT NULL, " +
+                        "`userId` TEXT NOT NULL, " +
+                        "`routeId` TEXT NOT NULL, " +
+                        "`fromPoiId` TEXT NOT NULL, " +
+                        "`toPoiId` TEXT NOT NULL, " +
+                        "`date` INTEGER NOT NULL, " +
+                        "PRIMARY KEY(`id`))"
+                )
+            }
+        }
+
         private fun prepopulate(db: SupportSQLiteDatabase) {
             Log.d(TAG, "Prepopulating database")
             db.execSQL(
@@ -829,7 +848,8 @@ abstract class MySmartRouteDatabase : RoomDatabase() {
                     MIGRATION_49_50,
                     MIGRATION_50_51,
                     MIGRATION_51_52,
-                    MIGRATION_52_53
+                    MIGRATION_52_53,
+                    MIGRATION_53_54
                 )
                     .addCallback(object : RoomDatabase.Callback() {
                         override fun onCreate(db: SupportSQLiteDatabase) {

--- a/app/src/main/java/com/ioannapergamali/mysmartroute/data/local/WalkingDao.kt
+++ b/app/src/main/java/com/ioannapergamali/mysmartroute/data/local/WalkingDao.kt
@@ -1,0 +1,16 @@
+package com.ioannapergamali.mysmartroute.data.local
+
+import androidx.room.Dao
+import androidx.room.Insert
+import androidx.room.OnConflictStrategy
+import androidx.room.Query
+import kotlinx.coroutines.flow.Flow
+
+@Dao
+interface WalkingDao {
+    @Insert(onConflict = OnConflictStrategy.REPLACE)
+    suspend fun insert(entity: WalkingRouteEntity)
+
+    @Query("SELECT * FROM walking WHERE userId = :userId")
+    fun getRoutesForUser(userId: String): Flow<List<WalkingRouteEntity>>
+}

--- a/app/src/main/java/com/ioannapergamali/mysmartroute/data/local/WalkingRouteEntity.kt
+++ b/app/src/main/java/com/ioannapergamali/mysmartroute/data/local/WalkingRouteEntity.kt
@@ -1,0 +1,17 @@
+package com.ioannapergamali.mysmartroute.data.local
+
+import androidx.room.Entity
+import androidx.room.PrimaryKey
+
+/**
+ * Αποθηκεύει τις διαδρομές πεζή που δηλώνει ο επιβάτης
+ */
+@Entity(tableName = "walking")
+data class WalkingRouteEntity(
+    @PrimaryKey val id: String = "",
+    val userId: String = "",
+    val routeId: String = "",
+    val fromPoiId: String = "",
+    val toPoiId: String = "",
+    val date: Long = 0L
+)

--- a/app/src/main/java/com/ioannapergamali/mysmartroute/viewmodel/VehicleRequestViewModel.kt
+++ b/app/src/main/java/com/ioannapergamali/mysmartroute/viewmodel/VehicleRequestViewModel.kt
@@ -12,6 +12,7 @@ import com.google.firebase.firestore.FirebaseFirestore
 import com.ioannapergamali.mysmartroute.data.local.MovingEntity
 import com.ioannapergamali.mysmartroute.data.local.MySmartRouteDatabase
 import com.ioannapergamali.mysmartroute.data.local.RouteDao
+import com.ioannapergamali.mysmartroute.data.local.WalkingRouteEntity
 import kotlinx.coroutines.Dispatchers
 import com.ioannapergamali.mysmartroute.utils.toFirestoreMap
 import com.ioannapergamali.mysmartroute.utils.toMovingEntity
@@ -162,13 +163,26 @@ class VehicleRequestViewModel : ViewModel() {
         viewModelScope.launch {
             val userId = FirebaseAuth.getInstance().currentUser?.uid ?: return@launch
             val id = UUID.randomUUID().toString()
+            val entity = WalkingRouteEntity(
+                id = id,
+                userId = userId,
+                routeId = routeId,
+                fromPoiId = fromPoiId,
+                toPoiId = toPoiId,
+                date = dateTime
+            )
             val data = mapOf(
                 "routeId" to routeId,
                 "fromPoiId" to fromPoiId,
                 "toPoiId" to toPoiId,
-                "date" to dateTime
+                "date" to dateTime,
+                "userId" to userId
             )
             try {
+                val dbInstance = MySmartRouteDatabase.getInstance(context)
+                dbInstance.walkingDao().insert(entity)
+
+                db.collection("walking").document(id).set(data).await()
                 db.collection("users")
                     .document(userId)
                     .collection("walking")


### PR DESCRIPTION
## Summary
- store walking routes in new Room table and DAO
- save walking routes in Firestore `walking` collection and user subcollection
- update database schema to version 54 with migration

## Testing
- `./gradlew test` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b03bac12188328a1d3a44c4ccf0dcc