### PR TITLE
Add Greek translation for select time string

### DIFF
--- a/app/src/main/res/values-el/strings.xml
+++ b/app/src/main/res/values-el/strings.xml
@@ -193,6 +193,7 @@
     <string name="select_route">Επιλογή διαδρομής</string>
     <string name="add_poi_option">Προσθήκη POI</string>
     <string name="select_date">Επιλογή ημερομηνίας</string>
+    <string name="select_time">Επιλογή ώρας</string>
     <string name="select_pois_screen_title">Επιλογή POI διαδρομής</string>
     <string name="choose_pois">Επιλογή σημείων ενδιαφέροντος</string>
     <string name="confirm_poi_selection">Επιβεβαίωση επιλογής</string>


### PR DESCRIPTION
## Summary
- add missing Greek translation for select_time

## Testing
- `./gradlew test` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_68bcc58ec12083289f2ec5d1a57489db