### PR TITLE
Fix duplicate map declarations in updateWalkDuration

### DIFF
--- a/app/src/main/java/com/ioannapergamali/mysmartroute/viewmodel/RouteViewModel.kt
+++ b/app/src/main/java/com/ioannapergamali/mysmartroute/viewmodel/RouteViewModel.kt
@@ -161,25 +161,23 @@ class RouteViewModel : ViewModel() {
                 FirebaseAuth.getInstance().currentUser?.uid?.let { uid ->
 
                     val userRef = firestore.collection("users").document(uid)
-                    val data = mapOf(
+                    val walkData = mapOf(
                         "userId" to userRef,
                         "routeId" to routeId,
                         "durationMinutes" to minutes
                     )
                     firestore.collection("walking").document(routeId)
-                        .set(data)
+                        .set(walkData)
                         .await()
-                    userRef
 
-                    val data = mapOf(
+                    val userData = mapOf(
                         "routeId" to routeId,
                         "durationMinutes" to minutes
                     )
                     firestore.collection("users").document(uid)
-
                         .collection("walking")
                         .document(routeId)
-                        .set(data)
+                        .set(userData)
                         .await()
                 }
             }


### PR DESCRIPTION
## Summary
- eliminate duplicate `data` map declarations in `updateWalkDuration`
- remove unused statement and clarify local map names

## Testing
- `./gradlew --no-daemon --console=plain test` *(fails: log shows only "Starting a Gradle Daemon" and terminates)*

------
https://chatgpt.com/codex/tasks/task_e_68b64bf6d1b88328a9cb60f2f065a151