### PR TITLE
Αποτροπή δημιουργίας κενών χρηστών

### DIFF
--- a/app/src/main/java/com/ioannapergamali/mysmartroute/data/local/FavoriteOperations.kt
+++ b/app/src/main/java/com/ioannapergamali/mysmartroute/data/local/FavoriteOperations.kt
@@ -2,15 +2,14 @@ package com.ioannapergamali.mysmartroute.data.local
 
 import androidx.room.Transaction
 
-/** Εισάγει αγαπημένο μεταφορικό μέσο εφόσον υπάρχει ο χρήστης. */
+/** Εισάγει αγαπημένο μεταφορικό μέσο μόνο αν υπάρχει ήδη ο χρήστης. */
 @Transaction
 suspend fun insertFavoriteSafely(
     favoriteDao: FavoriteDao,
     userDao: UserDao,
     favorite: FavoriteEntity
 ) {
-    if (userDao.getUser(favorite.userId) == null) {
-        userDao.insert(UserEntity(id = favorite.userId))
+    if (userDao.getUser(favorite.userId) != null) {
+        favoriteDao.insert(favorite)
     }
-    favoriteDao.insert(favorite)
 }

--- a/app/src/main/java/com/ioannapergamali/mysmartroute/data/local/SettingsOperations.kt
+++ b/app/src/main/java/com/ioannapergamali/mysmartroute/data/local/SettingsOperations.kt
@@ -4,8 +4,7 @@ import androidx.room.Transaction
 
 
 /**
- * Εισάγει ρυθμίσεις μόνο εφόσον υπάρχει η αντίστοιχη εγγραφή χρήστη.
- * Αν δεν υπάρχει, δημιουργείται πρώτα ένας χρήστης με το δοσμένο id.
+ * Εισάγει ρυθμίσεις μόνο αν υπάρχει ήδη ο χρήστης.
  */
 @Transaction
 suspend fun insertSettingsSafely(
@@ -13,9 +12,7 @@ suspend fun insertSettingsSafely(
     userDao: UserDao,
     settings: SettingsEntity
 ) {
-    val userId = settings.userId
-    if (userDao.getUser(userId) == null) {
-        userDao.insert(UserEntity(id = userId))
+    if (userDao.getUser(settings.userId) != null) {
+        settingsDao.insert(settings)
     }
-    settingsDao.insert(settings)
 }


### PR DESCRIPTION
## Περίληψη
- Αποτρέπεται η εισαγωγή αγαπημένων χωρίς προηγούμενη ύπαρξη χρήστη.
- Εισαγωγή ρυθμίσεων γίνεται μόνο όταν υπάρχει σχετική εγγραφή χρήστη.

## Έλεγχοι
- `./gradlew test` *(απέτυχε: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b681b7e628832882c295edba65381f