### PR TITLE
Align Kotlin JVM target with Java 17

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -68,3 +68,10 @@ dependencies {
     debugImplementation("androidx.compose.ui:ui-tooling:1.6.4")
     debugImplementation("androidx.compose.ui:ui-test-manifest:1.6.4")
 }
+
+kotlin {
+    jvmToolchain(17)
+    compilerOptions {
+        jvmTarget.set(org.jetbrains.kotlin.gradle.dsl.JvmTarget.JVM_17)
+    }
+}


### PR DESCRIPTION
## Summary
- Set Kotlin to use JVM toolchain 17 and target JVM 17 to match Java compile options

## Testing
- `./gradlew build` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b1632643fc8328b6a6d66401b17323