### PR TITLE
Κατάργηση προκαθορισμένων σημείων και επιλογή POI από μενού

### DIFF
--- a/app/src/main/java/com/ioannapergamali/mysmartroute/view/ui/screens/UserPointsScreen.kt
+++ b/app/src/main/java/com/ioannapergamali/mysmartroute/view/ui/screens/UserPointsScreen.kt
@@ -21,11 +21,12 @@ import androidx.navigation.NavController
 import androidx.compose.ui.Modifier
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.Add
-import java.util.UUID
 import com.ioannapergamali.mysmartroute.view.ui.components.ScreenContainer
 import com.ioannapergamali.mysmartroute.view.ui.components.TopBar
 import com.ioannapergamali.mysmartroute.repository.Point
 import com.ioannapergamali.mysmartroute.viewmodel.UserPointViewModel
+import com.ioannapergamali.mysmartroute.viewmodel.PoIViewModel
+import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.unit.dp
 
 /**
@@ -39,7 +40,14 @@ fun UserPointsScreen(
     openDrawer: () -> Unit,
     viewModel: UserPointViewModel = viewModel()
 ) {
+    val poiViewModel: PoIViewModel = viewModel()
+    val context = LocalContext.current
+    val pois by poiViewModel.pois.collectAsState()
+    LaunchedEffect(Unit) { poiViewModel.loadPois(context) }
     val pointsState = viewModel.points.collectAsState()
+    val availablePois by remember(pois, pointsState.value) {
+        mutableStateOf(viewModel.availablePois(pois))
+    }
     var editingPoint by remember { mutableStateOf<Point?>(null) }
     var mergingPoint by remember { mutableStateOf<Point?>(null) }
     var addingPoint by remember { mutableStateOf(false) }
@@ -114,26 +122,26 @@ fun UserPointsScreen(
     }
 
     if (addingPoint) {
-        var name by remember { mutableStateOf("") }
-        var details by remember { mutableStateOf("") }
-
         AlertDialog(
             onDismissRequest = { addingPoint = false },
-            title = { Text("Νέο σημείο") },
+            title = { Text("Επιλογή POI") },
             text = {
-                Column {
-                    OutlinedTextField(value = name, onValueChange = { name = it }, label = { Text("Όνομα") })
-                    OutlinedTextField(value = details, onValueChange = { details = it }, label = { Text("Στοιχεία") })
+                if (availablePois.isEmpty()) {
+                    Text("Δεν υπάρχουν διαθέσιμα POI")
+                } else {
+                    LazyColumn(modifier = Modifier.heightIn(max = 300.dp)) {
+                        items(availablePois) { poi ->
+                            TextButton(onClick = {
+                                viewModel.addPoint(Point(poi.id, poi.name, ""))
+                                addingPoint = false
+                            }) {
+                                Text(poi.name)
+                            }
+                        }
+                    }
                 }
             },
-            confirmButton = {
-                TextButton(onClick = {
-                    if (name.isNotBlank()) {
-                        viewModel.addPoint(Point(UUID.randomUUID().toString(), name, details))
-                    }
-                    addingPoint = false
-                }) { Text("Προσθήκη") }
-            },
+            confirmButton = {},
             dismissButton = {
                 TextButton(onClick = { addingPoint = false }) { Text("Άκυρο") }
             }

--- a/app/src/test/java/com/ioannapergamali/mysmartroute/viewmodel/UserPointViewModelTest.kt
+++ b/app/src/test/java/com/ioannapergamali/mysmartroute/viewmodel/UserPointViewModelTest.kt
@@ -1,19 +1,38 @@
 package com.ioannapergamali.mysmartroute.viewmodel
 
+import com.google.android.libraries.places.api.model.Place
+import com.ioannapergamali.mysmartroute.data.local.PoIEntity
+import com.ioannapergamali.mysmartroute.repository.Point
 import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
 import org.junit.Test
 
 /**
- * Έλεγχος ότι το [UserPointViewModel] φορτώνει δύο ενδεικτικά σημεία κατά την αρχικοποίηση.
+ * Έλεγχος ότι το [UserPointViewModel] δεν περιέχει προκαθορισμένα σημεία
+ * και ότι φιλτράρει τα POI με ίδιες συντεταγμένες.
  */
 class UserPointViewModelTest {
 
     @Test
-    fun init_preloadsDefaultPoints() {
+    fun init_hasNoDefaultPoints() {
         val viewModel = UserPointViewModel()
 
-        val names = viewModel.points.value.map { it.name }
-        assertEquals(listOf("Πλατεία Συντάγματος", "Ακρόπολη"), names)
+        assertTrue(viewModel.points.value.isEmpty())
+    }
+
+    @Test
+    fun availablePois_excludesSameCoordinates() {
+        val viewModel = UserPointViewModel()
+        viewModel.addPoint(Point("1", "A", ""))
+        val pois = listOf(
+            PoIEntity(id = "1", name = "A", lat = 1.0, lng = 2.0, type = Place.Type.ESTABLISHMENT),
+            PoIEntity(id = "2", name = "B", lat = 1.0, lng = 2.0, type = Place.Type.ESTABLISHMENT),
+            PoIEntity(id = "3", name = "C", lat = 3.0, lng = 4.0, type = Place.Type.ESTABLISHMENT)
+        )
+
+        val available = viewModel.availablePois(pois)
+
+        assertEquals(listOf(pois[2]), available)
     }
 }
 


### PR DESCRIPTION
## Περίληψη
- Αφαιρέθηκαν τα προεπιλεγμένα σημεία "Πλατεία Συντάγματος" και "Ακρόπολη" από το `UserPointViewModel`.
- Προστέθηκε μενού επιλογής POI στην οθόνη διαχείρισης σημείων χρηστών.
- Ενημερώθηκαν τα tests ώστε να επιβεβαιώνουν την απουσία προκαθορισμένων σημείων.
- Φιλτράρονται τα POI με ίδιες συντεταγμένες ώστε να μην εμφανίζονται διπλότυπα σημεία.

## Έλεγχοι
- `./gradlew test` *(αποτυχία: λείπει Android SDK)*


------
https://chatgpt.com/codex/tasks/task_e_68b7281b91e48328b4584292377625a0