### PR TITLE
chore: upgrade build plugins

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -1,8 +1,8 @@
 // Top-level build file where you can add configuration options common to all sub-projects/modules.
 
 plugins {
-    id("com.android.application") version "8.7.0" apply false
-    id("org.jetbrains.kotlin.android") version "1.9.24" apply false
+    id("com.android.application") version "8.12.2" apply false
+    id("org.jetbrains.kotlin.android") version "2.2.10" apply false
     id("com.google.gms.google-services") version "4.4.2" apply false
 
 }

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
 #Fri Aug 29 11:53:00 EEST 2025
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-8.9-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-9.0.0-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists


### PR DESCRIPTION
## Summary
- update Android Gradle and Kotlin plugins to latest versions
- bump Gradle wrapper to 9.0.0

## Testing
- `./gradlew --version`
- `./gradlew assembleDebug` *(fails: no output, likely missing Android SDK)*

------
https://chatgpt.com/codex/tasks/task_e_68b1713951688328affbd10bc673bda1