### PR TITLE
Εμφάνιση διαθέσιμων θέσεων στη λίστα μεταφορών

### DIFF
--- a/app/src/main/java/com/ioannapergamali/mysmartroute/view/ui/screens/AvailableTransportsScreen.kt
+++ b/app/src/main/java/com/ioannapergamali/mysmartroute/view/ui/screens/AvailableTransportsScreen.kt
@@ -49,6 +49,7 @@ private fun HeaderRow() {
         Text(stringResource(R.string.cost), modifier = Modifier.weight(1f))
         Text(stringResource(R.string.date), modifier = Modifier.weight(1f))
         Text(stringResource(R.string.time), modifier = Modifier.weight(1f))
+        Text(stringResource(R.string.seats_label), modifier = Modifier.weight(1f))
     }
     Divider()
 }
@@ -179,6 +180,7 @@ fun AvailableTransportsScreen(
                                 Text(decl.cost.toString(), modifier = Modifier.weight(1f))
                                 Text(dateText, modifier = Modifier.weight(1f))
                                 Text(timeText, modifier = Modifier.weight(1f))
+                                Text(availableSeats.toString(), modifier = Modifier.weight(1f))
                             }
                             Spacer(Modifier.height(4.dp))
                             Button(


### PR DESCRIPTION
## Περίληψη
- Προστέθηκε στήλη θέσεων στη κεφαλίδα της οθόνης διαθέσιμων μεταφορών.
- Εμφάνιση αριθμού διαθέσιμων θέσεων για κάθε μεταφορά στην αντίστοιχη γραμμή.

## Δοκιμές
- `./gradlew test` *(απέτυχε: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_68bd80ebe0f08328af2fd838a465443d