### PR TITLE
Βελτιώσεις προβολής μετακινήσεων

### DIFF
--- a/app/src/main/java/com/ioannapergamali/mysmartroute/data/local/MovingEntity.kt
+++ b/app/src/main/java/com/ioannapergamali/mysmartroute/data/local/MovingEntity.kt
@@ -38,6 +38,9 @@ data class MovingEntity(
     @Ignore
     var routeName: String = ""
 
+    @Ignore
+    var vehicleName: String = ""
+
     constructor(
         id: String = "",
         routeId: String = "",
@@ -54,7 +57,8 @@ data class MovingEntity(
         status: String = "open",
         requestNumber: Int = 0,
         driverName: String = "",
-        routeName: String = ""
+        routeName: String = "",
+        vehicleName: String = ""
     ) : this(
         id,
         routeId,
@@ -73,5 +77,6 @@ data class MovingEntity(
         this.createdByName = createdByName
         this.driverName = driverName
         this.routeName = routeName
+        this.vehicleName = vehicleName
     }
 }

--- a/app/src/main/java/com/ioannapergamali/mysmartroute/utils/FirestoreMappers.kt
+++ b/app/src/main/java/com/ioannapergamali/mysmartroute/utils/FirestoreMappers.kt
@@ -330,6 +330,7 @@ fun DocumentSnapshot.toMovingEntity(): MovingEntity? {
     val requestNumber = (getLong("requestNumber") ?: 0L).toInt()
     val driverName = getString("driverName") ?: ""
     val routeName = getString("routeName") ?: ""
+    val vehicleName = getString("vehicleName") ?: ""
     return MovingEntity(
         movingId,
         routeId,
@@ -346,7 +347,8 @@ fun DocumentSnapshot.toMovingEntity(): MovingEntity? {
         status,
         requestNumber,
         driverName,
-        routeName
+        routeName,
+        vehicleName
     )
 }
 

--- a/app/src/main/java/com/ioannapergamali/mysmartroute/view/ui/screens/PassengerMovingsScreen.kt
+++ b/app/src/main/java/com/ioannapergamali/mysmartroute/view/ui/screens/PassengerMovingsScreen.kt
@@ -1,12 +1,14 @@
 package com.ioannapergamali.mysmartroute.view.ui.screens
 
 import android.text.format.DateFormat
+import androidx.compose.foundation.horizontalScroll
+import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
-import androidx.compose.foundation.layout.RowScope
 import androidx.compose.foundation.layout.Spacer
-import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.rememberScrollState
 import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Scaffold
@@ -86,21 +88,29 @@ private fun MovingCategory(title: String, list: List<MovingEntity>) {
     if (list.isNotEmpty()) {
         Text(title, style = MaterialTheme.typography.titleMedium)
         Spacer(modifier = Modifier.height(8.dp))
-        Row(modifier = Modifier.fillMaxWidth()) {
-            TableCell(stringResource(R.string.route))
-            TableCell(stringResource(R.string.date))
-            TableCell(stringResource(R.string.cost))
-            TableCell(stringResource(R.string.duration))
-        }
-        list.forEach { m ->
-            val dateText = if (m.date > 0L) {
-                DateFormat.getDateFormat(context).format(Date(m.date))
-            } else ""
-            Row(modifier = Modifier.fillMaxWidth()) {
-                TableCell(m.routeName)
-                TableCell(dateText)
-                TableCell(String.format(Locale.getDefault(), "%.2f€", m.cost))
-                TableCell(m.durationMinutes.toString())
+        Column(modifier = Modifier.horizontalScroll(rememberScrollState())) {
+            Row {
+                TableCell(stringResource(R.string.route))
+                TableCell(stringResource(R.string.driver))
+                TableCell(stringResource(R.string.vehicle_name))
+                TableCell(stringResource(R.string.passenger))
+                TableCell(stringResource(R.string.date))
+                TableCell(stringResource(R.string.cost))
+                TableCell(stringResource(R.string.duration))
+            }
+            list.forEach { m ->
+                val dateText = if (m.date > 0L) {
+                    DateFormat.getDateFormat(context).format(Date(m.date))
+                } else ""
+                Row {
+                    TableCell(m.routeName)
+                    TableCell(m.driverName)
+                    TableCell(m.vehicleName)
+                    TableCell(m.createdByName)
+                    TableCell(dateText)
+                    TableCell(String.format(Locale.getDefault(), "%.2f€", m.cost))
+                    TableCell(m.durationMinutes.toString())
+                }
             }
         }
         Spacer(modifier = Modifier.height(16.dp))
@@ -108,11 +118,11 @@ private fun MovingCategory(title: String, list: List<MovingEntity>) {
 }
 
 @Composable
-private fun RowScope.TableCell(text: String) {
+private fun TableCell(text: String) {
     Text(
         text,
         modifier = Modifier
-            .weight(1f)
-            .padding(4.dp)
+            .width(120.dp)
+            .padding(4.dp),
     )
 }


### PR DESCRIPTION
## Περίληψη
- προστέθηκαν πεδία ονόματος οχήματος, οδηγού και επιβάτη στην οντότητα μετακίνησης
- εμφάνιση όλων των στοιχείων με οριζόντιο scroll στην οθόνη μετακινήσεων
- φόρτωση ονομάτων διαδρομών, οχημάτων και χρηστών από τη βάση

## Έλεγχοι
- `./gradlew test` *(απέτυχε: περιορισμοί περιβάλλοντος)*


------
https://chatgpt.com/codex/tasks/task_e_68bcf6dc653483288a52e31f514eb715