### PR TITLE
fix: load passenger movings from local when remote empty

### DIFF
--- a/app/src/main/java/com/ioannapergamali/mysmartroute/view/ui/screens/PassengerMovingsScreen.kt
+++ b/app/src/main/java/com/ioannapergamali/mysmartroute/view/ui/screens/PassengerMovingsScreen.kt
@@ -19,6 +19,7 @@ import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
+import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.unit.dp
@@ -37,9 +38,10 @@ import com.ioannapergamali.mysmartroute.viewmodel.VehicleRequestViewModel
 fun PassengerMovingsScreen(navController: NavController, openDrawer: () -> Unit) {
     val viewModel: VehicleRequestViewModel = viewModel()
     val movings by viewModel.movings.collectAsState()
+    val context = LocalContext.current
 
     LaunchedEffect(Unit) {
-        viewModel.loadPassengerMovings()
+        viewModel.loadPassengerMovings(context)
     }
 
     val now = System.currentTimeMillis()


### PR DESCRIPTION
## Summary
- Fallback to local Room data when Firestore has no passenger movings
- Pass context from passenger movings screen to ViewModel to load data

## Testing
- `./gradlew test` *(fails: no output, command terminated)*

------
https://chatgpt.com/codex/tasks/task_e_68c1bb3177a08328b962cd13b18dc0d0