### PR TITLE
Εμφάνιση όλων των πληροφοριών στις μετακινήσεις

### DIFF
--- a/app/src/main/java/com/ioannapergamali/mysmartroute/view/ui/screens/PassengerMovingsScreen.kt
+++ b/app/src/main/java/com/ioannapergamali/mysmartroute/view/ui/screens/PassengerMovingsScreen.kt
@@ -41,7 +41,7 @@ fun PassengerMovingsScreen(navController: NavController, openDrawer: () -> Unit)
     val movings by viewModel.movings.collectAsState()
 
     LaunchedEffect(Unit) {
-        viewModel.loadRequests(context)
+        viewModel.loadRequests(context, allUsers = true)
     }
 
     val now = System.currentTimeMillis()

--- a/app/src/main/java/com/ioannapergamali/mysmartroute/viewmodel/VehicleRequestViewModel.kt
+++ b/app/src/main/java/com/ioannapergamali/mysmartroute/viewmodel/VehicleRequestViewModel.kt
@@ -19,7 +19,6 @@ import kotlinx.coroutines.Dispatchers
 import com.ioannapergamali.mysmartroute.utils.toFirestoreMap
 import com.ioannapergamali.mysmartroute.utils.toMovingEntity
 import com.ioannapergamali.mysmartroute.utils.toTransportDeclarationEntity
-import com.ioannapergamali.mysmartroute.utils.NetworkUtils
 import com.ioannapergamali.mysmartroute.utils.NotificationUtils
 import com.ioannapergamali.mysmartroute.R
 import com.ioannapergamali.mysmartroute.data.local.SeatReservationEntity
@@ -103,16 +102,14 @@ class VehicleRequestViewModel(
             _requests.value = enrichedLocal
 
 
-            val snapshot = if (NetworkUtils.isInternetAvailable(context)) {
-                runCatching {
-                    if (allUsers) {
-                        db.collection("movings").get().await()
-                    } else if (userId != null) {
-                        val userRef = db.collection("users").document(userId)
-                        db.collection("movings").whereEqualTo("userId", userRef).get().await()
-                    } else null
-                }.getOrNull()
-            } else null
+            val snapshot = runCatching {
+                if (allUsers) {
+                    db.collection("movings").get().await()
+                } else if (userId != null) {
+                    val userRef = db.collection("users").document(userId)
+                    db.collection("movings").whereEqualTo("userId", userRef).get().await()
+                } else null
+            }.getOrNull()
 
             snapshot?.let { snap ->
                 val list = snap.documents.mapNotNull { it.toMovingEntity() }


### PR DESCRIPTION
## Περίληψη
- Ενημέρωση της `PassengerMovingsScreen` ώστε να φορτώνει όλα τα αιτήματα μετακινήσεων από το Firestore.
- Απλοποίηση της `loadRequests` αφαιρώντας τον έλεγχο σύνδεσης και επιχειρώντας πάντα ανάκτηση από το Firestore.

## Έλεγχοι
- `./gradlew test` *(αποτυχία: λείπει το Android SDK στο περιβάλλον CI)*

------
https://chatgpt.com/codex/tasks/task_e_68c1a756ed908328a283eb59c18f4dde