### PR TITLE
Fix loading of saved ratings on transport ranking screen

### DIFF
--- a/app/src/main/java/com/ioannapergamali/mysmartroute/view/ui/screens/RankTransportsScreen.kt
+++ b/app/src/main/java/com/ioannapergamali/mysmartroute/view/ui/screens/RankTransportsScreen.kt
@@ -25,8 +25,8 @@ import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
-import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
+import androidx.compose.runtime.saveable.rememberSaveable
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.res.stringResource
@@ -81,7 +81,7 @@ fun RankTransportsScreen(navController: NavController, openDrawer: () -> Unit) {
                     modifier = Modifier.fillMaxSize(),
                     contentPadding = PaddingValues(16.dp)
                 ) {
-                    items(trips) { trip ->
+                    items(trips, key = { it.moving.id }) { trip ->
                         TripRatingItem(trip) { rating, comment ->
                             viewModel.updateRating(context, trip.moving, rating, comment)
                         }
@@ -98,8 +98,12 @@ private fun TripRatingItem(
     trip: TripWithRating,
     onSave: (Int, String) -> Unit
 ) {
-    var rating by remember { mutableStateOf(trip.rating) }
-    var comment by remember { mutableStateOf(trip.comment) }
+    var rating by rememberSaveable(trip.moving.id) { mutableStateOf(trip.rating) }
+    var comment by rememberSaveable(trip.moving.id) { mutableStateOf(trip.comment) }
+    LaunchedEffect(trip.rating, trip.comment) {
+        rating = trip.rating
+        comment = trip.comment
+    }
     val context = LocalContext.current
     val dateText = if (trip.moving.date > 0L) {
         DateFormat.getDateFormat(context).format(Date(trip.moving.date))


### PR DESCRIPTION
## Summary
- use `rememberSaveable` keyed by trip to persist rating and comment
- sync rating state with trip updates via `LaunchedEffect`

## Testing
- `./gradlew test` *(stuck at 0% configuring; terminated due to environment limits)*

------
https://chatgpt.com/codex/tasks/task_e_68c1be91b4e88328ac832f0fa0ae49b4