### PR TITLE
Διόρθωση τίτλου ελέγχου PoI

### DIFF
--- a/app/src/main/java/com/ioannapergamali/mysmartroute/view/ui/screens/ReviewPoiScreen.kt
+++ b/app/src/main/java/com/ioannapergamali/mysmartroute/view/ui/screens/ReviewPoiScreen.kt
@@ -51,7 +51,7 @@ fun ReviewPoiScreen(navController: NavController, openDrawer: () -> Unit) {
     var editedName by remember { mutableStateOf("") }
     var mergeKeepId by remember { mutableStateOf<String?>(null) }
 
-    Scaffold(topBar = { TopBar(title = stringResource(R.string.view_pois), navController = navController, showMenu = true, onMenuClick = openDrawer) }) { padding ->
+    Scaffold(topBar = { TopBar(title = stringResource(R.string.review_poi), navController = navController, showMenu = true, onMenuClick = openDrawer) }) { padding ->
         ScreenContainer(modifier = Modifier.padding(padding), scrollable = false) {
             LazyColumn(modifier = Modifier.fillMaxSize()) {
                 items(pois) { poi ->


### PR DESCRIPTION
## Περίληψη
- Αντικαταστάθηκε ο τίτλος της οθόνης ελέγχου σημείων ενδιαφέροντος με το σωστό string πόρου

## Δοκιμές
- `./gradlew test` *(απέτυχε να ολοκληρωθεί: η διαδικασία έμεινε χωρίς έξοδο μετά τη λήψη του Gradle)*

------
https://chatgpt.com/codex/tasks/task_e_68b6ea2a11ec83288efc47cbf6a341b2