### PR TITLE
feat: store interesting routes locally

### DIFF
--- a/app/src/main/java/com/ioannapergamali/mysmartroute/data/local/FavoriteRouteDao.kt
+++ b/app/src/main/java/com/ioannapergamali/mysmartroute/data/local/FavoriteRouteDao.kt
@@ -1,0 +1,23 @@
+package com.ioannapergamali.mysmartroute.data.local
+
+import androidx.room.Dao
+import androidx.room.Insert
+import androidx.room.OnConflictStrategy
+import androidx.room.Query
+import kotlinx.coroutines.flow.Flow
+
+/** DAO για πρόσβαση στις αγαπημένες διαδρομές. */
+@Dao
+interface FavoriteRouteDao {
+    @Insert(onConflict = OnConflictStrategy.REPLACE)
+    suspend fun insert(favorite: FavoriteRouteEntity)
+
+    @Query("DELETE FROM favorite_routes WHERE userId = :userId")
+    suspend fun deleteAllForUser(userId: String)
+
+    @Query("SELECT routeId FROM favorite_routes WHERE userId = :userId")
+    fun getFavoritesForUser(userId: String): Flow<List<String>>
+
+    @Query("SELECT * FROM favorite_routes")
+    fun getAll(): Flow<List<FavoriteRouteEntity>>
+}

--- a/app/src/main/java/com/ioannapergamali/mysmartroute/data/local/FavoriteRouteEntity.kt
+++ b/app/src/main/java/com/ioannapergamali/mysmartroute/data/local/FavoriteRouteEntity.kt
@@ -1,0 +1,33 @@
+package com.ioannapergamali.mysmartroute.data.local
+
+import androidx.room.Entity
+import androidx.room.ForeignKey
+import androidx.room.Index
+
+/**
+ * Οντότητα Room που συνδέει έναν χρήστη με μια διαδρομή που τον ενδιαφέρει.
+ * Room entity linking a user to a route of interest.
+ */
+@Entity(
+    tableName = "favorite_routes",
+    primaryKeys = ["userId", "routeId"],
+    foreignKeys = [
+        ForeignKey(
+            entity = UserEntity::class,
+            parentColumns = ["id"],
+            childColumns = ["userId"],
+            onDelete = ForeignKey.CASCADE
+        ),
+        ForeignKey(
+            entity = RouteEntity::class,
+            parentColumns = ["id"],
+            childColumns = ["routeId"],
+            onDelete = ForeignKey.CASCADE
+        )
+    ],
+    indices = [Index("userId"), Index("routeId")]
+)
+data class FavoriteRouteEntity(
+    val userId: String,
+    val routeId: String
+)

