### PR TITLE
Αφαίρεση κειμένου από το κουμπί ανανέωσης

### DIFF
--- a/app/src/main/java/com/ioannapergamali/mysmartroute/view/ui/screens/RouteEditorScreen.kt
+++ b/app/src/main/java/com/ioannapergamali/mysmartroute/view/ui/screens/RouteEditorScreen.kt
@@ -185,9 +185,10 @@ fun RouteEditorScreen(navController: NavController, openDrawer: () -> Unit) {
                     onClick = { refreshRoute() },
                     enabled = routePoiIds.size >= 2 && !isKeyMissing
                 ) {
-                    Icon(Icons.Default.Refresh, contentDescription = null)
-                    Spacer(Modifier.width(8.dp))
-                    Text(stringResource(R.string.refresh_route))
+                    Icon(
+                        Icons.Default.Refresh,
+                        contentDescription = stringResource(R.string.refresh_route)
+                    )
                 }
             }
             DropdownMenu(


### PR DESCRIPTION
## ΠΕΡΙΛΗΨΗ
- Αφαιρέθηκε το κείμενο από το κουμπί ανανέωσης διαδρομής στην οθόνη επεξεργασίας διαδρομής, αφήνοντας μόνο το εικονίδιο Refresh.

## ΔΟΚΙΜΕΣ
- `./gradlew test` (απέτυχε: SDK location not found)


------
https://chatgpt.com/codex/tasks/task_e_68b6d47904748328b0b00c02a82f8b1b