### PR TITLE
Αποθήκευση αξιολογήσεων ταξιδιών στο Firestore

### DIFF
--- a/app/src/main/java/com/ioannapergamali/mysmartroute/model/classes/transports/TripRating.kt
+++ b/app/src/main/java/com/ioannapergamali/mysmartroute/model/classes/transports/TripRating.kt
@@ -1,0 +1,11 @@
+package com.ioannapergamali.mysmartroute.model.classes.transports
+
+/**
+ * Απλή κλάση δεδομένων για αποθήκευση βαθμολογίας ταξιδιού στο Firestore.
+ */
+data class TripRating(
+    val movingId: String = "",
+    val userId: String = "",
+    val rating: Int = 0,
+    val comment: String? = null
+)

--- a/app/src/main/java/com/ioannapergamali/mysmartroute/repository/TripRatingRepository.kt
+++ b/app/src/main/java/com/ioannapergamali/mysmartroute/repository/TripRatingRepository.kt
@@ -1,0 +1,24 @@
+package com.ioannapergamali.mysmartroute.repository
+
+import android.util.Log
+import com.google.firebase.firestore.FirebaseFirestore
+import com.ioannapergamali.mysmartroute.model.classes.transports.TripRating
+import kotlinx.coroutines.tasks.await
+
+/**
+ * Repository για αποθήκευση βαθμολογιών ταξιδιών στο Firestore.
+ */
+class TripRatingRepository {
+    private val db = FirebaseFirestore.getInstance()
+
+    suspend fun saveTripRating(rating: TripRating): Boolean {
+        val docId = "${rating.movingId}_${rating.userId}"
+        return try {
+            db.collection("trip_ratings").document(docId).set(rating).await()
+            true
+        } catch (e: Exception) {
+            Log.e("TripRatingRepo", "Αποτυχία αποθήκευσης", e)
+            false
+        }
+    }
+}

--- a/app/src/main/java/com/ioannapergamali/mysmartroute/view/ui/screens/RankTransportsScreen.kt
+++ b/app/src/main/java/com/ioannapergamali/mysmartroute/view/ui/screens/RankTransportsScreen.kt
@@ -83,7 +83,7 @@ fun RankTransportsScreen(navController: NavController, openDrawer: () -> Unit) {
                 ) {
                     items(trips, key = { it.moving.id }) { trip ->
                         TripRatingItem(trip) { rating, comment ->
-                            viewModel.updateRating(context, trip.moving, rating, comment)
+                            viewModel.saveTripRating(context, trip.moving, rating, comment)
                         }
                         Divider()
                     }


### PR DESCRIPTION
## Περιγραφή
- Προσθήκη `TripRating` data class για αποστολή βαθμολογιών στο Firestore
- Δημιουργία `TripRatingRepository` με μέθοδο αποθήκευσης στο Firestore
- Ενημέρωση `TripRatingViewModel` και `RankTransportsScreen` για χρήση της νέας λειτουργίας

## Δοκιμές
- `./gradlew test` (αποτυχία: SDK location not found)


------
https://chatgpt.com/codex/tasks/task_e_68c1c9b9b7008328b9880e0e033be6c1