### PR TITLE
Show movings headers for empty categories

### DIFF
--- a/app/src/main/java/com/ioannapergamali/mysmartroute/view/ui/screens/PassengerMovingsScreen.kt
+++ b/app/src/main/java/com/ioannapergamali/mysmartroute/view/ui/screens/PassengerMovingsScreen.kt
@@ -84,12 +84,14 @@ fun PassengerMovingsScreen(navController: NavController, openDrawer: () -> Unit)
 
 @Composable
 private fun MovingCategory(title: String, list: List<MovingEntity>) {
-    if (list.isNotEmpty()) {
-        Text(title, style = MaterialTheme.typography.titleMedium)
+    Text(title, style = MaterialTheme.typography.titleMedium)
+    Spacer(modifier = Modifier.height(8.dp))
+    MovingTable(list)
+    if (list.isEmpty()) {
         Spacer(modifier = Modifier.height(8.dp))
-        MovingTable(list)
-        Spacer(modifier = Modifier.height(16.dp))
+        Text(stringResource(R.string.no_movings))
     }
+    Spacer(modifier = Modifier.height(16.dp))
 }
 
 @Composable


### PR DESCRIPTION
## Summary
- Always show moving table headers and a message when a category has no entries

## Testing
- `./gradlew test` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_68c1e6a9b60c8328b33b9b162d4f7614