### PR TITLE
Προσθήκη κουμπιού αποθήκευσης στις διαδρομές πεζοπορίας

### DIFF
--- a/app/src/main/java/com/ioannapergamali/mysmartroute/view/ui/screens/WalkingRoutesScreen.kt
+++ b/app/src/main/java/com/ioannapergamali/mysmartroute/view/ui/screens/WalkingRoutesScreen.kt
@@ -77,20 +77,13 @@ private fun WalkingRow(
     onSave: () -> Unit,
     onRespond: (Boolean) -> Unit
 ) {
-
     Row(
         modifier = Modifier.fillMaxWidth(),
         horizontalArrangement = Arrangement.SpaceBetween
     ) {
         Text(m.routeName, modifier = Modifier.weight(1f))
         Row(horizontalArrangement = Arrangement.spacedBy(8.dp)) {
-            Button(onClick = onSave) {
-
-    Row(modifier = Modifier.fillMaxWidth(), horizontalArrangement = Arrangement.SpaceBetween) {
-        Text(m.routeName)
-        Row {
             TextButton(onClick = onSave) {
-
                 Text(stringResource(R.string.save))
             }
             TextButton(onClick = { onRespond(true) }) {


### PR DESCRIPTION
## Σύνοψη
- Προστέθηκε κουμπί `Αποθήκευση` στη λίστα διαδρομών πεζοπορίας ώστε να αποθηκεύονται οι διαδρομές στη βάση

## Έλεγχοι
- `./gradlew test` *(αποτυχία: λείπει Android SDK)*

------
https://chatgpt.com/codex/tasks/task_e_68b0504df06c832895c41c8f67f7d4bc