### PR TITLE
Προσθήκη υποστήριξης Firebase μέσω BoM

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -76,11 +76,12 @@ kotlin {
 
 dependencies {
 
-
     // Firebase
-
-
-
+    implementation(platform("com.google.firebase:firebase-bom:34.2.0"))
+    implementation("com.google.firebase:firebase-auth-ktx")
+    implementation("com.google.firebase:firebase-firestore-ktx")
+    implementation("com.google.firebase:firebase-storage-ktx")
+    implementation("com.google.firebase:firebase-dynamic-links-ktx")
 
     // Android core
     implementation(libs.androidx.core.ktx)


### PR DESCRIPTION
## Σύνοψη
- Προστέθηκε το Firebase BoM (έκδοση 34.2.0) και οι βασικές βιβλιοθήκες Firebase.

## Έλεγχοι
- `./gradlew :app:dependencies --configuration debugRuntimeClasspath`


------
https://chatgpt.com/codex/tasks/task_e_68b0beb8ac548328b7d9ecb17e4b4dd6