### PR TITLE
Ενημέρωση εκδόσεων Gradle και Kotlin

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -1,13 +1,13 @@
 // Top-level build file where you can add configuration options common to all sub-projects/modules.
 
 plugins {
-    id("com.android.application") version "8.7.2" apply false
+    id("com.android.application") version "8.12.2" apply false
     // Το plugin Compose απαιτείται σε Kotlin 2.x για να ενεργοποιηθεί ο
     // compiler του Jetpack Compose.
-    id("org.jetbrains.kotlin.plugin.compose") version "2.0.20" apply false
-    kotlin("kapt") version "2.0.20" apply false
+    id("org.jetbrains.kotlin.plugin.compose") version "2.2.10" apply false
+    kotlin("kapt") version "2.2.10" apply false
 
-    id("org.jetbrains.kotlin.android") version "2.0.20" apply false
+    id("org.jetbrains.kotlin.android") version "2.2.10" apply false
     // Plugin Google Services για Firebase
     id("com.google.gms.google-services") version "4.4.3" apply false
 }

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -6,8 +6,9 @@ pluginManagement {
         gradlePluginPortal()
     }
     plugins {
-        id("com.android.application") version "8.7.2" apply false
-        id("org.jetbrains.kotlin.android") version "2.0.20" apply false
+        id("com.android.application") version "8.12.2" apply false
+        id("org.jetbrains.kotlin.android") version "2.2.10" apply false
+        id("com.google.gms.google-services") version "4.4.3" apply false
     }
 }
 


### PR DESCRIPTION
## Περίληψη
- Αναβάθμιση σε Android Gradle Plugin 8.12.2 και Kotlin 2.2.10.
- Προσθήκη του plugin Google Services στο `settings.gradle.kts` για επίλυση εξαρτήσεων Firebase.

## Έλεγχοι
- `./gradlew --console=plain tasks --all` *(απέτυχε: λήψη εξαρτήσεων δεν ολοκληρώθηκε στο περιβάλλον ελέγχου)*


------
https://chatgpt.com/codex/tasks/task_e_68b10894ef608328a6f18d41cc27a11b