### PR TITLE
Remove Poi fields from walking and add startTime

### DIFF
--- a/app/src/main/java/com/ioannapergamali/mysmartroute/data/local/MySmartRouteDatabase.kt
+++ b/app/src/main/java/com/ioannapergamali/mysmartroute/data/local/MySmartRouteDatabase.kt
@@ -709,9 +709,7 @@ abstract class MySmartRouteDatabase : RoomDatabase() {
                         "`id` TEXT NOT NULL, " +
                         "`userId` TEXT NOT NULL, " +
                         "`routeId` TEXT NOT NULL, " +
-                        "`fromPoiId` TEXT NOT NULL, " +
-                        "`toPoiId` TEXT NOT NULL, " +
-                        "`date` INTEGER NOT NULL, " +
+                        "`startTime` INTEGER NOT NULL, " +
                         "PRIMARY KEY(`id`))"
                 )
             }
@@ -738,9 +736,7 @@ abstract class MySmartRouteDatabase : RoomDatabase() {
                         "`id` TEXT NOT NULL, " +
                         "`userId` TEXT NOT NULL, " +
                         "`routeId` TEXT NOT NULL, " +
-                        "`fromPoiId` TEXT NOT NULL, " +
-                        "`toPoiId` TEXT NOT NULL, " +
-                        "`date` INTEGER NOT NULL, " +
+                        "`startTime` INTEGER NOT NULL, " +
                         "PRIMARY KEY(`id`))"
                 )
             }

--- a/app/src/main/java/com/ioannapergamali/mysmartroute/data/local/WalkingEntity.kt
+++ b/app/src/main/java/com/ioannapergamali/mysmartroute/data/local/WalkingEntity.kt
@@ -11,7 +11,5 @@ data class WalkingEntity(
     @PrimaryKey val id: String,
     val userId: String,
     val routeId: String,
-    val fromPoiId: String,
-    val toPoiId: String,
-    val date: Long
+    val startTime: Long
 )


### PR DESCRIPTION
## Summary
- drop fromPoiId/toPoiId columns from local walking entity and migrations
- add startTime column for storing walking start timestamp

## Testing
- `./gradlew test` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b7f07fb3d883288f84412321c37227