### PR TITLE
Προσθήκη ελέγχου παραμέτρων στο walkingDuration

### DIFF
--- a/app/src/main/java/com/ioannapergamali/mysmartroute/utils/WalkingUtils.kt
+++ b/app/src/main/java/com/ioannapergamali/mysmartroute/utils/WalkingUtils.kt
@@ -12,11 +12,15 @@ object WalkingUtils {
 
     /**
      * Επιστρέφει την εκτιμώμενη διάρκεια περπατήματος για την απόσταση [distanceMeters].
+     * Η [distanceMeters] και η [speedMps] πρέπει να είναι θετικές τιμές.
      */
     fun walkingDuration(
         distanceMeters: Double,
         speedMps: Double = DEFAULT_WALKING_SPEED_MPS
     ): Duration {
+        require(distanceMeters >= 0 && speedMps > 0) {
+            "Η απόσταση και η ταχύτητα πρέπει να είναι θετικές"
+        }
         val seconds = distanceMeters / speedMps
         return seconds.toDuration(DurationUnit.SECONDS)
     }

--- a/app/src/test/java/com/ioannapergamali/mysmartroute/utils/WalkingUtilsTest.kt
+++ b/app/src/test/java/com/ioannapergamali/mysmartroute/utils/WalkingUtilsTest.kt
@@ -2,12 +2,27 @@ package com.ioannapergamali.mysmartroute.utils
 
 import kotlin.test.Test
 import kotlin.test.assertEquals
+import kotlin.test.assertFailsWith
 
 class WalkingUtilsTest {
     @Test
     fun walkingDuration_returnsSeconds() {
         val duration = WalkingUtils.walkingDuration(2800.0)
         assertEquals(2000, duration.inWholeSeconds)
+    }
+
+    @Test
+    fun walkingDuration_negativeDistance_throws() {
+        assertFailsWith<IllegalArgumentException> {
+            WalkingUtils.walkingDuration(-1.0)
+        }
+    }
+
+    @Test
+    fun walkingDuration_zeroSpeed_throws() {
+        assertFailsWith<IllegalArgumentException> {
+            WalkingUtils.walkingDuration(1000.0, 0.0)
+        }
     }
 }
 


### PR DESCRIPTION
## Περίληψη
- Έλεγχος ότι η απόσταση και η ταχύτητα είναι θετικές στη `walkingDuration`
- Προσθήκη δοκιμών για αρνητική απόσταση και μηδενική ταχύτητα

## Έλεγχοι
- `./gradlew test` *(απέτυχε: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b6ad37da84832896f36045f23236d6