### PR TITLE
Fix walking dao reference

### DIFF
--- a/app/src/main/java/com/ioannapergamali/mysmartroute/viewmodel/RouteViewModel.kt
+++ b/app/src/main/java/com/ioannapergamali/mysmartroute/viewmodel/RouteViewModel.kt
@@ -100,6 +100,8 @@ class RouteViewModel : ViewModel() {
         viewModelScope.launch {
             val db = MySmartRouteDatabase.getInstance(context)
             val routeDao = db.routeDao()
+            val walkingDao = db.walkingDao()
+            val userId = FirebaseAuth.getInstance().currentUser?.uid
 
             val walkingIds = mutableSetOf<String>()
 
@@ -113,7 +115,7 @@ class RouteViewModel : ViewModel() {
                 remoteWalks?.let { snap ->
                     walkingIds.addAll(snap.documents.mapNotNull { it.getString("routeId") })
                 }
-            } else {
+            } else if (userId != null) {
                 walkingIds.addAll(walkingDao.getRouteIdsForUser(userId).first())
             }
 


### PR DESCRIPTION
## Summary
- initialize `walkingDao` and `userId` when loading routes without duration

## Testing
- `./gradlew test` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b69ab480108328a1cb5679539838c5