### PR TITLE
fix: update gradleLocalProperties signature

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -1,6 +1,9 @@
 import com.android.build.gradle.internal.cxx.configure.gradleLocalProperties
 
-val mapsApiKey: String = gradleLocalProperties(rootDir).getProperty("MAPS_API_KEY") ?: ""
+// Διαβάζουμε το MAPS_API_KEY από το local.properties με την νέα υπογραφή που
+// απαιτεί τον παράγοντα providers στο AGP 8.5+
+val mapsApiKey: String = gradleLocalProperties(rootDir, providers)
+    .getProperty("MAPS_API_KEY") ?: ""
 
 plugins {
     id("com.android.application")


### PR DESCRIPTION
## Summary
- update gradleLocalProperties usage to pass providers for AGP 8.5+

## Testing
- `./gradlew help` *(fails: defaultConfig contains custom BuildConfig fields, but the feature is disabled)*

------
https://chatgpt.com/codex/tasks/task_e_68b15fbeedcc8328a20b49bd2c41af69