### PR TITLE
Fix ResetPasswordScreen layout

### DIFF
--- a/app/src/main/java/com/ioannapergamali/mysmartroute/view/ui/screens/ResetPasswordScreen.kt
+++ b/app/src/main/java/com/ioannapergamali/mysmartroute/view/ui/screens/ResetPasswordScreen.kt
@@ -51,7 +51,8 @@ fun ResetPasswordScreen(navController: NavController, openDrawer: () -> Unit) {
                         .observeBubble(bubbleState, 0) { email }
                 )
                 Spacer(modifier = Modifier.height(16.dp))
-     Text(stringResource(R.string.send_reset_email))
+                Button(onClick = { viewModel.resetPassword(email) }) {
+                    Text(stringResource(R.string.send_reset_email))
                 }
                 when (uiState) {
                     is AuthenticationViewModel.ResetPasswordState.Loading -> {


### PR DESCRIPTION
## Summary
- Add button to submit reset password request
- Fix composable block structure to avoid build errors

## Testing
- `./gradlew test` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b186501ca8832896597f98f1841895