### PR TITLE
Καταγραφή ώρας έναρξης περπατήματος

### DIFF
--- a/app/src/main/java/com/ioannapergamali/mysmartroute/repository/WalkRepository.kt
+++ b/app/src/main/java/com/ioannapergamali/mysmartroute/repository/WalkRepository.kt
@@ -1,0 +1,52 @@
+package com.ioannapergamali.mysmartroute.repository
+
+import com.google.firebase.auth.FirebaseAuth
+import com.google.firebase.firestore.FieldValue
+import com.google.firebase.firestore.FirebaseFirestore
+import kotlinx.coroutines.tasks.await
+
+/**
+ * Repository για διαχείριση των πεζών μετακινήσεων του χρήστη.
+ * Αποθηκεύει την ώρα έναρξης και μετατρέπει παλιές εγγραφές
+ * αφαιρώντας τα πεδία fromPoiId/toPoiId.
+ */
+class WalkRepository(
+    private val db: FirebaseFirestore = FirebaseFirestore.getInstance(),
+    private val auth: FirebaseAuth = FirebaseAuth.getInstance()
+) {
+    /**
+     * Ξεκινά μια πεζή μετακίνηση καταγράφοντας μόνο την ώρα έναρξης.
+     */
+    fun startWalk() {
+        val uid = auth.currentUser?.uid ?: return
+        val data = mapOf(
+            "startTime" to FieldValue.serverTimestamp()
+        )
+        db.collection("users")
+            .document(uid)
+            .collection("walks")
+            .add(data)
+    }
+
+    /**
+     * Μετατρέπει παλιές εγγραφές στο `walks` αφαιρώντας τα fromPoiId/toPoiId
+     * και προσθέτει startTime αν λείπει.
+     */
+    suspend fun migrateOldWalks() {
+        val users = db.collection("users").get().await()
+        users.forEach { user ->
+            val walks = user.reference.collection("walks").get().await()
+            walks.forEach { walk ->
+                val updates = hashMapOf<String, Any>(
+                    "fromPoiId" to FieldValue.delete(),
+                    "toPoiId" to FieldValue.delete()
+                )
+                if (walk.getTimestamp("startTime") == null) {
+                    updates["startTime"] = FieldValue.serverTimestamp()
+                }
+                walk.reference.update(updates).await()
+            }
+        }
+    }
+}
+

--- a/app/src/main/java/com/ioannapergamali/mysmartroute/viewmodel/VehicleRequestViewModel.kt
+++ b/app/src/main/java/com/ioannapergamali/mysmartroute/viewmodel/VehicleRequestViewModel.kt
@@ -22,6 +22,7 @@ import com.ioannapergamali.mysmartroute.utils.NotificationUtils
 import com.ioannapergamali.mysmartroute.R
 import com.ioannapergamali.mysmartroute.data.local.SeatReservationEntity
 import com.ioannapergamali.mysmartroute.viewmodel.MainActivity
+import com.ioannapergamali.mysmartroute.repository.WalkRepository
 
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
@@ -154,6 +155,7 @@ class VehicleRequestViewModel : ViewModel() {
                     "status" to "open"
                 )
                 db.collection("movings").document(id).set(data).await()
+                WalkRepository().startWalk()
             } catch (e: Exception) {
                 Log.e(TAG, "Failed to log walking", e)
             }


### PR DESCRIPTION
## Περίληψη
- Προστέθηκε `WalkRepository` για αποθήκευση της ώρας έναρξης και καθαρισμό παλιών πεδίων `fromPoiId`/`toPoiId`.
- Η `VehicleRequestViewModel.logWalking` καλεί πλέον το `WalkRepository` για να καταγράφεται το `startTime` κάθε περπατήματος.

## Έλεγχοι
- `./gradlew test` *(αποτυχία: λείπει Android SDK στο περιβάλλον εκτέλεσης)*

------
https://chatgpt.com/codex/tasks/task_e_68b7f42ae6ec8328a54395547ba016cb