### PR TITLE
Fix missing reviewPoi navigation route

### DIFF
--- a/app/src/main/java/com/ioannapergamali/mysmartroute/model/navigation/NavigationHost.kt
+++ b/app/src/main/java/com/ioannapergamali/mysmartroute/model/navigation/NavigationHost.kt
@@ -114,6 +114,9 @@ fun NavigationHost(
         composable("viewPois") {
             PoIListScreen(navController = navController, openDrawer = openDrawer)
         }
+        composable("reviewPoi") {
+            PoIListScreen(navController = navController, openDrawer = openDrawer)
+        }
         composable("editRoute") {
             RouteEditorScreen(navController = navController, openDrawer = openDrawer)
         }


### PR DESCRIPTION
## Summary
- add reviewPoi route to navigation graph so admin menu works

## Testing
- `ANDROID_HOME=/usr/lib/android-sdk ./gradlew test` *(fails: SDK licenses not accepted)*

------
https://chatgpt.com/codex/tasks/task_e_68b6d86ca0dc83288c7e401bf834baf6