### PR TITLE
Αποφυγή δημιουργίας κενών χρηστών για διαδρομές πεζή

### DIFF
--- a/app/src/main/java/com/ioannapergamali/mysmartroute/viewmodel/RouteViewModel.kt
+++ b/app/src/main/java/com/ioannapergamali/mysmartroute/viewmodel/RouteViewModel.kt
@@ -162,13 +162,16 @@ class RouteViewModel : ViewModel() {
                     val userRef = firestore.collection("users").document(uid)
                     val walkEntry = mapOf(
                         "durationMinutes" to minutes,
-                        "userId" to userRef,
+                        "userId" to uid,
                         "routeId" to routeId
                     )
 
-                    userRef.collection("walking")
-                        .add(walkEntry)
-                        .await()
+                    val snapshot = userRef.get().await()
+                    if (snapshot.exists()) {
+                        userRef.collection("walking")
+                            .add(walkEntry)
+                            .await()
+                    }
 
                     firestore.collection("walking")
                         .add(walkEntry)


### PR DESCRIPTION
## Περίληψη
- Έλεγχος ύπαρξης χρήστη πριν την καταγραφή διαδρομών πεζή
- Αποθήκευση userId ως συμβολοσειρά ώστε να μην παράγονται κενές εγγραφές

## Έλεγχοι
- `./gradlew test` *(αποτυχημένο: λείπει Android SDK)*

------
https://chatgpt.com/codex/tasks/task_e_68b65fee191c83288c323dd199a7e99c