### PR TITLE
Διόρθωση ονόματος πεδίου για την πεζή διάρκεια

### DIFF
--- a/app/src/main/java/com/ioannapergamali/mysmartroute/viewmodel/RouteViewModel.kt
+++ b/app/src/main/java/com/ioannapergamali/mysmartroute/viewmodel/RouteViewModel.kt
@@ -221,9 +221,9 @@ class RouteViewModel : ViewModel() {
             if (NetworkUtils.isInternetAvailable(context) && route != null) {
                 FirebaseAuth.getInstance().currentUser?.uid?.let { uid ->
                     val walkEntry = mapOf(
-
-                        "durationMinutes" to minutes,
-
+                        // Αποθηκεύουμε τη διάρκεια με το ίδιο κλειδί που
+                        // χρησιμοποιεί το υπόλοιπο σύστημα (walkDurationMinutes)
+                        "walkDurationMinutes" to minutes,
                         "routeId" to firestore.collection("routes").document(routeId),
                         "fromPoiId" to firestore.collection("pois").document(route.startPoiId),
                         "toPoiId" to firestore.collection("pois").document(route.endPoiId),


### PR DESCRIPTION
## Περίληψη
- Ευθυγράμμιση του κλειδιού `walkDurationMinutes` κατά την αποθήκευση της διάρκειας πεζής διαδρομής.

## Έλεγχοι
- `./gradlew test` *(απέτυχε: δεν βρέθηκε Android SDK)*

------
https://chatgpt.com/codex/tasks/task_e_68b6de41fe2883289f6a0b5f942ad816