### PR TITLE
Αφαίρεση διπλής κύλισης και ενημέρωση Compose BOM

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -79,8 +79,8 @@ dependencies {
     implementation("androidx.constraintlayout:constraintlayout:2.2.1")
 
     // Jetpack Compose
-    implementation(platform("androidx.compose:compose-bom:2025.07.00"))
-    androidTestImplementation(platform("androidx.compose:compose-bom:2025.07.00"))
+    implementation(platform("androidx.compose:compose-bom:2025.08.01"))
+    androidTestImplementation(platform("androidx.compose:compose-bom:2025.08.01"))
 
     // Χρήση της σταθερής έκδοσης Material3
     implementation("androidx.compose.material3:material3:1.3.2")

--- a/app/src/main/java/com/ioannapergamali/mysmartroute/view/ui/screens/ViewUsersScreen.kt
+++ b/app/src/main/java/com/ioannapergamali/mysmartroute/view/ui/screens/ViewUsersScreen.kt
@@ -37,7 +37,7 @@ fun ViewUsersScreen(navController: NavController, openDrawer: () -> Unit) {
             )
         }
     ) { padding ->
-        ScreenContainer(modifier = Modifier.padding(padding)) {
+        ScreenContainer(modifier = Modifier.padding(padding), scrollable = false) {
             if (summaries.isEmpty()) {
                 Text(stringResource(R.string.no_users))
             } else {


### PR DESCRIPTION
## Περίληψη
- Απενεργοποίηση του `scrollable` wrapper στο `ViewUsersScreen` ώστε να μην εμφωλεύεται `LazyColumn` σε κάθετα κυλιόμενο `Column`.
- Αναβάθμιση του Compose BOM στην έκδοση `2025.08.01` για χρήση των πιο πρόσφατων βιβλιοθηκών Compose.

## Έλεγχοι
- `./gradlew test` *(αποτυχία: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b69e28934c83288b2602e1f89aa0a1