### PR TITLE
Handle Firestore permission errors when populating POI types

### DIFF
--- a/app/src/main/java/com/ioannapergamali/mysmartroute/utils/PoiTypeInitializer.kt
+++ b/app/src/main/java/com/ioannapergamali/mysmartroute/utils/PoiTypeInitializer.kt
@@ -1,11 +1,13 @@
 package com.ioannapergamali.mysmartroute.utils
 
 import android.content.Context
+import android.util.Log
 import com.google.android.libraries.places.api.model.Place
 import com.google.firebase.firestore.FirebaseFirestore
 import com.ioannapergamali.mysmartroute.data.local.MySmartRouteDatabase
 import com.ioannapergamali.mysmartroute.data.local.PoiTypeEntity
 import kotlinx.coroutines.runBlocking
+import kotlinx.coroutines.tasks.await
 
 /**
  * Δημιουργεί τα έγγραφα της συλλογής `poi_types` στο Firestore αν δεν υπάρχουν.
@@ -16,11 +18,16 @@ fun populatePoiTypes(context: Context) {
     runBlocking {
         MySmartRouteDatabase.getInstance(context).poiTypeDao()
             .insertAll(types.map { PoiTypeEntity(it.name, it.name) })
-    }
-    for (type in types) {
-        val data = mapOf("id" to type.name, "name" to type.name)
-        firestore.collection("poi_types")
-            .document(type.name)
-            .set(data)
+        for (type in types) {
+            val data = mapOf("id" to type.name, "name" to type.name)
+            try {
+                firestore.collection("poi_types")
+                    .document(type.name)
+                    .set(data)
+                    .await()
+            } catch (e: Exception) {
+                Log.e("PoiTypeInitializer", "Αποτυχία εγγραφής τύπου ${type.name}", e)
+            }
+        }
     }
 }


### PR DESCRIPTION
## Summary
- Wrap POI type initialization writes in a coroutine
- Catch and log Firestore permission errors to avoid crashes

## Testing
- `./gradlew test` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b7b5a5439883288109c75fc0360211