### PR TITLE
Fix unresolved reference saveEditedRouteAsNewRoute in RouteModeScreen

### DIFF
--- a/app/src/main/java/com/ioannapergamali/mysmartroute/view/ui/screens/RouteModeScreen.kt
+++ b/app/src/main/java/com/ioannapergamali/mysmartroute/view/ui/screens/RouteModeScreen.kt
@@ -146,6 +146,22 @@ fun RouteModeScreen(
             pathPoints = emptyList()
         }
     }
+    suspend fun saveEditedRouteAsNewRoute(): String {
+        if (routePoiIds == originalPoiIds) return selectedRouteId ?: ""
+        val uid = FirebaseAuth.getInstance().currentUser?.uid ?: return selectedRouteId ?: ""
+        val username = FirebaseFirestore.getInstance()
+            .collection("users")
+            .document(uid)
+            .get()
+            .await()
+            .getString("username") ?: uid
+        val baseName = routes.find { it.id == selectedRouteId }?.name ?: "route"
+        return routeViewModel.addRoute(
+            context,
+            routePoiIds.toList(),
+            "${baseName}_edited_by_$username"
+        ) ?: selectedRouteId ?: ""
+    }
 
 
     LaunchedEffect(Unit) {


### PR DESCRIPTION
## Summary
- Implement saveEditedRouteAsNewRoute in RouteModeScreen

## Testing
- `./gradlew test` *(απέτυχε: Could not determine the dependencies of task ':app:testDebugUnitTest'. SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_68bca681dd7883288f252079d9f991c5