### PR TITLE
fix: provide context to reset password

### DIFF
--- a/app/src/main/java/com/ioannapergamali/mysmartroute/view/ui/screens/ResetPasswordScreen.kt
+++ b/app/src/main/java/com/ioannapergamali/mysmartroute/view/ui/screens/ResetPasswordScreen.kt
@@ -5,6 +5,7 @@ import androidx.compose.material3.*
 import androidx.compose.runtime.*
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.platform.LocalContext
 
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.unit.dp
@@ -22,6 +23,7 @@ fun ResetPasswordScreen(navController: NavController, openDrawer: () -> Unit) {
     val viewModel: AuthenticationViewModel = viewModel()
     val uiState by viewModel.resetPasswordState.collectAsState()
     var email by remember { mutableStateOf("") }
+    val context = LocalContext.current
     val bubbleState = LocalKeyboardBubbleState.current!!
 
 
@@ -51,7 +53,7 @@ fun ResetPasswordScreen(navController: NavController, openDrawer: () -> Unit) {
                         .observeBubble(bubbleState, 0) { email }
                 )
                 Spacer(modifier = Modifier.height(16.dp))
-                Button(onClick = { viewModel.resetPassword(email) }) {
+                Button(onClick = { viewModel.resetPassword(email, context) }) {
                     Text(stringResource(R.string.send_reset_email))
                 }
                 when (uiState) {


### PR DESCRIPTION
## Summary
- get `LocalContext.current` in `ResetPasswordScreen`
- pass `context` to `viewModel.resetPassword`

## Testing
- `./gradlew test` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b5d9680aac832880cdde3442e11144