### PR TITLE
Διόρθωση σφάλματος στο ProfileScreen

### DIFF
--- a/app/src/main/java/com/ioannapergamali/mysmartroute/view/ui/screens/ProfileScreen.kt
+++ b/app/src/main/java/com/ioannapergamali/mysmartroute/view/ui/screens/ProfileScreen.kt
@@ -41,18 +41,13 @@ fun ProfileScreen(navController: NavController, openDrawer: () -> Unit) {
     val imagePicker = rememberLauncherForActivityResult(ActivityResultContracts.GetContent()) { uri ->
         val uid = user?.uid ?: return@rememberLauncherForActivityResult
         uri ?: return@rememberLauncherForActivityResult
-filescreen-ppycbc
+
         Log.d("ProfileScreen", "Επιλέχθηκε εικόνα: $uri")
 
         val storageRef = FirebaseStorage.getInstance().reference
             .child("profileImages/$uid.jpg")
 
         Log.d("ProfileScreen", "Διαδρομή Storage: ${'$'}{storageRef.path}")
-
-
-        val storageRef = FirebaseStorage.getInstance().reference
-            .child("profileImages/$uid.jpg")
-
 
         storageRef.putFile(uri)
             .addOnSuccessListener {
@@ -62,13 +57,11 @@ filescreen-ppycbc
 
                     Log.d("ProfileScreen", "Λήφθηκε download URL: $url")
 
-
                     val docRef = FirebaseFirestore.getInstance()
                         .collection("users")
                         .document(uid)
 
                     docRef.update("photoUrl", url)
-
                         .addOnSuccessListener {
                             Log.d("ProfileScreen", "Αποθηκεύτηκε το URL στο Firestore")
                         }
@@ -76,9 +69,6 @@ filescreen-ppycbc
                             Log.e("ProfileScreen", "Αποτυχία ενημέρωσης Firestore", error)
                             docRef.set(mapOf("photoUrl" to url))
                         }
-
-                        .addOnFailureListener { docRef.set(mapOf("photoUrl" to url)) }
-
                 }
             }
             .addOnFailureListener { e ->


### PR DESCRIPTION
## Περίληψη
- Αφαιρέθηκε τυχαίο κείμενο `filescreen-ppycbc` που προκαλούσε σφάλμα μεταγλώττισης.
- Συγκαθάριση της λογικής αποθήκευσης εικόνας στο `ProfileScreen` και αποφυγή διπλών δηλώσεων.

## Δοκιμές
- `./gradlew test` *(αποτυχία: δεν βρέθηκε Android SDK)*

------
https://chatgpt.com/codex/tasks/task_e_68b5d67efee883289626fb7df693b260