### PR TITLE
Φιλτράρισμα διαδρομών χωρίς διάρκεια περπατήματος

### DIFF
--- a/app/src/main/java/com/ioannapergamali/mysmartroute/view/ui/screens/DefineDurationScreen.kt
+++ b/app/src/main/java/com/ioannapergamali/mysmartroute/view/ui/screens/DefineDurationScreen.kt
@@ -30,7 +30,7 @@ fun DefineDurationScreen(navController: NavController, openDrawer: () -> Unit) {
     val context = LocalContext.current
     val routeViewModel: RouteViewModel = viewModel()
     val routes by routeViewModel.routes.collectAsState()
-    val pendingRoutes = routes
+    val pendingRoutes = routes.filter { it.walkDurationMinutes == 0 }
     var routeExpanded by remember { mutableStateOf(false) }
     var selectedRouteId by rememberSaveable { mutableStateOf<String?>(null) }
     var durationMinutes by remember { mutableStateOf<Int?>(null) }
@@ -108,6 +108,8 @@ fun DefineDurationScreen(navController: NavController, openDrawer: () -> Unit) {
                     Button(onClick = {
                         val rId = selectedRouteId ?: return@Button
                         routeViewModel.updateWalkDuration(context, rId, mins)
+                        selectedRouteId = null
+                        durationMinutes = null
                     }) {
                         Text(stringResource(R.string.save))
                     }

--- a/app/src/main/java/com/ioannapergamali/mysmartroute/view/ui/screens/ViewUnassignedScreen.kt
+++ b/app/src/main/java/com/ioannapergamali/mysmartroute/view/ui/screens/ViewUnassignedScreen.kt
@@ -39,10 +39,11 @@ fun ViewUnassignedScreen(navController: NavController, openDrawer: () -> Unit) {
         }
     ) { padding ->
         ScreenContainer(modifier = Modifier.padding(padding)) {
-            if (routes.isEmpty()) {
+            val unassigned = routes.filter { it.walkDurationMinutes == 0 }
+            if (unassigned.isEmpty()) {
                 Text(stringResource(R.string.no_unassigned_routes))
             } else {
-                routes.forEach { route ->
+                unassigned.forEach { route ->
                     Row(
                         modifier = Modifier.fillMaxWidth(),
                         horizontalArrangement = Arrangement.spacedBy(8.dp)
@@ -70,6 +71,7 @@ fun ViewUnassignedScreen(navController: NavController, openDrawer: () -> Unit) {
                         Button(onClick = {
                             inputs[route.id]?.toIntOrNull()?.let { mins ->
                                 routeViewModel.updateWalkDuration(context, route.id, mins)
+                                inputs.remove(route.id)
                             }
                         }) {
                             Text(stringResource(R.string.save))


### PR DESCRIPTION
## Περίληψη
- Φιλτράρονται οι διαδρομές χωρίς καθορισμένη διάρκεια στα σχετικά screens.
- Απομάκρυνση διαδρομής από τη λίστα μετά την αποθήκευση της χρονικής διάρκειας.

## Έλεγχοι
- `./gradlew test` *(αποτυχία: λείπει Android SDK)*

------
https://chatgpt.com/codex/tasks/task_e_68b6a28cbf408328adbf197111d70fc9