### PR TITLE
Διόρθωση αναφοράς LocalLifecycleOwner

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -93,6 +93,7 @@ dependencies {
     implementation("androidx.navigation:navigation-compose:2.9.1")
     implementation("androidx.compose.material:material-icons-extended")
     implementation("io.coil-kt:coil-compose:2.7.0")
+    implementation("androidx.lifecycle:lifecycle-runtime-compose:2.9.3")
 
     // DataStore για αποθήκευση ρυθμίσεων
     implementation("androidx.datastore:datastore-preferences:1.1.7")

--- a/app/src/main/java/com/ioannapergamali/mysmartroute/view/ui/screens/FindVehicleScreen.kt
+++ b/app/src/main/java/com/ioannapergamali/mysmartroute/view/ui/screens/FindVehicleScreen.kt
@@ -19,6 +19,7 @@ import androidx.compose.ui.text.input.KeyboardType
 import androidx.compose.ui.unit.dp
 
 import androidx.lifecycle.*
+import androidx.lifecycle.compose.LocalLifecycleOwner
 
 import androidx.lifecycle.viewmodel.compose.viewModel
 import androidx.navigation.NavController


### PR DESCRIPTION
## Περίληψη
- Προστέθηκε το `LocalLifecycleOwner` στη FindVehicleScreen για σωστή παρακολούθηση του κύκλου ζωής.
- Ενημερώθηκε το build.gradle ώστε να συμπεριλάβει τη βιβλιοθήκη `lifecycle-runtime-compose`.

## Έλεγχοι
- `./gradlew test` *(αποτυχία: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_68bcb76009288328866dc81cdcd26acd