### PR TITLE
Αφαίρεση περιγραφής επιβάτη από το μενού

### DIFF
--- a/app/src/main/java/com/ioannapergamali/mysmartroute/view/ui/screens/MenuScreen.kt
+++ b/app/src/main/java/com/ioannapergamali/mysmartroute/view/ui/screens/MenuScreen.kt
@@ -115,21 +115,6 @@ private fun RoleMenu(
             text = stringResource(R.string.menu_role_prefix, role?.localizedName() ?: ""),
             style = MaterialTheme.typography.titleLarge
         )
-        val descKey = when (role) {
-
-            UserRole.PASSENGER -> "role_passenger_desc"
-            UserRole.DRIVER -> null
-            UserRole.ADMIN -> null
-
-            else -> null
-        }
-        descKey?.let { key ->
-            Spacer(Modifier.height(4.dp))
-            Text(
-                text = resolveString(key),
-                style = MaterialTheme.typography.bodyMedium
-            )
-        }
         Spacer(Modifier.height(8.dp))
         Card(
             modifier = Modifier.fillMaxWidth(),

--- a/app/src/main/res/values-el/strings.xml
+++ b/app/src/main/res/values-el/strings.xml
@@ -185,11 +185,6 @@
     <string name="save_route">Αποθήκευση διαδρομής</string>
     <string name="route_name">Όνομα διαδρομής</string>
     <string name="stops_header">Στάσεις</string>
-    <!-- Περιγραφές ρόλων -->
-
-    <string name="role_passenger_desc">Μπορείτε να δείτε διαδρομές και να κάνετε κρατήσεις.</string>
-
-    <string name="role_admin_desc">Έχετε πρόσβαση σε λειτουργίες διαχείρισης και ορισμού σημείων ενδιαφέροντος.</string>
     <string name="poi_outside_heraklion">Επιλέξτε σημείο εντός Ηρακλείου</string>
     <string name="search_address">Αναζήτηση διεύθυνσης</string>
     <string name="fill_all_fields">Συμπλήρωσε όλα τα πεδία</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -195,11 +195,6 @@
     <string name="legend_route_point">Σημεία διαδρομής</string>
     <string name="legend_unsaved_route">Μη αποθηκευμένη διαδρομή</string>
     <string name="legend_saved_route">Αποθηκευμένη διαδρομή</string>
-    <!-- Role descriptions -->
-
-    <string name="role_passenger_desc">You can view routes and make bookings.</string>
-
-    <string name="role_admin_desc">You have access to management functions and defining points of interest.</string>
     <string name="poi_outside_heraklion">Please select a point within Heraklion</string>
     <string name="search_address">Search address</string>
     <string name="fill_all_fields">Please fill in all fields</string>


### PR DESCRIPTION
## Περίληψη
- Καταργήθηκε η περιγραφή για τον ρόλο επιβάτη στο μενού
- Διαγράφηκαν οι σχετικές εγγραφές από τους πόρους strings

## Δοκιμές
- `./gradlew test` (απέτυχε: η διαδικασία δεν ολοκληρώθηκε στο δοσμένο περιβάλλον)


------
https://chatgpt.com/codex/tasks/task_e_68bd65353ea083288f0ad2aa97021ea7