### PR TITLE
Αποτροπή δημιουργίας κενού χρήστη στο περπάτημα

### DIFF
--- a/app/src/main/java/com/ioannapergamali/mysmartroute/viewmodel/VehicleRequestViewModel.kt
+++ b/app/src/main/java/com/ioannapergamali/mysmartroute/viewmodel/VehicleRequestViewModel.kt
@@ -14,7 +14,6 @@ import com.ioannapergamali.mysmartroute.data.local.MySmartRouteDatabase
 import com.ioannapergamali.mysmartroute.data.local.RouteDao
 import com.ioannapergamali.mysmartroute.data.local.WalkingRouteEntity
 import kotlinx.coroutines.Dispatchers
-import com.ioannapergamali.mysmartroute.utils.toFirestoreMap
 import com.ioannapergamali.mysmartroute.utils.toMovingEntity
 import com.ioannapergamali.mysmartroute.utils.toTransportDeclarationEntity
 import com.ioannapergamali.mysmartroute.utils.NetworkUtils
@@ -133,7 +132,7 @@ class VehicleRequestViewModel : ViewModel() {
         viewModelScope.launch {
             val dbInstance = MySmartRouteDatabase.getInstance(context)
             val dao = dbInstance.movingDao()
-            val userId = FirebaseAuth.getInstance().currentUser?.uid ?: ""
+            val userId = FirebaseAuth.getInstance().currentUser?.uid ?: return@launch
             val id = UUID.randomUUID().toString()
             val entity = MovingEntity(
                 id = id,
@@ -145,7 +144,14 @@ class VehicleRequestViewModel : ViewModel() {
             )
             dao.insert(entity)
             try {
-                db.collection("movings").document(id).set(entity.toFirestoreMap()).await()
+                val data = mapOf(
+                    "id" to id,
+                    "userId" to userId,
+                    "date" to dateTime,
+                    "vehicleId" to WALKING_ID,
+                    "status" to "open"
+                )
+                db.collection("movings").document(id).set(data).await()
             } catch (e: Exception) {
                 Log.e(TAG, "Failed to log walking", e)
             }


### PR DESCRIPTION
## Περίληψη
- Αποφεύγεται η δημιουργία κενών εγγραφών χρηστών κατά την καταγραφή περπατήματος

## Δοκιμές
- `./gradlew test` *(αποτυχία: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b66f3f3eb0832897a7aa445413fd81