### PR TITLE
Τοποθέτηση του κουμπιού "Αποθήκευση αιτήματος" κάτω από "Εύρεση τώρα"

### DIFF
--- a/app/src/main/java/com/ioannapergamali/mysmartroute/view/ui/screens/BookSeatScreen.kt
+++ b/app/src/main/java/com/ioannapergamali/mysmartroute/view/ui/screens/BookSeatScreen.kt
@@ -542,7 +542,7 @@ fun BookSeatScreen(
 
             Spacer(Modifier.height(16.dp))
 
-            Row(horizontalArrangement = Arrangement.spacedBy(8.dp)) {
+            Column(verticalArrangement = Arrangement.spacedBy(8.dp)) {
                 Button(
                     enabled = selectedRoute != null && startIndex != null && endIndex != null &&
                             datePickerState.selectedDateMillis != null,

--- a/app/src/main/java/com/ioannapergamali/mysmartroute/view/ui/screens/FindVehicleScreen.kt
+++ b/app/src/main/java/com/ioannapergamali/mysmartroute/view/ui/screens/FindVehicleScreen.kt
@@ -409,7 +409,7 @@ fun FindVehicleScreen(navController: NavController, openDrawer: () -> Unit) {
 
             Spacer(Modifier.height(16.dp))
 
-            Row(horizontalArrangement = Arrangement.spacedBy(8.dp)) {
+            Column(verticalArrangement = Arrangement.spacedBy(8.dp)) {
                 Button(
                     onClick = {
                         val fromIdx = startIndex ?: return@Button

--- a/app/src/main/java/com/ioannapergamali/mysmartroute/view/ui/screens/RouteModeScreen.kt
+++ b/app/src/main/java/com/ioannapergamali/mysmartroute/view/ui/screens/RouteModeScreen.kt
@@ -443,7 +443,7 @@ fun RouteModeScreen(
 
             Spacer(Modifier.height(16.dp))
 
-            Row(horizontalArrangement = Arrangement.spacedBy(8.dp)) {
+            Column(verticalArrangement = Arrangement.spacedBy(8.dp)) {
                 Button(
                     onClick = {
                         val fromIdx = startIndex ?: return@Button


### PR DESCRIPTION
## Summary
- Στο FindVehicleScreen, BookSeatScreen και RouteModeScreen, τα κουμπιά "Εύρεση τώρα" και "Αποθήκευση αιτήματος" στοιχίζονται πλέον κάθετα.

## Testing
- `./gradlew test` *(απέτυχε: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_68bcad2d9ec08328a16964f6e03c0010