### PR TITLE
Use Firebase BoM for dependencies

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -80,13 +80,12 @@ kotlin {
 }
 
 dependencies {
-    // Firebase - δήλωση ρητών εκδόσεων
-    implementation("com.google.firebase:firebase-auth-ktx:23.2.1")
-    implementation("com.google.firebase:firebase-firestore-ktx:25.1.4")
-    implementation("com.google.firebase:firebase-storage-ktx:21.0.2")
-
-    // Dynamic Links με την τελευταία διαθέσιμη έκδοση
-    implementation("com.google.firebase:firebase-dynamic-links:22.1.0")
+    // Firebase BoM για συνεπή διαχείριση εκδόσεων
+    implementation(platform("com.google.firebase:firebase-bom:34.1.0"))
+    implementation("com.google.firebase:firebase-auth-ktx")
+    implementation("com.google.firebase:firebase-firestore-ktx")
+    implementation("com.google.firebase:firebase-storage-ktx")
+    implementation("com.google.firebase:firebase-dynamic-links")
 
 
     // Android core


### PR DESCRIPTION
## Summary
- switch Firebase dependencies to use the Firebase BoM

## Testing
- `./gradlew :app:dependencies --configuration debugRuntimeClasspath` *(απέτυχε: πιθανόν έλλειψη Android SDK ή δικαιωμάτων)*

------
https://chatgpt.com/codex/tasks/task_e_68b0841a7fc483289e7e5b76c77cac19