### PR TITLE
Προσθήκη ελλειπόντων strings για τα μηνύματα σφαλμάτων πιστοποίησης

### DIFF
--- a/app/src/main/res/values-el/strings.xml
+++ b/app/src/main/res/values-el/strings.xml
@@ -36,6 +36,12 @@
     <string name="back_to_login">Επιστροφή στη σύνδεση</string>
     <string name="password_reset_email_sent">Στάλθηκε email επαναφοράς κωδικού</string>
 
+    <string name="email_required">Απαιτείται email</string>
+    <string name="error_invalid_email">Μη έγκυρο email</string>
+    <string name="error_user_not_found">Ο χρήστης δεν βρέθηκε</string>
+    <string name="error_operation_not_allowed">Η λειτουργία δεν επιτρέπεται</string>
+    <string name="error_send_reset">Αποτυχία αποστολής email επαναφοράς κωδικού</string>
+
     <string name="first_name">Όνομα</string>
     <string name="last_name">Επώνυμο</string>
     <string name="username">Όνομα χρήστη</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -34,6 +34,11 @@
     <string name="back_to_login">Back to login</string>
     <string name="password_reset_email_sent">Password reset email sent</string>
 
+    <string name="email_required">Email is required</string>
+    <string name="error_invalid_email">Invalid email address</string>
+    <string name="error_user_not_found">User not found</string>
+    <string name="error_operation_not_allowed">Operation not allowed</string>
+    <string name="error_send_reset">Failed to send password reset email</string>
 
     <string name="first_name">Name</string>
     <string name="last_name">Surname</string>


### PR DESCRIPTION
## Περίληψη
- Προστέθηκαν μηνύματα "email_required" και επιπλέον σφάλματα επαναφοράς κωδικού στα βασικά strings.
- Αντίστοιχες μεταφράσεις προστέθηκαν στο αρχείο για τα Ελληνικά.

## Έλεγχοι
- `./gradlew test` *(απέτυχε: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b5de11b7d48328acad4cac622308bb