### PR TITLE
Χειρισμός επιλογής initSystem στο μενού

### DIFF
--- a/app/src/main/java/com/ioannapergamali/mysmartroute/view/ui/screens/MenuScreen.kt
+++ b/app/src/main/java/com/ioannapergamali/mysmartroute/view/ui/screens/MenuScreen.kt
@@ -74,6 +74,7 @@ fun MenuScreen(navController: NavController, openDrawer: () -> Unit) {
                     val targetRoute = when (route) {
                         "definePoi" -> "definePoi?lat=&lng=&source=&view=false&routeId="
                         "createUser" -> "adminSignup"
+                        "initSystem" -> "databaseMenu"
                         else -> route
                     }
                     if (


### PR DESCRIPTION
## Περίληψη
- Προστέθηκε αντιστοίχιση της επιλογής `initSystem` στη διαδρομή `databaseMenu` ώστε να μην προκαλείται σφάλμα πλοήγησης.

## Έλεγχοι
- `./gradlew test` *(απέτυχε: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b6e83674ec8328987e8225861bd515