### PR TITLE
Fix trip rating retrieval and moving table width

### DIFF
--- a/app/src/main/java/com/ioannapergamali/mysmartroute/data/local/TripRatingDao.kt
+++ b/app/src/main/java/com/ioannapergamali/mysmartroute/data/local/TripRatingDao.kt
@@ -14,6 +14,9 @@ interface TripRatingDao {
     @Query("SELECT * FROM trip_ratings")
     fun getAll(): Flow<List<TripRatingEntity>>
 
+    @Query("SELECT * FROM trip_ratings WHERE movingId = :movingId AND userId = :userId LIMIT 1")
+    suspend fun get(movingId: String, userId: String): TripRatingEntity?
+
     @Insert(onConflict = OnConflictStrategy.REPLACE)
     suspend fun upsert(rating: TripRatingEntity)
 

--- a/app/src/main/java/com/ioannapergamali/mysmartroute/view/ui/screens/PassengerMovingsScreen.kt
+++ b/app/src/main/java/com/ioannapergamali/mysmartroute/view/ui/screens/PassengerMovingsScreen.kt
@@ -95,7 +95,11 @@ private fun MovingCategory(title: String, list: List<MovingEntity>) {
 @Composable
 private fun MovingTable(list: List<MovingEntity>) {
     val scrollState = rememberScrollState()
-    Column(modifier = Modifier.horizontalScroll(scrollState)) {
+    Column(
+        modifier = Modifier
+            .fillMaxWidth()
+            .horizontalScroll(scrollState)
+    ) {
         Row(Modifier.fillMaxWidth()) {
             TableHeaderCell(stringResource(R.string.route))
             TableHeaderCell(stringResource(R.string.driver))

--- a/app/src/main/java/com/ioannapergamali/mysmartroute/viewmodel/TripRatingViewModel.kt
+++ b/app/src/main/java/com/ioannapergamali/mysmartroute/viewmodel/TripRatingViewModel.kt
@@ -32,15 +32,18 @@ class TripRatingViewModel : ViewModel() {
             try {
                 val movings = db.movingDao().getAll().first()
                 movings.forEach { moving ->
-                    repository.getTripRating(moving.id, moving.userId)?.let { remote ->
-                        db.tripRatingDao().upsert(
-                            TripRatingEntity(
-                                moving.id,
-                                remote.userId,
-                                remote.rating,
-                                remote.comment ?: ""
+                    val local = db.tripRatingDao().get(moving.id, moving.userId)
+                    if (local == null) {
+                        repository.getTripRating(moving.id, moving.userId)?.let { remote ->
+                            db.tripRatingDao().upsert(
+                                TripRatingEntity(
+                                    moving.id,
+                                    remote.userId,
+                                    remote.rating,
+                                    remote.comment ?: ""
+                                )
                             )
-                        )
+                        }
                     }
                 }
             } catch (_: Exception) {


### PR DESCRIPTION
## Summary
- load locally saved trip ratings before requesting remote ones
- ensure moving list tables occupy full width so rows become visible

## Testing
- `./gradlew test` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_68c1e13fc19c83289d0aa991708b8557