### PR TITLE
Προσθήκη επεξεργάσιμου προφίλ με υποστήριξη κάμερας

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -6,6 +6,7 @@
     <uses-permission android:name="android.permission.ACCESS_NETWORK_STATE" />
     <uses-permission android:name="android.permission.ACCESS_COARSE_LOCATION" />
     <uses-permission android:name="android.permission.ACCESS_FINE_LOCATION" />
+    <uses-permission android:name="android.permission.CAMERA" />
 
     <application
         android:name=".MySmartRouteApplication"

--- a/app/src/main/java/com/ioannapergamali/mysmartroute/view/ui/screens/ProfileScreen.kt
+++ b/app/src/main/java/com/ioannapergamali/mysmartroute/view/ui/screens/ProfileScreen.kt
@@ -1,13 +1,17 @@
 package com.ioannapergamali.mysmartroute.view.ui.screens
 
+import android.Manifest
+import android.graphics.Bitmap
 import android.util.Log
 import androidx.activity.compose.rememberLauncherForActivityResult
 import androidx.activity.result.contract.ActivityResultContracts
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.shape.CircleShape
 import androidx.compose.material3.Button
+import androidx.compose.material3.OutlinedTextField
 import androidx.compose.material3.Scaffold
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
@@ -27,6 +31,7 @@ import com.google.firebase.storage.FirebaseStorage
 import com.ioannapergamali.mysmartroute.R
 import com.ioannapergamali.mysmartroute.view.ui.components.ScreenContainer
 import com.ioannapergamali.mysmartroute.view.ui.components.TopBar
