### PR TITLE
Διόρθωση αποθήκευσης PoI στο Firestore

### DIFF
--- a/app/src/main/java/com/ioannapergamali/mysmartroute/viewmodel/PoIViewModel.kt
+++ b/app/src/main/java/com/ioannapergamali/mysmartroute/viewmodel/PoIViewModel.kt
@@ -80,12 +80,19 @@ class PoIViewModel : ViewModel() {
                 lat = lat,
                 lng = lng
             )
-            dao.insert(poi)
-            _pois.value = _pois.value + poi
-            db.collection("pois")
-                .document(id)
-                .set(poi.toFirestoreMap())
-            _addState.value = AddPoiState.Success(id)
+            try {
+                db.collection("pois")
+                    .document(id)
+                    .set(poi.toFirestoreMap())
+                    .await()
+                dao.insert(poi)
+                _pois.value = _pois.value + poi
+                _addState.value = AddPoiState.Success(id)
+            } catch (e: Exception) {
+                _addState.value = AddPoiState.Error(
+                    e.localizedMessage ?: "Αποτυχία αποθήκευσης στο Firebase"
+                )
+            }
         }
     }
 


### PR DESCRIPTION
## Περίληψη
- αναμονή της εγγραφής στο Firestore πριν ενημερωθεί η τοπική βάση
- χειρισμός σφαλμάτων κατά την προσθήκη νέων PoI

## Έλεγχοι
- `./gradlew test` *(απέτυχε: λείπει το Android SDK)*

------
https://chatgpt.com/codex/tasks/task_e_68bd234ed0808328a4655711df1bc24d