### PR TITLE
Σύνδεση FavoritesRepository με FavoritePoisViewModel

### DIFF
--- a/app/src/main/java/com/ioannapergamali/mysmartroute/repository/FavoritesRepository.kt
+++ b/app/src/main/java/com/ioannapergamali/mysmartroute/repository/FavoritesRepository.kt
@@ -2,7 +2,7 @@ package com.ioannapergamali.mysmartroute.repository
 
 
 import com.google.firebase.auth.FirebaseAuth
-
+import com.google.firebase.firestore.DocumentReference
 import com.google.firebase.firestore.ktx.firestore
 import com.google.firebase.ktx.Firebase
 import com.ioannapergamali.mysmartroute.data.local.PoIEntity
@@ -26,14 +26,47 @@ class FavoritesRepository {
         .collection("pois")
 
     /**
-     * Αποθηκεύει ή ενημερώνει ένα αγαπημένο POI με αναφορά στο έγγραφο του.
+     * Αποθηκεύει ή ενημερώνει ένα αγαπημένο POI.
      */
-    suspend fun saveFavorite(poi: PoIEntity) {
+    suspend fun saveFavorite(poiId: String) {
         val uid = userId()
         if (uid.isBlank()) return
-        val poiRef = firestore.collection("pois").document(poi.id)
-        userFavorites(uid).document(poi.id).set(mapOf("poiRef" to poiRef)).await()
+        val poiRef = firestore.collection("pois").document(poiId)
+        userFavorites(uid).document(poiId).set(mapOf("poiRef" to poiRef)).await()
+    }
 
+    /**
+     * Overload που δέχεται οντότητα POI.
+     */
+    suspend fun saveFavorite(poi: PoIEntity) = saveFavorite(poi.id)
+
+    /**
+     * Αφαιρεί ένα POI από τα αγαπημένα.
+     */
+    suspend fun removeFavorite(poiId: String) {
+        val uid = userId()
+        if (uid.isBlank()) return
+        userFavorites(uid).document(poiId).delete().await()
+    }
+
+    /**
+     * Επιστρέφει τις αναφορές όλων των αγαπημένων POIs.
+     */
+    suspend fun getFavoriteRefs(): List<DocumentReference> {
+        val uid = userId()
+        if (uid.isBlank()) return emptyList()
+        val snap = userFavorites(uid).get().await()
+        return snap.documents.mapNotNull { it.getDocumentReference("poiRef") }
+    }
+
+    /**
+     * Φορτώνει τα πλήρη στοιχεία των αγαπημένων POIs.
+     */
+    suspend fun getFavoritePois(): List<PoIEntity> {
+        val refs = getFavoriteRefs()
+        return refs.mapNotNull { ref ->
+            ref.get().await().toObject(PoIEntity::class.java)
+        }
     }
 }
 

--- a/app/src/main/java/com/ioannapergamali/mysmartroute/viewmodel/FavoritePoisViewModel.kt
+++ b/app/src/main/java/com/ioannapergamali/mysmartroute/viewmodel/FavoritePoisViewModel.kt
@@ -1,10 +1,9 @@
 package com.ioannapergamali.mysmartroute.viewmodel
 
 import androidx.lifecycle.ViewModel
-import com.google.firebase.auth.FirebaseAuth
 import com.google.firebase.firestore.DocumentReference
-import com.google.firebase.firestore.FirebaseFirestore
-import kotlinx.coroutines.tasks.await
+import com.ioannapergamali.mysmartroute.data.local.PoIEntity
+import com.ioannapergamali.mysmartroute.repository.FavoritesRepository
 
 /**
  * ViewModel για τη διαχείριση αγαπημένων σημείων ενδιαφέροντος (POIs).
@@ -12,45 +11,28 @@ import kotlinx.coroutines.tasks.await
  * `users/{uid}/Favorites/data/pois/{poiId}` ως αναφορά
  * στο πραγματικό έγγραφο του POI.
  */
-class FavoritePoisViewModel : ViewModel() {
-    private val firestore = FirebaseFirestore.getInstance()
-
-    private fun userId() = FirebaseAuth.getInstance().currentUser?.uid ?: ""
-
-    private fun userPois(uid: String) = firestore
-        .collection("users")
-        .document(uid)
-        .collection("Favorites")
-        .document("data")
-        .collection("pois")
+class FavoritePoisViewModel(
+    private val repository: FavoritesRepository = FavoritesRepository()
+) : ViewModel() {
 
     /**
      * Προσθέτει ένα POI στα αγαπημένα του χρήστη.
      */
-    suspend fun addFavoritePoi(poiId: String) {
-        val uid = userId()
-        if (uid.isBlank()) return
-        val poiRef = firestore.collection("pois").document(poiId)
-        userPois(uid).document(poiId).set(mapOf("poiRef" to poiRef)).await()
-    }
+    suspend fun addFavoritePoi(poiId: String) = repository.saveFavorite(poiId)
 
     /**
      * Αφαιρεί ένα POI από τα αγαπημένα του χρήστη.
      */
-    suspend fun removeFavoritePoi(poiId: String) {
-        val uid = userId()
-        if (uid.isBlank()) return
-        userPois(uid).document(poiId).delete().await()
-    }
+    suspend fun removeFavoritePoi(poiId: String) = repository.removeFavorite(poiId)
 
     /**
-     * Επιστρέφει όλες τις αναφορές στα αγαπημένα POIs του χρήστη.
+     * Επιστρέφει τις οντότητες των αγαπημένων POIs του χρήστη.
      */
-    suspend fun getFavoritePois(): List<DocumentReference> {
-        val uid = userId()
-        if (uid.isBlank()) return emptyList()
-        val snap = userPois(uid).get().await()
-        return snap.documents.mapNotNull { it.getDocumentReference("poiRef") }
-    }
+    suspend fun getFavoritePois(): List<PoIEntity> = repository.getFavoritePois()
+
+    /**
+     * Επιστρέφει τις αναφορές των αγαπημένων POIs του χρήστη.
+     */
+    suspend fun getFavoritePoiRefs(): List<DocumentReference> = repository.getFavoriteRefs()
 }
 


### PR DESCRIPTION
## Summary
- Προστέθηκε μέθοδος φόρτωσης αγαπημένων POI στο FavoritesRepository
- Το FavoritePoisViewModel επιστρέφει πλέον οντότητες και αναφορές αγαπημένων POI μέσω του FavoritesRepository

## Testing
- `./gradlew test --console=plain` *(αποτυχία: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_68bd7f04ebcc8328bd27fd21284f94f2