+import java.io.ByteArrayOutputStream
 
 /**
  * Εμφανίζει τα στοιχεία του χρήστη και επιτρέπει την αλλαγή της φωτογραφίας προφίλ.
@@ -35,19 +40,15 @@ import com.ioannapergamali.mysmartroute.view.ui.components.TopBar
 @Composable
 fun ProfileScreen(navController: NavController, openDrawer: () -> Unit) {
     val user = FirebaseAuth.getInstance().currentUser
-    val username = remember { mutableStateOf<String?>(null) }
+    val username = remember { mutableStateOf("") }
     val photoUrl = remember { mutableStateOf<String?>(null) }
 
     val imagePicker = rememberLauncherForActivityResult(ActivityResultContracts.GetContent()) { uri ->
         val uid = user?.uid ?: return@rememberLauncherForActivityResult
         uri ?: return@rememberLauncherForActivityResult
 
-        Log.d("ProfileScreen", "Επιλέχθηκε εικόνα: $uri")
-
         val storageRef = FirebaseStorage.getInstance().reference
             .child("profileImages/$uid.jpg")
-
-        Log.d("ProfileScreen", "Διαδρομή Storage: ${'$'}{storageRef.path}")
 
         storageRef.putFile(uri)
             .addOnSuccessListener {
@@ -55,25 +56,55 @@ fun ProfileScreen(navController: NavController, openDrawer: () -> Unit) {
                     val url = downloadUri.toString()
                     photoUrl.value = url
 
-                    Log.d("ProfileScreen", "Λήφθηκε download URL: $url")
+                    val docRef = FirebaseFirestore.getInstance()
+                        .collection("users")
+                        .document(uid)
+
+                    docRef.update("photoUrl", url)
+                        .addOnFailureListener { docRef.set(mapOf("photoUrl" to url)) }
+                }
+            }
+            .addOnFailureListener { e ->
+                Log.e("ProfileScreen", "Αποτυχία ανεβάσματος εικόνας", e)
+            }
+    }
+
+    val cameraLauncher = rememberLauncherForActivityResult(ActivityResultContracts.TakePicturePreview()) { bitmap ->
+        val uid = user?.uid ?: return@rememberLauncherForActivityResult
+        bitmap ?: return@rememberLauncherForActivityResult
+
+        val baos = ByteArrayOutputStream()
+        bitmap.compress(Bitmap.CompressFormat.JPEG, 100, baos)
+        val data = baos.toByteArray()
+
+        val storageRef = FirebaseStorage.getInstance().reference
+            .child("profileImages/$uid.jpg")
+
+        storageRef.putBytes(data)
+            .addOnSuccessListener {
+                storageRef.downloadUrl.addOnSuccessListener { downloadUri ->
+                    val url = downloadUri.toString()
+                    photoUrl.value = url
 
                     val docRef = FirebaseFirestore.getInstance()
                         .collection("users")
                         .document(uid)
 
                     docRef.update("photoUrl", url)
-                        .addOnSuccessListener {
-                            Log.d("ProfileScreen", "Αποθηκεύτηκε το URL στο Firestore")
-                        }
-                        .addOnFailureListener { error ->
-                            Log.e("ProfileScreen", "Αποτυχία ενημέρωσης Firestore", error)
-                            docRef.set(mapOf("photoUrl" to url))
-                        }
+                        .addOnFailureListener { docRef.set(mapOf("photoUrl" to url)) }
                 }
             }
             .addOnFailureListener { e ->
                 Log.e("ProfileScreen", "Αποτυχία ανεβάσματος εικόνας", e)
             }
+    }
+
+    val permissionLauncher = rememberLauncherForActivityResult(ActivityResultContracts.RequestPermission()) { granted ->
+        if (granted) {
+            cameraLauncher.launch(null)
+        } else {
+            Log.d("ProfileScreen", "Δεν δόθηκε άδεια κάμερας")
+        }
     }
 
     LaunchedEffect(user) {
@@ -82,7 +113,7 @@ fun ProfileScreen(navController: NavController, openDrawer: () -> Unit) {
                 .document(uid)
                 .get()
                 .addOnSuccessListener { doc ->
-                    username.value = doc.getString("username")
+                    username.value = doc.getString("username") ?: ""
                     photoUrl.value = doc.getString("photoUrl")
 
 
@@ -127,8 +158,27 @@ fun ProfileScreen(navController: NavController, openDrawer: () -> Unit) {
                     Text(text = stringResource(id = R.string.upload_photo))
                 }
 
+                Button(onClick = { permissionLauncher.launch(Manifest.permission.CAMERA) }) {
+                    Text(text = stringResource(id = R.string.take_photo))
+                }
+
                 Text(text = "Email: ${user?.email ?: ""}")
-                username.value?.let { Text(text = "Username: $it") }
+
+                OutlinedTextField(
+                    value = username.value,
+                    onValueChange = { username.value = it },
+                    label = { Text(stringResource(R.string.username)) },
+                    modifier = Modifier.fillMaxWidth()
+                )
+
+                Button(onClick = {
+                    val uid = user?.uid ?: return@Button
+                    val docRef = FirebaseFirestore.getInstance().collection("users").document(uid)
+                    docRef.update("username", username.value)
+                        .addOnFailureListener { docRef.set(mapOf("username" to username.value)) }
+                }) {
+                    Text(text = stringResource(id = R.string.save))
+                }
             }
         }
     }

--- a/app/src/main/res/values-el/strings.xml
+++ b/app/src/main/res/values-el/strings.xml
@@ -68,6 +68,8 @@
     <string name="user_points">Σημεία χρηστών</string>
     <string name="admin_option">Επιλογή Διαχειριστή</string>
     <string name="profile">Προφίλ</string>
+    <string name="upload_photo">Ανέβασμα φωτογραφίας</string>
+    <string name="take_photo">Λήψη από κάμερα</string>
     <string name="guest">Επισκέπτης</string>
     <string name="exit">Έξοδος</string>
     <string name="credits">Ευχαριστίες</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -67,6 +67,7 @@
     <string name="admin_option">Admin Option</string>
     <string name="profile">Profile</string>
     <string name="upload_photo">Ανέβασμα φωτογραφίας</string>
+    <string name="take_photo">Λήψη από κάμερα</string>
     <string name="guest">Guest</string>
     <string name="exit">Exit</string>
     <string name="credits">Credits</string>


### PR DESCRIPTION
## Περίληψη
- Προστέθηκε άδεια κάμερας στο AndroidManifest.
- Εμπλουτίστηκε η οθόνη προφίλ με δυνατότητα επεξεργασίας ονόματος χρήστη, αποθήκευση στο Firestore και επιλογή εικόνας είτε από γκαλερί είτε από κάμερα.
- Προστέθηκαν νέες συμβολοσειρές για λειτουργίες κάμερας και μεταφράσεις.

## Δοκιμές
- `./gradlew test` *(αποτυχία: SDK location not found)*


------
https://chatgpt.com/codex/tasks/task_e_68b77a43ffb0832885116a661cd23145