### PR TITLE
Move user points to admin role menu

### DIFF
--- a/app/src/main/assets/menus.json
+++ b/app/src/main/assets/menus.json
@@ -142,6 +142,10 @@
             "route": "createUser"
           },
           {
+            "titleKey": "user_points",
+            "route": "userPoints"
+          },
+          {
             "titleKey": "edit_privileges",
             "route": "editPrivileges"
           },

--- a/app/src/main/java/com/ioannapergamali/mysmartroute/view/ui/components/NavigationDrawer.kt
+++ b/app/src/main/java/com/ioannapergamali/mysmartroute/view/ui/components/NavigationDrawer.kt
@@ -117,17 +117,6 @@ fun DrawerMenu(navController: NavController, closeDrawer: () -> Unit) {
             },
             icon = { Icon(Icons.Filled.Storage, contentDescription = null, tint = MaterialTheme.colorScheme.primary) }
         )
-        if (role.value == "ADMIN") {
-            NavigationDrawerItem(
-                label = { Text(stringResource(R.string.user_points)) },
-                selected = false,
-                onClick = {
-                    navController.navigate("userPoints")
-                    closeDrawer()
-                },
-                icon = { Icon(Icons.Filled.Place, contentDescription = null, tint = MaterialTheme.colorScheme.primary) }
-            )
-        }
         NavigationDrawerItem(
             label = { Text(stringResource(R.string.admin_option)) },
             selected = false,

--- a/app/src/main/java/com/ioannapergamali/mysmartroute/view/ui/screens/DatabaseMenuScreen.kt
+++ b/app/src/main/java/com/ioannapergamali/mysmartroute/view/ui/screens/DatabaseMenuScreen.kt
@@ -38,12 +38,6 @@ fun DatabaseMenuScreen(navController: NavController, openDrawer: () -> Unit) {
             Button(onClick = { navController.navigate("syncDb") }) {
                 Text(stringResource(R.string.sync_db))
             }
-            Spacer(modifier = Modifier.padding(8.dp))
-            Button(onClick = { navController.navigate("userPoints") }) {
-
-                Text(stringResource(R.string.user_points))
-
-            }
         }
     }
 }


### PR DESCRIPTION
## Summary
- remove User Points from navigation drawer
- expose User Points via admin role menu configuration
- clean up database menu

## Testing
- `./gradlew test` *(fails: download only)*

------
https://chatgpt.com/codex/tasks/task_e_68b6fb24a7bc8328bf8fd90cde4b66b9