### PR TITLE
Ενημέρωση AGP σε 8.11.0

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -1,7 +1,7 @@
 // Top-level build file where you can add configuration options common to all sub-projects/modules.
 
 plugins {
-    id("com.android.application") version "8.12.2" apply false
+    id("com.android.application") version "8.11.0" apply false
     // Το plugin Compose απαιτείται σε Kotlin 2.x για να ενεργοποιηθεί ο
     // compiler του Jetpack Compose.
     id("org.jetbrains.kotlin.plugin.compose") version "2.2.10" apply false

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,5 +1,5 @@
 [versions]
-agp = "8.12.2"
+agp = "8.11.0"
 kotlin = "2.2.10"
 coreKtx = "1.12.0"
 junit = "4.13.2"

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -6,7 +6,7 @@ pluginManagement {
         gradlePluginPortal()
     }
     plugins {
-        id("com.android.application") version "8.12.2" apply false
+        id("com.android.application") version "8.11.0" apply false
         id("org.jetbrains.kotlin.android") version "2.2.10" apply false
         id("com.google.gms.google-services") version "4.4.3" apply false
     }


### PR DESCRIPTION
## Σύνοψη
- Ενημερώθηκε η έκδοση του Android Gradle Plugin στην υποστηριζόμενη 8.11.0 σε όλα τα αρχεία ρυθμίσεων.

## Δοκιμές
- `./gradlew help`


------
https://chatgpt.com/codex/tasks/task_e_68b1172dea788328965ebe216324db61