### PR TITLE
Προσθήκη logging Firestore και συγχρονισμού RoutePoints

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -62,7 +62,7 @@ kotlin {
 }
 dependencies {
     // Firebase (BoM για αυτόματες εκδόσεις όλων των modules)
-    implementation(platform("com.google.firebase:firebase-bom:33.1.2"))
+    implementation(platform("com.google.firebase:firebase-bom:34.2.0"))
     implementation("com.google.firebase:firebase-auth-ktx")
     implementation("com.google.firebase:firebase-firestore-ktx")
     implementation("com.google.firebase:firebase-storage-ktx")


### PR DESCRIPTION
## Σύνοψη
- Αναβάθμιση Firebase BoM στην 34.2.0
- Καταγραφή αποτυχιών αποθήκευσης διαδρομής στο Firestore
- Συνάρτηση συγχρονισμού σημείων διαδρομής από Room στο Firestore

## Έλεγχοι
- `./gradlew test` *(αποτυχία: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_68bd5beee64483288f7438bcf3447465