### PR TITLE
Προσθήκη προβολής και συγχρονισμού όλων των πινάκων

### DIFF
--- a/app/src/main/java/com/ioannapergamali/mysmartroute/data/local/NotificationDao.kt
+++ b/app/src/main/java/com/ioannapergamali/mysmartroute/data/local/NotificationDao.kt
@@ -16,6 +16,9 @@ interface NotificationDao {
     @Query("SELECT * FROM notifications WHERE userId = :userId")
     fun getForUser(userId: String): Flow<List<NotificationEntity>>
 
+    @Query("SELECT * FROM notifications")
+    fun getAll(): Flow<List<NotificationEntity>>
+
     @Query("DELETE FROM notifications WHERE id = :id")
     suspend fun deleteById(id: String)
 }

--- a/app/src/main/java/com/ioannapergamali/mysmartroute/utils/FirestoreMappers.kt
+++ b/app/src/main/java/com/ioannapergamali/mysmartroute/utils/FirestoreMappers.kt
@@ -26,6 +26,7 @@ import com.ioannapergamali.mysmartroute.data.local.SeatReservationEntity
 import com.ioannapergamali.mysmartroute.data.local.FavoriteEntity
 import com.ioannapergamali.mysmartroute.data.local.TransferRequestEntity
 import com.ioannapergamali.mysmartroute.data.local.NotificationEntity
+import com.ioannapergamali.mysmartroute.data.local.TripRatingEntity
 import com.ioannapergamali.mysmartroute.model.enumerations.RequestStatus
 
 
@@ -545,4 +546,31 @@ fun DocumentSnapshot.toNotificationEntity(): NotificationEntity? {
     } ?: return null
     val msg = getString("message") ?: ""
     return NotificationEntity(idVal, userId, msg)
+}
+
+fun TripRatingEntity.toFirestoreMap(): Map<String, Any> = mapOf(
+    "movingId" to FirebaseFirestore.getInstance().collection("movings").document(movingId),
+    "userId" to FirebaseFirestore.getInstance().collection("users").document(userId),
+    "rating" to rating,
+    "comment" to comment
+)
+
+fun DocumentSnapshot.toTripRatingEntity(): TripRatingEntity? {
+    val movingId = when (val m = get("movingId")) {
+        is DocumentReference -> m.id
+        is String -> m
+        else -> getString("movingId")
+    } ?: return null
+    val userId = when (val u = get("userId")) {
+        is DocumentReference -> u.id
+        is String -> u
+        else -> getString("userId")
+    } ?: return null
+    val ratingVal = when (val r = get("rating")) {
+        is Long -> r.toInt()
+        is Double -> r.toInt()
+        else -> (getLong("rating") ?: 0L).toInt()
+    }
+    val commentVal = getString("comment") ?: ""
+    return TripRatingEntity(movingId, userId, ratingVal, commentVal)
 }

--- a/app/src/main/java/com/ioannapergamali/mysmartroute/view/ui/screens/FirebaseDatabaseScreen.kt
+++ b/app/src/main/java/com/ioannapergamali/mysmartroute/view/ui/screens/FirebaseDatabaseScreen.kt
@@ -111,6 +111,46 @@ fun FirebaseDatabaseScreen(navController: NavController, openDrawer: () -> Unit)
                     Text("${opt.id} (${opt.menuId}) -> ${opt.titleResKey} -> ${opt.route}")
                 }
                 item { Spacer(modifier = Modifier.padding(8.dp)) }
+                item { Text("Availabilities", style = MaterialTheme.typography.titleMedium) }
+                items(data!!.availabilities) { a ->
+                    Text("${a.userId} -> ${a.date}")
+                }
+                item { Spacer(modifier = Modifier.padding(8.dp)) }
+                item { Text("Seat Reservations", style = MaterialTheme.typography.titleMedium) }
+                items(data!!.seatReservations) { r ->
+                    Text("${r.id} route:${r.routeId} user:${r.userId}")
+                }
+                item { Spacer(modifier = Modifier.padding(8.dp)) }
+                item { Text("Transfer Requests", style = MaterialTheme.typography.titleMedium) }
+                items(data!!.transferRequests) { tr ->
+                    Text("${tr.requestNumber} route:${tr.routeId} status:${tr.status}")
+                }
+                item { Spacer(modifier = Modifier.padding(8.dp)) }
+                item { Text("Trip Ratings", style = MaterialTheme.typography.titleMedium) }
+                items(data!!.tripRatings) { t ->
+                    Text("${t.movingId} user:${t.userId} rating:${t.rating}")
+                }
+                item { Spacer(modifier = Modifier.padding(8.dp)) }
+                item { Text("Favorites", style = MaterialTheme.typography.titleMedium) }
+                items(data!!.favorites) { f ->
+                    Text("${f.id} user:${f.userId}")
+                }
+                item { Spacer(modifier = Modifier.padding(8.dp)) }
+                item { Text("Favorite Routes", style = MaterialTheme.typography.titleMedium) }
+                items(data!!.favoriteRoutes) { fr ->
+                    Text("${fr.userId} -> ${fr.routeId}")
+                }
+                item { Spacer(modifier = Modifier.padding(8.dp)) }
+                item { Text("User PoIs", style = MaterialTheme.typography.titleMedium) }
+                items(data!!.userPois) { up ->
+                    Text("${up.userId} -> ${up.poiId}")
+                }
+                item { Spacer(modifier = Modifier.padding(8.dp)) }
+                item { Text("Notifications", style = MaterialTheme.typography.titleMedium) }
+                items(data!!.notifications) { n ->
+                    Text("${n.userId} -> ${n.message}")
+                }
+                item { Spacer(modifier = Modifier.padding(8.dp)) }
                 item { Text("Authentication table δεν είναι διαθέσιμη από το client", color = MaterialTheme.colorScheme.error) }
                 }
             }

