### PR TITLE
Fix duplicate database initialization

### DIFF
--- a/app/src/main/java/com/ioannapergamali/mysmartroute/viewmodel/UserStatsViewModel.kt
+++ b/app/src/main/java/com/ioannapergamali/mysmartroute/viewmodel/UserStatsViewModel.kt
@@ -28,13 +28,8 @@ class UserStatsViewModel(application: Application) : AndroidViewModel(applicatio
 
     init {
 
- 
         viewModelScope.launch {
-
             val db = MySmartRouteDatabase.getInstance(application)
-
-            val db = MySmartRouteDatabase.getInstance(context)
-
 
             val users = db.userDao().getAllUsers().first()
             val movings = db.movingDao().getAll().first()


### PR DESCRIPTION
## Summary
- remove redundant database instance in UserStatsViewModel

## Testing
- `./gradlew test` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b5e0de64908328a00665c06053488a