### PR TITLE
Sync favorite vehicles with Firestore

### DIFF
--- a/app/src/main/java/com/ioannapergamali/mysmartroute/data/local/FavoriteDao.kt
+++ b/app/src/main/java/com/ioannapergamali/mysmartroute/data/local/FavoriteDao.kt
@@ -25,4 +25,7 @@ interface FavoriteDao {
     @Query("DELETE FROM favorites WHERE userId = :userId AND vehicleType = :vehicleType")
     suspend fun delete(userId: String, vehicleType: String)
 
+    @Query("DELETE FROM favorites WHERE userId = :userId")
+    suspend fun deleteAllForUser(userId: String)
+
 }

--- a/app/src/main/java/com/ioannapergamali/mysmartroute/view/ui/screens/ManageFavoritesScreen.kt
+++ b/app/src/main/java/com/ioannapergamali/mysmartroute/view/ui/screens/ManageFavoritesScreen.kt
@@ -29,6 +29,7 @@ import com.ioannapergamali.mysmartroute.viewmodel.FavoritesViewModel
 fun ManageFavoritesScreen(navController: NavController, openDrawer: () -> Unit) {
     val context = LocalContext.current
     val viewModel: FavoritesViewModel = viewModel()
+    LaunchedEffect(Unit) { viewModel.loadFavorites(context) }
     val preferred by viewModel.preferredFlow(context).collectAsState(initial = emptySet())
     val nonPreferred by viewModel.nonPreferredFlow(context).collectAsState(initial = emptySet())
 


### PR DESCRIPTION
## Summary
- load favorite vehicles from Firestore into local Room database
- expose new DAO method to clear user favorites
- trigger sync when opening ManageFavorites screen

## Testing
- `./gradlew test` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_68c1b641cd00832891038a592f068745