### PR TITLE
Show toast on transport declaration result

### DIFF
--- a/app/src/main/java/com/ioannapergamali/mysmartroute/view/ui/screens/AnnounceTransportScreen.kt
+++ b/app/src/main/java/com/ioannapergamali/mysmartroute/view/ui/screens/AnnounceTransportScreen.kt
@@ -36,6 +36,7 @@ import com.ioannapergamali.mysmartroute.model.enumerations.VehicleType
 import com.ioannapergamali.mysmartroute.model.enumerations.UserRole
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.graphics.vector.ImageVector
+import android.widget.Toast
 import com.ioannapergamali.mysmartroute.data.local.RouteEntity
 import com.ioannapergamali.mysmartroute.data.local.VehicleEntity
 import com.google.android.libraries.places.api.model.Place
@@ -454,19 +455,28 @@ fun AnnounceTransportScreen(navController: NavController, openDrawer: () -> Unit
                     val startTime = (timePickerState.hour * 60 + timePickerState.minute) * 60_000L
                     val driverId = selectedDriverId ?: ""
                     if (routeId != null && vehicle != null) {
-                        declarationViewModel.declareTransport(
-                            context,
-                            routeId,
-                            driverId,
-                            selectedVehicleId,
-                            vehicle,
-                            selectedVehicleSeats,
-                            cost,
-                            duration,
-                            date,
-                            startTime
-                        )
-                        navController.popBackStack()
+                        scope.launch {
+                            val success = declarationViewModel.declareTransport(
+                                context,
+                                routeId,
+                                driverId,
+                                selectedVehicleId,
+                                vehicle,
+                                selectedVehicleSeats,
+                                cost,
+                                duration,
+                                date,
+                                startTime
+                            )
+                            Toast.makeText(
+                                context,
+                                if (success) R.string.declare_success else R.string.declare_failure,
+                                Toast.LENGTH_SHORT
+                            ).show()
+                            if (success) {
+                                navController.popBackStack()
+                            }
+                        }
                     }
                 },
                 enabled = selectedRouteId != null && selectedVehicle != null && !calculating

--- a/app/src/main/res/values-el/strings.xml
+++ b/app/src/main/res/values-el/strings.xml
@@ -271,5 +271,7 @@
     <string name="walking_duration_result">Διάρκεια: %1$s</string>
     <string name="favorite_routes_saved">Οι διαδρομές αποθηκεύτηκαν</string>
     <string name="favorite_routes_save_failed">Αποτυχία αποθήκευσης διαδρομών</string>
+    <string name="declare_success">Η δήλωση στάλθηκε επιτυχώς</string>
+    <string name="declare_failure">Αποτυχία αποστολής δήλωσης</string>
 
 </resources>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -299,4 +299,6 @@
     <string name="no_reservation_found">No reservation found</string>
     <string name="favorite_routes_saved">Routes saved</string>
     <string name="favorite_routes_save_failed">Unable to save routes</string>
+    <string name="declare_success">Transport declared successfully</string>
+    <string name="declare_failure">Failed to declare transport</string>
 </resources>


### PR DESCRIPTION
## Summary
- notify user with toast after declaring transport indicating success or failure
- expose suspend `declareTransport` returning boolean
- add string resources for toast messages (EN/EL)

## Testing
- `./gradlew test` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_68bd08eced5c8328840489f54471f915