### PR TITLE
Ενημέρωση Gradle και εκδόσεων plugins

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -1,7 +1,7 @@
 // Top-level build file where you can add configuration options common to all sub-projects/modules.
 
 plugins {
-    id("com.android.application") version "8.6.0" apply false
+    id("com.android.application") version "8.7.2" apply false
     // Το plugin Compose απαιτείται σε Kotlin 2.x για να ενεργοποιηθεί ο
     // compiler του Jetpack Compose.
     id("org.jetbrains.kotlin.plugin.compose") version "2.0.20" apply false

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
 #Sun May 25 18:53:14 EEST 2025
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-8.7-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.9-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -7,7 +7,7 @@ pluginManagement {
     }
     plugins {
         id("com.android.application") version "8.7.2" apply false
-        id("org.jetbrains.kotlin.android") version "1.9.23" apply false
+        id("org.jetbrains.kotlin.android") version "2.0.20" apply false
     }
 }
 


### PR DESCRIPTION
## Σύνοψη
- Αναβάθμιση του Android Gradle plugin στην έκδοση 8.7.2
- Ευθυγράμμιση του Kotlin plugin στην έκδοση 2.0.20
- Αναβάθμιση του Gradle wrapper στην έκδοση 8.9

## Έλεγχοι
- `./gradlew assembleDebug` *(αποτυχία: δεν βρέθηκε Android SDK)*

------
https://chatgpt.com/codex/tasks/task_e_68b0eb206cd083289a973becee52bcd0