### PR TITLE
Απόκρυψη παρελθόντων μεταφορών στη λίστα διαθέσιμων

### DIFF
--- a/app/src/main/java/com/ioannapergamali/mysmartroute/utils/TransportFilters.kt
+++ b/app/src/main/java/com/ioannapergamali/mysmartroute/utils/TransportFilters.kt
@@ -16,3 +16,10 @@ fun TransportDeclarationEntity.matchesFavorites(
     if (nonPreferred.contains(type)) return false
     return true
 }
+
+/**
+ * Επιστρέφει `true` αν η δήλωση αναφέρεται σε μελλοντικό χρόνο.
+ */
+fun TransportDeclarationEntity.isUpcoming(now: Long = System.currentTimeMillis()): Boolean {
+    return date + startTime > now
+}

--- a/app/src/main/java/com/ioannapergamali/mysmartroute/view/ui/screens/AvailableTransportsScreen.kt
+++ b/app/src/main/java/com/ioannapergamali/mysmartroute/view/ui/screens/AvailableTransportsScreen.kt
@@ -27,6 +27,7 @@ import com.ioannapergamali.mysmartroute.viewmodel.BookingViewModel
 import com.ioannapergamali.mysmartroute.viewmodel.UserViewModel
 import com.ioannapergamali.mysmartroute.viewmodel.VehicleViewModel
 import com.ioannapergamali.mysmartroute.utils.matchesFavorites
+import com.ioannapergamali.mysmartroute.utils.isUpcoming
 import kotlinx.coroutines.launch
 import kotlin.math.max
 import java.time.Instant
@@ -108,6 +109,7 @@ fun AvailableTransportsScreen(
         if (seats != null && decl.seats < seats) return@filter false
         if (vehicleType != null && runCatching { VehicleType.valueOf(decl.vehicleType) }.getOrNull() != vehicleType) return@filter false
         if (!decl.matchesFavorites(preferred, nonPreferred)) return@filter false
+        if (!decl.isUpcoming()) return@filter false
         true
 
 


### PR DESCRIPTION
## Σκοπός
- Οι διαθέσιμες μεταφορές να φιλτράρονται ώστε να λαμβάνονται υπόψη μόνο οι προτιμώμενοι τύποι οχημάτων και να αποκλείονται όσες έχουν ήδη πραγματοποιηθεί.

## Αλλαγές
- Προστέθηκε βοηθητική συνάρτηση `isUpcoming` για έλεγχο μελλοντικής ημερομηνίας.
- Εφαρμογή του ελέγχου στη `AvailableTransportsScreen` για να αποκρύπτονται οι παρελθούσες δηλώσεις.

## Έλεγχοι
- `./gradlew test` *(αποτυχία: λείπει Android SDK)*

------
https://chatgpt.com/codex/tasks/task_e_68bcbf2737c8832883c290993ed6466f