### PR TITLE
Χρήση της categorizeMovings στην οθόνη μετακινήσεων επιβάτη

### DIFF
--- a/app/src/main/java/com/ioannapergamali/mysmartroute/view/ui/screens/PassengerMovingsScreen.kt
+++ b/app/src/main/java/com/ioannapergamali/mysmartroute/view/ui/screens/PassengerMovingsScreen.kt
@@ -28,7 +28,7 @@ import androidx.navigation.NavController
 import com.ioannapergamali.mysmartroute.R
 import com.ioannapergamali.mysmartroute.data.local.MovingEntity
 import com.ioannapergamali.mysmartroute.data.local.MovingStatus
-import com.ioannapergamali.mysmartroute.data.local.movingStatus
+import com.ioannapergamali.mysmartroute.data.local.categorizeMovings
 import com.ioannapergamali.mysmartroute.view.ui.components.ScreenContainer
 import com.ioannapergamali.mysmartroute.view.ui.components.TopBar
 import com.ioannapergamali.mysmartroute.viewmodel.VehicleRequestViewModel
@@ -44,8 +44,7 @@ fun PassengerMovingsScreen(navController: NavController, openDrawer: () -> Unit)
         viewModel.loadPassengerMovings(context)
     }
 
-    val now = System.currentTimeMillis()
-    val grouped = movings.groupBy { it.movingStatus(now) }
+    val grouped = categorizeMovings(movings)
 
     Scaffold(
         topBar = {


### PR DESCRIPTION
## Περίληψη
- Ενοποίηση ομαδοποίησης μετακινήσεων με χρήση της `categorizeMovings` στην οθόνη επιβάτη

## Έλεγχοι
- `./gradlew test` *(αποτυχία: λείπει Android SDK)*

------
https://chatgpt.com/codex/tasks/task_e_68c20a8d6d108328b1757db724c25c3d