### PR TITLE
Χρήση ρητών εκδόσεων Firebase

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -80,13 +80,12 @@ kotlin {
 }
 
 dependencies {
-    // Firebase (BoM για αυτόματες εκδόσεις όλων των modules)
-    implementation(platform("com.google.firebase:firebase-bom:34.1.0"))
-    implementation("com.google.firebase:firebase-auth-ktx")
-    implementation("com.google.firebase:firebase-firestore-ktx")
-    implementation("com.google.firebase:firebase-storage-ktx")
+    // Firebase - δήλωση ρητών εκδόσεων
+    implementation("com.google.firebase:firebase-auth-ktx:23.2.1")
+    implementation("com.google.firebase:firebase-firestore-ktx:25.1.4")
+    implementation("com.google.firebase:firebase-storage-ktx:21.0.2")
 
-    // Το Dynamic Links δεν καλύπτεται από το BoM, δηλώνουμε ρητά την έκδοση
+    // Dynamic Links με την τελευταία διαθέσιμη έκδοση
     implementation("com.google.firebase:firebase-dynamic-links:22.1.0")
 
 


### PR DESCRIPTION
## Περίληψη
- Ενημερώθηκαν τα dependencies του Firebase ώστε να χρησιμοποιούν ρητές, πρόσφατες εκδόσεις για auth, firestore και storage.
- Διατηρήθηκε η βιβλιοθήκη Dynamic Links με την τελευταία διαθέσιμη έκδοσή της.

## Δοκιμές
- `./gradlew :app:checkDebugAarMetadata` *(απέτυχε: λείπει το Android SDK στο περιβάλλον)*


------
https://chatgpt.com/codex/tasks/task_e_68b05f17ac348328b33d64b82ccf34cc