### PR TITLE
Διόρθωση φόρτωσης διαδρομών χωρίς διάρκεια

### DIFF
--- a/app/src/main/java/com/ioannapergamali/mysmartroute/view/ui/screens/ViewUnassignedScreen.kt
+++ b/app/src/main/java/com/ioannapergamali/mysmartroute/view/ui/screens/ViewUnassignedScreen.kt
@@ -26,7 +26,7 @@ fun ViewUnassignedScreen(navController: NavController, openDrawer: () -> Unit) {
     val inputs = remember { mutableStateMapOf<String, String>() }
     val coroutineScope = rememberCoroutineScope()
 
-    LaunchedEffect(Unit) { routeViewModel.loadRoutesWithoutDuration(context) }
+    LaunchedEffect(Unit) { routeViewModel.loadRoutesWithoutDuration() }
 
     Scaffold(
         topBar = {


### PR DESCRIPTION
## Summary
- αφαίρεση του context από την κλήση loadRoutesWithoutDuration ώστε να ταιριάζει με το ViewModel

## Testing
- `./gradlew test` *(απέτυχε: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b6a3dff464832880ce83a662c23374