### PR TITLE
Ενεργοποίηση κεντρικών αποθετηρίων για Firebase

### DIFF
--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -7,6 +7,7 @@ pluginManagement {
 }
 
 dependencyResolutionManagement {
+    repositoriesMode.set(RepositoriesMode.FAIL_ON_PROJECT_REPOS)
     repositories {
         google()
         mavenCentral()


### PR DESCRIPTION
## Σύνοψη
- Ενεργοποίηση του `RepositoriesMode.FAIL_ON_PROJECT_REPOS` ώστε όλα τα modules να χρησιμοποιούν Google και Maven Central για τις βιβλιοθήκες Firebase

## Δοκιμές
- `./gradlew help` *(διακόπηκε: Starting a Gradle Daemon)*
- `./gradlew tasks` *(διακόπηκε: Starting a Gradle Daemon, δεν εμφανίστηκε λίστα εργασιών)*

------
https://chatgpt.com/codex/tasks/task_e_68b0b4e1eb48832882eadfa28bd2ba3b