### PR TITLE
Προσθήκη διαγραφής σημείων με ενημέρωση διαδρομών

### DIFF
--- a/app/src/main/java/com/ioannapergamali/mysmartroute/repository/PointRepository.kt
+++ b/app/src/main/java/com/ioannapergamali/mysmartroute/repository/PointRepository.kt
@@ -51,6 +51,15 @@ class PointRepository {
         }
     }
 
+    /** Διαγραφή σημείου και ενημέρωση διαδρομών */
+    fun deletePoint(pointId: String) {
+        if (points.remove(pointId) != null) {
+            routes.values.forEach { route ->
+                route.pointIds.removeIf { it == pointId }
+            }
+        }
+    }
+
     /** Προσθήκη νέου σημείου */
     fun addPoint(point: Point) {
         points[point.id] = point

--- a/app/src/main/java/com/ioannapergamali/mysmartroute/view/ui/screens/UserPointsScreen.kt
+++ b/app/src/main/java/com/ioannapergamali/mysmartroute/view/ui/screens/UserPointsScreen.kt
@@ -64,6 +64,9 @@ fun UserPointsScreen(
                             Button(onClick = { mergingPoint = point }) {
                                 Text("Συγχώνευση")
                             }
+                            Button(onClick = { viewModel.deletePoint(point.id) }) {
+                                Text("Διαγραφή")
+                            }
                         }
                     }
                 }

--- a/app/src/main/java/com/ioannapergamali/mysmartroute/viewmodel/UserPointViewModel.kt
+++ b/app/src/main/java/com/ioannapergamali/mysmartroute/viewmodel/UserPointViewModel.kt
@@ -46,6 +46,12 @@ class UserPointViewModel(
         refreshPoints()
     }
 
+    /** Διαγραφή σημείου */
+    fun deletePoint(id: String) {
+        repository.deletePoint(id)
+        refreshPoints()
+    }
+
     /** Προσθήκη διαδρομής για τις δοκιμές. */
     fun addRoute(route: Route) {
         repository.addRoute(route)

--- a/app/src/test/java/com/ioannapergamali/mysmartroute/repository/PointRepositoryTest.kt
+++ b/app/src/test/java/com/ioannapergamali/mysmartroute/repository/PointRepositoryTest.kt
@@ -52,4 +52,16 @@ class PointRepositoryTest {
         assertEquals("Λεπτομέρειες Α\nΛεπτομέρειες Β", merged?.details)
         assertEquals(listOf("1", "1"), repo.getRoute("r")?.pointIds)
     }
+
+    @Test
+    fun deletePoint_removesPointAndUpdatesRoutes() {
+        val repo = PointRepository()
+        repo.addPoint(Point("1", "Α", ""))
+        repo.addRoute(Route("r", mutableListOf("1")))
+
+        repo.deletePoint("1")
+
+        assertNull(repo.getPoint("1"))
+        assertEquals(emptyList<String>(), repo.getRoute("r")?.pointIds)
+    }
 }


### PR DESCRIPTION
## Περιγραφή
- Προστέθηκε μέθοδος `deletePoint` στο `PointRepository` που αφαιρεί το σημείο και ενημερώνει τις διαδρομές.
- Προστέθηκε αντίστοιχη λειτουργία στο `UserPointViewModel` και κουμπί διαγραφής στην `UserPointsScreen`.
- Προστέθηκε unit test για τη διαγραφή σημείου.

## Έλεγχοι
- `./gradlew test` *(αποτυχία: δεν βρέθηκε Android SDK)*

------
https://chatgpt.com/codex/tasks/task_e_68b70254387083289e3e4340723349dd