### PR TITLE
Καθαρισμός παλιών walks και αποθήκευση ώρας

### DIFF
--- a/app/src/main/java/com/ioannapergamali/mysmartroute/repository/WalkRepository.kt
+++ b/app/src/main/java/com/ioannapergamali/mysmartroute/repository/WalkRepository.kt
@@ -19,43 +19,46 @@ class WalkRepository(
     private val auth: FirebaseAuth = FirebaseAuth.getInstance()
 ) {
     /**
+     * Καθαρίζει τυχόν παλιές εγγραφές `walks` του χρήστη αφαιρώντας τα
+     * πεδία `fromPoiId`/`toPoiId` και συμπληρώνοντας το `startTime` με την
+     * ώρα που επέλεξε ο χρήστης αν λείπει.
+     */
+    private suspend fun cleanupUserWalks(uid: String, startTimeMillis: Long) {
+        val snapshot = db.collection("users")
+            .document(uid)
+            .collection("walks")
+            .get()
+            .await()
+
+        snapshot.documents.forEach { walk ->
+            val updates = hashMapOf<String, Any>(
+                "fromPoiId" to FieldValue.delete(),
+                "toPoiId" to FieldValue.delete()
+            )
+
+            if (walk.get("startTime") == null) {
+                updates["startTime"] = Timestamp(Date(startTimeMillis))
+            }
+
+            walk.reference.update(updates).await()
+        }
+    }
+    /**
 
      * Ξεκινά μια πεζή μετακίνηση καταγράφοντας την ώρα που επέλεξε ο χρήστης.
      */
     suspend fun startWalk(startTimeMillis: Long) {
         val uid = auth.currentUser?.uid ?: return
+        cleanupUserWalks(uid, startTimeMillis)
         val data = mapOf(
             "startTime" to Timestamp(Date(startTimeMillis))
-
         )
         db.collection("users")
             .document(uid)
             .collection("walks")
             .add(data)
-
             .await()
-
     }
 
-    /**
-     * Μετατρέπει παλιές εγγραφές στο `walks` αφαιρώντας τα fromPoiId/toPoiId
-     * και προσθέτει startTime αν λείπει.
-     */
-    suspend fun migrateOldWalks() {
-        val users = db.collection("users").get().await()
-        users.forEach { user ->
-            val walks = user.reference.collection("walks").get().await()
-            walks.forEach { walk ->
-                val updates = hashMapOf<String, Any>(
-                    "fromPoiId" to FieldValue.delete(),
-                    "toPoiId" to FieldValue.delete()
-                )
-                if (walk.getTimestamp("startTime") == null) {
-                    updates["startTime"] = FieldValue.serverTimestamp()
-                }
-                walk.reference.update(updates).await()
-            }
-        }
-    }
 }
 


### PR DESCRIPTION
## Περίληψη
- Καθαρισμός των εγγραφών `walks` με διαγραφή των πεδίων `fromPoiId`/`toPoiId`
- Προσθήκη του `startTime` σε κάθε νέα διαδρομή με την ώρα που επέλεξε ο χρήστης

## Έλεγχοι
- `./gradlew test` *(απέτυχε: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b7fbd42ef48328940bf556e7556f9f