### PR TITLE
Fix Compose plugin setup

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -21,10 +21,6 @@ android {
     buildFeatures {
         compose = true
     }
-
-    composeOptions {
-        kotlinCompilerExtensionVersion = "1.5.11"
-    }
 }
 
 dependencies {

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -3,5 +3,6 @@
 plugins {
     id("com.android.application") version "8.5.0" apply false
     id("org.jetbrains.kotlin.android") version "2.1.0" apply false
+    id("org.jetbrains.kotlin.plugin.compose") version "2.1.0" apply false
     id("com.google.gms.google-services") version "4.4.2" apply false
 }


### PR DESCRIPTION
## Summary
- Configure Kotlin Compose plugin in root build script
- Simplify module build by relying on built-in Compose compiler

## Testing
- `./gradlew help`


------
https://chatgpt.com/codex/tasks/task_e_68b127368b708328a167b9e57e0faa62