--- a/app/src/main/java/com/ioannapergamali/mysmartroute/view/ui/screens/LocalDatabaseScreen.kt
+++ b/app/src/main/java/com/ioannapergamali/mysmartroute/view/ui/screens/LocalDatabaseScreen.kt
@@ -173,6 +173,78 @@ fun LocalDatabaseScreen(navController: NavController, openDrawer: () -> Unit) {
                         Text("${lang.id} -> ${lang.language}")
                     }
                 }
+                item { Spacer(modifier = Modifier.padding(8.dp)) }
+                item { Text("Availabilities", style = MaterialTheme.typography.titleMedium) }
+                if (data!!.availabilities.isEmpty()) {
+                    item { Text("Ο πίνακας είναι άδειος") }
+                } else {
+                    items(data!!.availabilities) { a ->
+                        Text("${a.userId} -> ${a.date}")
+                    }
+                }
+                item { Spacer(modifier = Modifier.padding(8.dp)) }
+                item { Text("Seat Reservations", style = MaterialTheme.typography.titleMedium) }
+                if (data!!.seatReservations.isEmpty()) {
+                    item { Text("Ο πίνακας είναι άδειος") }
+                } else {
+                    items(data!!.seatReservations) { r ->
+                        Text("${r.id} route:${r.routeId} user:${r.userId}")
+                    }
+                }
+                item { Spacer(modifier = Modifier.padding(8.dp)) }
+                item { Text("Transfer Requests", style = MaterialTheme.typography.titleMedium) }
+                if (data!!.transferRequests.isEmpty()) {
+                    item { Text("Ο πίνακας είναι άδειος") }
+                } else {
+                    items(data!!.transferRequests) { tr ->
+                        Text("${tr.requestNumber} route:${tr.routeId} status:${tr.status}")
+                    }
+                }
+                item { Spacer(modifier = Modifier.padding(8.dp)) }
+                item { Text("Trip Ratings", style = MaterialTheme.typography.titleMedium) }
+                if (data!!.tripRatings.isEmpty()) {
+                    item { Text("Ο πίνακας είναι άδειος") }
+                } else {
+                    items(data!!.tripRatings) { t ->
+                        Text("${t.movingId} user:${t.userId} rating:${t.rating}")
+                    }
+                }
+                item { Spacer(modifier = Modifier.padding(8.dp)) }
+                item { Text("Favorites", style = MaterialTheme.typography.titleMedium) }
+                if (data!!.favorites.isEmpty()) {
+                    item { Text("Ο πίνακας είναι άδειος") }
+                } else {
+                    items(data!!.favorites) { f ->
+                        Text("${f.id} user:${f.userId}")
+                    }
+                }
+                item { Spacer(modifier = Modifier.padding(8.dp)) }
+                item { Text("Favorite Routes", style = MaterialTheme.typography.titleMedium) }
+                if (data!!.favoriteRoutes.isEmpty()) {
+                    item { Text("Ο πίνακας είναι άδειος") }
+                } else {
+                    items(data!!.favoriteRoutes) { fr ->
+                        Text("${fr.userId} -> ${fr.routeId}")
+                    }
+                }
+                item { Spacer(modifier = Modifier.padding(8.dp)) }
+                item { Text("User PoIs", style = MaterialTheme.typography.titleMedium) }
+                if (data!!.userPois.isEmpty()) {
+                    item { Text("Ο πίνακας είναι άδειος") }
+                } else {
+                    items(data!!.userPois) { up ->
+                        Text("${up.userId} -> ${up.poiId}")
+                    }
+                }
+                item { Spacer(modifier = Modifier.padding(8.dp)) }
+                item { Text("Notifications", style = MaterialTheme.typography.titleMedium) }
+                if (data!!.notifications.isEmpty()) {
+                    item { Text("Ο πίνακας είναι άδειος") }
+                } else {
+                    items(data!!.notifications) { n ->
+                        Text("${n.userId} -> ${n.message}")
+                    }
+                }
                 }
             }
         }


### PR DESCRIPTION
## Περίληψη
- Ενσωμάτωση νέων πινάκων (κρατήσεις θέσεων, αιτήματα μεταφοράς, αξιολογήσεις διαδρομών, ειδοποιήσεις) στον συγχρονισμό με Firebase.
- Προβολή όλων των πινάκων στις οθόνες τοπικής και απομακρυσμένης βάσης.
- Επεκτάσεις Firestore mappers για μετατροπές TripRating.

## Δοκιμές
- `./gradlew test` *(απέτυχε: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_68c1f849508483288ed3c0108a56ac70