### PR TITLE
Configure Kotlin 1.9.24 and remove K2 compose plugin

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -8,7 +8,6 @@ val mapsApiKey: String = gradleLocalProperties(rootDir, providers)
 plugins {
     id("com.android.application")
     id("org.jetbrains.kotlin.android")
-    id("org.jetbrains.kotlin.plugin.compose")
     id("kotlin-kapt")
     id("com.google.gms.google-services")
 }
@@ -33,6 +32,10 @@ android {
         buildConfig = true
         compose = true
     }
+    composeOptions {
+        kotlinCompilerExtensionVersion = "1.5.14"
+    }
+
     buildToolsVersion = "34.0.0"
     compileOptions {
         sourceCompatibility = JavaVersion.VERSION_17

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -3,7 +3,6 @@
 plugins {
     id("com.android.application") version "8.7.0" apply false
     id("org.jetbrains.kotlin.android") version "1.9.24" apply false
-    id("org.jetbrains.kotlin.plugin.compose") version "2.0.0" apply false
     id("com.google.gms.google-services") version "4.4.2" apply false
 
 }

--- a/gradle.properties
+++ b/gradle.properties
@@ -24,5 +24,4 @@ android.nonTransitiveRClass=true
 #org.gradle.daemon=false
 
 kotlin.jvm.target=17
-kotlin.version=2.0.0
-kapt.useK2=true
+kotlin.version=1.9.24


### PR DESCRIPTION
## Summary
- Pin Kotlin to 1.9.24 and drop K2 flags
- Remove Kotlin 2.0 compose plugin and set explicit compiler extension

## Testing
- `./gradlew --console=plain clean assembleDebug` *(fails: Cannot find a Java installation on your machine matching this task's requirements)*

------
https://chatgpt.com/codex/tasks/task_e_68b16b4be0d483289936ad5d2e444e7e