### PR TITLE
Διόρθωση χρήσης του weight modifier

### DIFF
--- a/app/src/main/java/com/ioannapergamali/mysmartroute/view/ui/screens/WalkingRoutesScreen.kt
+++ b/app/src/main/java/com/ioannapergamali/mysmartroute/view/ui/screens/WalkingRoutesScreen.kt
@@ -1,12 +1,6 @@
 package com.ioannapergamali.mysmartroute.view.ui.screens
 
-import androidx.compose.foundation.layout.Arrangement
-import androidx.compose.foundation.layout.Row
-import androidx.compose.foundation.layout.Spacer
-import androidx.compose.foundation.layout.fillMaxWidth
-import androidx.compose.foundation.layout.height
-import androidx.compose.foundation.layout.padding
-import androidx.compose.foundation.layout.weight
+import androidx.compose.foundation.layout.*
 import androidx.compose.material3.*
 import androidx.compose.runtime.*
 import androidx.compose.ui.Modifier


### PR DESCRIPTION
## Περίληψη
- Αντικατάσταση των επιμέρους imports με `androidx.compose.foundation.layout.*` ώστε να είναι προσβάσιμη η συνάρτηση `weight`
- Αποφυγή εισαγωγής εσωτερικού `weight` property που προκαλούσε σφάλμα compiler

## Δοκιμές
- `./gradlew assembleDebug` *(αποτυχία: λείπει το Android SDK στο περιβάλλον build)*

------
https://chatgpt.com/codex/tasks/task_e_68b5db2332508328b51dfa6de0b3bf60