### PR TITLE
Προσθήκη φίλτρου τύπου οχήματος στην αναζήτηση μεταφορών

### DIFF
--- a/app/src/main/java/com/ioannapergamali/mysmartroute/model/navigation/NavigationHost.kt
+++ b/app/src/main/java/com/ioannapergamali/mysmartroute/model/navigation/NavigationHost.kt
@@ -38,6 +38,7 @@ import com.ioannapergamali.mysmartroute.view.ui.screens.InterestingRoutesScreen
 import com.ioannapergamali.mysmartroute.view.ui.screens.PrintCompletedScreen
 import com.ioannapergamali.mysmartroute.view.ui.screens.PrintListScreen
 import com.ioannapergamali.mysmartroute.view.ui.screens.PrintScheduledScreen
+import com.ioannapergamali.mysmartroute.model.enumerations.VehicleType
 import com.ioannapergamali.mysmartroute.view.ui.screens.PrintDeclarationsScreen
 import com.ioannapergamali.mysmartroute.view.ui.screens.PrintTicketScreen
 import com.ioannapergamali.mysmartroute.view.ui.screens.PrepareCompleteRouteScreen
@@ -227,14 +228,15 @@ fun NavigationHost(
         }
 
         composable(
-            "availableTransports?routeId={routeId}&startId={startId}&endId={endId}&maxCost={maxCost}&date={date}&seats={seats}",
+            "availableTransports?routeId={routeId}&startId={startId}&endId={endId}&maxCost={maxCost}&date={date}&seats={seats}&vehicleType={vehicleType}",
             arguments = listOf(
                 navArgument("routeId") { defaultValue = "" },
                 navArgument("startId") { defaultValue = "" },
                 navArgument("endId") { defaultValue = "" },
                 navArgument("maxCost") { defaultValue = "" },
                 navArgument("date") { defaultValue = "" },
-                navArgument("seats") { defaultValue = "" }
+                navArgument("seats") { defaultValue = "" },
+                navArgument("vehicleType") { defaultValue = "" }
             )
         ) { backStackEntry ->
             val rid = backStackEntry.arguments?.getString("routeId")
@@ -243,6 +245,8 @@ fun NavigationHost(
             val maxCost = backStackEntry.arguments?.getString("maxCost")?.toDoubleOrNull()
             val date = backStackEntry.arguments?.getString("date")?.toLongOrNull()
             val seats = backStackEntry.arguments?.getString("seats")?.toIntOrNull()
+            val vehicleTypeArg = backStackEntry.arguments?.getString("vehicleType")?.takeIf { it.isNotBlank() }
+            val vType = vehicleTypeArg?.let { runCatching { VehicleType.valueOf(it) }.getOrNull() }
             AvailableTransportsScreen(
                 navController = navController,
                 openDrawer = openDrawer,
@@ -251,7 +255,8 @@ fun NavigationHost(
                 endId = eid,
                 maxCost = maxCost,
                 date = date,
-                seats = seats
+                seats = seats,
+                vehicleType = vType
             )
         }
 

--- a/app/src/main/java/com/ioannapergamali/mysmartroute/view/ui/screens/AvailableTransportsScreen.kt
+++ b/app/src/main/java/com/ioannapergamali/mysmartroute/view/ui/screens/AvailableTransportsScreen.kt
@@ -64,7 +64,8 @@ fun AvailableTransportsScreen(
     endId: String?,
     maxCost: Double?,
     date: Long?,
-    seats: Int?
+    seats: Int?,
+    vehicleType: VehicleType?
 ) {
     val context = LocalContext.current
     val declarationViewModel: TransportDeclarationViewModel = viewModel()
@@ -105,6 +106,7 @@ fun AvailableTransportsScreen(
 
         if (date != null && date > 0 && decl.date != date) return@filter false
         if (seats != null && decl.seats < seats) return@filter false
+        if (vehicleType != null && runCatching { VehicleType.valueOf(decl.vehicleType) }.getOrNull() != vehicleType) return@filter false
         if (!decl.matchesFavorites(preferred, nonPreferred)) return@filter false
         true
 

--- a/app/src/main/java/com/ioannapergamali/mysmartroute/view/ui/screens/BookSeatScreen.kt
+++ b/app/src/main/java/com/ioannapergamali/mysmartroute/view/ui/screens/BookSeatScreen.kt
@@ -565,7 +565,7 @@ fun BookSeatScreen(
                                     "&startId=" + startId +
                                     "&endId=" + endId +
                                     "&maxCost=&date=" + dateMillis +
-                                    "&seats=1"
+                                    "&seats=1&vehicleType="
                         )
                     }
                 ) {

--- a/app/src/main/java/com/ioannapergamali/mysmartroute/view/ui/screens/FindVehicleScreen.kt
+++ b/app/src/main/java/com/ioannapergamali/mysmartroute/view/ui/screens/FindVehicleScreen.kt
@@ -47,6 +47,7 @@ import com.ioannapergamali.mysmartroute.viewmodel.PoIViewModel
 import com.ioannapergamali.mysmartroute.model.enumerations.VehicleType
 import com.ioannapergamali.mysmartroute.utils.MapsUtils
 import com.ioannapergamali.mysmartroute.utils.offsetPois
+import com.ioannapergamali.mysmartroute.view.ui.util.labelForVehicle
 import com.google.firebase.auth.FirebaseAuth
 import com.google.firebase.firestore.FirebaseFirestore
 import kotlinx.coroutines.tasks.await
@@ -76,6 +77,8 @@ fun FindVehicleScreen(navController: NavController, openDrawer: () -> Unit) {
     val originalPoiIds = remember { mutableStateListOf<String>() }
     var startIndex by rememberSaveable { mutableStateOf<Int?>(null) }
     var endIndex by rememberSaveable { mutableStateOf<Int?>(null) }
+    var vehicleTypeExpanded by remember { mutableStateOf(false) }
+    var selectedVehicleType by rememberSaveable { mutableStateOf<VehicleType?>(null) }
     var maxCostText by rememberSaveable { mutableStateOf("") }
     var message by remember { mutableStateOf("") }
     var pathPoints by remember { mutableStateOf<List<LatLng>>(emptyList()) }
@@ -409,6 +412,27 @@ fun FindVehicleScreen(navController: NavController, openDrawer: () -> Unit) {
 
             Spacer(Modifier.height(16.dp))
 
+            ExposedDropdownMenuBox(expanded = vehicleTypeExpanded, onExpandedChange = { vehicleTypeExpanded = !vehicleTypeExpanded }) {
+                OutlinedTextField(
+                    value = selectedVehicleType?.let { labelForVehicle(it) } ?: "",
+                    onValueChange = {},
+                    readOnly = true,
+                    label = { Text(stringResource(R.string.vehicle_type)) },
+                    trailingIcon = { ExposedDropdownMenuDefaults.TrailingIcon(expanded = vehicleTypeExpanded) },
+                    modifier = Modifier.menuAnchor().fillMaxWidth()
+                )
+                DropdownMenu(expanded = vehicleTypeExpanded, onDismissRequest = { vehicleTypeExpanded = false }) {
+                    VehicleType.values().forEach { type ->
+                        DropdownMenuItem(text = { Text(labelForVehicle(type)) }, onClick = {
+                            selectedVehicleType = type
+                            vehicleTypeExpanded = false
+                        })
+                    }
+                }
+            }
+
+            Spacer(Modifier.height(16.dp))
+
             Row(horizontalArrangement = Arrangement.spacedBy(8.dp)) {
                 Button(
                     onClick = {
@@ -431,7 +455,8 @@ fun FindVehicleScreen(navController: NavController, openDrawer: () -> Unit) {
                                 "&endId=" + toId +
                                 "&maxCost=" + cost +
                                 "&date=" + dateMillis +
-                                "&seats=1"
+                                "&seats=1" +
+                                "&vehicleType=" + (selectedVehicleType?.name ?: "")
                         )
                     },
                     enabled = selectedRouteId != null && startIndex != null && endIndex != null,

--- a/app/src/main/java/com/ioannapergamali/mysmartroute/view/ui/screens/RouteModeScreen.kt
+++ b/app/src/main/java/com/ioannapergamali/mysmartroute/view/ui/screens/RouteModeScreen.kt
@@ -44,6 +44,7 @@ import com.ioannapergamali.mysmartroute.viewmodel.TransferRequestViewModel
 import com.ioannapergamali.mysmartroute.model.enumerations.VehicleType
 import com.ioannapergamali.mysmartroute.utils.MapsUtils
 import com.ioannapergamali.mysmartroute.utils.offsetPois
+import com.ioannapergamali.mysmartroute.view.ui.util.labelForVehicle
 import androidx.lifecycle.compose.LocalLifecycleOwner
 import androidx.lifecycle.Lifecycle
 import androidx.lifecycle.LifecycleEventObserver
@@ -86,6 +87,8 @@ fun RouteModeScreen(
     val originalPoiIds = remember { mutableStateListOf<String>() }
     var startIndex by rememberSaveable { mutableStateOf<Int?>(null) }
     var endIndex by rememberSaveable { mutableStateOf<Int?>(null) }
+    var vehicleTypeExpanded by remember { mutableStateOf(false) }
+    var selectedVehicleType by rememberSaveable { mutableStateOf<VehicleType?>(null) }
     var message by remember { mutableStateOf("") }
     val datePickerState = rememberDatePickerState(System.currentTimeMillis())
     var showDatePicker by remember { mutableStateOf(false) }
@@ -433,6 +436,27 @@ fun RouteModeScreen(
                 Spacer(Modifier.height(16.dp))
             }
 
+            ExposedDropdownMenuBox(expanded = vehicleTypeExpanded, onExpandedChange = { vehicleTypeExpanded = !vehicleTypeExpanded }) {
+                OutlinedTextField(
+                    value = selectedVehicleType?.let { labelForVehicle(it) } ?: "",
+                    onValueChange = {},
+                    readOnly = true,
+                    label = { Text(stringResource(R.string.vehicle_type)) },
+                    trailingIcon = { ExposedDropdownMenuDefaults.TrailingIcon(expanded = vehicleTypeExpanded) },
+                    modifier = Modifier.menuAnchor().fillMaxWidth()
+                )
+                DropdownMenu(expanded = vehicleTypeExpanded, onDismissRequest = { vehicleTypeExpanded = false }) {
+                    VehicleType.values().forEach { type ->
+                        DropdownMenuItem(text = { Text(labelForVehicle(type)) }, onClick = {
+                            selectedVehicleType = type
+                            vehicleTypeExpanded = false
+                        })
+                    }
+                }
+            }
+
+            Spacer(Modifier.height(16.dp))
+
             OutlinedTextField(
                 value = seatsText,
                 onValueChange = { seatsText = it },
@@ -467,7 +491,8 @@ fun RouteModeScreen(
                                 "&endId=" + toId +
                                 "&maxCost=" + cost +
                                 "&date=" + date +
-                                "&seats=" + seats
+                                "&seats=" + seats +
+                                "&vehicleType=" + (selectedVehicleType?.name ?: "")
                         )
                     },
                     enabled = selectedRouteId != null && startIndex != null && endIndex != null,


### PR DESCRIPTION
## Περίληψη
- Προσθήκη επιλογής τύπου οχήματος στις οθόνες αναζήτησης διαδρομής και οχήματος
- Μετάδοση του επιλεγμένου τύπου οχήματος στη λίστα διαθέσιμων μεταφορών και φιλτράρισμα αποτελεσμάτων
- Ενημέρωση πλοήγησης και κρατήσεων ώστε να υποστηρίζεται το νέο φίλτρο

## Έλεγχοι
- `./gradlew test` *(απέτυχε: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_68bcac0d620083288c681326f9267ddc