### PR TITLE
Add icons to date and time fields in availability declaration

### DIFF
--- a/app/src/main/java/com/ioannapergamali/mysmartroute/view/ui/screens/AnnounceTransportScreen.kt
+++ b/app/src/main/java/com/ioannapergamali/mysmartroute/view/ui/screens/AnnounceTransportScreen.kt
@@ -8,6 +8,8 @@ import androidx.compose.material.icons.filled.DirectionsBike
 import androidx.compose.material.icons.filled.DirectionsBus
 import androidx.compose.material.icons.filled.DirectionsCar
 import androidx.compose.material.icons.filled.TwoWheeler
+import androidx.compose.material.icons.filled.DateRange
+import androidx.compose.material.icons.filled.AccessTime
 import androidx.compose.runtime.*
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.res.stringResource
@@ -383,6 +385,8 @@ fun AnnounceTransportScreen(navController: NavController, openDrawer: () -> Unit
             }
 
             Button(onClick = { showDatePicker = true }) {
+                Icon(Icons.Default.DateRange, contentDescription = null)
+                Spacer(Modifier.width(8.dp))
                 Text(selectedDateText)
             }
 
@@ -402,6 +406,8 @@ fun AnnounceTransportScreen(navController: NavController, openDrawer: () -> Unit
             Spacer(Modifier.height(16.dp))
 
             Button(onClick = { showTimePicker = true }) {
+                Icon(Icons.Default.AccessTime, contentDescription = null)
+                Spacer(Modifier.width(8.dp))
                 Text(selectedTimeText)
             }
 


### PR DESCRIPTION
## Summary
- show calendar and clock icons on availability date/time buttons

## Testing
- `./gradlew test --console=plain` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_68bd0824cf5c8328a23e71d4ffa875fd