### PR TITLE
Store walking duration for user walks

### DIFF
--- a/app/src/main/java/com/ioannapergamali/mysmartroute/view/ui/screens/WalkingScreen.kt
+++ b/app/src/main/java/com/ioannapergamali/mysmartroute/view/ui/screens/WalkingScreen.kt
@@ -45,6 +45,7 @@ import com.ioannapergamali.mysmartroute.viewmodel.PoIViewModel
 import com.ioannapergamali.mysmartroute.viewmodel.VehicleRequestViewModel
 import com.ioannapergamali.mysmartroute.model.enumerations.VehicleType
 import com.ioannapergamali.mysmartroute.utils.MapsUtils
+import com.ioannapergamali.mysmartroute.utils.WalkingUtils
 import android.app.TimePickerDialog
 import java.util.Calendar
 
@@ -200,13 +201,18 @@ fun WalkingScreen(navController: NavController, openDrawer: () -> Unit) {
                         val start = startIndex?.let { routePois[it].id } ?: return@ExtendedFloatingActionButton
                         val end = endIndex?.let { routePois[it].id } ?: return@ExtendedFloatingActionButton
                         val timestamp = System.currentTimeMillis()
-                        vehicleRequestViewModel.saveWalkingRoute(
-                            context,
-                            rId,
-                            start,
-                            end,
-                            timestamp
-                        )
+                        coroutineScope.launch {
+                            val distance = routeViewModel.getRouteDistance(context, rId)
+                            val minutes = WalkingUtils.walkingDuration(distance.toDouble()).inWholeMinutes.toInt()
+                            vehicleRequestViewModel.saveWalkingRoute(
+                                context,
+                                rId,
+                                start,
+                                end,
+                                timestamp,
+                                minutes
+                            )
+                        }
                     },
                     icon = { Icon(Icons.Default.Save, contentDescription = null) },
                     text = { Text(stringResource(R.string.save)) }

--- a/app/src/main/java/com/ioannapergamali/mysmartroute/viewmodel/VehicleRequestViewModel.kt
+++ b/app/src/main/java/com/ioannapergamali/mysmartroute/viewmodel/VehicleRequestViewModel.kt
@@ -164,7 +164,8 @@ class VehicleRequestViewModel : ViewModel() {
         routeId: String,
         fromPoiId: String,
         toPoiId: String,
-        dateTime: Long
+        dateTime: Long,
+        walkDurationMinutes: Int
     ) {
         viewModelScope.launch {
             val userId = FirebaseAuth.getInstance().currentUser?.uid ?: return@launch
@@ -176,7 +177,8 @@ class VehicleRequestViewModel : ViewModel() {
                 "routeId" to routeRef,
                 "fromPoiId" to fromPoiRef,
                 "toPoiId" to toPoiRef,
-                "date" to dateTime
+                "date" to dateTime,
+                "walkDurationMinutes" to walkDurationMinutes
             )
             try {
                 val userRef = db.collection("users").document(userId)


### PR DESCRIPTION
## Summary
- Save `walkDurationMinutes` alongside walk metadata in each user's `walks` subcollection
- Calculate walking duration when saving a route and pass it to the repository

## Testing
- `./gradlew test` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b6cd09ba80832880a9a98b7e761925