### PR TITLE
Αφαίρεση διπλού κουμπιού αποθήκευσης στην οθόνη περπατήματος

### DIFF
--- a/app/src/main/java/com/ioannapergamali/mysmartroute/view/ui/screens/WalkingScreen.kt
+++ b/app/src/main/java/com/ioannapergamali/mysmartroute/view/ui/screens/WalkingScreen.kt
@@ -396,27 +396,6 @@ fun WalkingScreen(navController: NavController, openDrawer: () -> Unit) {
             )
 
             Spacer(Modifier.height(16.dp))
-
-            Button(
-                onClick = {
-                    val rId = selectedRouteId ?: return@Button
-                    val start = startIndex?.let { routePois[it].id } ?: return@Button
-                    val end = endIndex?.let { routePois[it].id } ?: return@Button
-                    val timestamp = System.currentTimeMillis()
-                    vehicleRequestViewModel.saveWalkingRoute(
-                        context,
-                        rId,
-                        start,
-                        end,
-                        timestamp
-                    )
-                },
-                enabled = selectedRouteId != null && startIndex != null && endIndex != null
-            ) {
-                Text(stringResource(R.string.save))
-            }
-
-            Spacer(Modifier.height(16.dp))
         }
     }
 }


### PR DESCRIPTION
## Summary
- Αφαιρέθηκε το δεύτερο κουμπί "Αποθήκευση" από την οθόνη Περπάτημα ώστε να παραμένει μόνο η ενέργεια του floating action button.

## Testing
- `./gradlew test` *(απέτυχε: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b651e0f6f883289fc167b0b37a9a09