### PR TITLE
Αποθήκευση διάρκειας βάδισης με αναφορά χρήστη

### DIFF
--- a/app/src/main/java/com/ioannapergamali/mysmartroute/viewmodel/RouteViewModel.kt
+++ b/app/src/main/java/com/ioannapergamali/mysmartroute/viewmodel/RouteViewModel.kt
@@ -159,25 +159,19 @@ class RouteViewModel : ViewModel() {
                     .update("walkDurationMinutes", minutes).await()
 
                 FirebaseAuth.getInstance().currentUser?.uid?.let { uid ->
-
                     val userRef = firestore.collection("users").document(uid)
-                    val walkData = mapOf(
+                    val walkEntry = mapOf(
+                        "durationMinutes" to minutes,
                         "userId" to userRef,
-                        "routeId" to routeId,
-                        "durationMinutes" to minutes
+                        "routeId" to routeId
                     )
-                    firestore.collection("walking").document(routeId)
-                        .set(walkData)
+
+                    userRef.collection("walking")
+                        .add(walkEntry)
                         .await()
 
-                    val userData = mapOf(
-                        "routeId" to routeId,
-                        "durationMinutes" to minutes
-                    )
-                    firestore.collection("users").document(uid)
-                        .collection("walking")
-                        .document(routeId)
-                        .set(userData)
+                    firestore.collection("walking")
+                        .add(walkEntry)
                         .await()
                 }
             }


### PR DESCRIPTION
## Περίληψη
- Καταχώριση διάρκειας βάδισης στην υποσυλλογή `walking` του χρήστη
- Αποθήκευση εγγραφής και στην κεντρική συλλογή `walking` με `userId` ως `DocumentReference`

## Έλεγχοι
- `./gradlew test` *(απέτυχε: λείπει το Android SDK)*

------
https://chatgpt.com/codex/tasks/task_e_68b64eae0620832881ccbfe8fd037716