### PR TITLE
Χαρτογράφηση επιλογής 'createUser' σε διαθέσιμη διαδρομή

### DIFF
--- a/app/src/main/java/com/ioannapergamali/mysmartroute/view/ui/screens/MenuScreen.kt
+++ b/app/src/main/java/com/ioannapergamali/mysmartroute/view/ui/screens/MenuScreen.kt
@@ -71,10 +71,10 @@ fun MenuScreen(navController: NavController, openDrawer: () -> Unit) {
                 CircularProgressIndicator()
             } else {
                 RoleMenu(role, menus) { route ->
-                    val targetRoute = if (route == "definePoi") {
-                        "definePoi?lat=&lng=&source=&view=false&routeId="
-                    } else {
-                        route
+                    val targetRoute = when (route) {
+                        "definePoi" -> "definePoi?lat=&lng=&source=&view=false&routeId="
+                        "createUser" -> "adminSignup"
+                        else -> route
                     }
                     if (
                         targetRoute == "viewUsers" ||


### PR DESCRIPTION
## Περίληψη
- Προστέθηκε αντιστοίχιση της διαδρομής `createUser` στην υπάρχουσα οθόνη `adminSignup` ώστε να μην προκαλείται σφάλμα πλοήγησης.

## Έλεγχοι
- `./gradlew test` *(αποτυχημένη εκτέλεση λόγω ελλιπούς περιβάλλοντος Android SDK)*

------
https://chatgpt.com/codex/tasks/task_e_68b6d285da408328b41f984e62072f19