### PR TITLE
Προσθήκη αποθήκευσης και εμφάνισης διαδρομών πεζών

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -106,6 +106,7 @@ dependencies {
     implementation("com.google.android.gms:play-services-maps:19.2.0")
     implementation("com.google.maps.android:maps-compose:6.6.0")
     implementation("com.google.maps.android:maps-ktx:5.2.0")
+    implementation("com.google.maps.android:maps-utils-ktx:5.2.0")
     implementation("com.google.android.gms:play-services-location:21.3.0")
     implementation("com.google.android.libraries.places:places:3.4.0")
 

--- a/app/src/main/java/com/ioannapergamali/mysmartroute/data/local/WalkingRouteDao.kt
+++ b/app/src/main/java/com/ioannapergamali/mysmartroute/data/local/WalkingRouteDao.kt
@@ -1,0 +1,19 @@
+package com.ioannapergamali.mysmartroute.data.local
+
+import androidx.room.Dao
+import androidx.room.Insert
+import androidx.room.Query
+import kotlinx.coroutines.flow.Flow
+
+/**
+ * DAO για τις αποθηκευμένες διαδρομές πεζών.
+ */
+@Dao
+interface WalkingRouteDao {
+    @Insert
+    suspend fun insert(route: WalkingRouteEntity): Long
+
+    @Query("SELECT * FROM walking_routes")
+    fun getAll(): Flow<List<WalkingRouteEntity>>
+}
+

--- a/app/src/main/java/com/ioannapergamali/mysmartroute/data/local/WalkingRouteDatabase.kt
+++ b/app/src/main/java/com/ioannapergamali/mysmartroute/data/local/WalkingRouteDatabase.kt
@@ -1,0 +1,27 @@
+package com.ioannapergamali.mysmartroute.data.local
+
+import android.content.Context
+import androidx.room.Database
+import androidx.room.Room
+import androidx.room.RoomDatabase
+
+@Database(entities = [WalkingRouteEntity::class], version = 1)
+abstract class WalkingRouteDatabase : RoomDatabase() {
+    abstract fun dao(): WalkingRouteDao
+
+    companion object {
+        @Volatile
+        private var INSTANCE: WalkingRouteDatabase? = null
+
+        fun getDatabase(context: Context): WalkingRouteDatabase {
+            return INSTANCE ?: synchronized(this) {
+                Room.databaseBuilder(
+                    context.applicationContext,
+                    WalkingRouteDatabase::class.java,
+                    "walking_routes.db"
+                ).build().also { INSTANCE = it }
+            }
+        }
+    }
+}
+

--- a/app/src/main/java/com/ioannapergamali/mysmartroute/data/local/WalkingRouteEntity.kt
+++ b/app/src/main/java/com/ioannapergamali/mysmartroute/data/local/WalkingRouteEntity.kt
@@ -1,0 +1,19 @@
+package com.ioannapergamali.mysmartroute.data.local
+
+import androidx.room.Entity
+import androidx.room.PrimaryKey
+
+/**
+ * Οντότητα που αποθηκεύει μια διαδρομή πεζών με κωδικοποιημένη polyline.
+ */
+@Entity(tableName = "walking_routes")
+data class WalkingRouteEntity(
+    @PrimaryKey(autoGenerate = true) val id: Long = 0,
+    val name: String,
+    val startLat: Double,
+    val startLng: Double,
+    val endLat: Double,
+    val endLng: Double,
+    val polyline: String
+)
+

--- a/app/src/main/java/com/ioannapergamali/mysmartroute/view/ui/screens/WalkingRoutesScreen.kt
+++ b/app/src/main/java/com/ioannapergamali/mysmartroute/view/ui/screens/WalkingRoutesScreen.kt
@@ -1,7 +1,12 @@
 package com.ioannapergamali.mysmartroute.view.ui.screens
 
+import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.*
-import androidx.compose.material3.*
+import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.lazy.items
+import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.Scaffold
+import androidx.compose.material3.Text
 import androidx.compose.runtime.*
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.LocalContext
@@ -9,83 +14,73 @@ import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.unit.dp
 import androidx.lifecycle.viewmodel.compose.viewModel
 import androidx.navigation.NavController
+import com.google.android.gms.maps.CameraUpdateFactory
+import com.google.maps.android.compose.GoogleMap
+import com.google.maps.android.compose.Marker
+import com.google.maps.android.compose.MarkerState
+import com.google.maps.android.compose.Polyline
+import com.google.maps.android.compose.rememberCameraPositionState
+import com.google.maps.android.PolyUtil
 import com.ioannapergamali.mysmartroute.R
+import com.ioannapergamali.mysmartroute.data.local.WalkingRouteEntity
 import com.ioannapergamali.mysmartroute.view.ui.components.ScreenContainer
 import com.ioannapergamali.mysmartroute.view.ui.components.TopBar
-import com.ioannapergamali.mysmartroute.viewmodel.VehicleRequestViewModel
-import com.ioannapergamali.mysmartroute.data.local.MovingEntity
+import com.ioannapergamali.mysmartroute.viewmodel.WalkingRoutesViewModel
 
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable
 fun WalkingRoutesScreen(navController: NavController, openDrawer: () -> Unit) {
-    val viewModel: VehicleRequestViewModel = viewModel()
     val context = LocalContext.current
-    val movings by viewModel.movings.collectAsState()
+    val viewModel: WalkingRoutesViewModel = viewModel(factory = WalkingRoutesViewModel.Factory(context))
+    val routes by viewModel.routes.collectAsState()
+    var selected by remember { mutableStateOf<WalkingRouteEntity?>(null) }
+    val cameraState = rememberCameraPositionState()
 
-    LaunchedEffect(Unit) {
-        viewModel.loadRequests(context)
-    }
-
-    val walkingMovings = movings.filter { it.vehicleId == VehicleRequestViewModel.WALKING_ID }
-
-    Scaffold(
-        topBar = {
-            TopBar(
-                title = stringResource(R.string.walking_routes),
-                navController = navController,
-                showMenu = true,
-                onMenuClick = openDrawer
-            )
-        }
-    ) { padding ->
+    Scaffold(topBar = {
+        TopBar(
+            title = stringResource(R.string.walking_routes),
+            navController = navController,
+            showMenu = true,
+            onMenuClick = openDrawer
+        )
+    }) { padding ->
         ScreenContainer(modifier = Modifier.padding(padding)) {
-            if (walkingMovings.isEmpty()) {
-                Text(stringResource(R.string.no_walking_routes))
-            } else {
-                walkingMovings.forEach { m ->
-                    WalkingRow(
-                        m,
-                        onSave = {
-                            viewModel.saveWalkingRoute(
-                                context,
-                                m.routeId,
-                                m.startPoiId,
-                                m.endPoiId,
-                                m.date
-                            )
-                        },
-                        onRespond = { accept ->
-                            viewModel.setWalkingStatus(context, m.id, accept)
+            Column(Modifier.fillMaxSize()) {
+                GoogleMap(
+                    modifier = Modifier.weight(1f),
+                    cameraPositionState = cameraState
+                ) {
+                    selected?.let { route ->
+                        val points = PolyUtil.decode(route.polyline)
+                        if (points.isNotEmpty()) {
+                            Polyline(points = points)
+                            Marker(state = MarkerState(points.first()))
                         }
-                    )
-                    Spacer(Modifier.height(8.dp))
+                    }
+                }
+                if (routes.isEmpty()) {
+                    Text(stringResource(R.string.no_walking_routes), modifier = Modifier.padding(16.dp))
+                } else {
+                    LazyColumn(Modifier.fillMaxWidth().height(200.dp)) {
+                        items(routes) { route ->
+                            Text(
+                                route.name,
+                                modifier = Modifier
+                                    .fillMaxWidth()
+                                    .clickable {
+                                        selected = route
+                                        val points = PolyUtil.decode(route.polyline)
+                                        if (points.isNotEmpty()) {
+                                            cameraState.move(CameraUpdateFactory.newLatLngZoom(points.first(), 15f))
+                                        }
+                                    }
+                                    .padding(16.dp)
+                            )
+                        }
+                    }
                 }
             }
         }
     }
 }
 
-@Composable
-private fun WalkingRow(
-    m: MovingEntity,
-    onSave: () -> Unit,
-    onRespond: (Boolean) -> Unit
-) {
-    Row(
-        modifier = Modifier.fillMaxWidth(),
-        horizontalArrangement = Arrangement.SpaceBetween
-    ) {
-        Text(m.routeName, modifier = Modifier.weight(1f))
-        Row(horizontalArrangement = Arrangement.spacedBy(8.dp)) {
-            TextButton(onClick = onSave) {
-                Text(stringResource(R.string.save))
-            }
-            TextButton(onClick = { onRespond(true) }) {
-                Text(stringResource(R.string.accept_offer))
-            }
-            TextButton(onClick = { onRespond(false) }) {
-                Text(stringResource(R.string.reject_offer))
-            }
-        }
-    }
-}

--- a/app/src/main/java/com/ioannapergamali/mysmartroute/viewmodel/WalkingRoutesViewModel.kt
+++ b/app/src/main/java/com/ioannapergamali/mysmartroute/viewmodel/WalkingRoutesViewModel.kt
@@ -1,0 +1,80 @@
+package com.ioannapergamali.mysmartroute.viewmodel
+
+import android.content.Context
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.viewModelScope
+import androidx.lifecycle.viewmodel.initializer
+import androidx.lifecycle.viewmodel.viewModelFactory
+import com.google.android.gms.maps.model.LatLng
+import com.google.firebase.firestore.FirebaseFirestore
+import com.ioannapergamali.mysmartroute.data.local.WalkingRouteDao
+import com.ioannapergamali.mysmartroute.data.local.WalkingRouteDatabase
+import com.ioannapergamali.mysmartroute.data.local.WalkingRouteEntity
+import com.google.maps.android.PolyUtil
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.flow.SharingStarted
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.stateIn
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.tasks.await
+import kotlinx.coroutines.withContext
+import okhttp3.OkHttpClient
+import okhttp3.Request
+import org.json.JSONObject
+
+class WalkingRoutesViewModel(private val dao: WalkingRouteDao) : ViewModel() {
+    private val firestore = FirebaseFirestore.getInstance()
+    private val client = OkHttpClient()
+
+    val routes: StateFlow<List<WalkingRouteEntity>> =
+        dao.getAll().stateIn(viewModelScope, SharingStarted.WhileSubscribed(5000), emptyList())
+
+    fun saveRoute(name: String, origin: LatLng, destination: LatLng, apiKey: String) {
+        viewModelScope.launch {
+            val points = getWalkingRoute(origin, destination, apiKey)
+            val encoded = PolyUtil.encode(points)
+            val route = WalkingRouteEntity(
+                name = name,
+                startLat = origin.latitude,
+                startLng = origin.longitude,
+                endLat = destination.latitude,
+                endLng = destination.longitude,
+                polyline = encoded
+            )
+            val id = dao.insert(route)
+            firestore.collection("walking_routes").document(id.toString()).set(route).await()
+        }
+    }
+
+    private suspend fun getWalkingRoute(
+        origin: LatLng,
+        destination: LatLng,
+        apiKey: String
+    ): List<LatLng> = withContext(Dispatchers.IO) {
+        val url = "https://maps.googleapis.com/maps/api/directions/json" +
+            "?origin=${origin.latitude},${origin.longitude}" +
+            "&destination=${destination.latitude},${destination.longitude}" +
+            "&mode=walking&key=$apiKey"
+        val request = Request.Builder().url(url).build()
+        client.newCall(request).execute().use { response ->
+            val body = response.body?.string() ?: return@withContext emptyList()
+            if (!response.isSuccessful) return@withContext emptyList()
+            val json = JSONObject(body)
+            val encoded = json.getJSONArray("routes")
+                .getJSONObject(0)
+                .getJSONObject("overview_polyline")
+                .getString("points")
+            return@withContext PolyUtil.decode(encoded)
+        }
+    }
+
+    companion object {
+        fun Factory(context: Context) = viewModelFactory {
+            initializer {
+                val dao = WalkingRouteDatabase.getDatabase(context).dao()
+                WalkingRoutesViewModel(dao)
+            }
+        }
+    }
+}
+


### PR DESCRIPTION
## Περίληψη
- Προστέθηκε η βιβλιοθήκη `maps-utils-ktx` για εύκολο χειρισμό polyline.
- Δημιουργήθηκαν `WalkingRouteEntity`, DAO και Room database για τοπική αποθήκευση διαδρομών πεζών.
- Νέο `WalkingRoutesViewModel` που αποθηκεύει διαδρομές στη Room και στο Firebase, αντλώντας polyline από το Google Directions API.
- Ανασχεδιάστηκε η οθόνη `WalkingRoutesScreen` ώστε να προβάλλει τις αποθηκευμένες διαδρομές και να τις εμφανίζει στον χάρτη.

## Δοκιμές
- `./gradlew test` (αποτυχία: SDK location not found)


------
https://chatgpt.com/codex/tasks/task_e_68b6b8247e8483288dfe636cc6be2ad5