### PR TITLE
Μετονομασία επιλογών προβολής και αποθήκευσης POI

### DIFF
--- a/app/src/main/res/values-el/strings.xml
+++ b/app/src/main/res/values-el/strings.xml
@@ -94,7 +94,7 @@
     <string name="find_way">Εύρεση μέσου μεταφοράς</string>
     <string name="book_seat">Κράτηση θέσης ή αγορά εισιτηρίου</string>
     <string name="view_routes">Αποθήκευση ενδιαφερουσών διαδρομών</string>
-    <string name="view_transports">Προβολή μεταφορών</string>
+    <string name="view_transports">Προβολή ενδιαφερουσών διαδρομών και σημείων ενδιαφέροντος</string>
     <string name="print_ticket">Εκτύπωση κράτησης ή εισιτηρίου</string>
     <string name="cancel_seat">Ακύρωση κράτησης</string>
     <string name="rank_transports">Βαθμολόγηση και σχόλια μεταφορών</string>
@@ -201,7 +201,7 @@
     <string name="add_poi_option">Προσθήκη POI</string>
     <string name="select_date">Επιλογή ημερομηνίας</string>
     <string name="select_time">Επιλογή ώρας</string>
-    <string name="select_pois_screen_title">Αποθήκευση ενδιαφερόντων POI</string>
+    <string name="select_pois_screen_title">Αποθήκευση ενδιαφερόντων σημείων ενδιαφέροντος</string>
     <string name="choose_pois">Επιλογή σημείων ενδιαφέροντος</string>
     <string name="confirm_poi_selection">Επιβεβαίωση επιλογής</string>
     <string name="route_saved">Η διαδρομή αποθηκεύτηκε</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -91,7 +91,7 @@
     <string name="find_way">Find Way of Transport</string>
     <string name="book_seat">Book a Seat or Buy a Ticket</string>
     <string name="view_routes">Save Interesting Routes</string>
-    <string name="view_transports">View Transports</string>
+    <string name="view_transports">View interesting routes and points of interest</string>
     <string name="view_transport_requests">View Transport Requests</string>
     <string name="print_ticket">Print Booked Seat or Ticket</string>
     <string name="cancel_seat">Cancel Booked Seat</string>
@@ -213,7 +213,7 @@
     <string name="select_date">Select date</string>
     <string name="select_time">Select time</string>
     <string name="select_vehicle">Select vehicle</string>
-    <string name="select_pois_screen_title">Save interesting POIs</string>
+    <string name="select_pois_screen_title">Save interesting points of interest</string>
     <string name="choose_pois">Choose points of interest</string>
     <string name="confirm_poi_selection">Confirm selection</string>
     <string name="route_saved">Route saved</string>


### PR DESCRIPTION
## Σύνοψη
- Μετονομασία `view_transports` σε "Προβολή ενδιαφερουσών διαδρομών και σημείων ενδιαφέροντος"
- Μετονομασία `select_pois_screen_title` σε "Αποθήκευση ενδιαφερόντων σημείων ενδιαφέροντος"

## Έλεγχοι
- `./gradlew test` *(αποτυχία: λείπει Android SDK)*

------
https://chatgpt.com/codex/tasks/task_e_68bd122534ac8328a74aa374878a6684