### PR TITLE
Fix unclosed style tags in themes

### DIFF
--- a/app/src/main/res/values-night/themes.xml
+++ b/app/src/main/res/values-night/themes.xml
@@ -5,6 +5,7 @@
     <style name="Base.Theme.Mysmartroute" parent="Theme.Material3.DayNight">
         <item name="windowNoTitle">true</item>
         <item name="windowActionBar">false</item>
+    </style>
 
     <style name="Base.Theme.MySmartRoute" parent="Theme.Material3.DayNight.NoActionBar">
 

--- a/app/src/main/res/values/themes.xml
+++ b/app/src/main/res/values/themes.xml
@@ -5,6 +5,7 @@
     <style name="Base.Theme.Mysmartroute" parent="Theme.Material3.DayNight">
         <item name="windowNoTitle">true</item>
         <item name="windowActionBar">false</item>
+    </style>
 
     <style name="Base.Theme.MySmartRoute" parent="Theme.Material3.DayNight.NoActionBar">
 


### PR DESCRIPTION
## Summary
- close style tags in light and night theme resources

## Testing
- `./gradlew test` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b1578dd1c88328947d3842ee8431e5