### PR TITLE
Επιτρέπεται μετονομασία διαδρομών

### DIFF
--- a/app/src/main/java/com/ioannapergamali/mysmartroute/viewmodel/RouteViewModel.kt
+++ b/app/src/main/java/com/ioannapergamali/mysmartroute/viewmodel/RouteViewModel.kt
@@ -186,14 +186,23 @@ class RouteViewModel : ViewModel() {
         return id
     }
 
-    suspend fun updateRoute(context: Context, routeId: String, poiIds: List<String>) {
+    suspend fun updateRoute(
+        context: Context,
+        routeId: String,
+        poiIds: List<String>,
+        newName: String? = null
+    ) {
         if (routeId.isBlank() || poiIds.size < 2) return
         val db = MySmartRouteDatabase.getInstance(context)
         val routeDao = db.routeDao()
         val pointDao = db.routePointDao()
 
         val existing = routeDao.findById(routeId) ?: return
-        val updated = existing.copy(startPoiId = poiIds.first(), endPoiId = poiIds.last())
+        val updated = existing.copy(
+            name = newName.takeUnless { it.isNullOrBlank() } ?: existing.name,
+            startPoiId = poiIds.first(),
+            endPoiId = poiIds.last()
+        )
         val points = poiIds.mapIndexed { index, p -> RoutePointEntity(routeId, index, p) }
 
         if (NetworkUtils.isInternetAvailable(context)) {


### PR DESCRIPTION
## Περίληψη
- Επιτρέπει την αλλαγή ονόματος διαδρομής και αποθήκευση στην οθόνη επεξεργασίας
- Ενημέρωση RouteViewModel για αποθήκευση νέου ονόματος

## Έλεγχοι
- `./gradlew test` (απέτυχε: SDK location not found)


------
https://chatgpt.com/codex/tasks/task_e_68b6d7abe2888328bb3a097da31039d4