### PR TITLE
Ενημέρωση εκδόσεων Gradle και Kotlin

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -75,9 +75,9 @@ kotlin {
 }
 
 dependencies {
-
     // Firebase
-    implementation(platform("com.google.firebase:firebase-bom:34.2.0"))
+    val firebaseBom = platform("com.google.firebase:firebase-bom:34.2.0")
+    implementation(firebaseBom)
     implementation("com.google.firebase:firebase-auth-ktx")
     implementation("com.google.firebase:firebase-firestore-ktx")
     implementation("com.google.firebase:firebase-storage-ktx")

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -1,13 +1,13 @@
 // Top-level build file where you can add configuration options common to all sub-projects/modules.
 
 plugins {
-    id("com.android.application") version "8.7.2" apply false
+    id("com.android.application") version "8.12.2" apply false
     // Το plugin Compose απαιτείται σε Kotlin 2.x για να ενεργοποιηθεί ο
     // compiler του Jetpack Compose.
-    id("org.jetbrains.kotlin.plugin.compose") version "2.0.20" apply false
-    kotlin("kapt") version "2.0.20" apply false
+    id("org.jetbrains.kotlin.plugin.compose") version "2.2.10" apply false
+    kotlin("kapt") version "2.2.10" apply false
 
-    id("org.jetbrains.kotlin.android") version "2.0.20" apply false
+    id("org.jetbrains.kotlin.android") version "2.2.10" apply false
     // Plugin Google Services για Firebase
     id("com.google.gms.google-services") version "4.4.3" apply false
 }

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
 #Sun May 25 18:53:14 EEST 2025
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-8.9-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.13-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -6,8 +6,9 @@ pluginManagement {
         gradlePluginPortal()
     }
     plugins {
-        id("com.android.application") version "8.7.2" apply false
-        id("org.jetbrains.kotlin.android") version "2.0.20" apply false
+        id("com.android.application") version "8.12.2" apply false
+        id("org.jetbrains.kotlin.android") version "2.2.10" apply false
+        id("com.google.gms.google-services") version "4.4.3" apply false
     }
 }
 
@@ -16,6 +17,7 @@ dependencyResolutionManagement {
     repositories {
         google()
         mavenCentral()
+        maven("https://maven.google.com") // Επίλυση βιβλιοθηκών Firebase
     }
 }
 


### PR DESCRIPTION
## Περίληψη
- Προσθήκη του αποθετηρίου Google στο `settings.gradle.kts` για σωστή επίλυση των βιβλιοθηκών Firebase.
- Χρήση σταθερού Firebase BoM στο `app/build.gradle.kts` και απλούστερη δήλωση εξαρτήσεων.
- Αναβάθμιση του Gradle wrapper στην έκδοση 8.13 ώστε να είναι συμβατή με το AGP 8.12.2.

## Έλεγχοι
- `./gradlew --console=plain tasks --all`


------
https://chatgpt.com/codex/tasks/task_e_68b10894ef608328a6f18d41cc27a11b