### PR TITLE
Φόρτωση διαδρομών περπατήματος για ορισμό διάρκειας

### DIFF
--- a/app/src/main/java/com/ioannapergamali/mysmartroute/data/local/WalkingDao.kt
+++ b/app/src/main/java/com/ioannapergamali/mysmartroute/data/local/WalkingDao.kt
@@ -13,4 +13,7 @@ interface WalkingDao {
 
     @Query("SELECT * FROM walking WHERE userId = :userId")
     fun getRoutesForUser(userId: String): Flow<List<WalkingRouteEntity>>
+
+    @Query("SELECT DISTINCT routeId FROM walking")
+    suspend fun getAllRouteIds(): List<String>
 }

--- a/app/src/main/java/com/ioannapergamali/mysmartroute/view/ui/screens/DefineDurationScreen.kt
+++ b/app/src/main/java/com/ioannapergamali/mysmartroute/view/ui/screens/DefineDurationScreen.kt
@@ -30,13 +30,13 @@ fun DefineDurationScreen(navController: NavController, openDrawer: () -> Unit) {
     val context = LocalContext.current
     val routeViewModel: RouteViewModel = viewModel()
     val routes by routeViewModel.routes.collectAsState()
-    val pendingRoutes = routes.filter { it.walkDurationMinutes == 0 }
+    val pendingRoutes = routes
     var routeExpanded by remember { mutableStateOf(false) }
     var selectedRouteId by rememberSaveable { mutableStateOf<String?>(null) }
     var durationMinutes by remember { mutableStateOf<Int?>(null) }
     val coroutineScope = rememberCoroutineScope()
 
-    LaunchedEffect(Unit) { routeViewModel.loadRoutes(context, includeAll = true) }
+    LaunchedEffect(Unit) { routeViewModel.loadRoutesWithoutDuration(context) }
 
     Scaffold(
         topBar = {


### PR DESCRIPTION
## Περίληψη
- Φιλτράρονται οι διαδρομές χωρίς διάρκεια ώστε να εμφανίζονται μόνο όσες έχουν δηλωθεί ως περπάτημα
- Προσθήκη συνάρτησης στη βάση για εύρεση όλων των walking route ids
- Το UI φορτώνει πλέον μόνο τις σχετικές διαδρομές για ορισμό διάρκειας

## Έλεγχοι
- `./gradlew test` *(αποτυχία: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b68d3f0e9c832880bc996acd2bbd08