### PR TITLE
Increase Room DB version and enable destructive migration

### DIFF
--- a/app/src/main/java/com/ioannapergamali/mysmartroute/data/local/MySmartRouteDatabase.kt
+++ b/app/src/main/java/com/ioannapergamali/mysmartroute/data/local/MySmartRouteDatabase.kt
@@ -57,7 +57,7 @@ import com.ioannapergamali.mysmartroute.data.local.TripRatingDao
         TripRatingEntity::class,
         NotificationEntity::class
     ],
-    version = 58
+    version = 59
 )
 @TypeConverters(Converters::class)
 abstract class MySmartRouteDatabase : RoomDatabase() {
@@ -884,6 +884,7 @@ abstract class MySmartRouteDatabase : RoomDatabase() {
                     MIGRATION_56_57,
                     MIGRATION_57_58
                 )
+                    .fallbackToDestructiveMigration()
                     .addCallback(object : RoomDatabase.Callback() {
                         override fun onCreate(db: SupportSQLiteDatabase) {
                             prepopulate(db)


### PR DESCRIPTION
## Summary
- bump Room database schema version to 59
- enable destructive fallback migration to avoid integrity mismatches

## Testing
- `./gradlew test` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b721ce3f1c8328a401a05c868f9611