### PR TITLE
Προσθήκη repository για αγαπημένα POI

### DIFF
--- a/app/src/main/java/com/ioannapergamali/mysmartroute/repository/FavoritesRepository.kt
+++ b/app/src/main/java/com/ioannapergamali/mysmartroute/repository/FavoritesRepository.kt
@@ -1,0 +1,27 @@
+package com.ioannapergamali.mysmartroute.repository
+
+import com.google.firebase.firestore.ktx.firestore
+import com.google.firebase.ktx.Firebase
+import com.ioannapergamali.mysmartroute.data.local.PoIEntity
+import kotlinx.coroutines.tasks.await
+
+/**
+ * Repository για αποθήκευση αγαπημένων σημείων ενδιαφέροντος στο Firestore.
+ * Repository for storing favorite points of interest in Firestore.
+ */
+class FavoritesRepository {
+    private val favoritesRef = Firebase.firestore
+        .collection("Favorites")
+        .document("data")
+        .collection("pois")
+
+    /**
+     * Αποθηκεύει ή ενημερώνει ένα αγαπημένο POI με αναφορά στο έγγραφο του.
+     * Saves or updates a favorite POI referencing its document.
+     */
+    suspend fun saveFavorite(poi: PoIEntity) {
+        val poiRef = Firebase.firestore.collection("pois").document(poi.id)
+        favoritesRef.document(poi.id).set(mapOf("poiRef" to poiRef)).await()
+    }
+}
+


### PR DESCRIPTION
## Περιγραφή
- Προσθήκη `FavoritesRepository` για αποθήκευση αγαπημένων σημείων ενδιαφέροντος στο Firestore

## Έλεγχοι
- `./gradlew test` *(αποτυχία: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_68bd71f872f08328b8f909c7a0048fdb