### PR TITLE
Use DocumentReference for walks subcollection

### DIFF
--- a/app/src/main/java/com/ioannapergamali/mysmartroute/model/Walk.kt
+++ b/app/src/main/java/com/ioannapergamali/mysmartroute/model/Walk.kt
@@ -1,14 +1,16 @@
 package com.ioannapergamali.mysmartroute.model
 
 import com.google.firebase.Timestamp
+import com.google.firebase.firestore.DocumentReference
 
 /**
  * Αναπαράσταση μιας πεζής μετακίνησης που αποθηκεύεται στο Firestore.
  */
 data class Walk(
     val id: String = "",
-    val userId: String = "",
-    val routeId: String = "",
+    val fromPoiRef: DocumentReference? = null,
+    val routeRef: DocumentReference? = null,
+    val toPoiRef: DocumentReference? = null,
     val startTime: Timestamp? = null,
     val endTime: Timestamp? = null,
     val durationMinutes: Long = 0L

--- a/app/src/main/java/com/ioannapergamali/mysmartroute/repository/AdminWalkRepository.kt
+++ b/app/src/main/java/com/ioannapergamali/mysmartroute/repository/AdminWalkRepository.kt
@@ -23,8 +23,9 @@ class AdminWalkRepository {
             } else 0L
             Walk(
                 id = doc.id,
-                userId = doc.getString("userId") ?: "",
-                routeId = doc.getString("routeId") ?: "",
+                fromPoiRef = doc.getDocumentReference("fromPoiId"),
+                routeRef = doc.getDocumentReference("routeId"),
+                toPoiRef = doc.getDocumentReference("toPoiId"),
                 startTime = start,
                 endTime = end,
                 durationMinutes = duration

--- a/app/src/main/java/com/ioannapergamali/mysmartroute/viewmodel/VehicleRequestViewModel.kt
+++ b/app/src/main/java/com/ioannapergamali/mysmartroute/viewmodel/VehicleRequestViewModel.kt
@@ -169,12 +169,14 @@ class VehicleRequestViewModel : ViewModel() {
         viewModelScope.launch {
             val userId = FirebaseAuth.getInstance().currentUser?.uid ?: return@launch
             val id = UUID.randomUUID().toString()
+            val routeRef = db.collection("routes").document(routeId)
+            val fromPoiRef = db.collection("pois").document(fromPoiId)
+            val toPoiRef = db.collection("pois").document(toPoiId)
             val data = mapOf(
-                "routeId" to routeId,
-                "fromPoiId" to fromPoiId,
-                "toPoiId" to toPoiId,
-                "date" to dateTime,
-                "userId" to userId
+                "routeId" to routeRef,
+                "fromPoiId" to fromPoiRef,
+                "toPoiId" to toPoiRef,
+                "date" to dateTime
             )
             try {
                 val userRef = db.collection("users").document(userId)


### PR DESCRIPTION
## Summary
- Replace plain string ids in Walk model with `DocumentReference` fields
- Update repositories and view models to store from/to PoI and route references in `walks` subcollection

## Testing
- `./gradlew test` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b6b9b6effc8328a261cc34a142c892