### PR TITLE
Keep only durationMinutes in route walks

### DIFF
--- a/app/src/main/java/com/ioannapergamali/mysmartroute/model/Walk.kt
+++ b/app/src/main/java/com/ioannapergamali/mysmartroute/model/Walk.kt
@@ -1,15 +1,10 @@
 package com.ioannapergamali.mysmartroute.model
 
-import com.google.firebase.Timestamp
-import com.google.firebase.firestore.DocumentReference
-
 /**
  * Αναπαράσταση μιας πεζής μετακίνησης που αποθηκεύεται στο Firestore.
+ * Περιέχει μόνο το αναγνωριστικό και τη διάρκεια σε λεπτά.
  */
 data class Walk(
     val id: String = "",
-    val routeRef: DocumentReference? = null,
-    val startTime: Timestamp? = null,
-    val endTime: Timestamp? = null,
-    val walkDurationMinutes: Long = 0L
+    val durationMinutes: Long = 0L
 )

--- a/app/src/main/java/com/ioannapergamali/mysmartroute/repository/AdminWalkRepository.kt
+++ b/app/src/main/java/com/ioannapergamali/mysmartroute/repository/AdminWalkRepository.kt
@@ -11,21 +11,19 @@ class AdminWalkRepository {
     private val db = FirebaseFirestore.getInstance()
 
     /**
-     * Ανακτά όλα τα walks και διαβάζει το αποθηκευμένο `walkDurationMinutes`.
+     * Ανακτά όλες τις πεζές μετακινήσεις από τα subcollections `walks` των διαδρομών.
+     * Κάθε έγγραφο περιέχει μόνο τη διάρκεια σε λεπτά.
      */
     suspend fun fetchAllWalks(): List<Walk> {
         val snapshot = db.collectionGroup("walks").get().await()
-        return snapshot.documents.map { doc ->
-            val start = doc.getTimestamp("startTime")
-            val end = doc.getTimestamp("endTime")
-            val duration = doc.getLong("walkDurationMinutes") ?: 0L
-            Walk(
-                id = doc.id,
-                routeRef = doc.getDocumentReference("routeId"),
-                startTime = start,
-                endTime = end,
-                walkDurationMinutes = duration
-            )
-        }
+        return snapshot.documents
+            .filter { it.reference.parent.parent?.parent?.id == "routes" }
+            .map { doc ->
+                val duration = doc.getLong("durationMinutes") ?: 0L
+                Walk(
+                    id = doc.id,
+                    durationMinutes = duration
+                )
+            }
     }
 }


### PR DESCRIPTION
## Summary
- Simplified Walk μοντέλο ώστε οι εγγραφές στο `routes/{route}/walks` να αποθηκεύουν μόνο τη διάρκεια.
- Ενημέρωση του AdminWalkRepository για ανάκτηση μόνο της διάρκειας από τα subcollections `walks` των routes.
- Προσαρμογή του RouteViewModel για αποθήκευση της διάρκειας και εύρεση διαδρομών μέσω της ιεραρχίας εγγράφων.

## Testing
- `./gradlew test` *(αποτυχία: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b83a9f7a7883289e0b1301d1fca0da