### PR TITLE
Προσθήκη foundation-layout για Modifier.weight

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -89,6 +89,7 @@ dependencies {
     implementation("androidx.compose.ui:ui-text")
     implementation("androidx.compose.ui:ui-tooling-preview")
     implementation("androidx.compose.foundation:foundation")
+    implementation("androidx.compose.foundation:foundation-layout")
     implementation("androidx.compose.runtime:runtime-livedata")
     implementation("androidx.compose.runtime:runtime")
     implementation("androidx.navigation:navigation-compose:2.9.1")


### PR DESCRIPTION
## Περίληψη
- Προσθήκη `androidx.compose.foundation:foundation-layout` για σωστή χρήση του `Modifier.weight`

## Έλεγχοι
- `./gradlew test` (αποτυχία: SDK location not found)

------
https://chatgpt.com/codex/tasks/task_e_68c090743a888328b34b4c86df2e5e0c