### PR TITLE
Επιδιόρθωση σύγκρουσης κύλισης στο ViewTransportsScreen

### DIFF
--- a/app/src/main/java/com/ioannapergamali/mysmartroute/view/ui/screens/ViewTransportsScreen.kt
+++ b/app/src/main/java/com/ioannapergamali/mysmartroute/view/ui/screens/ViewTransportsScreen.kt
@@ -61,7 +61,7 @@ fun ViewTransportsScreen(navController: NavController, openDrawer: () -> Unit) {
             )
         }
     ) { padding ->
-        ScreenContainer(Modifier.padding(padding)) {
+        ScreenContainer(modifier = Modifier.padding(padding), scrollable = false) {
             if (favoriteRoutes.isEmpty()) {
                 Text(stringResource(R.string.no_interesting_routes))
             } else {


### PR DESCRIPTION
## Περίληψη
- Απενεργοποιήθηκε η κατακόρυφη κύλιση του `ScreenContainer` στο `ViewTransportsScreen` όταν χρησιμοποιείται `LazyColumn`.

## Έλεγχοι
- `./gradlew test` *(απέτυχε: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_68c1ece4d1588328a942a9e3595d085e