### PR TITLE
Ενημέρωση εκδόσεων Gradle και Kotlin

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -75,9 +75,9 @@ kotlin {
 }
 
 dependencies {
-
     // Firebase
-    implementation(platform("com.google.firebase:firebase-bom:34.2.0"))
+    val firebaseBom = platform("com.google.firebase:firebase-bom:34.2.0")
+    implementation(firebaseBom)
     implementation("com.google.firebase:firebase-auth-ktx")
     implementation("com.google.firebase:firebase-firestore-ktx")
     implementation("com.google.firebase:firebase-storage-ktx")

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -1,13 +1,20 @@
 // Top-level build file where you can add configuration options common to all sub-projects/modules.
 
 plugins {
-    id("com.android.application") version "8.7.2" apply false
+    id("com.android.application") version "8.12.2" apply false
     // Το plugin Compose απαιτείται σε Kotlin 2.x για να ενεργοποιηθεί ο
     // compiler του Jetpack Compose.
-    id("org.jetbrains.kotlin.plugin.compose") version "2.0.20" apply false
-    kotlin("kapt") version "2.0.20" apply false
+    id("org.jetbrains.kotlin.plugin.compose") version "2.2.10" apply false
+    kotlin("kapt") version "2.2.10" apply false
 
-    id("org.jetbrains.kotlin.android") version "2.0.20" apply false
+    id("org.jetbrains.kotlin.android") version "2.2.10" apply false
     // Plugin Google Services για Firebase
     id("com.google.gms.google-services") version "4.4.3" apply false
+}
+
+allprojects {
+    repositories {
+        google()
+        mavenCentral()
+    }
 }

--- a/gradle.properties
+++ b/gradle.properties
@@ -24,4 +24,4 @@ android.nonTransitiveRClass=true
 #org.gradle.daemon=false
 
 kotlin.jvm.target=17
-kotlin.version=2.0.20
+kotlin.version=2.2.10

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,6 +1,6 @@
 [versions]
-agp = "8.6.0"
-kotlin = "2.1.21"
+agp = "8.12.2"
+kotlin = "2.2.10"
 coreKtx = "1.12.0"
 junit = "4.13.2"
 junitVersion = "1.1.5"

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
 #Sun May 25 18:53:14 EEST 2025
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-8.9-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.13-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -6,13 +6,13 @@ pluginManagement {
         gradlePluginPortal()
     }
     plugins {
-        id("com.android.application") version "8.7.2" apply false
-        id("org.jetbrains.kotlin.android") version "2.0.20" apply false
+        id("com.android.application") version "8.12.2" apply false
+        id("org.jetbrains.kotlin.android") version "2.2.10" apply false
+        id("com.google.gms.google-services") version "4.4.3" apply false
     }
 }
 
 dependencyResolutionManagement {
-    repositoriesMode.set(RepositoriesMode.FAIL_ON_PROJECT_REPOS)
     repositories {
         google()
         mavenCentral()


### PR DESCRIPTION
## Περίληψη
- Απλοποιήθηκε η δήλωση αποθετηρίων στο `settings.gradle.kts` και προστέθηκε καθολικό μπλοκ `allprojects` για πρόσβαση στο Google Maven.
- Ενημερώθηκε η `kotlin.version` στο `gradle.properties` και οι εκδόσεις στο `libs.versions.toml` σε Kotlin 2.2.10 και AGP 8.12.2.

## Έλεγχοι
- `./gradlew --console=plain tasks --all`


------
https://chatgpt.com/codex/tasks/task_e_68b10894ef608328a6f18d41cc27a11b