### PR TITLE
Εμφάνιση στοιχείων επιβάτη σε κάρτα

### DIFF
--- a/app/src/main/res/values-el/strings.xml
+++ b/app/src/main/res/values-el/strings.xml
@@ -217,6 +217,7 @@
     <string name="delete_selected">Διαγραφή επιλεγμένων</string>
     <string name="delete_reservation">Διαγραφή</string>
     <string name="clear_selection">Καθαρισμός επιλογής</string>
+    <string name="passenger">Επιβάτης</string>
     <string name="no_reservations">Δεν βρέθηκαν κρατήσεις</string>
     <string name="no_declarations">Δεν βρέθηκαν δηλώσεις</string>
     <string name="max_cost">Μέγιστο κόστος</string>


### PR DESCRIPTION
## Περίληψη
- Προστέθηκε ελληνική μετάφραση για το πεδίο επιβάτη.
- Οι λεπτομέρειες κράτησης εμφανίζονται πλέον σε κάρτα με ονοματεπώνυμο επιβάτη από το Firestore όταν χρειάζεται.

## Δοκιμές
- `./gradlew :app:test` *(απέτυχε: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_68c1bc81380483288907f30fddbf106b