### PR TITLE
Διόρθωση ρυθμίσεων Gradle και ενημέρωση εκδόσεων

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -1,13 +1,13 @@
 // Top-level build file where you can add configuration options common to all sub-projects/modules.
 
 plugins {
-    id("com.android.application") version "8.6.0" apply false
+    id("com.android.application") version "8.12.2" apply false
     // Το plugin Compose απαιτείται σε Kotlin 2.x για να ενεργοποιηθεί ο
     // compiler του Jetpack Compose.
-    id("org.jetbrains.kotlin.plugin.compose") version "2.0.20" apply false
-    kotlin("kapt") version "2.0.20" apply false
+    id("org.jetbrains.kotlin.plugin.compose") version "2.2.10" apply false
+    kotlin("kapt") version "2.2.10" apply false
 
-    id("org.jetbrains.kotlin.android") version "2.0.20" apply false
+    id("org.jetbrains.kotlin.android") version "2.2.10" apply false
     // Plugin Google Services για Firebase
     id("com.google.gms.google-services") version "4.4.3" apply false
 }

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -1,5 +1,9 @@
 // Βασική διαμόρφωση Gradle
 pluginManagement {
+    plugins {
+        id("com.android.application") version "8.12.2"
+        kotlin("android") version "2.2.10"
+    }
     repositories {
         google()
         mavenCentral()


### PR DESCRIPTION
## Περίληψη
- Προστέθηκαν ορισμοί plugin και αποθετηρίων στο `settings.gradle.kts` με τις πιο πρόσφατες σταθερές εκδόσεις.
- Αναβαθμίστηκαν οι εκδόσεις των plugins στο `build.gradle.kts` (AGP 8.12.2 και Kotlin 2.2.10).

## Έλεγχοι
- `./gradlew --version`


------
https://chatgpt.com/codex/tasks/task_e_68b0cb10d3fc8328be411aa9d75cc2e5