### PR TITLE
Remove passenger role description from menu

### DIFF
--- a/app/src/main/java/com/ioannapergamali/mysmartroute/view/ui/screens/MenuScreen.kt
+++ b/app/src/main/java/com/ioannapergamali/mysmartroute/view/ui/screens/MenuScreen.kt
@@ -116,18 +116,6 @@ private fun RoleMenu(
             style = MaterialTheme.typography.titleLarge
         )
 
-        val descKey = when (role) {
-            UserRole.PASSENGER -> "role_passenger_desc"
-            else -> null
-        }
-        descKey?.let { key ->
-            Spacer(Modifier.height(4.dp))
-            Text(
-                text = resolveString(key),
-                style = MaterialTheme.typography.bodyMedium
-            )
-        }
-
         Spacer(Modifier.height(8.dp))
         Card(
             modifier = Modifier.fillMaxWidth(),


### PR DESCRIPTION
## Summary
- remove passenger role description key from menu screen

## Testing
- `./gradlew test` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_68bd719873ac8328b67d2a6d7eccdabb