### PR TITLE
Προσθήκη ελληνικών μεταφράσεων για toast διαδρομής

### DIFF
--- a/app/src/main/res/values-el/strings.xml
+++ b/app/src/main/res/values-el/strings.xml
@@ -199,7 +199,9 @@
     <string name="choose_pois">Επιλογή σημείων ενδιαφέροντος</string>
     <string name="confirm_poi_selection">Επιβεβαίωση επιλογής</string>
     <string name="route_saved">Η διαδρομή αποθηκεύτηκε</string>
+    <string name="route_saved_success">Η διαδρομή αποθηκεύτηκε με επιτυχία</string>
     <string name="route_save_failed">Η αποθήκευση διαδρομής απέτυχε</string>
+    <string name="route_exists">Υπάρχει ήδη διαδρομή με αυτό το όνομα</string>
     <string name="recalculate_route">Επανασχεδίαση διαδρομής</string>
     <string name="select_boarding">Επιλογή ως στάση επιβίβασης</string>
     <string name="select_dropoff">Επιλογή ως στάση αποβίβασης</string>


### PR DESCRIPTION
## Περίληψη
- Προσθήκη ελληνικού μηνύματος επιτυχούς αποθήκευσης διαδρομής
- Προσθήκη ελληνικού μηνύματος για ύπαρξη διαδρομής με ίδιο όνομα

## Δοκιμές
- `./gradlew test` *(απέτυχε: λείπει Android SDK)*

------
https://chatgpt.com/codex/tasks/task_e_68bd077d91188328be2da04fcfed7bfe