### PR TITLE
Διόρθωση στοίχισης τύπων οχήματος στην προετοιμασία διαδρομής

### DIFF
--- a/app/src/main/java/com/ioannapergamali/mysmartroute/view/ui/screens/PrepareCompleteRouteScreen.kt
+++ b/app/src/main/java/com/ioannapergamali/mysmartroute/view/ui/screens/PrepareCompleteRouteScreen.kt
@@ -49,7 +49,7 @@ import com.ioannapergamali.mysmartroute.viewmodel.AuthenticationViewModel
 import com.ioannapergamali.mysmartroute.model.enumerations.UserRole
 import com.google.firebase.auth.FirebaseAuth
 
-@OptIn(ExperimentalMaterial3Api::class)
+@OptIn(ExperimentalMaterial3Api::class, ExperimentalLayoutApi::class)
 @Composable
 fun PrepareCompleteRouteScreen(navController: NavController, openDrawer: () -> Unit) {
     val context = LocalContext.current
@@ -301,7 +301,10 @@ fun PrepareCompleteRouteScreen(navController: NavController, openDrawer: () -> U
                 Spacer(Modifier.height(16.dp))
 
                 Text(stringResource(R.string.vehicle_type))
-                Row(horizontalArrangement = Arrangement.spacedBy(8.dp)) {
+                FlowRow(
+                    horizontalArrangement = Arrangement.spacedBy(8.dp),
+                    verticalArrangement = Arrangement.spacedBy(8.dp)
+                ) {
                     VehicleType.values().forEach { type ->
                         val isSelected = selectedVehicle == type
                         Column(


### PR DESCRIPTION
## Περίληψη
- Χρήση `FlowRow` για περιτύλιξη των τύπων οχήματος ώστε να εμφανίζεται και το ποδήλατο
- Προσθήκη `ExperimentalLayoutApi` στο `PrepareCompleteRouteScreen`

## Έλεγχοι
- `./gradlew test` (αποτυχία: SDK location not found)


------
https://chatgpt.com/codex/tasks/task_e_68bcc47a9514832888abcc6e9a460025