### PR TITLE
Enable scrolling in interesting routes screen

### DIFF
--- a/app/src/main/java/com/ioannapergamali/mysmartroute/view/ui/screens/InterestingRoutesScreen.kt
+++ b/app/src/main/java/com/ioannapergamali/mysmartroute/view/ui/screens/InterestingRoutesScreen.kt
@@ -2,6 +2,7 @@ package com.ioannapergamali.mysmartroute.view.ui.screens
 
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.lazy.LazyColumn
@@ -55,7 +56,11 @@ fun InterestingRoutesScreen(navController: NavController, openDrawer: () -> Unit
             onMenuClick = openDrawer
         )
     }) { padding ->
-        Column(modifier = Modifier.padding(padding)) {
+        Column(
+            modifier = Modifier
+                .fillMaxSize()
+                .padding(padding)
+        ) {
             if (routes.isEmpty()) {
                 Text(stringResource(R.string.no_interesting_routes), modifier = Modifier.padding(16.dp))
             } else {


### PR DESCRIPTION
## Summary
- allow vertical scroll on InterestingRoutesScreen

## Testing
- `./gradlew test` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b768326d848328aa5f8e7a19d8e8d4