### PR TITLE
Use Kotlin 1.9.23 and stable Compose compiler

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -8,7 +8,6 @@ val mapsApiKey: String = gradleLocalProperties(rootDir, providers)
     plugins {
         id("com.android.application")
         id("org.jetbrains.kotlin.android")
-        id("org.jetbrains.kotlin.plugin.compose")
         id("kotlin-kapt")
         id("com.google.gms.google-services")
     }
@@ -38,6 +37,11 @@ android {
     compileOptions {
         sourceCompatibility = JavaVersion.VERSION_17
         targetCompatibility = JavaVersion.VERSION_17
+    }
+
+    composeOptions {
+        // Τελευταία σταθερή έκδοση του compiler για Compose και Kotlin 1.9.23
+        kotlinCompilerExtensionVersion = "1.5.14"
     }
 
     dependenciesInfo {

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -3,10 +3,8 @@
 plugins {
     id("com.android.application") version "8.5.0" apply false
 
-    id("org.jetbrains.kotlin.android") version "2.0.0" apply false
-    id("org.jetbrains.kotlin.plugin.compose") version "2.0.0" apply false
-
+    // Χρησιμοποιούμε τη σταθερή έκδοση 1.9.23 του Kotlin για συμβατότητα με το KAPT
+    id("org.jetbrains.kotlin.android") version "1.9.23" apply false
 
     id("com.google.gms.google-services") version "4.4.2" apply false
-   
 }

--- a/gradle.properties
+++ b/gradle.properties
@@ -24,4 +24,5 @@ android.nonTransitiveRClass=true
 #org.gradle.daemon=false
 
 kotlin.jvm.target=17
-kotlin.version=2.0.0
+# Συγχρονισμός με τη σταθερή έκδοση του Kotlin
+kotlin.version=1.9.23


### PR DESCRIPTION
## Summary
- switch project to Kotlin 1.9.23 for KAPT compatibility
- configure Compose compiler extension 1.5.14 and drop compose plugin

## Testing
- `./gradlew clean assembleDebug` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b19cc6b660832892da87766d4971cb