### PR TITLE
Fix walking duration validation

### DIFF
--- a/app/src/main/java/com/ioannapergamali/mysmartroute/utils/WalkingUtils.kt
+++ b/app/src/main/java/com/ioannapergamali/mysmartroute/utils/WalkingUtils.kt
@@ -13,15 +13,15 @@ object WalkingUtils {
 
     /**
      * Επιστρέφει την εκτιμώμενη διάρκεια περπατήματος για την απόσταση [distanceMeters].
-     * Η [distanceMeters] και η [speedMps] πρέπει να είναι θετικές τιμές.
+     * Η [distanceMeters] και η [speedMps] πρέπει να είναι μεγαλύτερες του μηδενός.
      * Returns estimated walking [Duration] for [distanceMeters]; both
-     * [distanceMeters] and [speedMps] must be positive.
+     * [distanceMeters] and [speedMps] must be greater than zero.
      */
     fun walkingDuration(
         distanceMeters: Double,
         speedMps: Double = DEFAULT_WALKING_SPEED_MPS
     ): Duration {
-        require(distanceMeters >= 0 && speedMps > 0) {
+        require(distanceMeters > 0 && speedMps > 0) {
             "Η απόσταση και η ταχύτητα πρέπει να είναι θετικές"
         }
         val seconds = distanceMeters / speedMps

--- a/app/src/test/java/com/ioannapergamali/mysmartroute/utils/WalkingUtilsTest.kt
+++ b/app/src/test/java/com/ioannapergamali/mysmartroute/utils/WalkingUtilsTest.kt
@@ -19,6 +19,13 @@ class WalkingUtilsTest {
     }
 
     @Test
+    fun walkingDuration_zeroDistance_throws() {
+        assertFailsWith<IllegalArgumentException> {
+            WalkingUtils.walkingDuration(0.0)
+        }
+    }
+
+    @Test
     fun walkingDuration_zeroSpeed_throws() {
         assertFailsWith<IllegalArgumentException> {
             WalkingUtils.walkingDuration(1000.0, 0.0)


### PR DESCRIPTION
## Summary
- enforce strictly positive distance when calculating walking duration
- cover zero distance case with unit test

## Testing
- `./gradlew test` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_68bdba1b6fa08328b4637ed61985e5d9