### PR TITLE
Προβολή ενδιαφερουσών διαδρομών

### DIFF
--- a/app/src/main/java/com/ioannapergamali/mysmartroute/data/local/MySmartRouteDatabase.kt
+++ b/app/src/main/java/com/ioannapergamali/mysmartroute/data/local/MySmartRouteDatabase.kt
@@ -262,6 +262,7 @@ abstract class MySmartRouteDatabase : RoomDatabase() {
                 insertOption("opt_passenger_13", passengerMenuId, "view_movings", "viewMovings")
                 insertOption("opt_passenger_14", passengerMenuId, "walking", "walking")
                 insertOption("opt_passenger_15", passengerMenuId, "walking_routes", "walkingRoutes")
+                insertOption("opt_passenger_16", passengerMenuId, "interesting_routes", "interestingRoutes")
 
                 val driverMenuId = "menu_driver_main"
                 insertMenu(driverMenuId, "role_driver", "driver_menu_title")
@@ -796,6 +797,7 @@ abstract class MySmartRouteDatabase : RoomDatabase() {
             insertOption("opt_passenger_13", passengerMenuId, "view_movings", "viewMovings")
             insertOption("opt_passenger_14", passengerMenuId, "walking", "walking")
             insertOption("opt_passenger_15", passengerMenuId, "walking_routes", "walkingRoutes")
+            insertOption("opt_passenger_16", passengerMenuId, "interesting_routes", "interestingRoutes")
 
             val driverMenuId = "menu_driver_main"
             insertMenu(driverMenuId, "role_driver", "driver_menu_title")

--- a/app/src/main/java/com/ioannapergamali/mysmartroute/model/navigation/NavigationHost.kt
+++ b/app/src/main/java/com/ioannapergamali/mysmartroute/model/navigation/NavigationHost.kt
@@ -34,6 +34,7 @@ import com.ioannapergamali.mysmartroute.view.ui.screens.RolesScreen
 import com.ioannapergamali.mysmartroute.view.ui.screens.ProfileScreen
 import com.ioannapergamali.mysmartroute.view.ui.screens.RouteEditorScreen
 import com.ioannapergamali.mysmartroute.view.ui.screens.ManageFavoritesScreen
+import com.ioannapergamali.mysmartroute.view.ui.screens.InterestingRoutesScreen
 import com.ioannapergamali.mysmartroute.view.ui.screens.PrintCompletedScreen
 import com.ioannapergamali.mysmartroute.view.ui.screens.PrintListScreen
 import com.ioannapergamali.mysmartroute.view.ui.screens.PrintScheduledScreen
@@ -193,6 +194,10 @@ fun NavigationHost(
 
         composable("manageFavorites") {
             ManageFavoritesScreen(navController = navController, openDrawer = openDrawer)
+        }
+
+        composable("interestingRoutes") {
+            InterestingRoutesScreen(navController = navController, openDrawer = openDrawer)
         }
 
         composable("routeMode") {

--- a/app/src/main/java/com/ioannapergamali/mysmartroute/view/ui/screens/InterestingRoutesScreen.kt
+++ b/app/src/main/java/com/ioannapergamali/mysmartroute/view/ui/screens/InterestingRoutesScreen.kt
@@ -1,0 +1,77 @@
+package com.ioannapergamali.mysmartroute.view.ui.screens
+
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.lazy.items
+import androidx.compose.material3.Checkbox
+import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.Scaffold
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.collectAsState
+import androidx.compose.runtime.getValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.unit.dp
+import androidx.lifecycle.viewmodel.compose.viewModel
+import androidx.navigation.NavController
+import com.ioannapergamali.mysmartroute.R
+import com.ioannapergamali.mysmartroute.view.ui.components.ScreenContainer
+import com.ioannapergamali.mysmartroute.view.ui.components.TopBar
+import com.ioannapergamali.mysmartroute.viewmodel.FavoriteRoutesViewModel
+import com.ioannapergamali.mysmartroute.viewmodel.RouteViewModel
+
+/** Οθόνη επιλογής διαδρομών που ενδιαφέρουν τον επιβάτη. */
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+fun InterestingRoutesScreen(navController: NavController, openDrawer: () -> Unit) {
+    val context = LocalContext.current
+    val routeViewModel: RouteViewModel = viewModel()
+    val favViewModel: FavoriteRoutesViewModel = viewModel()
+    val routes by routeViewModel.routes.collectAsState()
+    val favorites by favViewModel.favorites.collectAsState()
+
+    LaunchedEffect(Unit) {
+        routeViewModel.loadRoutes(context, includeAll = true)
+        favViewModel.loadFavorites()
+    }
+
+    Scaffold(topBar = {
+        TopBar(
+            title = stringResource(R.string.interesting_routes),
+            navController = navController,
+            showMenu = true,
+            onMenuClick = openDrawer
+        )
+    }) { padding ->
+        ScreenContainer(modifier = Modifier.padding(padding), scrollable = false) {
+            if (routes.isEmpty()) {
+                Text(stringResource(R.string.no_interesting_routes), modifier = Modifier.padding(16.dp))
+            } else {
+                LazyColumn {
+                    items(routes) { route ->
+                        val checked = favorites.contains(route.id)
+                        Row(
+                            verticalAlignment = Alignment.CenterVertically,
+                            modifier = Modifier
+                                .fillMaxWidth()
+                                .padding(16.dp)
+                        ) {
+                            Checkbox(
+                                checked = checked,
+                                onCheckedChange = { favViewModel.toggleFavorite(route.id) }
+                            )
+                            Text(route.name, modifier = Modifier.padding(start = 8.dp))
+                        }
+                    }
+                }
+            }
+        }
+    }
+}
+

--- a/app/src/main/java/com/ioannapergamali/mysmartroute/viewmodel/FavoriteRoutesViewModel.kt
+++ b/app/src/main/java/com/ioannapergamali/mysmartroute/viewmodel/FavoriteRoutesViewModel.kt
@@ -1,0 +1,67 @@
+package com.ioannapergamali.mysmartroute.viewmodel
+
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.viewModelScope
+import com.google.firebase.auth.FirebaseAuth
+import com.google.firebase.firestore.FirebaseFirestore
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.tasks.await
+import java.util.UUID
+
+/**
+ * ViewModel για αποθήκευση και ανάκτηση διαδρομών που ενδιαφέρουν τον επιβάτη.
+ * Οι διαδρομές αποθηκεύονται στο υποσυλλογή favorites -> routes του χρήστη.
+ */
+class FavoriteRoutesViewModel : ViewModel() {
+    private val firestore = FirebaseFirestore.getInstance()
+
+    private fun userRoutes(uid: String) = firestore.collection("users")
+        .document(uid)
+        .collection("favorites")
+        .document("routes")
+        .collection("items")
+
+    private fun userId() = FirebaseAuth.getInstance().currentUser?.uid ?: ""
+
+    private val _favorites = MutableStateFlow<Set<String>>(emptySet())
+    val favorites: StateFlow<Set<String>> = _favorites
+
+    /** Φορτώνει τις αγαπημένες διαδρομές του χρήστη. */
+    fun loadFavorites() {
+        val uid = userId()
+        if (uid.isBlank()) return
+        viewModelScope.launch {
+            val snap = runCatching { userRoutes(uid).get().await() }.getOrNull()
+            _favorites.value = snap?.documents
+                ?.mapNotNull { it.getString("routeId") }
+                ?.toSet() ?: emptySet()
+        }
+    }
+
+    /** Προσθέτει ή αφαιρεί μια διαδρομή από τα αγαπημένα. */
+    fun toggleFavorite(routeId: String) {
+        val uid = userId()
+        if (uid.isBlank()) return
+        viewModelScope.launch {
+            val current = _favorites.value
+            if (current.contains(routeId)) {
+                runCatching {
+                    userRoutes(uid)
+                        .whereEqualTo("routeId", routeId)
+                        .get()
+                        .await()
+                        .documents
+                        .forEach { it.reference.delete().await() }
+                }
+            } else {
+                val id = UUID.randomUUID().toString()
+                val data = mapOf("id" to id, "routeId" to routeId)
+                runCatching { userRoutes(uid).document(id).set(data).await() }
+            }
+            loadFavorites()
+        }
+    }
+}
+

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -222,6 +222,8 @@
     <string name="passenger">Passenger</string>
     <string name="favorites_preferred">Preferred transport modes</string>
     <string name="favorites_non_preferred">Non-preferred transport modes</string>
+    <string name="interesting_routes">Interesting routes</string>
+    <string name="no_interesting_routes">No routes available</string>
     <string name="add_favorite">Add</string>
     <string name="delete_favorite">Delete</string>
     <string name="delete_selected">Delete selected</string>


### PR DESCRIPTION
## Περίληψη
- Προσθήκη ViewModel για αποθήκευση αγαπημένων διαδρομών στο Firestore.
- Νέα οθόνη `InterestingRoutesScreen` με επιλογή διαδρομών μέσω checkbox.
- Ενημέρωση πλοήγησης και μενού επιβάτη για πρόσβαση στην οθόνη.

## Έλεγχοι
- `./gradlew test` *(αποτυχία: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b738a20fa88328b61948af5340b2ea