### PR TITLE
Store favorite POIs locally

### DIFF
--- a/app/src/main/java/com/ioannapergamali/mysmartroute/viewmodel/FavoritePoisViewModel.kt
+++ b/app/src/main/java/com/ioannapergamali/mysmartroute/viewmodel/FavoritePoisViewModel.kt
@@ -1,17 +1,15 @@
 package com.ioannapergamali.mysmartroute.viewmodel
 
 import androidx.lifecycle.ViewModel
-import com.google.firebase.firestore.DocumentReference
+import kotlinx.coroutines.flow.Flow
 import com.ioannapergamali.mysmartroute.repository.FavoritesRepository
 
 /**
  * ViewModel για τη διαχείριση αγαπημένων σημείων ενδιαφέροντος (POIs).
- * Τα αγαπημένα αποθηκεύονται στη διαδρομή
- * `users/{uid}/Favorites/data/pois/{poiId}` ως αναφορά
- * στο πραγματικό έγγραφο του POI.
+ * Τα αγαπημένα αποθηκεύονται τοπικά στη βάση Room μέσα από το `FavoritesRepository`.
  */
 class FavoritePoisViewModel(
-    private val repository: FavoritesRepository = FavoritesRepository()
+    private val repository: FavoritesRepository
 ) : ViewModel() {
 
     /**
@@ -27,6 +25,6 @@ class FavoritePoisViewModel(
     /**
      * Επιστρέφει όλες τις αναφορές στα αγαπημένα POIs του χρήστη.
      */
-    suspend fun getFavoritePois(): List<DocumentReference> = repository.getFavoriteRefs()
+    fun getFavoritePoiIds(): Flow<List<String>> = repository.getFavoriteIds()
 }
 


### PR DESCRIPTION
## Summary
- Replace Firestore-based FavoritesRepository with Room implementation
- Update FavoritePoisViewModel to expose local favorite IDs

## Testing
- `./gradlew test` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_68bd980c72248328a7edd36f474c8bdf