### PR TITLE
Fix sourceSets exclude syntax

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -47,7 +47,9 @@ android {
         includeInBundle = false
     }
 
-    sourceSets["main"].java.exclude("**/caches/**")
+    sourceSets.named("main") {
+        java.exclude("**/caches/**")
+    }
 
 }
 


### PR DESCRIPTION
## Summary
- fix source set exclude by configuring Java block via `sourceSets.named`

## Testing
- `./gradlew help`


------
https://chatgpt.com/codex/tasks/task_e_68b18b3d4800832885acae4d1eb6cdf1