### PR TITLE
fix: avoid NPE in reset password

### DIFF
--- a/app/src/main/java/com/ioannapergamali/mysmartroute/view/ui/screens/ResetPasswordScreen.kt
+++ b/app/src/main/java/com/ioannapergamali/mysmartroute/view/ui/screens/ResetPasswordScreen.kt
@@ -24,7 +24,6 @@ fun ResetPasswordScreen(navController: NavController, openDrawer: () -> Unit) {
     val uiState by viewModel.resetPasswordState.collectAsState()
     var email by remember { mutableStateOf("") }
     val context = LocalContext.current
-    val bubbleState = LocalKeyboardBubbleState.current!!
 
 
     Scaffold(
@@ -40,6 +39,7 @@ fun ResetPasswordScreen(navController: NavController, openDrawer: () -> Unit) {
         }
     ) { padding ->
         ScreenContainer(modifier = Modifier.padding(padding)) {
+            val bubbleState = LocalKeyboardBubbleState.current!!
             Column(
                 modifier = Modifier.fillMaxWidth(),
                 horizontalAlignment = Alignment.CenterHorizontally


### PR DESCRIPTION
## Summary
- avoid calling `LocalKeyboardBubbleState.current` before it's provided in `ResetPasswordScreen`

## Testing
- `./gradlew test --console=plain` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b7550006f88328b40c922bcff919ce