### PR TITLE
Απλοποίηση φόρτωσης εικόνας προφίλ με Coil

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -96,7 +96,6 @@ dependencies {
     implementation("androidx.compose.runtime:runtime")
     implementation("androidx.navigation:navigation-compose:2.9.1")
     implementation("androidx.compose.material:material-icons-extended")
-    implementation("io.coil-kt:coil-compose:2.7.0")
 
     // Glide για φόρτωση εικόνων προφίλ
     implementation("com.github.bumptech.glide:glide:4.16.0")

--- a/app/src/main/java/com/ioannapergamali/mysmartroute/view/ui/screens/ProfileScreen.kt
+++ b/app/src/main/java/com/ioannapergamali/mysmartroute/view/ui/screens/ProfileScreen.kt
@@ -5,6 +5,7 @@ import android.graphics.Bitmap
 import android.util.Log
 import androidx.activity.compose.rememberLauncherForActivityResult
 import androidx.activity.result.contract.ActivityResultContracts
+import androidx.compose.foundation.Image
 import androidx.compose.foundation.border
 import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.*
@@ -22,12 +23,10 @@ import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
 import androidx.compose.ui.layout.ContentScale
-import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.unit.dp
 import androidx.navigation.NavController
-import coil.compose.AsyncImage
-import coil.request.ImageRequest
+import coil.compose.rememberAsyncImagePainter
 import com.google.firebase.auth.FirebaseAuth
 import com.google.firebase.firestore.FirebaseFirestore
 import com.google.firebase.firestore.SetOptions
@@ -52,7 +51,6 @@ fun ProfileScreen(navController: NavController, openDrawer: () -> Unit) {
     val postalCode = remember { mutableStateOf("") }
     val username = remember { mutableStateOf("") }
     val photoUrl = remember { mutableStateOf<String?>(null) }
-    val context = LocalContext.current
 
     val imagePicker = rememberLauncherForActivityResult(ActivityResultContracts.GetContent()) { uri ->
         val uid = user?.uid ?: return@rememberLauncherForActivityResult
@@ -173,26 +171,8 @@ fun ProfileScreen(navController: NavController, openDrawer: () -> Unit) {
                     contentAlignment = Alignment.Center
                 ) {
                     if (photoUrl.value != null) {
-                        AsyncImage(
-                            model = ImageRequest.Builder(context)
-                                .data(photoUrl.value)
-                                .crossfade(true)
-                                .listener(
-                                    onStart = {
-                                        Log.d("ProfileScreen", "Ξεκίνησε η φόρτωση εικόνας")
-                                    },
-                                    onSuccess = { _, _ ->
-                                        Log.d("ProfileScreen", "Η εικόνα φορτώθηκε επιτυχώς")
-                                    },
-                                    onError = { _, errorResult ->
-                                        Log.e(
-                                            "ProfileScreen",
-                                            "Αποτυχία φόρτωσης εικόνας",
-                                            errorResult.throwable
-                                        )
-                                    }
-                                )
-                                .build(),
+                        Image(
+                            painter = rememberAsyncImagePainter(model = photoUrl.value),
                             contentDescription = null,
                             modifier = Modifier.fillMaxSize(),
                             contentScale = ContentScale.Crop


### PR DESCRIPTION
## Περίληψη
- Απλοποιήθηκε η φόρτωση της εικόνας προφίλ με `rememberAsyncImagePainter`
- Αφαιρέθηκε το επιπλέον dependency του Coil από το `build.gradle.kts`

## Έλεγχοι
- `./gradlew test` (αποτυχία: SDK location not found)


------
https://chatgpt.com/codex/tasks/task_e_68b7ba9eb18c83289fe7efb9435d4b88