### PR TITLE
Επισκόπηση ονομάτων σημείων για τον διαχειριστή

### DIFF
--- a/app/src/main/java/com/ioannapergamali/mysmartroute/viewmodel/AdminPoiViewModel.kt
+++ b/app/src/main/java/com/ioannapergamali/mysmartroute/viewmodel/AdminPoiViewModel.kt
@@ -22,6 +22,13 @@ class AdminPoiViewModel(private val repo: AdminPoiRepository) : ViewModel() {
         initialValue = emptyList()
     )
 
+    /** Λίστα με τα ονόματα των σημείων για γρήγορη επισκόπηση. */
+    val poiNames: StateFlow<List<String>> = repo.getPoiNames().stateIn(
+        scope = viewModelScope,
+        started = SharingStarted.Eagerly,
+        initialValue = emptyList()
+    )
+
     fun updatePoi(poi: PoIEntity) {
         viewModelScope.launch { repo.updatePoi(poi) }
     }


### PR DESCRIPTION
## Σύνοψη
- Προστέθηκε `StateFlow` με όλα τα ονόματα PoI ώστε ο διαχειριστής να έχει άμεση επισκόπηση.

## Έλεγχοι
- `./gradlew test` (απέτυχε: SDK location not found)


------
https://chatgpt.com/codex/tasks/task_e_68b6ff37768c83288d374b2c0fb9b95c