### PR TITLE
Initialize Maps SDK before camera updates

### DIFF
--- a/app/src/main/java/com/ioannapergamali/mysmartroute/view/ui/screens/ViewRoutesScreen.kt
+++ b/app/src/main/java/com/ioannapergamali/mysmartroute/view/ui/screens/ViewRoutesScreen.kt
@@ -11,6 +11,7 @@ import androidx.compose.ui.res.dimensionResource
 import androidx.lifecycle.viewmodel.compose.viewModel
 import androidx.navigation.NavController
 import com.google.android.gms.maps.CameraUpdateFactory
+import com.google.android.gms.maps.MapsInitializer
 import com.google.android.gms.maps.model.LatLng
 import com.google.maps.android.compose.GoogleMap
 import com.google.maps.android.compose.Marker
@@ -44,7 +45,10 @@ fun ViewRoutesScreen(navController: NavController, openDrawer: () -> Unit) {
     val apiKey = MapsUtils.getApiKey(context)
     val isKeyMissing = apiKey.isBlank()
 
-    LaunchedEffect(Unit) { routeViewModel.loadRoutes(context, includeAll = true) }
+    LaunchedEffect(Unit) {
+        MapsInitializer.initialize(context)
+        routeViewModel.loadRoutes(context, includeAll = true)
+    }
 
     Scaffold(
         topBar = {


### PR DESCRIPTION
## Summary
- initialize Maps SDK before requesting camera updates to avoid `CameraUpdateFactory` NPE

## Testing
- `./gradlew test` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b6696e35c88328bcb72be55974f4d7