--- a/app/src/main/java/com/ioannapergamali/mysmartroute/view/ui/screens/InterestingRoutesScreen.kt
+++ b/app/src/main/java/com/ioannapergamali/mysmartroute/view/ui/screens/InterestingRoutesScreen.kt
@@ -53,7 +53,7 @@ fun InterestingRoutesScreen(navController: NavController, openDrawer: () -> Unit
 
     LaunchedEffect(Unit) {
         routeViewModel.loadRoutes(context, includeAll = true)
-        favViewModel.loadFavorites()
+        favViewModel.loadFavorites(context)
     }
 
     Scaffold(
@@ -70,7 +70,7 @@ fun InterestingRoutesScreen(navController: NavController, openDrawer: () -> Unit
             if (routes.isNotEmpty()) {
                 FloatingActionButton(
                     onClick = {
-                        favViewModel.saveFavorites { success ->
+                        favViewModel.saveFavorites(context) { success ->
                             val msg = if (success) {
                                 R.string.favorite_routes_saved
                             } else {
@@ -122,7 +122,7 @@ fun InterestingRoutesScreen(navController: NavController, openDrawer: () -> Unit
 
             Button(
                 onClick = {
-                    favViewModel.saveFavorites { success ->
+                    favViewModel.saveFavorites(context) { success ->
                         val msg = if (success) {
                             R.string.favorite_routes_saved
                         } else {

--- a/app/src/main/java/com/ioannapergamali/mysmartroute/view/ui/screens/ViewRoutesScreen.kt
+++ b/app/src/main/java/com/ioannapergamali/mysmartroute/view/ui/screens/ViewRoutesScreen.kt
@@ -55,7 +55,7 @@ fun ViewRoutesScreen(navController: NavController, openDrawer: () -> Unit) {
     LaunchedEffect(Unit) {
         MapsInitializer.initialize(context)
         routeViewModel.loadRoutes(context, includeAll = true)
-        favViewModel.loadFavorites()
+        favViewModel.loadFavorites(context)
     }
 
     Scaffold(
@@ -75,7 +75,7 @@ fun ViewRoutesScreen(navController: NavController, openDrawer: () -> Unit) {
                             if (!favorites.contains(route.id)) {
                                 favViewModel.toggleFavorite(route.id)
                             }
-                            favViewModel.saveFavorites { success ->
+                            favViewModel.saveFavorites(context) { success ->
                                 val msg = if (success) {
                                     R.string.favorite_routes_saved
                                 } else {

--- a/app/src/main/java/com/ioannapergamali/mysmartroute/viewmodel/DatabaseViewModel.kt
+++ b/app/src/main/java/com/ioannapergamali/mysmartroute/viewmodel/DatabaseViewModel.kt
@@ -28,6 +28,7 @@ import com.ioannapergamali.mysmartroute.data.local.LanguageSettingEntity
 import com.ioannapergamali.mysmartroute.data.local.FavoriteEntity
 import com.ioannapergamali.mysmartroute.data.local.insertFavoriteSafely
 import com.ioannapergamali.mysmartroute.utils.toFavoriteEntity
+import com.ioannapergamali.mysmartroute.data.local.FavoriteRouteEntity
 import com.ioannapergamali.mysmartroute.data.local.UserPoiEntity
 import com.ioannapergamali.mysmartroute.data.local.insertUserPoiSafely
 import com.ioannapergamali.mysmartroute.utils.toUserPoiEntity
@@ -116,6 +117,7 @@ class DatabaseViewModel : ViewModel() {
                 db.transportDeclarationDao().getAll(),
                 db.availabilityDao().getAll(),
                 db.favoriteDao().getAll(),
+                db.favoriteRouteDao().getAll(),
                 db.userPoiDao().getAll()
             ) { values ->
                 val users = values[0] as List<UserEntity>
@@ -133,7 +135,8 @@ class DatabaseViewModel : ViewModel() {
                 val declarations = values[12] as List<TransportDeclarationEntity>
                 val availabilities = values[13] as List<AvailabilityEntity>
                 val favorites = values[14] as List<FavoriteEntity>
-                val userPois = values[15] as List<UserPoiEntity>
+                val favoriteRoutes = values[15] as List<FavoriteRouteEntity>
+                val userPois = values[16] as List<UserPoiEntity>
 
                 DatabaseData(
                     users,
@@ -151,6 +154,7 @@ class DatabaseViewModel : ViewModel() {
                     declarations,
                     availabilities,
                     favorites,
+                    favoriteRoutes,
                     userPois
                 )
             }.collect { data ->
@@ -160,7 +164,8 @@ class DatabaseViewModel : ViewModel() {
                     "pois:${data.pois.size} poiTypes:${data.poiTypes.size} settings:${data.settings.size} roles:${data.roles.size} " +
                     "menus:${data.menus.size} options:${data.menuOptions.size} routes:${data.routes.size} " +
                     "points:${data.routePoints.size} movings:${data.movings.size} declarations:${data.declarations.size}" +
-                    " availabilities:${data.availabilities.size} favorites:${data.favorites.size} userPois:${data.userPois.size}"
+                    " availabilities:${data.availabilities.size} favorites:${data.favorites.size} favRoutes:${data.favoriteRoutes.size} " +
+                    "userPois:${data.userPois.size}"
                 )
                 _localData.value = data
             }
@@ -603,6 +608,7 @@ data class DatabaseData(
     val declarations: List<TransportDeclarationEntity>,
     val availabilities: List<AvailabilityEntity>,
     val favorites: List<FavoriteEntity>,
+    val favoriteRoutes: List<FavoriteRouteEntity>,
     val userPois: List<UserPoiEntity>
 )
 


### PR DESCRIPTION
## Summary
- add Room entity/DAO to persist passenger favorite routes
- sync favorites between Firestore and local DB via ViewModel
- bump database schema to v62 with migration and expose favorites in DatabaseViewModel

## Testing
- `./gradlew test` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_68bd5feefbfc8328a3e0c25afb79d191