### PR TITLE
Διόρθωση τύπου στο onError του Coil

### DIFF
--- a/app/src/main/java/com/ioannapergamali/mysmartroute/view/ui/screens/ProfileScreen.kt
+++ b/app/src/main/java/com/ioannapergamali/mysmartroute/view/ui/screens/ProfileScreen.kt
@@ -183,8 +183,12 @@ fun ProfileScreen(navController: NavController, openDrawer: () -> Unit) {
                                     onSuccess = { _, _ ->
                                         Log.d("ProfileScreen", "Η εικόνα φορτώθηκε επιτυχώς")
                                     },
-                                    onError = { _, throwable ->
-                                        Log.e("ProfileScreen", "Αποτυχία φόρτωσης εικόνας", throwable)
+                                    onError = { _, errorResult ->
+                                        Log.e(
+                                            "ProfileScreen",
+                                            "Αποτυχία φόρτωσης εικόνας",
+                                            errorResult.throwable
+                                        )
                                     }
                                 )
                                 .build(),


### PR DESCRIPTION
## Περίληψη
- Χρησιμοποιήθηκε το `errorResult.throwable` στον listener του Coil ώστε το `onError` να δέχεται `Throwable`

## Έλεγχοι
- `./gradlew test --no-daemon` (απέτυχε: SDK location not found)


------
https://chatgpt.com/codex/tasks/task_e_68b79f3ce104832885a1801ed31aa429