### PR TITLE
Προσθήκη οθόνης προβολής σημείων

### DIFF
--- a/app/src/main/java/com/ioannapergamali/mysmartroute/view/ui/screens/UserPointsScreen.kt
+++ b/app/src/main/java/com/ioannapergamali/mysmartroute/view/ui/screens/UserPointsScreen.kt
@@ -1,0 +1,25 @@
+package com.ioannapergamali.mysmartroute.view.ui.screens
+
+import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.lazy.items
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.collectAsState
+import androidx.lifecycle.viewmodel.compose.viewModel
+import com.ioannapergamali.mysmartroute.viewmodel.UserPointViewModel
+
+/**
+ * Απλή οθόνη που εμφανίζει τα ονόματα όλων των σημείων που έχουν
+ * προσθέσει οι χρήστες. Η λίστα ενημερώνεται αυτόματα όταν αλλάξουν
+ * τα δεδομένα στο [UserPointViewModel].
+ */
+@Composable
+fun UserPointsScreen(viewModel: UserPointViewModel = viewModel()) {
+    val pointsState = viewModel.points.collectAsState()
+
+    LazyColumn {
+        items(pointsState.value) { point ->
+            Text(text = point.name)
+        }
+    }
+}


### PR DESCRIPTION
## Περίληψη
- Προσθήκη Compose οθόνης `UserPointsScreen` για επισκόπηση όλων των σημείων

## Δοκιμές
- `./gradlew test` (αποτυχία: SDK location not found)


------
https://chatgpt.com/codex/tasks/task_e_68b6d4ec85e88328843aec4816b20bac