### PR TITLE
Fix missing save button in interesting routes screen

### DIFF
--- a/app/src/main/java/com/ioannapergamali/mysmartroute/view/ui/screens/InterestingRoutesScreen.kt
+++ b/app/src/main/java/com/ioannapergamali/mysmartroute/view/ui/screens/InterestingRoutesScreen.kt
@@ -8,10 +8,12 @@ import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.items
 
-import androidx.compose.material3.Button
-
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.Save
 import androidx.compose.material3.Checkbox
 import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.FloatingActionButton
+import androidx.compose.material3.Icon
 import androidx.compose.material3.Scaffold
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
@@ -48,14 +50,37 @@ fun InterestingRoutesScreen(navController: NavController, openDrawer: () -> Unit
         favViewModel.loadFavorites()
     }
 
-    Scaffold(topBar = {
-        TopBar(
-            title = stringResource(R.string.interesting_routes),
-            navController = navController,
-            showMenu = true,
-            onMenuClick = openDrawer
-        )
-    }) { padding ->
+    Scaffold(
+        topBar = {
+            TopBar(
+                title = stringResource(R.string.interesting_routes),
+                navController = navController,
+                showMenu = true,
+                onMenuClick = openDrawer
+            )
+        },
+        floatingActionButton = {
+            if (routes.isNotEmpty()) {
+                FloatingActionButton(
+                    onClick = {
+                        favViewModel.saveFavorites { success ->
+                            val msg = if (success) {
+                                R.string.favorite_routes_saved
+                            } else {
+                                R.string.favorite_routes_save_failed
+                            }
+                            Toast.makeText(context, context.getString(msg), Toast.LENGTH_SHORT).show()
+                        }
+                    }
+                ) {
+                    Icon(
+                        Icons.Filled.Save,
+                        contentDescription = stringResource(R.string.save)
+                    )
+                }
+            }
+        }
+    ) { padding ->
         Column(
             modifier = Modifier
                 .fillMaxSize()
@@ -64,11 +89,7 @@ fun InterestingRoutesScreen(navController: NavController, openDrawer: () -> Unit
             if (routes.isEmpty()) {
                 Text(stringResource(R.string.no_interesting_routes), modifier = Modifier.padding(16.dp))
             } else {
-
                 LazyColumn(modifier = Modifier.weight(1f)) {
-
-               
-
                     items(routes) { route ->
                         val checked = favorites.contains(route.id)
                         Row(
@@ -85,25 +106,6 @@ fun InterestingRoutesScreen(navController: NavController, openDrawer: () -> Unit
                         }
                     }
                 }
-
-                Button(
-                    onClick = {
-                        favViewModel.saveFavorites { success ->
-                            val msg = if (success) {
-                                R.string.favorite_routes_saved
-                            } else {
-                                R.string.favorite_routes_save_failed
-                            }
-                            Toast.makeText(context, context.getString(msg), Toast.LENGTH_SHORT).show()
-                        }
-                    },
-                    modifier = Modifier
-                        .align(Alignment.End)
-                        .padding(16.dp)
-                ) {
-                    Text(stringResource(R.string.save))
-                }
-
             }
         }
     }


### PR DESCRIPTION
## Summary
- show a floating action button to save selected routes in the InterestingRoutes screen

## Testing
- `./gradlew test` *(fails: build did not complete, Gradle daemon start)*

------
https://chatgpt.com/codex/tasks/task_e_68b76ae5bde08328a485178c4da7e72d