### PR TITLE
Χρήση DocumentReference στο walking και ενημέρωση Firebase BoM

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -62,7 +62,7 @@ kotlin {
 }
 dependencies {
     // Firebase (BoM για αυτόματες εκδόσεις όλων των modules)
-    implementation(platform("com.google.firebase:firebase-bom:33.1.2"))
+    implementation(platform("com.google.firebase:firebase-bom:34.2.0"))
     implementation("com.google.firebase:firebase-auth-ktx")
     implementation("com.google.firebase:firebase-firestore-ktx")
     implementation("com.google.firebase:firebase-storage-ktx")

--- a/app/src/main/java/com/ioannapergamali/mysmartroute/viewmodel/VehicleRequestViewModel.kt
+++ b/app/src/main/java/com/ioannapergamali/mysmartroute/viewmodel/VehicleRequestViewModel.kt
@@ -163,6 +163,7 @@ class VehicleRequestViewModel : ViewModel() {
         viewModelScope.launch {
             val userId = FirebaseAuth.getInstance().currentUser?.uid ?: return@launch
             val id = UUID.randomUUID().toString()
+            val userRef = db.collection("users").document(userId)
             val entity = WalkingRouteEntity(
                 id = id,
                 userId = userId,
@@ -176,15 +177,14 @@ class VehicleRequestViewModel : ViewModel() {
                 "fromPoiId" to fromPoiId,
                 "toPoiId" to toPoiId,
                 "date" to dateTime,
-                "userId" to userId
+                "userId" to userRef
             )
             try {
                 val dbInstance = MySmartRouteDatabase.getInstance(context)
                 dbInstance.walkingDao().insert(entity)
 
                 db.collection("walking").document(id).set(data).await()
-                db.collection("users")
-                    .document(userId)
+                userRef
                     .collection("walking")
                     .document(id)
                     .set(data)


### PR DESCRIPTION
## Περίληψη
- Χρήση `DocumentReference` για το `userId` κατά την αποθήκευση διαδρομών πεζών.
- Αναβάθμιση Firebase BoM στην έκδοση 34.2.0.

## Έλεγχοι
- `./gradlew test` (αποτυχία: λείπει Android SDK)


------
https://chatgpt.com/codex/tasks/task_e_68b5e99139b48328aa6b8e336cf273ba