### PR TITLE
Προβολή διαδρομών χωρίς καταχωρημένη διάρκεια

### DIFF
--- a/app/src/main/java/com/ioannapergamali/mysmartroute/view/ui/screens/ViewUnassignedScreen.kt
+++ b/app/src/main/java/com/ioannapergamali/mysmartroute/view/ui/screens/ViewUnassignedScreen.kt
@@ -26,9 +26,7 @@ fun ViewUnassignedScreen(navController: NavController, openDrawer: () -> Unit) {
     val inputs = remember { mutableStateMapOf<String, String>() }
     val coroutineScope = rememberCoroutineScope()
 
-    LaunchedEffect(Unit) { routeViewModel.loadRoutes(context, includeAll = true) }
-
-    val unassigned = routes.filter { it.walkDurationMinutes == 0 }
+    LaunchedEffect(Unit) { routeViewModel.loadRoutesWithoutDuration(context) }
 
     Scaffold(
         topBar = {
@@ -41,10 +39,10 @@ fun ViewUnassignedScreen(navController: NavController, openDrawer: () -> Unit) {
         }
     ) { padding ->
         ScreenContainer(modifier = Modifier.padding(padding)) {
-            if (unassigned.isEmpty()) {
+            if (routes.isEmpty()) {
                 Text(stringResource(R.string.no_unassigned_routes))
             } else {
-                unassigned.forEach { route ->
+                routes.forEach { route ->
                     Row(
                         modifier = Modifier.fillMaxWidth(),
                         horizontalArrangement = Arrangement.spacedBy(8.dp)


### PR DESCRIPTION
## Περίληψη
- Προστέθηκε στο `RouteViewModel` μέθοδος `loadRoutesWithoutDuration` για φόρτωση διαδρομών χωρίς καταχωρημένη διάρκεια
- Αναπροσαρμόστηκε η `ViewUnassignedScreen` ώστε να χρησιμοποιεί τη νέα μέθοδο και να εμφανίζει μόνο τις διαδρομές χωρίς διάρκεια

## Δοκιμές
- `./gradlew test` *(απέτυχε να ολοκληρωθεί: Daemon will be stopped at the end of the build)*

------
https://chatgpt.com/codex/tasks/task_e_68b66bfcfd1883289f6b0e1858ab062b