### PR TITLE
Προβολή διαδρομών χωρίς διάρκεια περπατήματος

### DIFF
--- a/app/src/main/java/com/ioannapergamali/mysmartroute/data/local/MySmartRouteDatabase.kt
+++ b/app/src/main/java/com/ioannapergamali/mysmartroute/data/local/MySmartRouteDatabase.kt
@@ -57,7 +57,7 @@ import com.ioannapergamali.mysmartroute.data.local.WalkingDao
         NotificationEntity::class,
         WalkingRouteEntity::class
     ],
-    version = 54
+    version = 55
 )
 @TypeConverters(Converters::class)
 abstract class MySmartRouteDatabase : RoomDatabase() {
@@ -716,6 +716,12 @@ abstract class MySmartRouteDatabase : RoomDatabase() {
             }
         }
 
+        private val MIGRATION_54_55 = object : Migration(54, 55) {
+            override fun migrate(database: SupportSQLiteDatabase) {
+                database.execSQL("ALTER TABLE `routes` ADD COLUMN `walkDurationMinutes` INTEGER NOT NULL DEFAULT 0")
+            }
+        }
+
         private fun prepopulate(db: SupportSQLiteDatabase) {
             Log.d(TAG, "Prepopulating database")
             db.execSQL(
@@ -849,7 +855,8 @@ abstract class MySmartRouteDatabase : RoomDatabase() {
                     MIGRATION_50_51,
                     MIGRATION_51_52,
                     MIGRATION_52_53,
-                    MIGRATION_53_54
+                    MIGRATION_53_54,
+                    MIGRATION_54_55
                 )
                     .addCallback(object : RoomDatabase.Callback() {
                         override fun onCreate(db: SupportSQLiteDatabase) {

--- a/app/src/main/java/com/ioannapergamali/mysmartroute/data/local/RouteDao.kt
+++ b/app/src/main/java/com/ioannapergamali/mysmartroute/data/local/RouteDao.kt
@@ -22,6 +22,12 @@ interface RouteDao {
     @Query("SELECT * FROM routes WHERE id = :id LIMIT 1")
     suspend fun findById(id: String): RouteEntity?
 
+    @Query("SELECT * FROM routes WHERE walkDurationMinutes = 0")
+    fun getRoutesWithoutWalkDuration(): kotlinx.coroutines.flow.Flow<List<RouteEntity>>
+
+    @Query("UPDATE routes SET walkDurationMinutes = :minutes WHERE id = :id")
+    suspend fun updateWalkDuration(id: String, minutes: Int)
+
     @Query("UPDATE routes SET startPoiId = CASE WHEN startPoiId = :oldId THEN :newId ELSE startPoiId END, endPoiId = CASE WHEN endPoiId = :oldId THEN :newId ELSE endPoiId END")
     suspend fun updatePoiReferences(oldId: String, newId: String)
 }

--- a/app/src/main/java/com/ioannapergamali/mysmartroute/data/local/RouteEntity.kt
+++ b/app/src/main/java/com/ioannapergamali/mysmartroute/data/local/RouteEntity.kt
@@ -9,5 +9,7 @@ data class RouteEntity(
     val userId: String = "",
     val name: String = "",
     val startPoiId: String = "",
-    val endPoiId: String = ""
+    val endPoiId: String = "",
+    /** Διάρκεια διαδρομής πεζή σε λεπτά (0 αν δεν έχει οριστεί). */
+    val walkDurationMinutes: Int = 0
 )

--- a/app/src/main/java/com/ioannapergamali/mysmartroute/model/navigation/NavigationHost.kt
+++ b/app/src/main/java/com/ioannapergamali/mysmartroute/model/navigation/NavigationHost.kt
@@ -16,6 +16,7 @@ import com.ioannapergamali.mysmartroute.view.ui.screens.DirectionsMapScreen
 import com.ioannapergamali.mysmartroute.view.ui.screens.PoIListScreen
 import com.ioannapergamali.mysmartroute.view.ui.screens.DefinePoiScreen
 import com.ioannapergamali.mysmartroute.view.ui.screens.DefineDurationScreen
+import com.ioannapergamali.mysmartroute.view.ui.screens.ViewUnassignedScreen
 import com.ioannapergamali.mysmartroute.view.ui.screens.SettingsScreen
 import com.ioannapergamali.mysmartroute.view.ui.screens.AboutScreen
 import com.ioannapergamali.mysmartroute.view.ui.screens.SupportScreen
@@ -143,6 +144,10 @@ fun NavigationHost(
         }
         composable("defineDuration") {
             DefineDurationScreen(navController = navController, openDrawer = openDrawer)
+        }
+
+        composable("viewUnassigned") {
+            ViewUnassignedScreen(navController = navController, openDrawer = openDrawer)
         }
 
 

--- a/app/src/main/java/com/ioannapergamali/mysmartroute/utils/FirestoreMappers.kt
+++ b/app/src/main/java/com/ioannapergamali/mysmartroute/utils/FirestoreMappers.kt
@@ -179,6 +179,7 @@ fun RouteEntity.toFirestoreMap(points: List<RoutePointEntity> = emptyList()): Ma
     "name" to name,
     "start" to FirebaseFirestore.getInstance().collection("pois").document(startPoiId),
     "end" to FirebaseFirestore.getInstance().collection("pois").document(endPoiId),
+    "walkDurationMinutes" to walkDurationMinutes,
     "points" to points.sortedBy { it.position }.map {
         FirebaseFirestore.getInstance().collection("pois").document(it.poiId)
     }
@@ -198,7 +199,8 @@ fun DocumentSnapshot.toRouteEntity(): RouteEntity? {
         is String -> raw
         else -> getString("end")
     } ?: return null
-    return RouteEntity(routeId, userId, routeName, start, end)
+    val walkDur = (getLong("walkDurationMinutes") ?: 0L).toInt()
+    return RouteEntity(routeId, userId, routeName, start, end, walkDur)
 }
 
 fun DocumentSnapshot.toRouteWithPoints(): Pair<RouteEntity, List<RoutePointEntity>>? {

--- a/app/src/main/java/com/ioannapergamali/mysmartroute/view/ui/screens/ViewUnassignedScreen.kt
+++ b/app/src/main/java/com/ioannapergamali/mysmartroute/view/ui/screens/ViewUnassignedScreen.kt
@@ -1,0 +1,71 @@
+package com.ioannapergamali.mysmartroute.view.ui.screens
+
+import androidx.compose.foundation.layout.*
+import androidx.compose.foundation.text.KeyboardOptions
+import androidx.compose.material3.*
+import androidx.compose.runtime.*
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.text.input.KeyboardType
+import androidx.compose.ui.unit.dp
+import androidx.lifecycle.viewmodel.compose.viewModel
+import androidx.navigation.NavController
+import com.ioannapergamali.mysmartroute.R
+import com.ioannapergamali.mysmartroute.view.ui.components.ScreenContainer
+import com.ioannapergamali.mysmartroute.view.ui.components.TopBar
+import com.ioannapergamali.mysmartroute.viewmodel.RouteViewModel
+
+@Composable
+fun ViewUnassignedScreen(navController: NavController, openDrawer: () -> Unit) {
+    val context = LocalContext.current
+    val routeViewModel: RouteViewModel = viewModel()
+    val routes by routeViewModel.routes.collectAsState()
+    val inputs = remember { mutableStateMapOf<String, String>() }
+
+    LaunchedEffect(Unit) { routeViewModel.loadRoutes(context, includeAll = true) }
+
+    val unassigned = routes.filter { it.walkDurationMinutes == 0 }
+
+    Scaffold(
+        topBar = {
+            TopBar(
+                title = stringResource(R.string.view_unassigned),
+                navController = navController,
+                showMenu = true,
+                onMenuClick = openDrawer
+            )
+        }
+    ) { padding ->
+        ScreenContainer(modifier = Modifier.padding(padding)) {
+            if (unassigned.isEmpty()) {
+                Text(stringResource(R.string.no_unassigned_routes))
+            } else {
+                unassigned.forEach { route ->
+                    Row(
+                        modifier = Modifier.fillMaxWidth(),
+                        horizontalArrangement = Arrangement.spacedBy(8.dp)
+                    ) {
+                        Text(route.name, modifier = Modifier.weight(1f))
+                        OutlinedTextField(
+                            value = inputs.getOrElse(route.id) { "" },
+                            onValueChange = { inputs[route.id] = it },
+                            label = { Text(stringResource(R.string.duration)) },
+                            singleLine = true,
+                            keyboardOptions = KeyboardOptions(keyboardType = KeyboardType.Number),
+                            modifier = Modifier.width(100.dp)
+                        )
+                        Button(onClick = {
+                            inputs[route.id]?.toIntOrNull()?.let { mins ->
+                                routeViewModel.updateWalkDuration(context, route.id, mins)
+                            }
+                        }) {
+                            Text(stringResource(R.string.save))
+                        }
+                    }
+                    Spacer(Modifier.height(8.dp))
+                }
+            }
+        }
+    }
+}

--- a/app/src/main/java/com/ioannapergamali/mysmartroute/viewmodel/RouteViewModel.kt
+++ b/app/src/main/java/com/ioannapergamali/mysmartroute/viewmodel/RouteViewModel.kt
@@ -149,6 +149,21 @@ class RouteViewModel : ViewModel() {
         points.forEach { pointDao.insert(it) }
     }
 
+    fun updateWalkDuration(context: Context, routeId: String, minutes: Int) {
+        viewModelScope.launch {
+            val db = MySmartRouteDatabase.getInstance(context)
+            val dao = db.routeDao()
+            dao.updateWalkDuration(routeId, minutes)
+            if (NetworkUtils.isInternetAvailable(context)) {
+                firestore.collection("routes").document(routeId)
+                    .update("walkDurationMinutes", minutes).await()
+            }
+            _routes.value = _routes.value.map {
+                if (it.id == routeId) it.copy(walkDurationMinutes = minutes) else it
+            }
+        }
+    }
+
     /**
      * Υπολογίζει τη διάρκεια διαδρομής με βάση τα αποθηκευμένα σημεία και το επιλεγμένο όχημα.
      * Χρησιμοποιεί το Google Maps Directions API για να επιστρέψει τη διάρκεια σε λεπτά.

--- a/app/src/main/res/values-el/strings.xml
+++ b/app/src/main/res/values-el/strings.xml
@@ -119,6 +119,7 @@
     <string name="define_poi">Ορισμός σημείου ενδιαφέροντος</string>
     <string name="define_duration">Ορισμός διάρκειας μετακίνησης με τα πόδια</string>
     <string name="view_unassigned">Προβολή μη εκχωρημένων διαδρομών</string>
+    <string name="no_unassigned_routes">Δεν υπάρχουν διαδρομές χωρίς διάρκεια περπατήματος</string>
     <string name="review_poi">Έλεγχος ονομάτων σημείων ενδιαφέροντος</string>
     <string name="rank_drivers">Προβολή 10 καλύτερων και χειρότερων οδηγών</string>
     <string name="top_drivers">Κορυφαίοι 10 οδηγοί</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -118,6 +118,7 @@
     <string name="define_poi">Define Point of Interest</string>
     <string name="define_duration">Define Duration of Travel by Foot</string>
     <string name="view_unassigned">View List of Unassigned Routes</string>
+    <string name="no_unassigned_routes">No routes without walking duration</string>
     <string name="review_poi">Review Point of Interest Names</string>
     <string name="rank_drivers">Show 10 Best and Worst Drivers</string>
     <string name="top_drivers">Top 10 drivers</string>


### PR DESCRIPTION
## Περίληψη
- Προσθήκη πεδίου `walkDurationMinutes` στις διαδρομές και αποθήκευση στο Firestore και τη Room
- Οθόνη διαχειριστή για προβολή διαδρομών χωρίς χρόνο περπατήματος και δυνατότητα ορισμού του
- Προσθήκη migration και πλοήγηση στην νέα οθόνη από το μενού

## Έλεγχοι
- `./gradlew test` *(απέτυχε: SDK location not found)*


------
https://chatgpt.com/codex/tasks/task_e_68b5e8d7a64883289b2f7106d6159fca