### PR TITLE
Εμφάνιση διαδρομών με μικρότερο ή ίσο κόστος

### DIFF
--- a/app/src/main/java/com/ioannapergamali/mysmartroute/view/ui/screens/AvailableTransportsScreen.kt
+++ b/app/src/main/java/com/ioannapergamali/mysmartroute/view/ui/screens/AvailableTransportsScreen.kt
@@ -105,6 +105,7 @@ fun AvailableTransportsScreen(
 
     val today = remember { LocalDate.now().atStartOfDay(ZoneId.systemDefault()).toInstant().toEpochMilli() }
     val sortedDecls = declarations.filter { decl ->
+        // Η δήλωση πρέπει να έχει κόστος μικρότερο ή ίσο με αυτό που όρισε ο χρήστης
         if (maxCost != null && decl.cost > maxCost) return@filter false
         if (decl.date < today) return@filter false
         if (date != null && date >= today && decl.date != date) return@filter false


### PR DESCRIPTION
## Περίληψη
- Προστέθηκε επεξηγηματικό σχόλιο στο `AvailableTransportsScreen` ώστε να είναι σαφές ότι φιλτράρονται οι διαδρομές με κόστος μικρότερο ή ίσο από το μέγιστο που ορίζει ο χρήστης.

## Έλεγχοι
- `./gradlew test` *(αποτυχημένο: απαιτείται Android SDK)*

------
https://chatgpt.com/codex/tasks/task_e_68bcc221b42483289c32963a5832d073