### PR TITLE
Αποφυγή nested scrolling σε οθόνες με LazyColumn

### DIFF
--- a/app/src/main/java/com/ioannapergamali/mysmartroute/view/ui/screens/ViewUnassignedScreen.kt
+++ b/app/src/main/java/com/ioannapergamali/mysmartroute/view/ui/screens/ViewUnassignedScreen.kt
@@ -41,7 +41,7 @@ fun ViewUnassignedScreen(navController: NavController, openDrawer: () -> Unit) {
             )
         }
     ) { padding ->
-        ScreenContainer(modifier = Modifier.padding(padding)) {
+        ScreenContainer(modifier = Modifier.padding(padding), scrollable = false) {
             val unassigned = routes
             if (unassigned.isEmpty()) {
                 Text(stringResource(R.string.no_unassigned_routes))

--- a/app/src/main/java/com/ioannapergamali/mysmartroute/view/ui/screens/WalkingRoutesScreen.kt
+++ b/app/src/main/java/com/ioannapergamali/mysmartroute/view/ui/screens/WalkingRoutesScreen.kt
@@ -39,7 +39,7 @@ fun WalkingRoutesScreen(navController: NavController, openDrawer: () -> Unit) {
             onMenuClick = openDrawer
         )
     }) { padding ->
-        ScreenContainer(modifier = Modifier.padding(padding)) {
+        ScreenContainer(modifier = Modifier.padding(padding), scrollable = false) {
             if (routes.isEmpty()) {
                 Text(stringResource(R.string.no_walking_routes), modifier = Modifier.padding(16.dp))
             } else {


### PR DESCRIPTION
## Summary
- Ρύθμιση `scrollable = false` στο `ScreenContainer` των WalkingRoutesScreen και ViewUnassignedScreen ώστε να μην φωλιάζει `LazyColumn`

## Testing
- `./gradlew lint` *(απέτυχε: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b6e73f23c08328a92f62a340824cac