### PR TITLE
Display icons only on passenger action buttons

### DIFF
--- a/app/src/main/java/com/ioannapergamali/mysmartroute/view/ui/screens/BookSeatScreen.kt
+++ b/app/src/main/java/com/ioannapergamali/mysmartroute/view/ui/screens/BookSeatScreen.kt
@@ -6,6 +6,8 @@ import androidx.compose.material.icons.filled.Delete
 import androidx.compose.material.icons.filled.Flag
 import androidx.compose.material.icons.filled.Place
 import androidx.compose.material.icons.filled.Refresh
+import androidx.compose.material.icons.filled.Search
+import androidx.compose.material.icons.filled.Save
 import androidx.compose.material3.Button
 import androidx.compose.material3.Divider
 import androidx.compose.material3.DropdownMenu
@@ -567,7 +569,10 @@ fun BookSeatScreen(
                         )
                     }
                 ) {
-                    Text(stringResource(R.string.find_now))
+                    Icon(
+                        Icons.Default.Search,
+                        contentDescription = stringResource(R.string.find_now)
+                    )
                 }
                 Button(
                     enabled = selectedRoute != null && startIndex != null && endIndex != null &&
@@ -597,7 +602,10 @@ fun BookSeatScreen(
                         }
                     }
                 ) {
-                    Text(stringResource(R.string.save_request))
+                    Icon(
+                        Icons.Default.Save,
+                        contentDescription = stringResource(R.string.save_request)
+                    )
                 }
             }
 

--- a/app/src/main/java/com/ioannapergamali/mysmartroute/view/ui/screens/FindVehicleScreen.kt
+++ b/app/src/main/java/com/ioannapergamali/mysmartroute/view/ui/screens/FindVehicleScreen.kt
@@ -5,6 +5,8 @@ import androidx.compose.material3.*
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.Delete
 import androidx.compose.material.icons.filled.Refresh
+import androidx.compose.material.icons.filled.Search
+import androidx.compose.material.icons.filled.Save
 import androidx.compose.material3.menuAnchor
 import androidx.compose.runtime.*
 import androidx.compose.runtime.saveable.rememberSaveable
@@ -434,7 +436,10 @@ fun FindVehicleScreen(navController: NavController, openDrawer: () -> Unit) {
                     },
                     enabled = selectedRouteId != null && startIndex != null && endIndex != null,
                 ) {
-                    Text(stringResource(R.string.find_now))
+                    Icon(
+                        Icons.Default.Search,
+                        contentDescription = stringResource(R.string.find_now)
+                    )
                 }
                 Button(
                     onClick = {
@@ -457,7 +462,10 @@ fun FindVehicleScreen(navController: NavController, openDrawer: () -> Unit) {
                     },
                     enabled = selectedRouteId != null && startIndex != null && endIndex != null,
                 ) {
-                    Text(stringResource(R.string.save_request))
+                    Icon(
+                        Icons.Default.Save,
+                        contentDescription = stringResource(R.string.save_request)
+                    )
                 }
             }
             if (message.isNotBlank()) {

--- a/app/src/main/java/com/ioannapergamali/mysmartroute/view/ui/screens/RouteModeScreen.kt
+++ b/app/src/main/java/com/ioannapergamali/mysmartroute/view/ui/screens/RouteModeScreen.kt
@@ -4,6 +4,8 @@ import androidx.compose.foundation.layout.*
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.Delete
 import androidx.compose.material.icons.filled.Refresh
+import androidx.compose.material.icons.filled.Search
+import androidx.compose.material.icons.filled.Save
 import androidx.compose.material3.*
 import androidx.compose.material3.DatePicker
 import androidx.compose.material3.DatePickerDialog
@@ -454,7 +456,10 @@ fun RouteModeScreen(
                     },
                     enabled = selectedRouteId != null && startIndex != null && endIndex != null,
                 ) {
-                    Text(stringResource(R.string.find_now))
+                    Icon(
+                        Icons.Default.Search,
+                        contentDescription = stringResource(R.string.find_now)
+                    )
                 }
                 Button(
                     onClick = {
@@ -479,7 +484,10 @@ fun RouteModeScreen(
                     },
                     enabled = selectedRouteId != null && startIndex != null && endIndex != null,
                 ) {
-                    Text(stringResource(R.string.save_request))
+                    Icon(
+                        Icons.Default.Save,
+                        contentDescription = stringResource(R.string.save_request)
+                    )
                 }
             }
 


### PR DESCRIPTION
## Summary
- show only search icon on "Find now" button
- show only save icon on "Save request" button

## Testing
- `./gradlew test` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_68bca631db4c832886fa505cbfc43c91