### PR TITLE
Replace POI confirm button with save icon

### DIFF
--- a/app/src/main/java/com/ioannapergamali/mysmartroute/view/ui/screens/SelectRoutePoisScreen.kt
+++ b/app/src/main/java/com/ioannapergamali/mysmartroute/view/ui/screens/SelectRoutePoisScreen.kt
@@ -4,6 +4,8 @@ import android.widget.Toast
 import androidx.compose.foundation.layout.*
 import androidx.compose.foundation.selection.toggleable
 import androidx.compose.material3.*
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.Save
 import androidx.compose.runtime.*
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
@@ -172,7 +174,7 @@ fun SelectRoutePoisScreen(navController: NavController, openDrawer: () -> Unit) 
 
                 Spacer(Modifier.height(16.dp))
 
-                Button(onClick = {
+                IconButton(onClick = {
                     scope.launch {
                         val saved = saveEditedRouteIfChanged()
                         if (saved == true) {
@@ -184,7 +186,10 @@ fun SelectRoutePoisScreen(navController: NavController, openDrawer: () -> Unit) 
                         }
                     }
                 }) {
-                    Text(stringResource(R.string.confirm_poi_selection))
+                    Icon(
+                        imageVector = Icons.Filled.Save,
+                        contentDescription = stringResource(R.string.save)
+                    )
                 }
             }
         }

--- a/app/src/main/res/values-el/strings.xml
+++ b/app/src/main/res/values-el/strings.xml
@@ -203,7 +203,6 @@
     <string name="select_time">Επιλογή ώρας</string>
     <string name="select_pois_screen_title">Αποθήκευση ενδιαφερόντων σημείων ενδιαφέροντος</string>
     <string name="choose_pois">Επιλογή σημείων ενδιαφέροντος</string>
-    <string name="confirm_poi_selection">Επιβεβαίωση επιλογής</string>
     <string name="route_saved">Η διαδρομή αποθηκεύτηκε</string>
     <string name="route_saved_success">Η διαδρομή αποθηκεύτηκε με επιτυχία</string>
     <string name="route_save_failed">Η αποθήκευση διαδρομής απέτυχε</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -215,7 +215,6 @@
     <string name="select_vehicle">Select vehicle</string>
     <string name="select_pois_screen_title">Save interesting points of interest</string>
     <string name="choose_pois">Choose points of interest</string>
-    <string name="confirm_poi_selection">Confirm selection</string>
     <string name="route_saved">Route saved</string>
     <string name="route_save_failed">Unable to save route</string>
     <string name="recalculate_route">Recalculate route</string>


### PR DESCRIPTION
## Summary
- use save icon instead of text confirmation when selecting route POIs
- remove unused `confirm_poi_selection` string resources

## Testing
- `./gradlew test` *(fails: Gradle build did not complete)*

------
https://chatgpt.com/codex/tasks/task_e_68bd14a17ea08328917bbd260c2f6244