### PR TITLE
Προσθήκη οθόνης διαδρομών επιβάτη

### DIFF
--- a/app/src/main/java/com/ioannapergamali/mysmartroute/model/navigation/NavigationHost.kt
+++ b/app/src/main/java/com/ioannapergamali/mysmartroute/model/navigation/NavigationHost.kt
@@ -59,6 +59,7 @@ import com.ioannapergamali.mysmartroute.view.ui.screens.ReservationDetailsScreen
 import com.ioannapergamali.mysmartroute.view.ui.screens.RankTransportsScreen
 import com.ioannapergamali.mysmartroute.view.ui.screens.RankDriversScreen
 import com.ioannapergamali.mysmartroute.view.ui.screens.UserPointsScreen
+import com.ioannapergamali.mysmartroute.view.ui.screens.PassengerRoutesScreen
 import com.ioannapergamali.mysmartroute.R
 
 
@@ -285,6 +286,10 @@ fun NavigationHost(
 
         composable("walkingRoutes") {
             WalkingRoutesScreen(navController = navController, openDrawer = openDrawer)
+        }
+
+        composable("passengerRoutes") {
+            PassengerRoutesScreen(navController = navController, openDrawer = openDrawer)
         }
 
         composable("rankTransports") {

--- a/app/src/main/java/com/ioannapergamali/mysmartroute/view/ui/screens/PassengerRoutesScreen.kt
+++ b/app/src/main/java/com/ioannapergamali/mysmartroute/view/ui/screens/PassengerRoutesScreen.kt
@@ -1,0 +1,62 @@
+package com.ioannapergamali.mysmartroute.view.ui.screens
+
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.lazy.items
+import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.Scaffold
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.collectAsState
+import androidx.compose.runtime.getValue
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.unit.dp
+import androidx.lifecycle.viewmodel.compose.viewModel
+import androidx.navigation.NavController
+import com.ioannapergamali.mysmartroute.R
+import com.ioannapergamali.mysmartroute.view.ui.components.ScreenContainer
+import com.ioannapergamali.mysmartroute.view.ui.components.TopBar
+import com.ioannapergamali.mysmartroute.viewmodel.RouteViewModel
+
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+fun PassengerRoutesScreen(navController: NavController, openDrawer: () -> Unit) {
+    val context = LocalContext.current
+    val routeViewModel: RouteViewModel = viewModel()
+    val routes by routeViewModel.routes.collectAsState()
+
+    LaunchedEffect(Unit) {
+        routeViewModel.loadRoutes(context)
+    }
+
+    Scaffold(topBar = {
+        TopBar(
+            title = stringResource(R.string.passenger_routes),
+            navController = navController,
+            showMenu = true,
+            onMenuClick = openDrawer
+        )
+    }) { padding ->
+        ScreenContainer(modifier = Modifier.padding(padding), scrollable = false) {
+            if (routes.isEmpty()) {
+                Text(stringResource(R.string.no_passenger_routes), modifier = Modifier.padding(16.dp))
+            } else {
+                LazyColumn {
+                    items(routes) { route ->
+                        Text(
+                            route.name,
+                            modifier = Modifier
+                                .fillMaxWidth()
+                                .padding(16.dp)
+                        )
+                    }
+                }
+            }
+        }
+    }
+}
+

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -253,6 +253,9 @@
     <string name="walking_routes">Walking routes</string>
     <string name="no_walking_routes">No walking routes</string>
 
+    <string name="passenger_routes">Passenger routes</string>
+    <string name="no_passenger_routes">No routes</string>
+
     <string name="distance_meters">Distance (m)</string>
     <string name="calculate">Calculate</string>
     <string name="walking_duration_result">Duration: %1$s</string>


### PR DESCRIPTION
## Περίληψη
- Προστέθηκε οθόνη PassengerRoutes για την εμφάνιση διαδρομών του επιβάτη.
- Ενημερώθηκε το NavigationHost και τα string resources.

## Δοκιμές
- `./gradlew test` (αποτυχία: SDK location not found)


------
https://chatgpt.com/codex/tasks/task_e_68b6f4a8dc6483289f1129f311728ecd