### PR TITLE
Αποθήκευση επιλεγμένων POI διαδρομής

### DIFF
--- a/app/src/main/java/com/ioannapergamali/mysmartroute/viewmodel/FavoriteRoutePoisViewModel.kt
+++ b/app/src/main/java/com/ioannapergamali/mysmartroute/viewmodel/FavoriteRoutePoisViewModel.kt
@@ -1,0 +1,71 @@
+package com.ioannapergamali.mysmartroute.viewmodel
+
+import android.content.Context
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.viewModelScope
+import com.google.firebase.auth.FirebaseAuth
+import com.google.firebase.firestore.FirebaseFirestore
+import com.ioannapergamali.mysmartroute.data.local.MySmartRouteDatabase
+import com.ioannapergamali.mysmartroute.data.local.UserPoiEntity
+import com.ioannapergamali.mysmartroute.data.local.insertUserPoiSafely
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.tasks.await
+
+/**
+ * ViewModel για την αποθήκευση των επιλεγμένων POI μιας διαδρομής
+ * τόσο τοπικά όσο και στο Firebase.
+ */
+class FavoriteRoutePoisViewModel : ViewModel() {
+    private val firestore = FirebaseFirestore.getInstance()
+
+    private fun userId(): String = FirebaseAuth.getInstance().currentUser?.uid ?: ""
+
+    private fun userDoc(uid: String) = firestore.collection("users").document(uid)
+
+    /**
+     * Αποθηκεύει τα επιλεγμένα σημεία μιας διαδρομής.
+     * Τα δεδομένα αποθηκεύονται στο `users/{uid}/favorites/data/pois/{routeId_poiId}`
+     * με πεδία `routeRef` και `poiRef`.
+     */
+    fun saveFavorites(
+        context: Context,
+        routeId: String,
+        poiIds: List<String>,
+        onComplete: (Boolean) -> Unit = {}
+    ) {
+        val uid = userId()
+        if (uid.isBlank()) {
+            onComplete(false)
+            return
+        }
+        viewModelScope.launch {
+            val routeRef = firestore.collection("routes").document(routeId)
+            val col = userDoc(uid).collection("favorites").document("data").collection("pois")
+
+            val batch = firestore.batch()
+            val existing = col.whereEqualTo("routeRef", routeRef).get().await()
+            existing.documents.forEach { batch.delete(it.reference) }
+            poiIds.forEach { poiId ->
+                val poiRef = firestore.collection("pois").document(poiId)
+                val docId = "${routeId}_$poiId"
+                batch.set(col.document(docId), mapOf("routeRef" to routeRef, "poiRef" to poiRef))
+            }
+            val remoteResult = runCatching { batch.commit().await() }.isSuccess
+
+            val db = MySmartRouteDatabase.getInstance(context)
+            val dao = db.userPoiDao()
+            val userDao = db.userDao()
+            val poiDao = db.poIDao()
+            poiIds.forEach { poiId ->
+                val entity = UserPoiEntity(
+                    id = "$uid-$poiId",
+                    userId = uid,
+                    poiId = poiId
+                )
+                insertUserPoiSafely(dao, userDao, poiDao, entity)
+            }
+            onComplete(remoteResult)
+        }
+    }
+}
+

--- a/app/src/main/res/values-el/strings.xml
+++ b/app/src/main/res/values-el/strings.xml
@@ -268,6 +268,8 @@
     <string name="walking_duration_result">Διάρκεια: %1$s</string>
     <string name="favorite_routes_saved">Οι διαδρομές αποθηκεύτηκαν</string>
     <string name="favorite_routes_save_failed">Αποτυχία αποθήκευσης διαδρομών</string>
+    <string name="favorite_pois_saved">Τα σημεία αποθηκεύτηκαν</string>
+    <string name="favorite_pois_save_failed">Αποτυχία αποθήκευσης σημείων</string>
     <string name="declare_success">Η δήλωση στάλθηκε επιτυχώς</string>
     <string name="declare_failure">Αποτυχία αποστολής δήλωσης</string>
 

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -294,6 +294,8 @@
     <string name="no_reservation_found">No reservation found</string>
     <string name="favorite_routes_saved">Routes saved</string>
     <string name="favorite_routes_save_failed">Unable to save routes</string>
+    <string name="favorite_pois_saved">Points saved</string>
+    <string name="favorite_pois_save_failed">Unable to save points</string>
     <string name="declare_success">Transport declared successfully</string>
     <string name="declare_failure">Failed to declare transport</string>
 </resources>


### PR DESCRIPTION
## Περίληψη
- Προστέθηκε `FavoriteRoutePoisViewModel` για ταυτόχρονη αποθήκευση επιλεγμένων POI σε Firebase και τοπικά.
- Ενημερώθηκε η `SelectRoutePoisScreen` ώστε το κουμπί αποθήκευσης να χρησιμοποιεί το νέο ViewModel και να αποθηκεύει τα επιλεγμένα σημεία.
- Προστέθηκαν νέα μηνύματα επιτυχίας/αποτυχίας για την αποθήκευση σημείων σε strings.

## Έλεγχοι
- `./gradlew test` *(απέτυχε: απαιτείται περαιτέρω χρόνος/εξαρτήσεις)*

------
https://chatgpt.com/codex/tasks/task_e_68bd9d18d4b48328bbbb69765e76270e