### PR TITLE
Εμφάνιση και συγχώνευση διπλών POI

### DIFF
--- a/app/src/main/java/com/ioannapergamali/mysmartroute/utils/PoiUtils.kt
+++ b/app/src/main/java/com/ioannapergamali/mysmartroute/utils/PoiUtils.kt
@@ -37,3 +37,17 @@ fun poisAtLocation(
         abs(it.lng - point.longitude) < tolerance
     }
 
+/**
+ * Επιστρέφει ομάδες από POI που μοιράζονται τις ίδιες
+ * συντεταγμένες αλλά έχουν διαφορετικό όνομα. Χρησιμοποιείται
+ * ώστε ο διαχειριστής να μπορεί να τα συγχωνεύσει σε ένα.
+ */
+fun duplicatePois(
+    pois: List<PoIEntity>
+): List<List<PoIEntity>> =
+    pois.groupBy { it.lat to it.lng }
+        .values
+        .filter { group ->
+            group.size > 1 && group.map { it.name }.toSet().size > 1
+        }
+


### PR DESCRIPTION
## Περίληψη
- Προσθήκη βοηθητικής συνάρτησης για εντοπισμό POI με ίδιες συντεταγμένες και διαφορετικό όνομα.
- Ενημέρωση της UserPointsScreen ώστε να εμφανίζει τα διπλά POI και να επιτρέπει τη συγχώνευσή τους σε ένα.

## Έλεγχοι
- `./gradlew test` *(αποτυχία: SDK location not found)*


------
https://chatgpt.com/codex/tasks/task_e_68b72f28602c8328800a76038147da28