### PR TITLE
Ανάγνωση διαδρομών χωρίς διάρκεια απευθείας

### DIFF
--- a/app/src/main/java/com/ioannapergamali/mysmartroute/model/Walk.kt
+++ b/app/src/main/java/com/ioannapergamali/mysmartroute/model/Walk.kt
@@ -1,10 +1,15 @@
 package com.ioannapergamali.mysmartroute.model
 
+import com.google.firebase.Timestamp
+
 /**
  * Αναπαράσταση μιας πεζής μετακίνησης που αποθηκεύεται στο Firestore.
  */
 data class Walk(
-    val routeId: String = "",
+    val id: String = "",
     val userId: String = "",
+    val routeId: String = "",
+    val startTime: Timestamp? = null,
+    val endTime: Timestamp? = null,
     val durationMinutes: Long = 0L
 )

--- a/app/src/main/java/com/ioannapergamali/mysmartroute/repository/AdminWalkRepository.kt
+++ b/app/src/main/java/com/ioannapergamali/mysmartroute/repository/AdminWalkRepository.kt
@@ -1,0 +1,34 @@
+package com.ioannapergamali.mysmartroute.repository
+
+import com.google.firebase.firestore.FirebaseFirestore
+import kotlinx.coroutines.tasks.await
+import com.ioannapergamali.mysmartroute.model.Walk
+
+/**
+ * Repository για συλλογή όλων των πεζών μετακινήσεων από όλα τα `walks` subcollections.
+ */
+class AdminWalkRepository {
+    private val db = FirebaseFirestore.getInstance()
+
+    /**
+     * Ανακτά όλα τα walks και υπολογίζει τη διάρκεια τους βάσει startTime/endTime.
+     */
+    suspend fun fetchAllWalks(): List<Walk> {
+        val snapshot = db.collectionGroup("walks").get().await()
+        return snapshot.documents.map { doc ->
+            val start = doc.getTimestamp("startTime")
+            val end = doc.getTimestamp("endTime")
+            val duration = if (start != null && end != null) {
+                (end.seconds - start.seconds) / 60
+            } else 0L
+            Walk(
+                id = doc.id,
+                userId = doc.getString("userId") ?: "",
+                routeId = doc.getString("routeId") ?: "",
+                startTime = start,
+                endTime = end,
+                durationMinutes = duration
+            )
+        }
+    }
+}

--- a/app/src/main/java/com/ioannapergamali/mysmartroute/viewmodel/RouteViewModel.kt
+++ b/app/src/main/java/com/ioannapergamali/mysmartroute/viewmodel/RouteViewModel.kt
@@ -5,12 +5,12 @@ import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import com.google.firebase.auth.FirebaseAuth
 import com.google.firebase.firestore.FirebaseFirestore
-import com.google.firebase.firestore.ktx.toObject
 import com.ioannapergamali.mysmartroute.data.local.MySmartRouteDatabase
 import com.ioannapergamali.mysmartroute.data.local.RouteEntity
 import com.ioannapergamali.mysmartroute.data.local.RoutePointEntity
 import com.ioannapergamali.mysmartroute.data.local.PoIEntity
 import com.ioannapergamali.mysmartroute.model.Walk
+import com.ioannapergamali.mysmartroute.repository.AdminWalkRepository
 import com.ioannapergamali.mysmartroute.utils.toFirestoreMap
 import com.ioannapergamali.mysmartroute.utils.toRouteEntity
 import com.ioannapergamali.mysmartroute.utils.toRouteWithPoints
@@ -30,6 +30,7 @@ import java.util.UUID
  */
 class RouteViewModel : ViewModel() {
     private val firestore = FirebaseFirestore.getInstance()
+    private val adminWalkRepo = AdminWalkRepository()
 
     private val _routes = MutableStateFlow<List<RouteEntity>>(emptyList())
     val routes: StateFlow<List<RouteEntity>> = _routes
@@ -74,10 +75,7 @@ class RouteViewModel : ViewModel() {
      */
     fun loadAllWalksForAdmin() {
         viewModelScope.launch {
-            val snapshot = runCatching {
-                firestore.collectionGroup("walks").get().await()
-            }.getOrNull()
-            _walks.value = snapshot?.documents?.mapNotNull { it.toObject<Walk>() } ?: emptyList()
+            _walks.value = runCatching { adminWalkRepo.fetchAllWalks() }.getOrElse { emptyList() }
         }
     }
 
@@ -117,24 +115,15 @@ class RouteViewModel : ViewModel() {
     fun loadRoutesWithoutDuration() {
         viewModelScope.launch {
             val snapshot = runCatching {
-                firestore.collectionGroup("walks").get().await()
+                firestore.collection("routes")
+                    .whereEqualTo("walkDurationMinutes", 0)
+                    .get()
+                    .await()
             }.getOrNull()
 
-            val routeIds = snapshot?.documents
-                ?.mapNotNull { it.getString("routeId") }
+            _routes.value = snapshot?.documents
+                ?.mapNotNull { it.toRouteEntity() }
                 ?: emptyList()
-
-            val fetched = mutableListOf<RouteEntity>()
-            for (id in routeIds) {
-                val doc = runCatching {
-                    firestore.collection("routes").document(id).get().await()
-                }.getOrNull()
-                val route = doc?.toRouteEntity()
-                if (route != null && route.walkDurationMinutes == 0) {
-                    fetched += route
-                }
-            }
-            _routes.value = fetched
         }
     }
 


### PR DESCRIPTION
## Σύνοψη
- Ενημέρωση της `loadRoutesWithoutDuration` ώστε να αναζητά διαδρομές περπατήματος χωρίς διάρκεια κατευθείαν από τη συλλογή `routes`

## Δοκιμές
- `./gradlew test` *(αποτυχία: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b6abace8848328b5f7d78541a5ba14