### PR TITLE
Προσθήκη οθόνης BookingDetails με εμφάνιση επιβάτη

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -9,6 +9,7 @@ val mapsApiKey: String = gradleLocalProperties(rootDir, providers)
         id("com.android.application")
         id("org.jetbrains.kotlin.android")
         id("kotlin-kapt")
+        id("kotlin-parcelize")
         id("com.google.gms.google-services")
         id("org.jetbrains.kotlin.plugin.compose")
     }

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -33,6 +33,9 @@
                 <category android:name="android.intent.category.LAUNCHER" />
             </intent-filter>
         </activity>
+        <activity
+            android:name=".viewmodel.BookingDetailsActivity"
+            android:exported="false" />
     </application>
 
 </manifest>

--- a/app/src/main/java/com/ioannapergamali/mysmartroute/model/classes/booking/Booking.kt
+++ b/app/src/main/java/com/ioannapergamali/mysmartroute/model/classes/booking/Booking.kt
@@ -1,0 +1,18 @@
+package com.ioannapergamali.mysmartroute.model.classes.booking
+
+import android.os.Parcelable
+import kotlinx.parcelize.Parcelize
+
+@Parcelize
+/**
+ * Δεδομένα μιας κράτησης για απλή προβολή στοιχείων.
+ */
+data class Booking(
+    val date: String,
+    val route: String,
+    val startPoint: String,
+    val destination: String,
+    val driver: String,
+    val cost: Double,
+    val passengerName: String? = null
+) : Parcelable

--- a/app/src/main/java/com/ioannapergamali/mysmartroute/view/ui/screens/BookingDetailsScreen.kt
+++ b/app/src/main/java/com/ioannapergamali/mysmartroute/view/ui/screens/BookingDetailsScreen.kt
@@ -1,0 +1,20 @@
+package com.ioannapergamali.mysmartroute.view.ui.screens
+
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import com.ioannapergamali.mysmartroute.model.classes.booking.Booking
+
+/**
+ * Προβάλλει τα στοιχεία κράτησης και ειδικά το ονοματεπώνυμο του επιβάτη.
+ */
+@Composable
+fun BookingDetailsScreen(booking: Booking) {
+    val passenger = booking.passengerName?.takeIf { it.isNotBlank() } ?: "Δεν δηλώθηκε"
+
+    Text(
+        text = "Επιβάτης: $passenger",
+        style = MaterialTheme.typography.bodyLarge,
+        color = MaterialTheme.colorScheme.onBackground
+    )
+}

--- a/app/src/main/java/com/ioannapergamali/mysmartroute/viewmodel/BookingDetailsActivity.kt
+++ b/app/src/main/java/com/ioannapergamali/mysmartroute/viewmodel/BookingDetailsActivity.kt
@@ -1,0 +1,33 @@
+package com.ioannapergamali.mysmartroute.viewmodel
+
+import android.os.Bundle
+import androidx.activity.ComponentActivity
+import androidx.activity.compose.setContent
+import com.ioannapergamali.mysmartroute.model.classes.booking.Booking
+import com.ioannapergamali.mysmartroute.view.ui.AppFont
+import com.ioannapergamali.mysmartroute.view.ui.AppTheme
+import com.ioannapergamali.mysmartroute.view.ui.MysmartrouteTheme
+import com.ioannapergamali.mysmartroute.view.ui.screens.BookingDetailsScreen
+
+/**
+ * Απλή δραστηριότητα Jetpack Compose για εμφάνιση στοιχείων κράτησης.
+ */
+class BookingDetailsActivity : ComponentActivity() {
+
+    override fun onCreate(savedInstanceState: Bundle?) {
+        super.onCreate(savedInstanceState)
+
+        val booking: Booking = intent.getParcelableExtra("booking")
+            ?: Booking("", "", "", "", "", 0.0)
+
+        setContent {
+            MysmartrouteTheme(
+                theme = AppTheme.Ocean,
+                darkTheme = false,
+                font = AppFont.SansSerif.fontFamily
+            ) {
+                BookingDetailsScreen(booking = booking)
+            }
+        }
+    }
+}


### PR DESCRIPTION
## Περίληψη
- δημιουργία data class `Booking` με πεδίο ονοματεπωνύμου επιβάτη
- προσθήκη composable `BookingDetailsScreen` για εμφάνιση του επιβάτη
- νέα δραστηριότητα `BookingDetailsActivity` και δήλωση στο Manifest

## Έλεγχοι
- `./gradlew test` *(απέτυχε: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_68c1edffad2c8328a62dbe1ece406d27