### PR TITLE
Φόρτωση διαδρομών περπατήματος για ορισμό διάρκειας

### DIFF
--- a/app/src/main/java/com/ioannapergamali/mysmartroute/data/local/WalkingDao.kt
+++ b/app/src/main/java/com/ioannapergamali/mysmartroute/data/local/WalkingDao.kt
@@ -13,4 +13,7 @@ interface WalkingDao {
 
     @Query("SELECT * FROM walking WHERE userId = :userId")
     fun getRoutesForUser(userId: String): Flow<List<WalkingRouteEntity>>
+
+    @Query("SELECT DISTINCT routeId FROM walking WHERE userId = :userId")
+    suspend fun getRouteIdsForUser(userId: String): List<String>
 }

--- a/app/src/main/java/com/ioannapergamali/mysmartroute/view/ui/screens/DefineDurationScreen.kt
+++ b/app/src/main/java/com/ioannapergamali/mysmartroute/view/ui/screens/DefineDurationScreen.kt
@@ -30,13 +30,13 @@ fun DefineDurationScreen(navController: NavController, openDrawer: () -> Unit) {
     val context = LocalContext.current
     val routeViewModel: RouteViewModel = viewModel()
     val routes by routeViewModel.routes.collectAsState()
-    val pendingRoutes = routes.filter { it.walkDurationMinutes == 0 }
+    val pendingRoutes = routes
     var routeExpanded by remember { mutableStateOf(false) }
     var selectedRouteId by rememberSaveable { mutableStateOf<String?>(null) }
     var durationMinutes by remember { mutableStateOf<Int?>(null) }
     val coroutineScope = rememberCoroutineScope()
 
-    LaunchedEffect(Unit) { routeViewModel.loadRoutes(context, includeAll = true) }
+    LaunchedEffect(Unit) { routeViewModel.loadRoutesWithoutDuration(context) }
 
     Scaffold(
         topBar = {

--- a/app/src/main/java/com/ioannapergamali/mysmartroute/viewmodel/RouteViewModel.kt
+++ b/app/src/main/java/com/ioannapergamali/mysmartroute/viewmodel/RouteViewModel.kt
@@ -100,22 +100,40 @@ class RouteViewModel : ViewModel() {
         viewModelScope.launch {
             val db = MySmartRouteDatabase.getInstance(context)
             val routeDao = db.routeDao()
-            val local = routeDao.getRoutesWithoutWalkDuration().first()
+            val walkingDao = db.walkingDao()
+            val userId = FirebaseAuth.getInstance().currentUser?.uid ?: return@launch
+            val walkingIds = mutableSetOf<String>()
+            walkingIds.addAll(walkingDao.getRouteIdsForUser(userId))
 
             if (NetworkUtils.isInternetAvailable(context)) {
-                val snapshot = runCatching {
-                    firestore.collection("routes")
-                        .whereEqualTo("walkDurationMinutes", 0)
+                val remoteWalks = runCatching {
+                    firestore.collection("users")
+                        .document(userId)
+                        .collection("walks")
                         .get()
                         .await()
                 }.getOrNull()
-                if (snapshot != null) {
-                    val list = snapshot.documents.mapNotNull { it.toRouteEntity() }
-                    _routes.value = list
-                    list.forEach { routeDao.insert(it) }
-                } else {
-                    _routes.value = local
+                remoteWalks?.let { snap ->
+                    walkingIds.addAll(snap.documents.mapNotNull { it.getString("routeId") })
                 }
+            }
+
+            val local = routeDao.getRoutesWithoutWalkDuration().first()
+                .filter { it.id in walkingIds }
+
+            if (NetworkUtils.isInternetAvailable(context)) {
+                val fetched = mutableListOf<RouteEntity>()
+                for (id in walkingIds) {
+                    val doc = runCatching {
+                        firestore.collection("routes").document(id).get().await()
+                    }.getOrNull()
+                    val route = doc?.toRouteEntity()
+                    if (route != null && route.walkDurationMinutes == 0) {
+                        fetched += route
+                        routeDao.insert(route)
+                    }
+                }
+                _routes.value = if (fetched.isNotEmpty()) fetched else local
             } else {
                 _routes.value = local
             }


### PR DESCRIPTION
## Περίληψη
- Λήψη αναγνωριστικών διαδρομών πεζή ανά χρήστη από τη βάση και το Firestore
- Φόρτωση των αντίστοιχων routes χωρίς ορισμένη διάρκεια

## Έλεγχοι
- `./gradlew test` *(αποτυχία: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b68d3f0e9c832880bc996acd2bbd08