### PR TITLE
Show unsuccessful for expired requests

### DIFF
--- a/app/src/main/java/com/ioannapergamali/mysmartroute/view/ui/screens/ViewRequestsScreen.kt
+++ b/app/src/main/java/com/ioannapergamali/mysmartroute/view/ui/screens/ViewRequestsScreen.kt
@@ -156,6 +156,8 @@ fun ViewRequestsScreen(
                                 "$dateStr $timeStr"
                             } else ""
                             val costText = if (req.cost == Double.MAX_VALUE) "-" else req.cost.toString()
+                            val isExpired = req.date > 0L && System.currentTimeMillis() > req.date && req.status != "completed"
+                            val statusText = if (isExpired) stringResource(R.string.request_unsuccessful) else req.status
                             Row(
                                 modifier = Modifier.padding(vertical = 8.dp),
                                 verticalAlignment = Alignment.CenterVertically,
@@ -164,7 +166,7 @@ fun ViewRequestsScreen(
                                 Text(routeName, modifier = Modifier.width(columnWidth))
                                 Text(costText, modifier = Modifier.width(columnWidth))
                                 Text(dateTimeText, modifier = Modifier.width(columnWidth))
-                                if (req.status == "pending") {
+                                if (req.status == "pending" && !isExpired) {
                                     val dName = driverNames[req.driverId] ?: ""
                                     Text(dName, modifier = Modifier.width(columnWidth))
                                     Button(onClick = {
@@ -200,7 +202,7 @@ fun ViewRequestsScreen(
                                         Text(stringResource(R.string.cancel_request))
                                     }
                                 } else {
-                                    Text(req.status, modifier = Modifier.width(columnWidth))
+                                    Text(statusText, modifier = Modifier.width(columnWidth))
                                 }
                             }
                             Divider()

--- a/app/src/main/java/com/ioannapergamali/mysmartroute/view/ui/screens/ViewTransportRequestsScreen.kt
+++ b/app/src/main/java/com/ioannapergamali/mysmartroute/view/ui/screens/ViewTransportRequestsScreen.kt
@@ -180,7 +180,7 @@ fun ViewTransportRequestsScreen(
                                 Text(costText, modifier = Modifier.width(columnWidth))
                                 Text(dateTimeText, modifier = Modifier.width(columnWidth))
                                 Text(req.requestNumber.toString(), modifier = Modifier.width(columnWidth))
-                                val isExpired = req.date > 0L && System.currentTimeMillis() > req.date
+                                val isExpired = req.date > 0L && System.currentTimeMillis() > req.date && req.status != "completed"
                                 if (req.status == "open" && !isExpired) {
                                     Button(
                                         onClick = {
@@ -192,7 +192,7 @@ fun ViewTransportRequestsScreen(
                                         Text(stringResource(R.string.notify_passenger))
                                     }
                                 } else {
-                                    val statusText = if (isExpired) stringResource(R.string.request_expired) else req.status
+                                    val statusText = if (isExpired) stringResource(R.string.request_unsuccessful) else req.status
                                     Text(statusText, modifier = Modifier.width(columnWidth))
                                 }
                             }

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -248,6 +248,7 @@
     <string name="notify_passenger">Notify passenger</string>
     <string name="notify_selected">Notify selected</string>
     <string name="request_expired">Request expired</string>
+    <string name="request_unsuccessful">Ανεπιτυχής</string>
     <string name="accept_offer">Accept</string>
     <string name="reject_offer">Reject</string>
     <string name="no_notifications">No notifications</string>


### PR DESCRIPTION
## Summary
- display "Ανεπιτυχής" on request screens when the date has passed and the route wasn't completed
- add string resource for the new status

## Testing
- `./gradlew test` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_68bcbf83296483289176cce7f14856c4