### PR TITLE
Fix driver promotion/demotion parameter order

### DIFF
--- a/app/src/main/java/com/ioannapergamali/mysmartroute/viewmodel/UserViewModel.kt
+++ b/app/src/main/java/com/ioannapergamali/mysmartroute/viewmodel/UserViewModel.kt
@@ -186,10 +186,10 @@ class UserViewModel : ViewModel() {
         }
 
         // Καθαρίζουμε τα δεδομένα του οδηγού από Room και Firestore
-        demoteDriverToPassenger(dbInstance, driverId)
+        demoteDriverToPassenger(dbInstance, driverId = driverId)
     }
 
     private suspend fun handlePassengerPromotion(dbInstance: MySmartRouteDatabase, userId: String) {
-        promotePassengerToDriver(dbInstance, userId)
+        promotePassengerToDriver(dbInstance, passengerId = userId)
     }
 }


### PR DESCRIPTION
## Summary
- fix driver promotion/demotion helper calls to use named IDs

## Testing
- `./gradlew test` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b5e2ac96a4832885bdb70c8b945913