### PR TITLE
Fix loading of saved ratings on transport ranking screen

### DIFF
--- a/app/src/main/java/com/ioannapergamali/mysmartroute/view/ui/screens/RankTransportsScreen.kt
+++ b/app/src/main/java/com/ioannapergamali/mysmartroute/view/ui/screens/RankTransportsScreen.kt
@@ -81,7 +81,7 @@ fun RankTransportsScreen(navController: NavController, openDrawer: () -> Unit) {
                     modifier = Modifier.fillMaxSize(),
                     contentPadding = PaddingValues(16.dp)
                 ) {
-                    items(trips) { trip ->
+                    items(trips, key = { it.moving.id }) { trip ->
                         TripRatingItem(trip) { rating, comment ->
                             viewModel.updateRating(context, trip.moving, rating, comment)
                         }
@@ -98,8 +98,8 @@ private fun TripRatingItem(
     trip: TripWithRating,
     onSave: (Int, String) -> Unit
 ) {
-    var rating by remember { mutableStateOf(trip.rating) }
-    var comment by remember { mutableStateOf(trip.comment) }
+    var rating by remember(trip.rating) { mutableStateOf(trip.rating) }
+    var comment by remember(trip.comment) { mutableStateOf(trip.comment) }
     val context = LocalContext.current
     val dateText = if (trip.moving.date > 0L) {
         DateFormat.getDateFormat(context).format(Date(trip.moving.date))


### PR DESCRIPTION
## Summary
- ensure LazyColumn uses stable keys for trip items
- reset rating and comment state when underlying trip data changes

## Testing
- `./gradlew test` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_68c1be91b4e88328ac832f0fa0ae49b4