### PR TITLE
Αφαίρεση περιγραφής επιβάτη από το μενού

### DIFF
--- a/app/src/main/java/com/ioannapergamali/mysmartroute/view/ui/screens/MenuScreen.kt
+++ b/app/src/main/java/com/ioannapergamali/mysmartroute/view/ui/screens/MenuScreen.kt
@@ -116,9 +116,7 @@ private fun RoleMenu(
             style = MaterialTheme.typography.titleLarge
         )
         val descKey = when (role) {
-            UserRole.PASSENGER -> "role_passenger_desc"
             UserRole.DRIVER -> "role_driver_desc"
-            UserRole.ADMIN -> null
             else -> null
         }
         descKey?.let { key ->

--- a/app/src/main/res/values-el/strings.xml
+++ b/app/src/main/res/values-el/strings.xml
@@ -186,7 +186,6 @@
     <string name="route_name">Όνομα διαδρομής</string>
     <string name="stops_header">Στάσεις</string>
     <!-- Περιγραφές ρόλων -->
-    <string name="role_passenger_desc">Μπορείτε να δείτε διαδρομές και να κάνετε κρατήσεις.</string>
     <string name="role_driver_desc">Μπορείτε να δηλώνετε διαθέσιμες μεταφορές και να διαχειρίζεστε οχήματα.</string>
     <string name="role_admin_desc">Έχετε πρόσβαση σε λειτουργίες διαχείρισης και ορισμού σημείων ενδιαφέροντος.</string>
     <string name="poi_outside_heraklion">Επιλέξτε σημείο εντός Ηρακλείου</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -196,7 +196,6 @@
     <string name="legend_unsaved_route">Μη αποθηκευμένη διαδρομή</string>
     <string name="legend_saved_route">Αποθηκευμένη διαδρομή</string>
     <!-- Role descriptions -->
-    <string name="role_passenger_desc">You can view routes and make bookings.</string>
     <string name="role_driver_desc">You can announce transports and manage vehicles.</string>
     <string name="role_admin_desc">You have access to management functions and defining points of interest.</string>
     <string name="poi_outside_heraklion">Please select a point within Heraklion</string>


### PR DESCRIPTION
## Περίληψη
- Μη εμφάνιση περιγραφής για τον ρόλο επιβάτη στο MenuScreen
- Διαγραφή του κειμένου `role_passenger_desc` από τα resources

## Δοκιμές
- `./gradlew test` *(απέτυχε: το Gradle έμεινε στο στάδιο εκκίνησης του Daemon)*

------
https://chatgpt.com/codex/tasks/task_e_68bd60b3f1448328b9078ab4ebb9fa25