### PR TITLE
Add icons to date and time buttons in passenger search

### DIFF
--- a/app/src/main/java/com/ioannapergamali/mysmartroute/view/ui/screens/FindPassengersScreen.kt
+++ b/app/src/main/java/com/ioannapergamali/mysmartroute/view/ui/screens/FindPassengersScreen.kt
@@ -11,6 +11,9 @@ import androidx.compose.material3.OutlinedTextField
 import androidx.compose.material3.menuAnchor
 import androidx.compose.material3.TimePicker
 import androidx.compose.material3.rememberTimePickerState
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.DateRange
+import androidx.compose.material.icons.filled.AccessTime
 import androidx.compose.runtime.*
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
@@ -111,10 +114,20 @@ fun FindPassengersScreen(
 
         ScreenContainer(modifier = Modifier.padding(padding), scrollable = false) {
             Button(onClick = { showDatePicker = true }) {
+                Icon(
+                    Icons.Default.DateRange,
+                    contentDescription = stringResource(R.string.date)
+                )
+                Spacer(Modifier.width(8.dp))
                 Text(selectedDateText)
             }
             Spacer(modifier = Modifier.height(8.dp))
             Button(onClick = { showTimePicker = true }) {
+                Icon(
+                    Icons.Default.AccessTime,
+                    contentDescription = stringResource(R.string.time)
+                )
+                Spacer(Modifier.width(8.dp))
                 Text(selectedTimeText)
             }
             Spacer(modifier = Modifier.height(8.dp))


### PR DESCRIPTION
## Summary
- add calendar and clock icons to date and time selection buttons on FindPassengers screen

## Testing
- `./gradlew test` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_68bd0d0a0d9083289e85b99d1cb5b71e