### PR TITLE
Μετατροπή userId σε αναφορά στα movings

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -65,7 +65,7 @@ dependencies {
     // Firebase (BoM για αυτόματες εκδόσεις όλων των modules)
     implementation(platform("com.google.firebase:firebase-bom:34.2.0"))
     implementation("com.google.firebase:firebase-auth-ktx")
-    // Χρήση της νεότερης έκδοσης Firestore ώστε το userId να αποθηκεύεται ως String
+    // Χρήση της νεότερης έκδοσης Firestore ώστε το userId να αποθηκεύεται ως αναφορά
     implementation("com.google.firebase:firebase-firestore-ktx:25.1.4")
     implementation("com.google.firebase:firebase-storage-ktx")
 

--- a/app/src/main/java/com/ioannapergamali/mysmartroute/utils/FirestoreMappers.kt
+++ b/app/src/main/java/com/ioannapergamali/mysmartroute/utils/FirestoreMappers.kt
@@ -266,8 +266,8 @@ fun MovingEntity.toFirestoreMap(): Map<String, Any> {
     val map = mutableMapOf<String, Any>(
         "id" to id,
         "routeId" to FirebaseFirestore.getInstance().collection("routes").document(routeId),
-        // Αποθηκεύουμε το userId ως απλή συμβολοσειρά για ευκολότερα ερωτήματα
-        "userId" to userId,
+        // Αποθηκεύουμε το userId ως αναφορά στο έγγραφο του χρήστη
+        "userId" to FirebaseFirestore.getInstance().collection("users").document(userId),
         "date" to date,
         "cost" to cost,
         "durationMinutes" to durationMinutes,

--- a/app/src/main/java/com/ioannapergamali/mysmartroute/viewmodel/VehicleRequestViewModel.kt
+++ b/app/src/main/java/com/ioannapergamali/mysmartroute/viewmodel/VehicleRequestViewModel.kt
@@ -98,7 +98,10 @@ class VehicleRequestViewModel(
                 if (allUsers) {
                     db.collection("movings").get().await()
                 } else if (userId != null) {
-                    db.collection("movings").whereEqualTo("userId", userId).get().await()
+                    db.collection("movings").whereEqualTo(
+                        "userId",
+                        db.collection("users").document(userId)
+                    ).get().await()
                 } else null
             }.getOrNull()
 
@@ -166,10 +169,16 @@ class VehicleRequestViewModel(
                 dao.getAll().first().filter { it.userId == uid || it.driverId == uid }
 
             val passengerSnapshot = runCatching {
-                db.collection("movings").whereEqualTo("userId", uid).get().await()
+                db.collection("movings").whereEqualTo(
+                    "userId",
+                    db.collection("users").document(uid)
+                ).get().await()
             }.getOrNull()
             val driverSnapshot = runCatching {
-                db.collection("movings").whereEqualTo("driverId", uid).get().await()
+                db.collection("movings").whereEqualTo(
+                    "driverId",
+                    db.collection("users").document(uid)
+                ).get().await()
             }.getOrNull()
 
             val remote =
@@ -234,7 +243,7 @@ class VehicleRequestViewModel(
             try {
                 val data = mapOf(
                     "id" to id,
-                    "userId" to userId,
+                    "userId" to FirebaseFirestore.getInstance().collection("users").document(userId),
                     "date" to dateTime,
                     "vehicleId" to WALKING_ID,
                     "status" to "open"


### PR DESCRIPTION
## Περίληψη
- Αποθήκευση του userId των movings ως DocumentReference στο Firebase
- Ενημέρωση των ερωτημάτων και της καταγραφής περπατήματος για χρήση αναφοράς χρήστη
- Σχόλιο στο build script για νέα συμπεριφορά Firestore

## Έλεγχοι
- `./gradlew test` (απέτυχε: SDK location not found)


------
https://chatgpt.com/codex/tasks/task_e_68c200e7d3a88328830683e83070e669