### PR TITLE
Remove POI refs from walks and record provided start time

### DIFF
--- a/app/src/main/java/com/ioannapergamali/mysmartroute/model/Walk.kt
+++ b/app/src/main/java/com/ioannapergamali/mysmartroute/model/Walk.kt
@@ -8,9 +8,7 @@ import com.google.firebase.firestore.DocumentReference
  */
 data class Walk(
     val id: String = "",
-    val fromPoiRef: DocumentReference? = null,
     val routeRef: DocumentReference? = null,
-    val toPoiRef: DocumentReference? = null,
     val startTime: Timestamp? = null,
     val endTime: Timestamp? = null,
     val walkDurationMinutes: Long = 0L

--- a/app/src/main/java/com/ioannapergamali/mysmartroute/repository/AdminWalkRepository.kt
+++ b/app/src/main/java/com/ioannapergamali/mysmartroute/repository/AdminWalkRepository.kt
@@ -21,9 +21,7 @@ class AdminWalkRepository {
             val duration = doc.getLong("walkDurationMinutes") ?: 0L
             Walk(
                 id = doc.id,
-                fromPoiRef = doc.getDocumentReference("fromPoiId"),
                 routeRef = doc.getDocumentReference("routeId"),
-                toPoiRef = doc.getDocumentReference("toPoiId"),
                 startTime = start,
                 endTime = end,
                 walkDurationMinutes = duration

--- a/app/src/main/java/com/ioannapergamali/mysmartroute/view/ui/screens/WalkingScreen.kt
+++ b/app/src/main/java/com/ioannapergamali/mysmartroute/view/ui/screens/WalkingScreen.kt
@@ -220,8 +220,6 @@ fun WalkingScreen(navController: NavController, openDrawer: () -> Unit) {
                 ExtendedFloatingActionButton(
                     onClick = {
                         val rId = selectedRouteId ?: return@ExtendedFloatingActionButton
-                        val start = startIndex?.let { routePois[it].id } ?: return@ExtendedFloatingActionButton
-                        val end = endIndex?.let { routePois[it].id } ?: return@ExtendedFloatingActionButton
                         val timestamp = calendar.timeInMillis
                         coroutineScope.launch {
                             val distance = routeViewModel.getRouteDistance(context, rId)
@@ -229,8 +227,6 @@ fun WalkingScreen(navController: NavController, openDrawer: () -> Unit) {
                             vehicleRequestViewModel.saveWalkingRoute(
                                 context,
                                 rId,
-                                start,
-                                end,
                                 timestamp,
                                 minutes
                             )

--- a/app/src/main/java/com/ioannapergamali/mysmartroute/viewmodel/RouteViewModel.kt
+++ b/app/src/main/java/com/ioannapergamali/mysmartroute/viewmodel/RouteViewModel.kt
@@ -5,6 +5,7 @@ import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import com.google.firebase.auth.FirebaseAuth
 import com.google.firebase.firestore.FirebaseFirestore
+import com.google.firebase.Timestamp
 import com.ioannapergamali.mysmartroute.data.local.MySmartRouteDatabase
 import com.ioannapergamali.mysmartroute.data.local.RouteEntity
 import com.ioannapergamali.mysmartroute.data.local.RoutePointEntity
@@ -252,8 +253,7 @@ class RouteViewModel : ViewModel() {
                         // χρησιμοποιεί το υπόλοιπο σύστημα (walkDurationMinutes)
                         "walkDurationMinutes" to minutes,
                         "routeId" to firestore.collection("routes").document(routeId),
-                        "fromPoiId" to firestore.collection("pois").document(route.startPoiId),
-                        "toPoiId" to firestore.collection("pois").document(route.endPoiId),
+                        "startTime" to Timestamp.now(),
                         "userId" to firestore.collection("users").document(uid)
                     )
                     firestore.collection("routes").document(routeId)

--- a/app/src/main/java/com/ioannapergamali/mysmartroute/viewmodel/VehicleRequestViewModel.kt
+++ b/app/src/main/java/com/ioannapergamali/mysmartroute/viewmodel/VehicleRequestViewModel.kt
@@ -9,6 +9,7 @@ import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import com.google.firebase.auth.FirebaseAuth
 import com.google.firebase.firestore.FirebaseFirestore
+import com.google.firebase.Timestamp
 import com.ioannapergamali.mysmartroute.data.local.MovingEntity
 import com.ioannapergamali.mysmartroute.data.local.MySmartRouteDatabase
 import com.ioannapergamali.mysmartroute.data.local.RouteDao
@@ -27,6 +28,7 @@ import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.tasks.await
+import java.util.Date
 import java.util.UUID
 
 data class PassengerRequest(
@@ -162,22 +164,16 @@ class VehicleRequestViewModel : ViewModel() {
     fun saveWalkingRoute(
         context: Context,
         routeId: String,
-        fromPoiId: String,
-        toPoiId: String,
-        dateTime: Long,
+        startTimeMillis: Long,
         walkDurationMinutes: Int
     ) {
         viewModelScope.launch {
             val userId = FirebaseAuth.getInstance().currentUser?.uid ?: return@launch
             val id = UUID.randomUUID().toString()
             val routeRef = db.collection("routes").document(routeId)
-            val fromPoiRef = db.collection("pois").document(fromPoiId)
-            val toPoiRef = db.collection("pois").document(toPoiId)
             val data = mapOf(
                 "routeId" to routeRef,
-                "fromPoiId" to fromPoiRef,
-                "toPoiId" to toPoiRef,
-                "date" to dateTime,
+                "startTime" to Timestamp(Date(startTimeMillis)),
                 "walkDurationMinutes" to walkDurationMinutes
             )
             try {


### PR DESCRIPTION
## Summary
- drop from/to POI references from walk documents
- `updateWalkDuration` now records start time
- UI and viewmodels store the provided start time

## Testing
- `./gradlew test --console=plain` *(failed: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b7e754083883289aa2e7911360917e