### PR TITLE
Προσθήκη συλλογικού ερωτήματος walks για διαχειριστή

### DIFF
--- a/app/src/main/java/com/ioannapergamali/mysmartroute/model/Walk.kt
+++ b/app/src/main/java/com/ioannapergamali/mysmartroute/model/Walk.kt
@@ -1,0 +1,10 @@
+package com.ioannapergamali.mysmartroute.model
+
+/**
+ * Αναπαράσταση μιας πεζής μετακίνησης που αποθηκεύεται στο Firestore.
+ */
+data class Walk(
+    val routeId: String = "",
+    val userId: String = "",
+    val durationMinutes: Long = 0L
+)

--- a/app/src/main/java/com/ioannapergamali/mysmartroute/view/ui/screens/DefineDurationScreen.kt
+++ b/app/src/main/java/com/ioannapergamali/mysmartroute/view/ui/screens/DefineDurationScreen.kt
@@ -36,7 +36,10 @@ fun DefineDurationScreen(navController: NavController, openDrawer: () -> Unit) {
     var durationMinutes by remember { mutableStateOf<Int?>(null) }
     val coroutineScope = rememberCoroutineScope()
 
-    LaunchedEffect(Unit) { routeViewModel.loadRoutesWithoutDuration(context) }
+    LaunchedEffect(Unit) {
+        routeViewModel.loadAllWalksForAdmin()
+        routeViewModel.loadRoutesWithoutDuration(context)
+    }
 
     Scaffold(
         topBar = {


### PR DESCRIPTION
## Περίληψη
- Προστέθηκε data class `Walk` για την αναπαράσταση πεζών μετακινήσεων.
- Επεκτάθηκε το `RouteViewModel` με συλλογή όλων των εγγράφων `walks` μέσω collection group.
- Ενημερώθηκε το `DefineDurationScreen` ώστε να φορτώνει τις πεζές μετακινήσεις του διαχειριστή.

## Έλεγχοι
- `./gradlew test` *(αποτυχία: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b69d059d748328b943a47452c8e408