### PR TITLE
Αποφυγή δημιουργίας κενών εγγράφων χρηστών στο Firestore

### DIFF
--- a/app/src/main/java/com/ioannapergamali/mysmartroute/viewmodel/DatabaseViewModel.kt
+++ b/app/src/main/java/com/ioannapergamali/mysmartroute/viewmodel/DatabaseViewModel.kt
@@ -445,10 +445,11 @@ class DatabaseViewModel : ViewModel() {
                         "Local data -> users:${users.size} vehicles:${vehicles.size} pois:${pois.size} poiTypes:${poiTypes.size} settings:${settings.size} roles:${roles.size} menus:${menus.size} options:${menuOptions.size} routes:${routes.size} points:${routePoints.size} movings:${movings.size} declarations:${declarations.size} availabilities:${availabilities.size} favorites:${favorites.size}"
                     )
 
-                    users.forEach {
+                    // Αποφεύγουμε την δημιουργία κενών εγγράφων στο Firestore
+                    users.filter { it.id.isNotBlank() && it.name.isNotBlank() }.forEach { user ->
                         firestore.collection("users")
-                            .document(it.id)
-                            .set(it.toFirestoreMap()).await()
+                            .document(user.id)
+                            .set(user.toFirestoreMap()).await()
                     }
                     vehicles.forEach {
                         firestore.collection("vehicles")


### PR DESCRIPTION
## Περίληψη
- Φιλτράρισμα χρηστών χωρίς έγκυρο id/όνομα πριν τον συγχρονισμό με το Firestore

## Έλεγχοι
- `./gradlew test` (απέτυχε: λήψη Gradle – δεν ολοκληρώθηκαν τα tests)


------
https://chatgpt.com/codex/tasks/task_e_68b68a78d2a48328a0919f491fb84074