### PR TITLE
Load walking routes from walks subcollections

### DIFF
--- a/app/src/main/java/com/ioannapergamali/mysmartroute/view/ui/screens/DefineDurationScreen.kt
+++ b/app/src/main/java/com/ioannapergamali/mysmartroute/view/ui/screens/DefineDurationScreen.kt
@@ -30,17 +30,13 @@ fun DefineDurationScreen(navController: NavController, openDrawer: () -> Unit) {
     val context = LocalContext.current
     val routeViewModel: RouteViewModel = viewModel()
     val routes by routeViewModel.routes.collectAsState()
-    val pendingRoutes = routes.filter { it.walkDurationMinutes == 0 }
     var routeExpanded by remember { mutableStateOf(false) }
     var selectedRouteId by rememberSaveable { mutableStateOf<String?>(null) }
     var durationMinutes by remember { mutableStateOf<Int?>(null) }
     val coroutineScope = rememberCoroutineScope()
 
     LaunchedEffect(Unit) {
-
-        routeViewModel.loadRoutesWithoutDuration()
-
-
+        routeViewModel.loadRoutesFromWalks()
     }
 
     Scaffold(
@@ -54,14 +50,14 @@ fun DefineDurationScreen(navController: NavController, openDrawer: () -> Unit) {
         }
     ) { padding ->
         ScreenContainer(modifier = Modifier.padding(padding)) {
-            if (pendingRoutes.isEmpty()) {
+            if (routes.isEmpty()) {
                 Text(stringResource(R.string.no_walking_routes))
             } else {
                 ExposedDropdownMenuBox(
                     expanded = routeExpanded,
                     onExpandedChange = { routeExpanded = !routeExpanded }
                 ) {
-                    val selectedRoute = pendingRoutes.find { it.id == selectedRouteId }
+                    val selectedRoute = routes.find { it.id == selectedRouteId }
                     OutlinedTextField(
                         value = selectedRoute?.name ?: "",
                         onValueChange = {},
@@ -74,7 +70,7 @@ fun DefineDurationScreen(navController: NavController, openDrawer: () -> Unit) {
                         expanded = routeExpanded,
                         onDismissRequest = { routeExpanded = false }
                     ) {
-                        pendingRoutes.forEach { route ->
+                        routes.forEach { route ->
                             DropdownMenuItem(
                                 text = { Text(route.name) },
                                 onClick = {

--- a/app/src/main/java/com/ioannapergamali/mysmartroute/viewmodel/RouteViewModel.kt
+++ b/app/src/main/java/com/ioannapergamali/mysmartroute/viewmodel/RouteViewModel.kt
@@ -127,6 +127,28 @@ class RouteViewModel : ViewModel() {
         }
     }
 
+    /**
+     * Φορτώνει τα routes που εμφανίζονται στις υποσυλλογές `walks`.
+     * Χρησιμοποιεί το reference του `routeId` για να ανακτήσει τα στοιχεία της διαδρομής.
+     */
+    fun loadRoutesFromWalks() {
+        viewModelScope.launch {
+            val snapshot = runCatching {
+                firestore.collectionGroup("walks").get().await()
+            }.getOrNull()
+
+            val routeEntities = snapshot?.documents
+                ?.mapNotNull { it.getDocumentReference("routeId") }
+                ?.distinct()
+                ?.mapNotNull { ref ->
+                    runCatching { ref.get().await().toRouteEntity() }.getOrNull()
+                }
+                ?: emptyList()
+
+            _routes.value = routeEntities
+        }
+    }
+
     suspend fun getPointsCount(context: Context, routeId: String): Int {
         val dao = MySmartRouteDatabase.getInstance(context).routePointDao()
         return dao.getPointsForRoute(routeId).first().size


### PR DESCRIPTION
## Summary
- Fetch routes referenced in `walks` subcollections
- Show all walking routes for admin to update duration

## Testing
- `./gradlew test` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b6bd02d8d88328b8b4e918e801a0bb