### PR TITLE
Προσθήκη repository διαχείρισης σημείων ενδιαφέροντος

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -126,6 +126,9 @@ dependencies {
 
     // Testing
     testImplementation("junit:junit:4.13.2")
+    testImplementation("androidx.test:core:1.6.1")
+    testImplementation("org.robolectric:robolectric:4.13")
+    testImplementation("androidx.room:room-testing:2.7.1")
     androidTestImplementation("androidx.test.ext:junit:1.1.5")
     androidTestImplementation("androidx.test.espresso:espresso-core:3.5.1")
 }

--- a/app/src/main/java/com/ioannapergamali/mysmartroute/repository/AdminPoiRepository.kt
+++ b/app/src/main/java/com/ioannapergamali/mysmartroute/repository/AdminPoiRepository.kt
@@ -1,0 +1,38 @@
+package com.ioannapergamali.mysmartroute.repository
+
+import com.ioannapergamali.mysmartroute.data.local.MySmartRouteDatabase
+import com.ioannapergamali.mysmartroute.data.local.PoIEntity
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.map
+
+/**
+ * Repository για τον διαχειριστή ώστε να ελέγχει ονόματα PoI,
+ * να ενημερώνει στοιχεία και να ομαδοποιεί σημεία.
+ */
+class AdminPoiRepository(private val db: MySmartRouteDatabase) {
+    private val poiDao = db.poIDao()
+    private val routePointDao = db.routePointDao()
+    private val routeDao = db.routeDao()
+
+    /** Επιστροφή όλων των ονομάτων σημείων που έχουν καταχωριστεί. */
+    fun getPoiNames(): Flow<List<String>> = poiDao.getAll().map { list -> list.map { it.name } }
+
+    /** Επιστροφή όλων των σημείων. */
+    fun getAllPois(): Flow<List<PoIEntity>> = poiDao.getAll()
+
+    /** Ενημέρωση στοιχείων σημείου. */
+    suspend fun updatePoi(poi: PoIEntity) {
+        poiDao.insert(poi)
+    }
+
+    /**
+     * Συγχώνευση δύο σημείων. Το removeId διαγράφεται και όλες οι
+     * διαδρομές/σημεία που το αναφέρουν ενημερώνονται να δείχνουν στο keepId.
+     */
+    suspend fun mergePois(keepId: String, removeId: String) {
+        routePointDao.updatePoiReferences(removeId, keepId)
+        routeDao.updatePoiReferences(removeId, keepId)
+        poiDao.deleteById(removeId)
+    }
+}
+

--- a/app/src/test/java/com/ioannapergamali/mysmartroute/repository/AdminPoiRepositoryTest.kt
+++ b/app/src/test/java/com/ioannapergamali/mysmartroute/repository/AdminPoiRepositoryTest.kt
@@ -1,0 +1,59 @@
+package com.ioannapergamali.mysmartroute.repository
+
+import android.content.Context
+import androidx.room.Room
+import androidx.test.core.app.ApplicationProvider
+import com.google.android.libraries.places.api.model.Place
+import com.ioannapergamali.mysmartroute.data.local.*
+import kotlinx.coroutines.flow.first
+import kotlinx.coroutines.runBlocking
+import org.junit.After
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNull
+import org.junit.Assert.assertTrue
+import org.junit.Before
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+
+/**
+ * Έλεγχοι για το [AdminPoiRepository].
+ */
+@RunWith(RobolectricTestRunner::class)
+class AdminPoiRepositoryTest {
+    private lateinit var db: MySmartRouteDatabase
+    private lateinit var repo: AdminPoiRepository
+
+    @Before
+    fun setup() {
+        val context = ApplicationProvider.getApplicationContext<Context>()
+        db = Room.inMemoryDatabaseBuilder(context, MySmartRouteDatabase::class.java)
+            .allowMainThreadQueries()
+            .build()
+        repo = AdminPoiRepository(db)
+    }
+
+    @After
+    fun tearDown() {
+        db.close()
+    }
+
+    @Test
+    fun mergePois_updatesRoutesAndRemovesPoi() = runBlocking {
+        val type = PoiTypeEntity(id = Place.Type.ESTABLISHMENT.name, name = "")
+        db.poiTypeDao().insertAll(listOf(type))
+        val poi1 = PoIEntity(id = "1", name = "A", type = Place.Type.ESTABLISHMENT)
+        val poi2 = PoIEntity(id = "2", name = "B", type = Place.Type.ESTABLISHMENT)
+        db.poIDao().insertAll(listOf(poi1, poi2))
+        db.routeDao().insert(RouteEntity(id = "r", userId = "u", name = "r", startPoiId = "1", endPoiId = "2"))
+        db.routePointDao().insert(RoutePointEntity(routeId = "r", position = 0, poiId = "2"))
+
+        repo.mergePois("1", "2")
+
+        assertNull(db.poIDao().findById("2"))
+        assertEquals("1", db.routeDao().findById("r")?.endPoiId)
+        val points = db.routePointDao().getPointsForRoute("r").first()
+        assertTrue(points.all { it.poiId == "1" })
+    }
+}
+


### PR DESCRIPTION
## Summary
- Προσθήκη `AdminPoiRepository` για προβολή, ενημέρωση και ομαδοποίηση σημείων ενδιαφέροντος.
- Δημιουργία unit test για έλεγχο συγχώνευσης σημείων και ενημέρωσης διαδρομών.
- Ενημέρωση εξαρτήσεων δοκιμών με AndroidX Test, Robolectric και Room testing.

## Testing
- `./gradlew test` *(απέτυχε: Could not determine the dependencies of task ':app:testDebugUnitTest'. SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b6dd8d581c8328a01137c81f34fea5