### PR TITLE
Avoid duplicate POIs by using unique coordinate index

### DIFF
--- a/app/src/main/java/com/ioannapergamali/mysmartroute/data/local/PoIDao.kt
+++ b/app/src/main/java/com/ioannapergamali/mysmartroute/data/local/PoIDao.kt
@@ -7,10 +7,10 @@ import androidx.room.Query
 
 @Dao
 interface PoIDao {
-    @Insert(onConflict = OnConflictStrategy.REPLACE)
+    @Insert(onConflict = OnConflictStrategy.IGNORE)
     suspend fun insertAll(pois: List<PoIEntity>)
 
-    @Insert(onConflict = OnConflictStrategy.REPLACE)
+    @Insert(onConflict = OnConflictStrategy.IGNORE)
     suspend fun insert(poi: PoIEntity)
 
     @Query("SELECT * FROM pois")

--- a/app/src/main/java/com/ioannapergamali/mysmartroute/data/local/PoIEntity.kt
+++ b/app/src/main/java/com/ioannapergamali/mysmartroute/data/local/PoIEntity.kt
@@ -19,7 +19,10 @@ import com.google.android.libraries.places.api.model.Place
             onDelete = ForeignKey.RESTRICT
         )
     ],
-    indices = [Index("typeId")]
+    indices = [
+        Index(value = ["lat", "lng"], unique = true),
+        Index("typeId")
+    ]
 )
 data class PoIEntity(
     @PrimaryKey val id: String = "",


### PR DESCRIPTION
## Summary
- enforce unique lat/lng index on PoIEntity to prevent duplicates
- insert POIs with OnConflictStrategy.IGNORE instead of REPLACE

## Testing
- `./gradlew test` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b7162e2bfc832897984b12d44117ce