### PR TITLE
Fix unresolved reference to ACRA

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -79,6 +79,10 @@ dependencies {
     implementation("androidx.compose.material3:material3")
     implementation("com.google.android.material:material:1.12.0")
 
+    // 🔹 ACRA για αναφορές σφαλμάτων
+    implementation("ch.acra:acra-ktx:5.12.0")
+    implementation("ch.acra:acra-mail:5.12.0")
+
     debugImplementation("androidx.compose.ui:ui-tooling")
     debugImplementation("androidx.compose.ui:ui-test-manifest")
 


### PR DESCRIPTION
## Summary
- add ACRA ktx and mail dependencies to resolve missing imports

## Testing
- `./gradlew test` *(fails: Starting a Gradle Daemon, environment lacks Android SDK)*

------
https://chatgpt.com/codex/tasks/task_e_68b455df37c083288425a6ad5ef5e4a9