### PR TITLE
feat: εντοπισμός διπλών PoI

### DIFF
--- a/app/src/main/java/com/ioannapergamali/mysmartroute/repository/AdminPoiRepository.kt
+++ b/app/src/main/java/com/ioannapergamali/mysmartroute/repository/AdminPoiRepository.kt
@@ -20,6 +20,21 @@ class AdminPoiRepository(private val db: MySmartRouteDatabase) {
     /** Επιστροφή όλων των σημείων. */
     fun getAllPois(): Flow<List<PoIEntity>> = poiDao.getAll()
 
+    /**
+     * Επιστρέφει ομάδες σημείων που μοιράζονται ίδιες συντεταγμένες
+     * αλλά έχουν διαφορετικό όνομα. Χρήσιμο για εντοπισμό διπλών
+     * καταχωρίσεων ώστε να συγχωνευθούν.
+     */
+    fun getPoisWithSameCoordinatesDifferentName(): Flow<List<List<PoIEntity>>> =
+        poiDao.getAll().map { pois ->
+            pois.groupBy { it.lat to it.lng }
+                .values
+                .filter { group ->
+                    group.size > 1 && group.map { it.name }.toSet().size > 1
+                }
+                .map { it }
+        }
+
     /** Ενημέρωση στοιχείων σημείου. */
     suspend fun updatePoi(poi: PoIEntity) {
         poiDao.insert(poi)

--- a/app/src/main/java/com/ioannapergamali/mysmartroute/viewmodel/AdminPoiViewModel.kt
+++ b/app/src/main/java/com/ioannapergamali/mysmartroute/viewmodel/AdminPoiViewModel.kt
@@ -29,6 +29,14 @@ class AdminPoiViewModel(private val repo: AdminPoiRepository) : ViewModel() {
         initialValue = emptyList()
     )
 
+    /** Ομάδες πιθανών διπλών σημείων βάσει συντεταγμένων. */
+    val duplicatePois: StateFlow<List<List<PoIEntity>>> =
+        repo.getPoisWithSameCoordinatesDifferentName().stateIn(
+            scope = viewModelScope,
+            started = SharingStarted.Eagerly,
+            initialValue = emptyList()
+        )
+
     fun updatePoi(poi: PoIEntity) {
         viewModelScope.launch { repo.updatePoi(poi) }
     }

--- a/app/src/test/java/com/ioannapergamali/mysmartroute/repository/AdminPoiRepositoryTest.kt
+++ b/app/src/test/java/com/ioannapergamali/mysmartroute/repository/AdminPoiRepositoryTest.kt
@@ -55,5 +55,20 @@ class AdminPoiRepositoryTest {
         val points = db.routePointDao().getPointsForRoute("r").first()
         assertTrue(points.all { it.poiId == "1" })
     }
+
+    @Test
+    fun getPoisWithSameCoordinatesDifferentName_returnsDuplicateGroups() = runBlocking {
+        val type = PoiTypeEntity(id = Place.Type.ESTABLISHMENT.name, name = "")
+        db.poiTypeDao().insertAll(listOf(type))
+        val poi1 = PoIEntity(id = "1", name = "A", type = Place.Type.ESTABLISHMENT, lat = 1.0, lng = 2.0)
+        val poi2 = PoIEntity(id = "2", name = "B", type = Place.Type.ESTABLISHMENT, lat = 1.0, lng = 2.0)
+        val poi3 = PoIEntity(id = "3", name = "C", type = Place.Type.ESTABLISHMENT, lat = 3.0, lng = 4.0)
+        db.poIDao().insertAll(listOf(poi1, poi2, poi3))
+
+        val duplicates = repo.getPoisWithSameCoordinatesDifferentName().first()
+
+        assertEquals(1, duplicates.size)
+        assertTrue(duplicates[0].map { it.id }.toSet() == setOf("1", "2"))
+    }
 }
 


### PR DESCRIPTION
## Summary
- πρόσθετο φίλτρο για ομάδες σημείων με ίδιες συντεταγμένες και διαφορετικά ονόματα
- εμφάνιση των πιθανών διπλών σημείων στο AdminPoiViewModel
- δοκιμή επαλήθευσης για εύρεση διπλών PoI

## Testing
- `./gradlew test` *(αποτυχία: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b711a55c888328aaae609f746baf38