### PR TITLE
Αποθήκευση διαδρομών πεζών σε υποσυλλογή χρήστη

### DIFF
--- a/app/src/main/java/com/ioannapergamali/mysmartroute/viewmodel/RouteViewModel.kt
+++ b/app/src/main/java/com/ioannapergamali/mysmartroute/viewmodel/RouteViewModel.kt
@@ -190,8 +190,9 @@ class RouteViewModel : ViewModel() {
                         "userId" to uid,
                         "routeId" to routeId
                     )
-
-                    firestore.collection("walking")
+                    firestore.collection("users")
+                        .document(uid)
+                        .collection("walks")
                         .add(walkEntry)
                         .await()
                 }

--- a/app/src/main/java/com/ioannapergamali/mysmartroute/viewmodel/VehicleRequestViewModel.kt
+++ b/app/src/main/java/com/ioannapergamali/mysmartroute/viewmodel/VehicleRequestViewModel.kt
@@ -188,8 +188,8 @@ class VehicleRequestViewModel : ViewModel() {
             try {
                 val dbInstance = MySmartRouteDatabase.getInstance(context)
                 dbInstance.walkingDao().insert(entity)
-
-                db.collection("walking").document(id).set(data).await()
+                val userRef = db.collection("users").document(userId)
+                userRef.collection("walks").document(id).set(data).await()
                 Toast.makeText(context, R.string.route_saved, Toast.LENGTH_SHORT).show()
             } catch (e: Exception) {
                 Log.e(TAG, "Failed to save walking route", e)


### PR DESCRIPTION
## Περιγραφή
- Καταγραφή διαδρομών πεζών σε υποσυλλογή `walks` κάτω από κάθε χρήστη
- Ενημέρωση αποθήκευσης διάρκειας περπατήματος σε υποσυλλογή χρήστη

## Έλεγχοι
- `./gradlew test` *(απέτυχε: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b6876db61083289db4e524769cd278