### PR TITLE
Enable BuildConfig and update Java target

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -30,6 +30,7 @@ android {
     }
 
     buildFeatures {
+        buildConfig = true
         compose = true
         viewBinding = false
     }
@@ -37,7 +38,7 @@ android {
     ndkVersion = "29.0.13846066 rc3"
     compileOptions {
         sourceCompatibility = JavaVersion.VERSION_17
-        targetCompatibility = JavaVersion.VERSION_1_7
+        targetCompatibility = JavaVersion.VERSION_17
     }
     dependenciesInfo {
         includeInApk = false


### PR DESCRIPTION
## Summary
- enable BuildConfig generation for custom fields
- align Java target compatibility with source

## Testing
- `./gradlew --console=plain --no-daemon assembleDebug` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b161c131388328858bf7489abdffc5