### PR TITLE
Εμφάνιση εναλλακτικών τιμών στις μετακινήσεις

### DIFF
--- a/app/src/main/java/com/ioannapergamali/mysmartroute/view/ui/screens/PassengerMovingsScreen.kt
+++ b/app/src/main/java/com/ioannapergamali/mysmartroute/view/ui/screens/PassengerMovingsScreen.kt
@@ -102,11 +102,15 @@ private fun MovingCategory(title: String, list: List<MovingEntity>) {
                 val dateText = if (m.date > 0L) {
                     DateFormat.getDateFormat(context).format(Date(m.date))
                 } else ""
+                val routeText = m.routeName.ifBlank { m.routeId }
+                val driverText = m.driverName.ifBlank { m.driverId }
+                val vehicleText = m.vehicleName.ifBlank { m.vehicleId }
+                val passengerText = m.createdByName.ifBlank { m.userId }
                 Row {
-                    TableCell(m.routeName)
-                    TableCell(m.driverName)
-                    TableCell(m.vehicleName)
-                    TableCell(m.createdByName)
+                    TableCell(routeText)
+                    TableCell(driverText)
+                    TableCell(vehicleText)
+                    TableCell(passengerText)
                     TableCell(dateText)
                     TableCell(String.format(Locale.getDefault(), "%.2f€", m.cost))
                     TableCell(m.durationMinutes.toString())


### PR DESCRIPTION
## Περιγραφή
- Προστέθηκαν εναλλακτικές τιμές (id) σε διαδρομή, οδηγό, όχημα και επιβάτη όταν λείπουν ονόματα στην οθόνη μετακινήσεων επιβάτη.

## Δοκιμές
- `./gradlew test` *(αποτυχία: δεν βρέθηκε Android SDK)*

------
https://chatgpt.com/codex/tasks/task_e_68c06712e1848328ab575033301ea071