### PR TITLE
Add Greek translation for register button

### DIFF
--- a/app/src/main/java/com/ioannapergamali/mysmartroute/view/ui/screens/RegisterVehicleScreen.kt
+++ b/app/src/main/java/com/ioannapergamali/mysmartroute/view/ui/screens/RegisterVehicleScreen.kt
@@ -354,7 +354,7 @@ fun RegisterVehicleScreen(navController: NavController, openDrawer: () -> Unit) 
                 val colorParam = if (usingCustomColor) customColorName else color.name
                 viewModel.registerVehicle(context, name, description, type, seat, colorParam, plate)
             }) {
-                Text("Register")
+                Text(stringResource(R.string.register))
             }
         }
     }

--- a/app/src/main/res/values-el/strings.xml
+++ b/app/src/main/res/values-el/strings.xml
@@ -155,6 +155,7 @@
     <string name="ok">OK</string>
     <string name="cancel">Ακύρωση</string>
     <string name="announce">Αποστολή</string>
+    <string name="register">Καταχώρηση</string>
     <string name="duration_format">Διάρκεια: %1$d λεπτά</string>
     <string name="app_language">Γλώσσα εφαρμογής</string>
     <string name="poi_name">Όνομα POI</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -154,6 +154,7 @@
     <string name="ok">OK</string>
     <string name="cancel">Cancel</string>
     <string name="announce">Announce</string>
+    <string name="register">Register</string>
     <string name="duration_format">Duration: %1$d min</string>
     <string name="app_language">App Language</string>
     <string name="poi_name">PoI Name</string>


### PR DESCRIPTION
## Summary
- Replace hardcoded register label with string resource
- Provide English and Greek translations for new register string

## Testing
- `./gradlew test` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_68bd004d17bc8328ae00a54a878a46c3