### PR TITLE
Μεταφορά σημείων χρηστών στο μενού διαχειριστή

### DIFF
--- a/app/src/main/java/com/ioannapergamali/mysmartroute/model/navigation/NavigationHost.kt
+++ b/app/src/main/java/com/ioannapergamali/mysmartroute/model/navigation/NavigationHost.kt
@@ -386,7 +386,7 @@ fun NavigationHost(
         }
 
         composable("userPoints") {
-            UserPointsScreen()
+            UserPointsScreen(navController = navController, openDrawer = openDrawer)
         }
 
 

--- a/app/src/main/java/com/ioannapergamali/mysmartroute/view/ui/screens/DatabaseMenuScreen.kt
+++ b/app/src/main/java/com/ioannapergamali/mysmartroute/view/ui/screens/DatabaseMenuScreen.kt
@@ -38,6 +38,10 @@ fun DatabaseMenuScreen(navController: NavController, openDrawer: () -> Unit) {
             Button(onClick = { navController.navigate("syncDb") }) {
                 Text(stringResource(R.string.sync_db))
             }
+            Spacer(modifier = Modifier.padding(8.dp))
+            Button(onClick = { navController.navigate("userPoints") }) {
+                Text("Σημεία χρηστών")
+            }
         }
     }
 }

--- a/app/src/main/java/com/ioannapergamali/mysmartroute/view/ui/screens/MenuScreen.kt
+++ b/app/src/main/java/com/ioannapergamali/mysmartroute/view/ui/screens/MenuScreen.kt
@@ -67,9 +67,6 @@ fun MenuScreen(navController: NavController, openDrawer: () -> Unit) {
         }
     ) { paddingValues ->
         ScreenContainer(modifier = Modifier.padding(paddingValues), scrollable = false) {
-            Button(onClick = { navController.navigate("userPoints") }) {
-                Text("Σημεία χρηστών")
-            }
             if (menus.isEmpty()) {
                 CircularProgressIndicator()
             } else {

--- a/app/src/main/java/com/ioannapergamali/mysmartroute/view/ui/screens/UserPointsScreen.kt
+++ b/app/src/main/java/com/ioannapergamali/mysmartroute/view/ui/screens/UserPointsScreen.kt
@@ -2,15 +2,21 @@ package com.ioannapergamali.mysmartroute.view.ui.screens
 
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.items
 import androidx.compose.material3.AlertDialog
 import androidx.compose.material3.Button
+import androidx.compose.material3.Scaffold
 import androidx.compose.material3.Text
 import androidx.compose.material3.TextButton
 import androidx.compose.material3.OutlinedTextField
 import androidx.compose.runtime.*
 import androidx.lifecycle.viewmodel.compose.viewModel
+import androidx.navigation.NavController
+import androidx.compose.ui.Modifier
+import com.ioannapergamali.mysmartroute.view.ui.components.ScreenContainer
+import com.ioannapergamali.mysmartroute.view.ui.components.TopBar
 import com.ioannapergamali.mysmartroute.repository.Point
 import com.ioannapergamali.mysmartroute.viewmodel.UserPointViewModel
 
@@ -20,25 +26,46 @@ import com.ioannapergamali.mysmartroute.viewmodel.UserPointViewModel
  * τα δεδομένα στο [UserPointViewModel].
  */
 @Composable
-fun UserPointsScreen(viewModel: UserPointViewModel = viewModel()) {
+fun UserPointsScreen(
+    navController: NavController,
+    openDrawer: () -> Unit,
+    viewModel: UserPointViewModel = viewModel()
+) {
     val pointsState = viewModel.points.collectAsState()
     var editingPoint by remember { mutableStateOf<Point?>(null) }
     var mergingPoint by remember { mutableStateOf<Point?>(null) }
 
-    LazyColumn {
-        items(pointsState.value) { point ->
-            Row {
-                Column {
-                    Text(text = point.name)
-                    if (point.details.isNotEmpty()) {
-                        Text(text = point.details)
+    Scaffold(
+        topBar = {
+            TopBar(
+                title = "Σημεία χρηστών",
+                navController = navController,
+                showMenu = true,
+                onMenuClick = openDrawer
+            )
+        }
+    ) { padding ->
+        ScreenContainer(modifier = Modifier.padding(padding)) {
+            if (pointsState.value.isEmpty()) {
+                Text("Δεν υπάρχουν σημεία")
+            } else {
+                LazyColumn {
+                    items(pointsState.value) { point ->
+                        Row {
+                            Column {
+                                Text(text = point.name)
+                                if (point.details.isNotEmpty()) {
+                                    Text(text = point.details)
+                                }
+                            }
+                            Button(onClick = { editingPoint = point }) {
+                                Text("Επεξεργασία")
+                            }
+                            Button(onClick = { mergingPoint = point }) {
+                                Text("Συγχώνευση")
+                            }
+                        }
                     }
-                }
-                Button(onClick = { editingPoint = point }) {
-                    Text("Επεξεργασία")
-                }
-                Button(onClick = { mergingPoint = point }) {
-                    Text("Συγχώνευση")
                 }
             }
         }


### PR DESCRIPTION
## Σύνοψη
- Μεταφέρθηκε η επιλογή "Σημεία χρηστών" από το γενικό μενού στο μενού διαχειριστή.
- Προστέθηκε μπάρα τίτλου και περιεχόμενο στην οθόνη σημείων χρηστών ώστε να μην είναι κενή.
- Ενημερώθηκε η πλοήγηση για την νέα υπογραφή της οθόνης σημείων χρηστών.

## Δοκιμές
- `./gradlew test` (απέτυχε: SDK location not found)


------
https://chatgpt.com/codex/tasks/task_e_68b6f41276b083288fbd35ff661adefb