### PR TITLE
Προσθήκη import για dp σε WalkingRoutesScreen

### DIFF
--- a/app/src/main/java/com/ioannapergamali/mysmartroute/view/ui/screens/WalkingRoutesScreen.kt
+++ b/app/src/main/java/com/ioannapergamali/mysmartroute/view/ui/screens/WalkingRoutesScreen.kt
@@ -13,6 +13,7 @@ import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.unit.dp
 import androidx.lifecycle.viewmodel.compose.viewModel
 import androidx.navigation.NavController
 import com.ioannapergamali.mysmartroute.R


### PR DESCRIPTION
## Περίληψη
- Εισαγωγή του `androidx.compose.ui.unit.dp` στην οθόνη WalkingRoutes ώστε να λυθεί το σφάλμα "Unresolved reference 'dp'".

## Δοκιμές
- `./gradlew test` *(αποτυγχάνει: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b6e51908e08328ad1c514eb111c7ae