### PR TITLE
Add Firebase usage example and kotlin kapt DSL

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -5,7 +5,7 @@ plugins {
     id("com.android.application")
     id("org.jetbrains.kotlin.android")
     id("org.jetbrains.kotlin.plugin.compose")
-    id("kotlin-kapt")
+    kotlin("kapt")
     id("com.google.gms.google-services")
 }
 

--- a/app/src/main/java/com/ioannapergamali/mysmartroute/firebase/FirebaseExample.kt
+++ b/app/src/main/java/com/ioannapergamali/mysmartroute/firebase/FirebaseExample.kt
@@ -1,0 +1,21 @@
+package com.ioannapergamali.mysmartroute.firebase
+
+import com.google.firebase.auth.FirebaseAuth
+import com.google.firebase.firestore.FirebaseFirestore
+import com.google.firebase.storage.FirebaseStorage
+
+/**
+ * Παράδειγμα απλής χρήσης των Firebase Auth, Firestore και Storage.
+ */
+object FirebaseExample {
+    private val auth: FirebaseAuth by lazy { FirebaseAuth.getInstance() }
+    private val db: FirebaseFirestore by lazy { FirebaseFirestore.getInstance() }
+    private val storage: FirebaseStorage by lazy { FirebaseStorage.getInstance() }
+
+    fun signIn(email: String, password: String) =
+        auth.signInWithEmailAndPassword(email, password)
+
+    fun fetchUsers() = db.collection("users").get()
+
+    fun getFileRef(path: String) = storage.reference.child(path)
+}


### PR DESCRIPTION
## Summary
- χρησιμοποιήθηκε το Kotlin DSL `kotlin("kapt")` αντί για `kotlin-kapt`
- προστέθηκε απλό παράδειγμα χρήσης Firebase Auth, Firestore και Storage

## Testing
- `./gradlew tasks`
- `./gradlew build` *(απέτυχε: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b05002936883288fcfbbce70db84c3