### PR TITLE
chore: wire Google Maps API key

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -1,3 +1,7 @@
+import com.android.build.gradle.internal.cxx.configure.gradleLocalProperties
+
+val mapsApiKey: String = gradleLocalProperties(rootDir).getProperty("MAPS_API_KEY") ?: ""
+
 plugins {
     id("com.android.application")
     id("org.jetbrains.kotlin.android")
@@ -17,6 +21,9 @@ android {
         targetSdk = 35
         versionCode = 1
         versionName = "1.0"
+
+        manifestPlaceholders["MAPS_API_KEY"] = mapsApiKey
+        buildConfigField("String", "MAPS_API_KEY", "\"$mapsApiKey\"")
     }
 
     buildFeatures {


### PR DESCRIPTION
## Summary
- read MAPS_API_KEY from local.properties and expose via BuildConfig
- pass MAPS_API_KEY placeholder to manifest

## Testing
- `./gradlew :app:processDebugMainManifest` *(fails: environment issue)*
- `./gradlew --version`


------
https://chatgpt.com/codex/tasks/task_e_68b158e395a48328993d37e18f79b94d