### PR TITLE
Αποτροπή δημιουργίας κενού χρήστη στο περπάτημα

### DIFF
--- a/app/src/main/java/com/ioannapergamali/mysmartroute/viewmodel/VehicleRequestViewModel.kt
+++ b/app/src/main/java/com/ioannapergamali/mysmartroute/viewmodel/VehicleRequestViewModel.kt
@@ -133,7 +133,7 @@ class VehicleRequestViewModel : ViewModel() {
         viewModelScope.launch {
             val dbInstance = MySmartRouteDatabase.getInstance(context)
             val dao = dbInstance.movingDao()
-            val userId = FirebaseAuth.getInstance().currentUser?.uid ?: ""
+            val userId = FirebaseAuth.getInstance().currentUser?.uid ?: return@launch
             val id = UUID.randomUUID().toString()
             val entity = MovingEntity(
                 id = id,


### PR DESCRIPTION
## Περίληψη
- Αποτρέπεται η καταγραφή περπατήματος όταν δεν υπάρχει συνδεδεμένος χρήστης

## Δοκιμές
- `./gradlew test` *(αποτυχία: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b66f3f3eb0832897a7aa445413fd81