### PR TITLE
Διόρθωση ελέγχου διαδρομών στο MenuScreen

### DIFF
--- a/app/src/main/java/com/ioannapergamali/mysmartroute/view/ui/screens/MenuScreen.kt
+++ b/app/src/main/java/com/ioannapergamali/mysmartroute/view/ui/screens/MenuScreen.kt
@@ -77,12 +77,18 @@ fun MenuScreen(navController: NavController, openDrawer: () -> Unit) {
                         "initSystem" -> "databaseMenu"
                         else -> route
                     }
+
+                    val destinationExists = if (targetRoute.startsWith("definePoi")) {
+                        navController.graph.any {
+                            it.route == "definePoi?lat={lat}&lng={lng}&source={source}&view={view}&routeId={routeId}"
+                        }
+                    } else {
+                        navController.graph.any { it.route == targetRoute }
+                    }
+
                     if (
                         targetRoute == "viewUsers" ||
-                        (targetRoute.isNotEmpty() && navController.graph.any {
-                            it.route == "definePoi?lat={lat}&lng={lng}&source={source}&view={view}&routeId={routeId}" ||
-                                it.route == targetRoute
-                        })
+                        (targetRoute.isNotEmpty() && destinationExists)
                     ) {
                         navController.navigate(targetRoute)
                     } else {


### PR DESCRIPTION
## Σκοπός
- Αποφυγή του σφάλματος `Navigation destination that matches route cancelSeat cannot be found`.

## Αλλαγές
- Προστέθηκε ξεχωριστός έλεγχος για ύπαρξη προορισμού πριν από την πλοήγηση.

## Έλεγχοι
- `./gradlew test` *(αποτυχία: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b75b798e248328871bc329bc8b719a