### PR TITLE
Μετονομασία μενού αποθήκευσης διαδρομών

### DIFF
--- a/app/src/main/res/values-el/strings.xml
+++ b/app/src/main/res/values-el/strings.xml
@@ -93,7 +93,7 @@
     <string name="find_vehicle">Εύρεση οχήματος βάσει κόστους</string>
     <string name="find_way">Εύρεση μέσου μεταφοράς</string>
     <string name="book_seat">Κράτηση θέσης ή αγορά εισιτηρίου</string>
-    <string name="view_routes">Προβολή ενδιαφερουσών διαδρομών</string>
+    <string name="view_routes">Αποθήκευση ενδιαφερουσών διαδρομών</string>
     <string name="view_transports">Προβολή μεταφορών</string>
     <string name="print_ticket">Εκτύπωση κράτησης ή εισιτηρίου</string>
     <string name="cancel_seat">Ακύρωση κράτησης</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -90,7 +90,7 @@
     <string name="find_vehicle">Find a Vehicle based on Cost</string>
     <string name="find_way">Find Way of Transport</string>
     <string name="book_seat">Book a Seat or Buy a Ticket</string>
-    <string name="view_routes">View Interesting Routes</string>
+    <string name="view_routes">Save Interesting Routes</string>
     <string name="view_transports">View Transports</string>
     <string name="view_transport_requests">View Transport Requests</string>
     <string name="print_ticket">Print Booked Seat or Ticket</string>


### PR DESCRIPTION
## Σύνοψη
- Μετονομασία του στοιχείου `view_routes` σε "Αποθήκευση ενδιαφερουσών διαδρομών" στα ελληνικά και "Save Interesting Routes" στα αγγλικά.

## Δοκιμές
- `./gradlew test` *(αποτυχία: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_68bcf85ded348328a49d5c146d5d4fe7