### PR TITLE
Handle open status in movingStatus

### DIFF
--- a/app/src/main/java/com/ioannapergamali/mysmartroute/data/local/MovingStatus.kt
+++ b/app/src/main/java/com/ioannapergamali/mysmartroute/data/local/MovingStatus.kt
@@ -22,11 +22,10 @@ enum class MovingStatus {
  * και τη χρονική στιγμή της μετακίνησης.
  */
 fun MovingEntity.movingStatus(now: Long = System.currentTimeMillis()): MovingStatus {
-    val s = status.lowercase()
-    return when {
-        s == "completed" -> MovingStatus.COMPLETED
-        s == "accepted" -> MovingStatus.ACTIVE
-        s != "accepted" && date > now -> MovingStatus.PENDING
+    return when (status.lowercase()) {
+        "completed" -> MovingStatus.COMPLETED
+        "accepted" -> MovingStatus.ACTIVE
+        "open" -> if (date > now) MovingStatus.PENDING else MovingStatus.UNSUCCESSFUL
         else -> MovingStatus.UNSUCCESSFUL
     }
 }


### PR DESCRIPTION
## Summary
- map `open` moving entities to pending or unsuccessful statuses

## Testing
- `./gradlew test` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_68c20d8383a083289f7233c5ec080654