### PR TITLE
Χρήση Firestore references για βαθμολογίες

### DIFF
--- a/app/src/main/java/com/ioannapergamali/mysmartroute/repository/TripRatingRepository.kt
+++ b/app/src/main/java/com/ioannapergamali/mysmartroute/repository/TripRatingRepository.kt
@@ -5,16 +5,40 @@ import com.google.firebase.firestore.FirebaseFirestore
 import com.ioannapergamali.mysmartroute.model.classes.transports.TripRating
 import kotlinx.coroutines.tasks.await
 
+data class TripRatingDetails(
+    val tripRating: TripRating,
+    val moving: MovingInfo?,
+    val user: UserInfo?
+)
+
+data class MovingInfo(
+    val title: String = "",
+    val date: Long = 0L
+)
+
+data class UserInfo(
+    val name: String = "",
+    val avatarUrl: String = ""
+)
+
 /**
  * Repository για αποθήκευση βαθμολογιών ταξιδιών στο Firestore.
  */
 class TripRatingRepository {
     private val db = FirebaseFirestore.getInstance()
 
-    suspend fun saveTripRating(rating: TripRating): Boolean {
-        val docId = "${rating.movingId}_${rating.userId}"
+    suspend fun saveTripRating(movingId: String, userId: String, rating: Int, comment: String?): Boolean {
+        val docId = "${movingId}_${userId}"
+        val movingRef = db.collection("movings").document(movingId)
+        val userRef = db.collection("users").document(userId)
+        val data = mapOf(
+            "moving" to movingRef,
+            "user" to userRef,
+            "rating" to rating,
+            "comment" to comment
+        )
         return try {
-            db.collection("trip_ratings").document(docId).set(rating).await()
+            db.collection("trip_ratings").document(docId).set(data).await()
             true
         } catch (e: Exception) {
             Log.e("TripRatingRepo", "Αποτυχία αποθήκευσης", e)
@@ -24,13 +48,26 @@ class TripRatingRepository {
 
 
     /**
-     * Επιστρέφει τη βαθμολογία που έχει δώσει ο χρήστης για συγκεκριμένη μετακίνηση.
+     * Επιστρέφει τη βαθμολογία που έχει δώσει ο χρήστης για συγκεκριμένη μετακίνηση
+     * μαζί με τις πληροφορίες μετακίνησης και χρήστη.
      */
-    suspend fun getTripRating(movingId: String, userId: String): TripRating? {
+    suspend fun getTripRating(movingId: String, userId: String): TripRatingDetails? {
         val docId = "${movingId}_${userId}"
         return try {
-            db.collection("trip_ratings").document(docId).get().await()
-                .toObject(TripRating::class.java)
+            val snap = db.collection("trip_ratings").document(docId).get().await()
+            val movingRef = snap.getDocumentReference("moving")
+            val userRef = snap.getDocumentReference("user")
+            val rating = snap.getLong("rating")?.toInt() ?: 0
+            val comment = snap.getString("comment")
+
+            val moving = movingRef?.get()?.await()?.toObject(MovingInfo::class.java)
+            val user = userRef?.get()?.await()?.toObject(UserInfo::class.java)
+
+            TripRatingDetails(
+                TripRating(movingRef?.id ?: movingId, userRef?.id ?: userId, rating, comment),
+                moving,
+                user
+            )
         } catch (e: Exception) {
             Log.e("TripRatingRepo", "Αποτυχία ανάκτησης", e)
             null

--- a/app/src/main/java/com/ioannapergamali/mysmartroute/viewmodel/TripRatingViewModel.kt
+++ b/app/src/main/java/com/ioannapergamali/mysmartroute/viewmodel/TripRatingViewModel.kt
@@ -7,7 +7,6 @@ import com.ioannapergamali.mysmartroute.R
 import com.ioannapergamali.mysmartroute.data.local.MovingEntity
 import com.ioannapergamali.mysmartroute.data.local.MySmartRouteDatabase
 import com.ioannapergamali.mysmartroute.data.local.TripRatingEntity
-import com.ioannapergamali.mysmartroute.model.classes.transports.TripRating
 import com.ioannapergamali.mysmartroute.model.classes.transports.TripWithRating
 import com.ioannapergamali.mysmartroute.repository.TripRatingRepository
 import kotlinx.coroutines.flow.MutableStateFlow
@@ -38,9 +37,9 @@ class TripRatingViewModel : ViewModel() {
                             db.tripRatingDao().upsert(
                                 TripRatingEntity(
                                     moving.id,
-                                    remote.userId,
-                                    remote.rating,
-                                    remote.comment ?: ""
+                                    remote.tripRating.userId,
+                                    remote.tripRating.rating,
+                                    remote.tripRating.comment ?: ""
                                 )
                             )
                         }
@@ -75,7 +74,10 @@ class TripRatingViewModel : ViewModel() {
                     TripRatingEntity(moving.id, moving.userId, rating, comment)
                 )
                 val success = repository.saveTripRating(
-                    TripRating(moving.id, moving.userId, rating, comment)
+                    moving.id,
+                    moving.userId,
+                    rating,
+                    comment,
                 )
                 _message.value = if (success) {
                     context.getString(R.string.rating_saved_success)


### PR DESCRIPTION
## Περίληψη
- Αποθήκευση βαθμολογιών στο Firestore με DocumentReferences προς movings και users
- Ανάκτηση βαθμολογίας μαζί με τα στοιχεία μετακίνησης και χρήστη
- Προσαρμογή TripRatingViewModel στις νέες υπογραφές του repository

## Έλεγχοι
- `./gradlew test` (απέτυχε: SDK location not found)


------
https://chatgpt.com/codex/tasks/task_e_68c1e5df4a74832898e132744a0c230d