### PR TITLE
Add Google and Maven repos for Firebase dependencies

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -69,6 +69,11 @@ android {
     }
 
 }
+repositories {
+    google()
+    mavenCentral()
+}
+
 
 kotlin {
     jvmToolchain(21)

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -9,7 +9,7 @@ pluginManagement {
 }
 
 dependencyResolutionManagement {
-    repositoriesMode.set(RepositoriesMode.FAIL_ON_PROJECT_REPOS)
+    repositoriesMode.set(RepositoriesMode.PREFER_PROJECT)
     repositories {
         google()
         mavenCentral()


### PR DESCRIPTION
## Summary
- declare google() and mavenCentral() repositories in the app module so Firebase artifacts resolve
- allow project-level repositories via `RepositoriesMode.PREFER_PROJECT`

## Testing
- `./gradlew test` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b05854a12c83288bb47799d32dabf6