### PR TITLE
Handle Firestore errors when initializing menus

### DIFF
--- a/app/src/main/java/com/ioannapergamali/mysmartroute/viewmodel/AuthenticationViewModel.kt
+++ b/app/src/main/java/com/ioannapergamali/mysmartroute/viewmodel/AuthenticationViewModel.kt
@@ -536,7 +536,12 @@ class AuthenticationViewModel : ViewModel() {
         val menuDao = dbLocal.menuDao()
         val optionDao = dbLocal.menuOptionDao()
 
-        val existingRoles = db.collection("roles").get().await().documents.associateBy { it.id }
+        val existingRoles = try {
+            db.collection("roles").get().await().documents.associateBy { it.id }
+        } catch (e: Exception) {
+            Log.w(TAG, "Αποτυχία ανάκτησης ρόλων από το Firestore", e)
+            emptyMap()
+        }
         val batch = db.batch()
         var commitNeeded = false
 
@@ -585,7 +590,11 @@ class AuthenticationViewModel : ViewModel() {
         }
 
         if (commitNeeded) {
-            batch.commit().await()
+            try {
+                batch.commit().await()
+            } catch (e: Exception) {
+                Log.w(TAG, "Αποτυχία αποστολής μενού στο Firestore", e)
+            }
         }
     }
 


### PR DESCRIPTION
## Summary
- Avoid crashing when Firestore is unreachable during menu initialization
- Load default menus from local assets even if remote sync fails

## Testing
- `./gradlew test` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b7c6e7c5648328a604890338e0c1fe