### PR TITLE
Κατηγοριοποίηση και προβολή μετακινήσεων

### DIFF
--- a/app/src/main/java/com/ioannapergamali/mysmartroute/data/local/MovingStatus.kt
+++ b/app/src/main/java/com/ioannapergamali/mysmartroute/data/local/MovingStatus.kt
@@ -25,3 +25,12 @@ fun MovingEntity.movingStatus(now: Long = System.currentTimeMillis()): MovingSta
     status != "accepted" && date > now -> MovingStatus.PENDING
     else -> MovingStatus.UNSUCCESSFUL
 }
+
+/**
+ * Ομαδοποιεί μια λίστα από [MovingEntity] ανά [MovingStatus].
+ */
+fun categorizeMovings(
+    movings: List<MovingEntity>,
+    now: Long = System.currentTimeMillis()
+): Map<MovingStatus, List<MovingEntity>> =
+    movings.groupBy { it.movingStatus(now) }

--- a/app/src/main/java/com/ioannapergamali/mysmartroute/view/ui/screens/MovingListScreen.kt
+++ b/app/src/main/java/com/ioannapergamali/mysmartroute/view/ui/screens/MovingListScreen.kt
@@ -1,0 +1,39 @@
+package com.ioannapergamali.mysmartroute.view.ui.screens
+
+import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.lazy.items
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import com.ioannapergamali.mysmartroute.data.local.MovingEntity
+import com.ioannapergamali.mysmartroute.data.local.categorizeMovings
+import java.time.Instant
+import java.time.ZoneId
+import java.time.format.DateTimeFormatter
+
+/**
+ * Εμφανίζει τις μετακινήσεις κατηγοριοποιημένες ανάλογα με την
+ * [com.ioannapergamali.mysmartroute.data.local.MovingStatus].
+ */
+@Composable
+fun MovingListScreen(movings: List<MovingEntity>) {
+    val categorized = categorizeMovings(movings)
+    LazyColumn {
+        categorized.forEach { (status, list) ->
+            item {
+                Text(
+                    text = status.name,
+                    style = MaterialTheme.typography.titleMedium
+                )
+            }
+            items(list) { moving ->
+                Text("Μετακίνηση ${moving.id} – ${formatDate(moving.date)}")
+            }
+        }
+    }
+}
+
+private fun formatDate(epochMillis: Long): String =
+    Instant.ofEpochMilli(epochMillis)
+        .atZone(ZoneId.systemDefault())
+        .format(DateTimeFormatter.ofPattern("yyyy-MM-dd HH:mm"))


### PR DESCRIPTION
## Περίληψη
- Προσθήκη βοηθητικής συνάρτησης για ομαδοποίηση `MovingEntity` ανά `MovingStatus`.
- Δημιουργία οθόνης Jetpack Compose που εμφανίζει τις μετακινήσεις ταξινομημένες ανά κατηγορία.

## Έλεγχοι
- `./gradlew test` *(απέτυχε: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b74c5a654c8328b68d7f272b203389