### PR TITLE
Διαχείριση σημείων χρηστών με προσθήκη και διαγραφή

### DIFF
--- a/app/src/main/java/com/ioannapergamali/mysmartroute/repository/PointRepository.kt
+++ b/app/src/main/java/com/ioannapergamali/mysmartroute/repository/PointRepository.kt
@@ -51,6 +51,15 @@ class PointRepository {
         }
     }
 
+    /** Διαγραφή σημείου και ενημέρωση διαδρομών */
+    fun deletePoint(pointId: String) {
+        if (points.remove(pointId) != null) {
+            routes.values.forEach { route ->
+                route.pointIds.removeIf { it == pointId }
+            }
+        }
+    }
+
     /** Προσθήκη νέου σημείου */
     fun addPoint(point: Point) {
         points[point.id] = point

--- a/app/src/main/java/com/ioannapergamali/mysmartroute/view/ui/screens/UserPointsScreen.kt
+++ b/app/src/main/java/com/ioannapergamali/mysmartroute/view/ui/screens/UserPointsScreen.kt
@@ -7,6 +7,8 @@ import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.items
 import androidx.compose.material3.AlertDialog
 import androidx.compose.material3.Button
+import androidx.compose.material3.FloatingActionButton
+import androidx.compose.material3.Icon
 import androidx.compose.material3.Scaffold
 import androidx.compose.material3.Text
 import androidx.compose.material3.TextButton
@@ -15,6 +17,9 @@ import androidx.compose.runtime.*
 import androidx.lifecycle.viewmodel.compose.viewModel
 import androidx.navigation.NavController
 import androidx.compose.ui.Modifier
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.Add
+import java.util.UUID
 import com.ioannapergamali.mysmartroute.view.ui.components.ScreenContainer
 import com.ioannapergamali.mysmartroute.view.ui.components.TopBar
 import com.ioannapergamali.mysmartroute.repository.Point
@@ -34,6 +39,7 @@ fun UserPointsScreen(
     val pointsState = viewModel.points.collectAsState()
     var editingPoint by remember { mutableStateOf<Point?>(null) }
     var mergingPoint by remember { mutableStateOf<Point?>(null) }
+    var addingPoint by remember { mutableStateOf(false) }
 
     Scaffold(
         topBar = {
@@ -43,6 +49,11 @@ fun UserPointsScreen(
                 showMenu = true,
                 onMenuClick = openDrawer
             )
+        },
+        floatingActionButton = {
+            FloatingActionButton(onClick = { addingPoint = true }) {
+                Icon(Icons.Filled.Add, contentDescription = "Προσθήκη")
+            }
         }
     ) { padding ->
         ScreenContainer(modifier = Modifier.padding(padding)) {
@@ -63,6 +74,9 @@ fun UserPointsScreen(
                             }
                             Button(onClick = { mergingPoint = point }) {
                                 Text("Συγχώνευση")
+                            }
+                            Button(onClick = { viewModel.deletePoint(point.id) }) {
+                                Text("Διαγραφή")
                             }
                         }
                     }
@@ -92,6 +106,33 @@ fun UserPointsScreen(
             },
             dismissButton = {
                 TextButton(onClick = { editingPoint = null }) { Text("Άκυρο") }
+            }
+        )
+    }
+
+    if (addingPoint) {
+        var name by remember { mutableStateOf("") }
+        var details by remember { mutableStateOf("") }
+
+        AlertDialog(
+            onDismissRequest = { addingPoint = false },
+            title = { Text("Νέο σημείο") },
+            text = {
+                Column {
+                    OutlinedTextField(value = name, onValueChange = { name = it }, label = { Text("Όνομα") })
+                    OutlinedTextField(value = details, onValueChange = { details = it }, label = { Text("Στοιχεία") })
+                }
+            },
+            confirmButton = {
+                TextButton(onClick = {
+                    if (name.isNotBlank()) {
+                        viewModel.addPoint(Point(UUID.randomUUID().toString(), name, details))
+                    }
+                    addingPoint = false
+                }) { Text("Προσθήκη") }
+            },
+            dismissButton = {
+                TextButton(onClick = { addingPoint = false }) { Text("Άκυρο") }
             }
         )
     }

--- a/app/src/main/java/com/ioannapergamali/mysmartroute/viewmodel/UserPointViewModel.kt
+++ b/app/src/main/java/com/ioannapergamali/mysmartroute/viewmodel/UserPointViewModel.kt
@@ -46,6 +46,12 @@ class UserPointViewModel(
         refreshPoints()
     }
 
+    /** Διαγραφή σημείου */
+    fun deletePoint(id: String) {
+        repository.deletePoint(id)
+        refreshPoints()
+    }
+
     /** Προσθήκη διαδρομής για τις δοκιμές. */
     fun addRoute(route: Route) {
         repository.addRoute(route)

--- a/app/src/test/java/com/ioannapergamali/mysmartroute/repository/PointRepositoryTest.kt
+++ b/app/src/test/java/com/ioannapergamali/mysmartroute/repository/PointRepositoryTest.kt
@@ -52,4 +52,16 @@ class PointRepositoryTest {
         assertEquals("Λεπτομέρειες Α\nΛεπτομέρειες Β", merged?.details)
         assertEquals(listOf("1", "1"), repo.getRoute("r")?.pointIds)
     }
+
+    @Test
+    fun deletePoint_removesPointAndUpdatesRoutes() {
+        val repo = PointRepository()
+        repo.addPoint(Point("1", "Α", ""))
+        repo.addRoute(Route("r", mutableListOf("1")))
+
+        repo.deletePoint("1")
+
+        assertNull(repo.getPoint("1"))
+        assertEquals(emptyList<String>(), repo.getRoute("r")?.pointIds)
+    }
 }


### PR DESCRIPTION
## Περιγραφή
- Προστέθηκε μέθοδος `deletePoint` στο `PointRepository` που αφαιρεί το σημείο και ενημερώνει τις διαδρομές.
- Προστέθηκε αντίστοιχη λειτουργία στο `UserPointViewModel` και κουμπί διαγραφής στην `UserPointsScreen`.
- Προστέθηκε κουμπί προσθήκης νέου σημείου με διάλογο εισαγωγής.
- Προστέθηκε unit test για τη διαγραφή σημείου.

## Έλεγχοι
- `./gradlew test` *(αποτυχία: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b70254387083289e3e4340723349dd