### PR TITLE
Απλούστευση ρυθμίσεων αποθετηρίων

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -69,9 +69,11 @@ android {
     }
 
 }
-//
-// Οι repositories δηλώνονται πλέον κεντρικά στο settings.gradle.kts
-//
+repositories {
+    google()
+    mavenCentral()
+}
+
 kotlin {
     jvmToolchain(21)
 }

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -1,5 +1,3 @@
-import org.gradle.api.initialization.resolve.RepositoriesMode
-
 pluginManagement {
     repositories {
         google()
@@ -9,7 +7,6 @@ pluginManagement {
 }
 
 dependencyResolutionManagement {
-    repositoriesMode.set(RepositoriesMode.FAIL_ON_PROJECT_REPOS)
     repositories {
         google()
         mavenCentral()


### PR DESCRIPTION
## Σύνοψη
- Αφαιρέθηκε το `RepositoriesMode.FAIL_ON_PROJECT_REPOS` και κρατήθηκαν μόνο τα repositories της Google και του Maven Central στο `settings.gradle.kts`
- Προστέθηκε `repositories { google(); mavenCentral() }` στο `app/build.gradle.kts` για να επιλυθούν οι εξαρτήσεις Firebase

## Δοκιμές
- `./gradlew assembleDebug` (αποτυχία: SDK location not found)


------
https://chatgpt.com/codex/tasks/task_e_68b0a8741d1083288c153b6ff4387494