### PR TITLE
fix: load passenger movings from local and normalize status

### DIFF
--- a/app/src/main/java/com/ioannapergamali/mysmartroute/data/local/MovingStatus.kt
+++ b/app/src/main/java/com/ioannapergamali/mysmartroute/data/local/MovingStatus.kt
@@ -21,11 +21,14 @@ enum class MovingStatus {
  * Υπολογίζει την [MovingStatus] μιας [MovingEntity] με βάση την κατάσταση αποδοχής
  * και τη χρονική στιγμή της μετακίνησης.
  */
-fun MovingEntity.movingStatus(now: Long = System.currentTimeMillis()): MovingStatus = when {
-    status == "completed" -> MovingStatus.COMPLETED
-    status == "accepted" -> MovingStatus.ACTIVE
-    status != "accepted" && date > now -> MovingStatus.PENDING
-    else -> MovingStatus.UNSUCCESSFUL
+fun MovingEntity.movingStatus(now: Long = System.currentTimeMillis()): MovingStatus {
+    val s = status.lowercase()
+    return when {
+        s == "completed" -> MovingStatus.COMPLETED
+        s == "accepted" -> MovingStatus.ACTIVE
+        s != "accepted" && date > now -> MovingStatus.PENDING
+        else -> MovingStatus.UNSUCCESSFUL
+    }
 }
 
 /**

--- a/app/src/main/java/com/ioannapergamali/mysmartroute/utils/FirestoreMappers.kt
+++ b/app/src/main/java/com/ioannapergamali/mysmartroute/utils/FirestoreMappers.kt
@@ -331,7 +331,7 @@ fun DocumentSnapshot.toMovingEntity(): MovingEntity? {
         is String -> d
         else -> getString("driverId")
     } ?: ""
-    val status = getString("status") ?: "open"
+    val status = getString("status")?.lowercase() ?: "open"
     val requestNumber = (getLong("requestNumber") ?: 0L).toInt()
     val driverName = getString("driverName") ?: ""
     val routeName = getString("routeName") ?: ""

--- a/app/src/main/java/com/ioannapergamali/mysmartroute/view/ui/screens/PassengerMovingsScreen.kt
+++ b/app/src/main/java/com/ioannapergamali/mysmartroute/view/ui/screens/PassengerMovingsScreen.kt
@@ -19,6 +19,7 @@ import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
+import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.unit.dp
@@ -37,9 +38,10 @@ import com.ioannapergamali.mysmartroute.viewmodel.VehicleRequestViewModel
 fun PassengerMovingsScreen(navController: NavController, openDrawer: () -> Unit) {
     val viewModel: VehicleRequestViewModel = viewModel()
     val movings by viewModel.movings.collectAsState()
+    val context = LocalContext.current
 
     LaunchedEffect(Unit) {
-        viewModel.loadPassengerMovings()
+        viewModel.loadPassengerMovings(context)
     }
 
     val now = System.currentTimeMillis()


### PR DESCRIPTION
## Summary
- Fallback to local Room data when Firestore has no passenger movings
- Pass context from passenger movings screen to ViewModel to load data
- Normalize moving status values to show completed, pending and unsuccessful routes

## Testing
- `./gradlew test --console=plain` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_68c1bb3177a08328b962cd13b18dc0d0