### PR TITLE
Rename route POI selection menu title

### DIFF
--- a/app/src/main/res/values-el/strings.xml
+++ b/app/src/main/res/values-el/strings.xml
@@ -201,7 +201,7 @@
     <string name="add_poi_option">Προσθήκη POI</string>
     <string name="select_date">Επιλογή ημερομηνίας</string>
     <string name="select_time">Επιλογή ώρας</string>
-    <string name="select_pois_screen_title">Επιλογή POI διαδρομής</string>
+    <string name="select_pois_screen_title">Αποθήκευση ενδιαφερόντων POI</string>
     <string name="choose_pois">Επιλογή σημείων ενδιαφέροντος</string>
     <string name="confirm_poi_selection">Επιβεβαίωση επιλογής</string>
     <string name="route_saved">Η διαδρομή αποθηκεύτηκε</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -213,7 +213,7 @@
     <string name="select_date">Select date</string>
     <string name="select_time">Select time</string>
     <string name="select_vehicle">Select vehicle</string>
-    <string name="select_pois_screen_title">Select Route POIs</string>
+    <string name="select_pois_screen_title">Save interesting POIs</string>
     <string name="choose_pois">Choose points of interest</string>
     <string name="confirm_poi_selection">Confirm selection</string>
     <string name="route_saved">Route saved</string>


### PR DESCRIPTION
## Summary
- rename "Select Route POIs" menu title to "Save interesting POIs" in English and Greek resources

## Testing
- `./gradlew test` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_68bd0f90c1c883288ffee19986bfaa0d