### PR TITLE
Προβολή διαδρομών πεζών από το Firestore

### DIFF
--- a/app/src/main/java/com/ioannapergamali/mysmartroute/view/ui/screens/WalkingRoutesScreen.kt
+++ b/app/src/main/java/com/ioannapergamali/mysmartroute/view/ui/screens/WalkingRoutesScreen.kt
@@ -1,40 +1,34 @@
 package com.ioannapergamali.mysmartroute.view.ui.screens
 
-import androidx.compose.foundation.clickable
-import androidx.compose.foundation.layout.*
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.items
 import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.Scaffold
 import androidx.compose.material3.Text
-import androidx.compose.runtime.*
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.collectAsState
+import androidx.compose.runtime.getValue
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.res.stringResource
-import androidx.compose.ui.unit.dp
 import androidx.lifecycle.viewmodel.compose.viewModel
 import androidx.navigation.NavController
-import com.google.android.gms.maps.CameraUpdateFactory
-import com.google.maps.android.compose.GoogleMap
-import com.google.maps.android.compose.Marker
-import com.google.maps.android.compose.MarkerState
-import com.google.maps.android.compose.Polyline
-import com.google.maps.android.compose.rememberCameraPositionState
-import com.google.maps.android.PolyUtil
 import com.ioannapergamali.mysmartroute.R
-import com.ioannapergamali.mysmartroute.data.local.WalkingRouteEntity
 import com.ioannapergamali.mysmartroute.view.ui.components.ScreenContainer
 import com.ioannapergamali.mysmartroute.view.ui.components.TopBar
-import com.ioannapergamali.mysmartroute.viewmodel.WalkingRoutesViewModel
+import com.ioannapergamali.mysmartroute.viewmodel.RouteViewModel
 
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable
 fun WalkingRoutesScreen(navController: NavController, openDrawer: () -> Unit) {
-    val context = LocalContext.current
-    val viewModel: WalkingRoutesViewModel = viewModel(factory = WalkingRoutesViewModel.Factory(context))
-    val routes by viewModel.routes.collectAsState()
-    var selected by remember { mutableStateOf<WalkingRouteEntity?>(null) }
-    val cameraState = rememberCameraPositionState()
+    val routeViewModel: RouteViewModel = viewModel()
+    val routes by routeViewModel.routes.collectAsState()
+
+    LaunchedEffect(Unit) {
+        routeViewModel.loadUserWalkingRoutes()
+    }
 
     Scaffold(topBar = {
         TopBar(
@@ -45,38 +39,17 @@ fun WalkingRoutesScreen(navController: NavController, openDrawer: () -> Unit) {
         )
     }) { padding ->
         ScreenContainer(modifier = Modifier.padding(padding)) {
-            Column(Modifier.fillMaxSize()) {
-                GoogleMap(
-                    modifier = Modifier.weight(1f),
-                    cameraPositionState = cameraState
-                ) {
-                    selected?.let { route ->
-                        val points = PolyUtil.decode(route.polyline)
-                        if (points.isNotEmpty()) {
-                            Polyline(points = points)
-                            Marker(state = MarkerState(points.first()))
-                        }
-                    }
-                }
-                if (routes.isEmpty()) {
-                    Text(stringResource(R.string.no_walking_routes), modifier = Modifier.padding(16.dp))
-                } else {
-                    LazyColumn(Modifier.fillMaxWidth().height(200.dp)) {
-                        items(routes) { route ->
-                            Text(
-                                route.name,
-                                modifier = Modifier
-                                    .fillMaxWidth()
-                                    .clickable {
-                                        selected = route
-                                        val points = PolyUtil.decode(route.polyline)
-                                        if (points.isNotEmpty()) {
-                                            cameraState.move(CameraUpdateFactory.newLatLngZoom(points.first(), 15f))
-                                        }
-                                    }
-                                    .padding(16.dp)
-                            )
-                        }
+            if (routes.isEmpty()) {
+                Text(stringResource(R.string.no_walking_routes), modifier = Modifier.padding(16.dp))
+            } else {
+                LazyColumn {
+                    items(routes) { route ->
+                        Text(
+                            route.name,
+                            modifier = Modifier
+                                .fillMaxWidth()
+                                .padding(16.dp)
+                        )
                     }
                 }
             }


### PR DESCRIPTION
## Περίληψη
- Προστέθηκε μέθοδος `loadUserWalkingRoutes` στο `RouteViewModel` για άντληση διαδρομών από το subcollection `walks` του χρήστη.
- Απλοποιήθηκε το `WalkingRoutesScreen` ώστε να εμφανίζει τις παραπάνω διαδρομές σε λίστα.

## Έλεγχοι
- `./gradlew test` *(αποτυχία: λείπει το Android SDK)*

------
https://chatgpt.com/codex/tasks/task_e_68b6e1113c788328b58bff588b9d66c2