### PR TITLE
Αφαίρεση φίλτρων τύπου οχήματος και θέσεων στην αναζήτηση μεταφορών

### DIFF
--- a/app/src/main/java/com/ioannapergamali/mysmartroute/model/navigation/NavigationHost.kt
+++ b/app/src/main/java/com/ioannapergamali/mysmartroute/model/navigation/NavigationHost.kt
@@ -38,7 +38,6 @@ import com.ioannapergamali.mysmartroute.view.ui.screens.InterestingRoutesScreen
 import com.ioannapergamali.mysmartroute.view.ui.screens.PrintCompletedScreen
 import com.ioannapergamali.mysmartroute.view.ui.screens.PrintListScreen
 import com.ioannapergamali.mysmartroute.view.ui.screens.PrintScheduledScreen
-import com.ioannapergamali.mysmartroute.model.enumerations.VehicleType
 import com.ioannapergamali.mysmartroute.view.ui.screens.PrintDeclarationsScreen
 import com.ioannapergamali.mysmartroute.view.ui.screens.PrintTicketScreen
 import com.ioannapergamali.mysmartroute.view.ui.screens.PrepareCompleteRouteScreen
@@ -228,15 +227,13 @@ fun NavigationHost(
         }
 
         composable(
-            "availableTransports?routeId={routeId}&startId={startId}&endId={endId}&maxCost={maxCost}&date={date}&seats={seats}&vehicleType={vehicleType}",
+            "availableTransports?routeId={routeId}&startId={startId}&endId={endId}&maxCost={maxCost}&date={date}",
             arguments = listOf(
                 navArgument("routeId") { defaultValue = "" },
                 navArgument("startId") { defaultValue = "" },
                 navArgument("endId") { defaultValue = "" },
                 navArgument("maxCost") { defaultValue = "" },
-                navArgument("date") { defaultValue = "" },
-                navArgument("seats") { defaultValue = "" },
-                navArgument("vehicleType") { defaultValue = "" }
+                navArgument("date") { defaultValue = "" }
             )
         ) { backStackEntry ->
             val rid = backStackEntry.arguments?.getString("routeId")
@@ -244,9 +241,6 @@ fun NavigationHost(
             val eid = backStackEntry.arguments?.getString("endId")
             val maxCost = backStackEntry.arguments?.getString("maxCost")?.toDoubleOrNull()
             val date = backStackEntry.arguments?.getString("date")?.toLongOrNull()
-            val seats = backStackEntry.arguments?.getString("seats")?.toIntOrNull()
-            val vehicleTypeArg = backStackEntry.arguments?.getString("vehicleType")?.takeIf { it.isNotBlank() }
-            val vType = vehicleTypeArg?.let { runCatching { VehicleType.valueOf(it) }.getOrNull() }
             AvailableTransportsScreen(
                 navController = navController,
                 openDrawer = openDrawer,
@@ -254,9 +248,7 @@ fun NavigationHost(
                 startId = sid,
                 endId = eid,
                 maxCost = maxCost,
-                date = date,
-                seats = seats,
-                vehicleType = vType
+                date = date
             )
         }
 

--- a/app/src/main/java/com/ioannapergamali/mysmartroute/view/ui/screens/AvailableTransportsScreen.kt
+++ b/app/src/main/java/com/ioannapergamali/mysmartroute/view/ui/screens/AvailableTransportsScreen.kt
@@ -19,7 +19,6 @@ import com.ioannapergamali.mysmartroute.model.enumerations.VehicleType
 import com.ioannapergamali.mysmartroute.view.ui.components.ScreenContainer
 import com.ioannapergamali.mysmartroute.view.ui.components.TopBar
 import com.ioannapergamali.mysmartroute.view.ui.util.iconForVehicle
-import com.ioannapergamali.mysmartroute.view.ui.util.labelForVehicle
 import com.ioannapergamali.mysmartroute.viewmodel.FavoritesViewModel
 import com.ioannapergamali.mysmartroute.viewmodel.TransportDeclarationViewModel
 import com.ioannapergamali.mysmartroute.viewmodel.ReservationViewModel
@@ -47,9 +46,7 @@ private fun HeaderRow() {
         Spacer(modifier = Modifier.width(40.dp))
         Text(stringResource(R.string.driver), modifier = Modifier.weight(1f))
         Text(stringResource(R.string.vehicle_name), modifier = Modifier.weight(1f))
-        Text(stringResource(R.string.vehicle_type), modifier = Modifier.weight(1f))
         Text(stringResource(R.string.cost), modifier = Modifier.weight(1f))
-        Text(stringResource(R.string.seats_label), modifier = Modifier.weight(1f))
         Text(stringResource(R.string.date), modifier = Modifier.weight(1f))
         Text(stringResource(R.string.time), modifier = Modifier.weight(1f))
     }
@@ -65,9 +62,7 @@ fun AvailableTransportsScreen(
     startId: String?,
     endId: String?,
     maxCost: Double?,
-    date: Long?,
-    seats: Int?,
-    vehicleType: VehicleType?
+    date: Long?
 ) {
     val context = LocalContext.current
     val declarationViewModel: TransportDeclarationViewModel = viewModel()
@@ -107,10 +102,11 @@ fun AvailableTransportsScreen(
     val sortedDecls = declarations.filter { decl ->
         // Η δήλωση πρέπει να έχει κόστος μικρότερο ή ίσο με αυτό που όρισε ο χρήστης
         if (maxCost != null && decl.cost > maxCost) return@filter false
+        val reserved = reservationCounts[decl.id] ?: 0
+        val availableSeats = max(0, decl.seats - reserved)
+        if (availableSeats <= 0) return@filter false
         if (decl.date < today) return@filter false
         if (date != null && date >= today && decl.date != date) return@filter false
-        if (seats != null && decl.seats < seats) return@filter false
-        if (vehicleType != null && runCatching { VehicleType.valueOf(decl.vehicleType) }.getOrNull() != vehicleType) return@filter false
         if (!decl.matchesFavorites(preferred, nonPreferred)) return@filter false
         if (!decl.isUpcoming()) return@filter false
         true
@@ -180,9 +176,7 @@ fun AvailableTransportsScreen(
                                 }
                                 Text(driver, modifier = Modifier.weight(1f))
                                 Text(vehicleName, modifier = Modifier.weight(1f))
-                                Text(type?.let { labelForVehicle(it) } ?: "", modifier = Modifier.weight(1f))
                                 Text(decl.cost.toString(), modifier = Modifier.weight(1f))
-                                Text(availableSeats.toString(), modifier = Modifier.weight(1f))
                                 Text(dateText, modifier = Modifier.weight(1f))
                                 Text(timeText, modifier = Modifier.weight(1f))
                             }

--- a/app/src/main/java/com/ioannapergamali/mysmartroute/view/ui/screens/BookSeatScreen.kt
+++ b/app/src/main/java/com/ioannapergamali/mysmartroute/view/ui/screens/BookSeatScreen.kt
@@ -564,8 +564,7 @@ fun BookSeatScreen(
                                     r.id +
                                     "&startId=" + startId +
                                     "&endId=" + endId +
-                                    "&maxCost=&date=" + dateMillis +
-                                    "&seats=1&vehicleType="
+                                    "&maxCost=&date=" + dateMillis
                         )
                     }
                 ) {

--- a/app/src/main/java/com/ioannapergamali/mysmartroute/view/ui/screens/FindVehicleScreen.kt
+++ b/app/src/main/java/com/ioannapergamali/mysmartroute/view/ui/screens/FindVehicleScreen.kt
@@ -424,7 +424,7 @@ fun FindVehicleScreen(navController: NavController, openDrawer: () -> Unit) {
                                 "&startId=" + fromId +
                                 "&endId=" + toId +
                                 "&maxCost=" + cost +
-                                "&date=&seats=&vehicleType="
+                                "&date="
                         )
                     },
                     enabled = selectedRouteId != null && startIndex != null && endIndex != null,

--- a/app/src/main/java/com/ioannapergamali/mysmartroute/view/ui/screens/RouteModeScreen.kt
+++ b/app/src/main/java/com/ioannapergamali/mysmartroute/view/ui/screens/RouteModeScreen.kt
@@ -10,7 +10,6 @@ import androidx.compose.material3.*
 import androidx.compose.material3.DatePicker
 import androidx.compose.material3.DatePickerDialog
 import androidx.compose.material3.rememberDatePickerState
-import androidx.compose.material3.menuAnchor
 import androidx.annotation.StringRes
 import androidx.compose.foundation.text.KeyboardOptions
 import androidx.compose.runtime.*
@@ -44,7 +43,6 @@ import com.ioannapergamali.mysmartroute.viewmodel.TransferRequestViewModel
 import com.ioannapergamali.mysmartroute.model.enumerations.VehicleType
 import com.ioannapergamali.mysmartroute.utils.MapsUtils
 import com.ioannapergamali.mysmartroute.utils.offsetPois
-import com.ioannapergamali.mysmartroute.view.ui.util.labelForVehicle
 import androidx.lifecycle.compose.LocalLifecycleOwner
 import androidx.lifecycle.Lifecycle
 import androidx.lifecycle.LifecycleEventObserver
@@ -87,8 +85,6 @@ fun RouteModeScreen(
     val originalPoiIds = remember { mutableStateListOf<String>() }
     var startIndex by rememberSaveable { mutableStateOf<Int?>(null) }
     var endIndex by rememberSaveable { mutableStateOf<Int?>(null) }
-    var vehicleTypeExpanded by remember { mutableStateOf(false) }
-    var selectedVehicleType by rememberSaveable { mutableStateOf<VehicleType?>(null) }
     var message by remember { mutableStateOf("") }
     val datePickerState = rememberDatePickerState(System.currentTimeMillis())
     var showDatePicker by remember { mutableStateOf(false) }
@@ -105,7 +101,6 @@ fun RouteModeScreen(
     var calculating by remember { mutableStateOf(false) }
     var pendingPoi by remember { mutableStateOf<Triple<String, Double, Double>?>(null) }
     var maxCostText by rememberSaveable { mutableStateOf("") }
-    var seatsText by rememberSaveable { mutableStateOf("") }
 
     suspend fun saveEditedRouteIfChanged(): String {
         val routeId = selectedRouteId ?: return ""
@@ -436,35 +431,6 @@ fun RouteModeScreen(
                 Spacer(Modifier.height(16.dp))
             }
 
-            ExposedDropdownMenuBox(expanded = vehicleTypeExpanded, onExpandedChange = { vehicleTypeExpanded = !vehicleTypeExpanded }) {
-                OutlinedTextField(
-                    value = selectedVehicleType?.let { labelForVehicle(it) } ?: "",
-                    onValueChange = {},
-                    readOnly = true,
-                    label = { Text(stringResource(R.string.vehicle_type)) },
-                    trailingIcon = { ExposedDropdownMenuDefaults.TrailingIcon(expanded = vehicleTypeExpanded) },
-                    modifier = Modifier.menuAnchor().fillMaxWidth()
-                )
-                DropdownMenu(expanded = vehicleTypeExpanded, onDismissRequest = { vehicleTypeExpanded = false }) {
-                    VehicleType.values().forEach { type ->
-                        DropdownMenuItem(text = { Text(labelForVehicle(type)) }, onClick = {
-                            selectedVehicleType = type
-                            vehicleTypeExpanded = false
-                        })
-                    }
-                }
-            }
-
-            Spacer(Modifier.height(16.dp))
-
-            OutlinedTextField(
-                value = seatsText,
-                onValueChange = { seatsText = it },
-                label = { Text(stringResource(R.string.seats_label)) },
-                keyboardOptions = KeyboardOptions(keyboardType = KeyboardType.Number),
-                modifier = Modifier.fillMaxWidth()
-            )
-
             Spacer(Modifier.height(16.dp))
 
             Column(verticalArrangement = Arrangement.spacedBy(8.dp)) {
@@ -479,7 +445,6 @@ fun RouteModeScreen(
                         val fromId = routePois[fromIdx].id
                         val toId = routePois[toIdx].id
                         val cost = maxCostText.toDoubleOrNull() ?: Double.MAX_VALUE
-                        val seats = seatsText.toIntOrNull() ?: 1
                         val routeId = selectedRouteId ?: return@Button
                         val date = datePickerState.selectedDateMillis ?: 0L
 
@@ -490,9 +455,7 @@ fun RouteModeScreen(
                                 "&startId=" + fromId +
                                 "&endId=" + toId +
                                 "&maxCost=" + cost +
-                                "&date=" + date +
-                                "&seats=" + seats +
-                                "&vehicleType=" + (selectedVehicleType?.name ?: "")
+                                "&date=" + date
                         )
                     },
                     enabled = selectedRouteId != null && startIndex != null && endIndex != null,
@@ -513,7 +476,6 @@ fun RouteModeScreen(
                             val fromId = routePois[fromIdx].id
                             val toId = routePois[toIdx].id
                             val cost = maxCostText.toDoubleOrNull() ?: Double.MAX_VALUE
-                            val seats = seatsText.toIntOrNull() ?: 1
                             val date = datePickerState.selectedDateMillis ?: 0L
                             val routeId = saveEditedRouteAsNewRoute()
 


### PR DESCRIPTION
## Περίληψη
- Καταργήθηκε η αποστολή παραμέτρων τύπου οχήματος και θέσεων στην πλοήγηση προς την οθόνη διαθέσιμων μεταφορών.
- Η οθόνη διαθέσιμων μεταφορών φιλτράρει πλέον τις δηλώσεις βάσει προτιμήσεων χρήστη και διαθεσιμότητας θέσεων.
- Αφαιρέθηκαν τα πεδία επιλογής τύπου οχήματος και θέσεων από την οθόνη αναζήτησης διαδρομής.

## Έλεγχοι
- `./gradlew test` *(απέτυχε: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_68bd0dd416dc8328b1bf66ad7c3a96bc