### PR TITLE
Update Kotlin to 2.0.21 and align Compose compiler

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -40,8 +40,8 @@ android {
     }
 
     composeOptions {
-        // Τελευταία σταθερή έκδοση του compiler για Compose και Kotlin 1.9.25
-        kotlinCompilerExtensionVersion = "1.5.15"
+        // Τελευταία σταθερή έκδοση του compiler για Kotlin 2.0.21
+        kotlinCompilerExtensionVersion = "1.6.11"
     }
 
     dependenciesInfo {

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -3,8 +3,8 @@
 plugins {
     id("com.android.application") version "8.12.2" apply false
 
-    // Χρήση της τελευταίας σταθερής έκδοσης 1.9.25 του Kotlin για συμβατότητα με το KAPT
-    id("org.jetbrains.kotlin.android") version "1.9.25" apply false
+    // Χρήση της τελευταίας σταθερής έκδοσης 2.0.21 του Kotlin
+    id("org.jetbrains.kotlin.android") version "2.0.21" apply false
 
     id("com.google.gms.google-services") version "4.4.3" apply false
 }

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,6 +1,6 @@
 [versions]
-agp = "8.11.0"
-kotlin = "2.2.10"
+agp = "8.12.2"
+kotlin = "2.0.21"
 coreKtx = "1.12.0"
 junit = "4.13.2"
 junitVersion = "1.1.5"


### PR DESCRIPTION
## Summary
- update Kotlin plugin to 2.0.21
- align Compose compiler extension to 1.6.11
- refresh version catalog entries for Kotlin and AGP

## Testing
- `./gradlew -q help` *(fails: configuring project did not complete in time)*

------
https://chatgpt.com/codex/tasks/task_e_68b46a7e56d08328b7440c9eea535be2