### PR TITLE
Αφαίρεση ανώνυμης σύνδεσης Firebase

### DIFF
--- a/app/src/main/java/com/ioannapergamali/mysmartroute/viewmodel/MainActivity.kt
+++ b/app/src/main/java/com/ioannapergamali/mysmartroute/viewmodel/MainActivity.kt
@@ -37,9 +37,6 @@ import kotlinx.coroutines.runBlocking
 import kotlinx.coroutines.launch
 import com.ioannapergamali.mysmartroute.model.interfaces.ThemeOption
 import android.view.WindowManager
-import com.google.firebase.auth.ktx.auth
-import com.google.firebase.firestore.ktx.firestore
-import com.google.firebase.ktx.Firebase
 
 
 
@@ -69,12 +66,6 @@ class MainActivity : ComponentActivity() {
         // Συγχρονισμός ρυθμίσεων από τη βάση
         settingsViewModel.syncSettings(this)
         requestViewModel.loadRequests(this)
-        // Απλό παράδειγμα χρήσης Firebase Auth & Firestore
-        val auth = Firebase.auth
-        val db = Firebase.firestore
-        auth.signInAnonymously()
-            .addOnFailureListener { e -> Log.e("Auth", "Αποτυχία σύνδεσης", e) }
-        db.collection("debug").add(mapOf("ts" to System.currentTimeMillis()))
         // Έλεγχος φόρτωσης του Maps API key
         val apiKey = MapsUtils.getApiKey(this)
         Log.d("Maps", "API key loaded? ${apiKey.isNotEmpty()}")


### PR DESCRIPTION
## Περίληψη
- Διαγραφή κλήσης `signInAnonymously` από το `MainActivity` ώστε να μην δημιουργούνται αυτόματα λογαριασμοί μόνο με `uid`.
- Καθαρισμός αντίστοιχων imports Firebase.

## Δοκιμές
- `./gradlew test` *(αποτυχία: δεν βρέθηκε Android SDK)*

------
https://chatgpt.com/codex/tasks/task_e_68b66293498c8328b43b95f721206c87