### PR TITLE
Σταθεροποίηση εκδόσεων AGP και Kotlin

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -5,23 +5,22 @@ import com.android.build.gradle.internal.cxx.configure.gradleLocalProperties
 val mapsApiKey: String = gradleLocalProperties(rootDir, providers)
     .getProperty("MAPS_API_KEY") ?: ""
 
-plugins {
-    id("com.android.application")
-    id("org.jetbrains.kotlin.android")
-    id("kotlin-kapt")
-    id("com.google.gms.google-services")
-    id("org.jetbrains.kotlin.plugin.compose")
-}
+    plugins {
+        id("com.android.application")
+        id("org.jetbrains.kotlin.android")
+        id("kotlin-kapt")
+        id("com.google.gms.google-services")
+    }
 
 android {
     // Απαραίτητο namespace για AGP 8+
     namespace = "com.ioannapergamali.mysmartroute"
-    compileSdk = 35
+    compileSdk = 34
 
     defaultConfig {
         applicationId = "com.ioannapergamali.mysmartroute"
-        minSdk = 26
-        targetSdk = 35
+        minSdk = 24
+        targetSdk = 34
         versionCode = 1
         versionName = "1.0"
 

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -1,9 +1,8 @@
 // Top-level build file where you can add configuration options common to all sub-projects/modules.
 
 plugins {
-    id("com.android.application") version "8.11.0" apply false
-    id("org.jetbrains.kotlin.android") version "2.2.10" apply false
-    id("org.jetbrains.kotlin.plugin.compose") version "2.0.0" apply false
+    id("com.android.application") version "8.3.2" apply false
+    id("org.jetbrains.kotlin.android") version "1.9.23" apply false
     id("com.google.gms.google-services") version "4.4.2" apply false
 
 }

--- a/gradle.properties
+++ b/gradle.properties
@@ -6,7 +6,7 @@
 # http://www.gradle.org/docs/current/userguide/build_environment.html
 # Specifies the JVM arguments used for the daemon process.
 # The setting is particularly useful for tweaking memory settings.
-org.gradle.jvmargs=-Xmx2048m -Dfile.encoding=UTF-8
+org.gradle.jvmargs=-Xmx4g -XX:MaxMetaspaceSize=1g -XX:+HeapDumpOnOutOfMemoryError -Dfile.encoding=UTF-8
 # When configured, Gradle will run in incubating parallel mode.
 # This option should only be used with decoupled projects. For more details, visit
 # https://developer.android.com/r/tools/gradle-multi-project-decoupled-projects
@@ -24,4 +24,4 @@ android.nonTransitiveRClass=true
 #org.gradle.daemon=false
 
 kotlin.jvm.target=17
-kotlin.version=1.9.24
+kotlin.version=1.9.23


### PR DESCRIPTION
## Περίληψη
- Ενημέρωση του root build script ώστε να χρησιμοποιεί σταθερές εκδόσεις Android Gradle Plugin 8.3.2 και Kotlin 1.9.23.
- Προσαρμογή `gradle.properties` με αυξημένες JVM μνήμες και ευθυγράμμιση της Kotlin έκδοσης.
- Απλοποίηση του module build script: αφαίρεση compose plugin και στόχευση στο API 34 με minSdk 24.

## Έλεγχοι
- `./gradlew assembleDebug` *(αποτυχία: Cannot find a Java installation on your machine matching: {languageVersion=17...})*


------
https://chatgpt.com/codex/tasks/task_e_68b180ec1f6083289d15e29226bbd798