### PR TITLE
fix: collect driver ratings flow

### DIFF
--- a/app/src/main/java/com/ioannapergamali/mysmartroute/viewmodel/DriverRatingViewModel.kt
+++ b/app/src/main/java/com/ioannapergamali/mysmartroute/viewmodel/DriverRatingViewModel.kt
@@ -27,7 +27,7 @@ class DriverRatingViewModel : ViewModel() {
                 val topIds = top.map { it.driverId }.toSet()
                 _bestDrivers.value = top
                 _worstDrivers.value = worst.filterNot { it.driverId in topIds }
-            }.collect()
+            }.collect { }
         }
     }
 }


### PR DESCRIPTION
## Summary
- add empty collector when combining driver rating flows

## Testing
- `./gradlew test` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b5dfb4ae78832895efae164a2f5993