### PR TITLE
Αφαίρεση constraints από FavoriteRouteEntity

### DIFF
--- a/app/src/main/java/com/ioannapergamali/mysmartroute/data/local/FavoriteRouteEntity.kt
+++ b/app/src/main/java/com/ioannapergamali/mysmartroute/data/local/FavoriteRouteEntity.kt
@@ -1,7 +1,6 @@
 package com.ioannapergamali.mysmartroute.data.local
 
 import androidx.room.Entity
-import androidx.room.ForeignKey
 import androidx.room.Index
 
 /**
@@ -11,20 +10,6 @@ import androidx.room.Index
 @Entity(
     tableName = "favorite_routes",
     primaryKeys = ["userId", "routeId"],
-    foreignKeys = [
-        ForeignKey(
-            entity = UserEntity::class,
-            parentColumns = ["id"],
-            childColumns = ["userId"],
-            onDelete = ForeignKey.CASCADE
-        ),
-        ForeignKey(
-            entity = RouteEntity::class,
-            parentColumns = ["id"],
-            childColumns = ["routeId"],
-            onDelete = ForeignKey.CASCADE
-        )
-    ],
     indices = [Index("userId"), Index("routeId")]
 )
 data class FavoriteRouteEntity(

--- a/app/src/main/java/com/ioannapergamali/mysmartroute/data/local/MySmartRouteDatabase.kt
+++ b/app/src/main/java/com/ioannapergamali/mysmartroute/data/local/MySmartRouteDatabase.kt
@@ -65,7 +65,7 @@ import com.ioannapergamali.mysmartroute.data.local.TripRatingDao
         NotificationEntity::class,
         UserPoiEntity::class
     ],
-    version = 62
+    version = 63
 )
 @TypeConverters(Converters::class)
 abstract class MySmartRouteDatabase : RoomDatabase() {


### PR DESCRIPTION
## Περίληψη
- Κατάργηση των συσχετίσεων ξένων κλειδιών από την οντότητα `FavoriteRouteEntity` για αποφυγή σφαλμάτων εισαγωγής.
- Ενημέρωση της έκδοσης της βάσης δεδομένων Room ώστε να εφαρμοστεί το νέο σχήμα.

## Δοκιμές
- `./gradlew test` *(απέτυχε: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_68bd6504b9a08328aa5f4701e5ed95f9