### PR TITLE
Προσθήκη εικονιδίου στο κουμπί αποθήκευσης διαδρομής

### DIFF
--- a/app/src/main/java/com/ioannapergamali/mysmartroute/view/ui/screens/DeclareRouteScreen.kt
+++ b/app/src/main/java/com/ioannapergamali/mysmartroute/view/ui/screens/DeclareRouteScreen.kt
@@ -601,6 +601,8 @@ fun DeclareRouteScreen(navController: NavController, openDrawer: () -> Unit) {
                 },
                 enabled = routePois.size >= 2 && routeName.isNotBlank()
             ) {
+                Icon(Icons.Default.Save, contentDescription = null)
+                Spacer(Modifier.width(8.dp))
                 Text(stringResource(R.string.save_route))
             }
 


### PR DESCRIPTION
## Περίληψη
- Προσθήκη εικονιδίου Save στο κουμπί "Αποθήκευση" της οθόνης δήλωσης διαδρομής

## Έλεγχοι
- `./gradlew test` *(απέτυχε: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_68bd6195c29c8328a88bf65e3621ffee