### PR TITLE
Σύνδεση FavoritesRepository με FavoritePoisViewModel

### DIFF
--- a/app/src/main/java/com/ioannapergamali/mysmartroute/viewmodel/FavoritePoisViewModel.kt
+++ b/app/src/main/java/com/ioannapergamali/mysmartroute/viewmodel/FavoritePoisViewModel.kt
@@ -1,10 +1,8 @@
 package com.ioannapergamali.mysmartroute.viewmodel
 
 import androidx.lifecycle.ViewModel
-import com.google.firebase.auth.FirebaseAuth
 import com.google.firebase.firestore.DocumentReference
-import com.google.firebase.firestore.FirebaseFirestore
-import kotlinx.coroutines.tasks.await
+import com.ioannapergamali.mysmartroute.repository.FavoritesRepository
 
 /**
  * ViewModel για τη διαχείριση αγαπημένων σημείων ενδιαφέροντος (POIs).
@@ -12,45 +10,23 @@ import kotlinx.coroutines.tasks.await
  * `users/{uid}/Favorites/data/pois/{poiId}` ως αναφορά
  * στο πραγματικό έγγραφο του POI.
  */
-class FavoritePoisViewModel : ViewModel() {
-    private val firestore = FirebaseFirestore.getInstance()
-
-    private fun userId() = FirebaseAuth.getInstance().currentUser?.uid ?: ""
-
-    private fun userPois(uid: String) = firestore
-        .collection("users")
-        .document(uid)
-        .collection("Favorites")
-        .document("data")
-        .collection("pois")
+class FavoritePoisViewModel(
+    private val repository: FavoritesRepository = FavoritesRepository()
+) : ViewModel() {
 
     /**
      * Προσθέτει ένα POI στα αγαπημένα του χρήστη.
      */
-    suspend fun addFavoritePoi(poiId: String) {
-        val uid = userId()
-        if (uid.isBlank()) return
-        val poiRef = firestore.collection("pois").document(poiId)
-        userPois(uid).document(poiId).set(mapOf("poiRef" to poiRef)).await()
-    }
+    suspend fun addFavoritePoi(poiId: String) = repository.saveFavorite(poiId)
 
     /**
      * Αφαιρεί ένα POI από τα αγαπημένα του χρήστη.
      */
-    suspend fun removeFavoritePoi(poiId: String) {
-        val uid = userId()
-        if (uid.isBlank()) return
-        userPois(uid).document(poiId).delete().await()
-    }
+    suspend fun removeFavoritePoi(poiId: String) = repository.removeFavorite(poiId)
 
     /**
      * Επιστρέφει όλες τις αναφορές στα αγαπημένα POIs του χρήστη.
      */
-    suspend fun getFavoritePois(): List<DocumentReference> {
-        val uid = userId()
-        if (uid.isBlank()) return emptyList()
-        val snap = userPois(uid).get().await()
-        return snap.documents.mapNotNull { it.getDocumentReference("poiRef") }
-    }
+    suspend fun getFavoritePois(): List<DocumentReference> = repository.getFavoriteRefs()
 }
 


### PR DESCRIPTION
## Summary
- Προσθήκη μεθόδων αποθήκευσης, διαγραφής και ανάκτησης στο FavoritesRepository
- Αναμόρφωση FavoritePoisViewModel ώστε να χρησιμοποιεί το FavoritesRepository

## Testing
- `./gradlew test --console=plain` *(αποτυχία: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_68bd7f04ebcc8328bd27fd21284f94f2