### PR TITLE
Αφαίρεση περιγραφής από το μενού οδηγού

### DIFF
--- a/app/src/main/java/com/ioannapergamali/mysmartroute/view/ui/screens/MenuScreen.kt
+++ b/app/src/main/java/com/ioannapergamali/mysmartroute/view/ui/screens/MenuScreen.kt
@@ -116,11 +116,7 @@ private fun RoleMenu(
             style = MaterialTheme.typography.titleLarge
         )
         val descKey = when (role) {
-
             UserRole.PASSENGER -> "role_passenger_desc"
-            UserRole.DRIVER -> null
-            UserRole.ADMIN -> null
-
             else -> null
         }
         descKey?.let { key ->


### PR DESCRIPTION
## Περίληψη
- Καταργήθηκε η περιγραφή στο μενού του ρόλου οδηγού ώστε να μην εμφανίζεται περιττό κείμενο.

## Δοκιμές
- `./gradlew test` *(αποτυχία: λείπει το Android SDK στο περιβάλλον)*

------
https://chatgpt.com/codex/tasks/task_e_68bd654472288328a336e69fce1c988b