### PR TITLE
Διόρθωση κατάρρευσης LazyColumn

### DIFF
--- a/app/src/main/java/com/ioannapergamali/mysmartroute/view/ui/screens/PrintDeclarationsScreen.kt
+++ b/app/src/main/java/com/ioannapergamali/mysmartroute/view/ui/screens/PrintDeclarationsScreen.kt
@@ -8,6 +8,7 @@ import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.layout.weight
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.items
 import androidx.compose.material3.Button
@@ -106,7 +107,7 @@ fun PrintDeclarationsScreen(navController: NavController, openDrawer: () -> Unit
                     Text(stringResource(R.string.delete_selected))
                 }
                 Spacer(modifier = Modifier.height(8.dp))
-                LazyColumn {
+                LazyColumn(modifier = Modifier.weight(1f)) {
                     items(declarations) { decl ->
                         val isChecked = selected[decl.id] ?: false
                         DeclarationItem(

--- a/app/src/main/java/com/ioannapergamali/mysmartroute/view/ui/screens/UserPointsScreen.kt
+++ b/app/src/main/java/com/ioannapergamali/mysmartroute/view/ui/screens/UserPointsScreen.kt
@@ -3,6 +3,8 @@ package com.ioannapergamali.mysmartroute.view.ui.screens
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.heightIn
+import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.items
 import androidx.compose.material3.AlertDialog
@@ -24,6 +26,7 @@ import com.ioannapergamali.mysmartroute.view.ui.components.ScreenContainer
 import com.ioannapergamali.mysmartroute.view.ui.components.TopBar
 import com.ioannapergamali.mysmartroute.repository.Point
 import com.ioannapergamali.mysmartroute.viewmodel.UserPointViewModel
+import androidx.compose.ui.unit.dp
 
 /**
  * Απλή οθόνη που εμφανίζει τα ονόματα όλων των σημείων που έχουν
@@ -56,11 +59,11 @@ fun UserPointsScreen(
             }
         }
     ) { padding ->
-        ScreenContainer(modifier = Modifier.padding(padding)) {
+        ScreenContainer(modifier = Modifier.padding(padding), scrollable = false) {
             if (pointsState.value.isEmpty()) {
                 Text("Δεν υπάρχουν σημεία")
             } else {
-                LazyColumn {
+                LazyColumn(modifier = Modifier.fillMaxWidth()) {
                     items(pointsState.value) { point ->
                         Row {
                             Column {
@@ -142,7 +145,7 @@ fun UserPointsScreen(
             onDismissRequest = { mergingPoint = null },
             title = { Text("Συγχώνευση με...") },
             text = {
-                LazyColumn {
+                LazyColumn(modifier = Modifier.heightIn(max = 300.dp)) {
                     items(pointsState.value.filter { it.id != point.id }) { other ->
                         TextButton(onClick = {
                             viewModel.mergePoints(point.id, other.id)


### PR DESCRIPTION
## Περίληψη
- Απενεργοποίηση κάθετης κύλισης στο `UserPointsScreen` και καθορισμός μέγιστου ύψους στη λίστα συγχώνευσης.
- Προσθήκη `Modifier.weight(1f)` στο `PrintDeclarationsScreen` για σωστή κατανομή ύψους στη `LazyColumn`.

## Έλεγχοι
- `./gradlew test` *(αποτυχία: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b70b81ff948328a776227ee9e7941b