### PR TITLE
Προσθήκη μεθόδου getRouteIdsForUser στο WalkingDao

### DIFF
--- a/app/src/main/java/com/ioannapergamali/mysmartroute/data/local/WalkingDao.kt
+++ b/app/src/main/java/com/ioannapergamali/mysmartroute/data/local/WalkingDao.kt
@@ -14,6 +14,8 @@ interface WalkingDao {
     @Query("SELECT * FROM walking WHERE userId = :userId")
     fun getRoutesForUser(userId: String): Flow<List<WalkingRouteEntity>>
 
+    @Query("SELECT DISTINCT routeId FROM walking WHERE userId = :userId")
+    suspend fun getRouteIdsForUser(userId: String): List<String>
 
     @Query("SELECT DISTINCT routeId FROM walking")
     suspend fun getAllRouteIds(): List<String>


### PR DESCRIPTION
## Περίληψη
- Προστέθηκε η μέθοδος `getRouteIdsForUser` στο `WalkingDao` για επιστροφή μοναδικών ταυτοτήτων διαδρομών ανά χρήστη.
- Η αλλαγή διορθώνει το `Unresolved reference` στο `RouteViewModel`.

## Δοκιμές
- `./gradlew test` *(απέτυχε: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b6945e7fd0832893b513ef9f4703ac