### PR TITLE
Add debug logs for moving screens

### DIFF
--- a/app/src/main/java/com/ioannapergamali/mysmartroute/data/local/MovingStatus.kt
+++ b/app/src/main/java/com/ioannapergamali/mysmartroute/data/local/MovingStatus.kt
@@ -2,6 +2,8 @@
 // Statuses for moving.
 package com.ioannapergamali.mysmartroute.data.local
 
+import android.util.Log
+
 /**
  * Περιγράφει την κατάσταση μιας μετακίνησης όπως εμφανίζεται στην εφαρμογή.
  *
@@ -17,17 +19,21 @@ enum class MovingStatus {
     COMPLETED
 }
 
+private const val TAG = "MovingStatus"
+
 /**
  * Υπολογίζει την [MovingStatus] μιας [MovingEntity] με βάση την κατάσταση αποδοχής
  * και τη χρονική στιγμή της μετακίνησης.
  */
 fun MovingEntity.movingStatus(now: Long = System.currentTimeMillis()): MovingStatus {
-    return when (status.lowercase()) {
+    val result = when (status.lowercase()) {
         "completed" -> MovingStatus.COMPLETED
         "accepted" -> MovingStatus.ACTIVE
         "open" -> if (date > now) MovingStatus.PENDING else MovingStatus.UNSUCCESSFUL
         else -> MovingStatus.UNSUCCESSFUL
     }
+    Log.d(TAG, "Μετακίνηση ${'$'}id με raw status '${'$'}status' ταξινομήθηκε ως ${'$'}result")
+    return result
 }
 
 /**
@@ -36,5 +42,10 @@ fun MovingEntity.movingStatus(now: Long = System.currentTimeMillis()): MovingSta
 fun categorizeMovings(
     movings: List<MovingEntity>,
     now: Long = System.currentTimeMillis()
-): Map<MovingStatus, List<MovingEntity>> =
-    movings.groupBy { it.movingStatus(now) }
+): Map<MovingStatus, List<MovingEntity>> {
+    val grouped = movings.groupBy { it.movingStatus(now) }
+    grouped.forEach { (status, list) ->
+        Log.d(TAG, "Ομαδοποίηση ${'$'}status -> ${'$'}{list.size} εγγραφές")
+    }
+    return grouped
+}

--- a/app/src/main/java/com/ioannapergamali/mysmartroute/view/ui/screens/MovingScreen.kt
+++ b/app/src/main/java/com/ioannapergamali/mysmartroute/view/ui/screens/MovingScreen.kt
@@ -1,5 +1,6 @@
 package com.ioannapergamali.mysmartroute.view.ui.screens
 
+import android.util.Log
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.items
 import androidx.compose.material3.MaterialTheme
@@ -15,17 +16,21 @@ import java.time.Instant
 import java.time.ZoneId
 import java.time.format.DateTimeFormatter
 
+private const val TAG = "MovingScreen"
+
 /**
  * Οθόνη που εμφανίζει τις μετακινήσεις ομαδοποιημένες ανά κατάσταση.
  */
 @Composable
 fun MovingScreen(viewModel: MovingViewModel = hiltViewModel()) {
     val movings by viewModel.state.collectAsState()
+    Log.d(TAG, "Σύνολο μετακινήσεων: ${'$'}{movings.size}")
     val grouped = categorizeMovings(movings)
 
     LazyColumn {
         MovingStatus.values().forEach { status ->
             val list = grouped[status].orEmpty()
+            Log.d(TAG, "Κατηγορία ${'$'}status περιέχει ${'$'}{list.size} εγγραφές")
             item {
                 Text(
                     text = titleFor(status),
@@ -36,7 +41,8 @@ fun MovingScreen(viewModel: MovingViewModel = hiltViewModel()) {
                 item { Text("Δεν βρέθηκαν μετακινήσεις") }
             } else {
                 items(list) { moving ->
-                    Text("Μετακίνηση ${moving.id} – ${formatDate(moving.date)}")
+                    Log.d(TAG, "Εμφάνιση μετακίνησης ${'$'}{moving.id} με ημερομηνία ${'$'}{formatDate(moving.date)}")
+                    Text("Μετακίνηση ${'$'}{moving.id} – ${'$'}{formatDate(moving.date)}")
                 }
             }
         }

--- a/app/src/main/java/com/ioannapergamali/mysmartroute/view/ui/screens/PassengerMovingsScreen.kt
+++ b/app/src/main/java/com/ioannapergamali/mysmartroute/view/ui/screens/PassengerMovingsScreen.kt
@@ -1,5 +1,6 @@
 package com.ioannapergamali.mysmartroute.view.ui.screens
 
+import android.util.Log
 import androidx.compose.foundation.horizontalScroll
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
@@ -33,6 +34,7 @@ import com.ioannapergamali.mysmartroute.view.ui.components.ScreenContainer
 import com.ioannapergamali.mysmartroute.view.ui.components.TopBar
 import com.ioannapergamali.mysmartroute.viewmodel.VehicleRequestViewModel
 
+private const val TAG = "PassengerMovingsScreen"
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable
 fun PassengerMovingsScreen(navController: NavController, openDrawer: () -> Unit) {
@@ -44,7 +46,12 @@ fun PassengerMovingsScreen(navController: NavController, openDrawer: () -> Unit)
         viewModel.loadPassengerMovings(context)
     }
 
-    val grouped = categorizeMovings(movings)
+    Log.d(TAG, "Φόρτωση ${'$'}{movings.size} μετακινήσεων επιβάτη")
+    val grouped = categorizeMovings(movings).also { map ->
+        map.forEach { (status, list) ->
+            Log.d(TAG, "Κατηγορία ${'$'}status έχει ${'$'}{list.size} εγγραφές")
+        }
+    }
 
     Scaffold(
         topBar = {
@@ -83,6 +90,7 @@ fun PassengerMovingsScreen(navController: NavController, openDrawer: () -> Unit)
 
 @Composable
 private fun MovingCategory(title: String, list: List<MovingEntity>) {
+    Log.d(TAG, "Εμφάνιση κατηγορίας ${'$'}title με ${'$'}{list.size} εγγραφές")
     Text(title, style = MaterialTheme.typography.titleMedium)
     Spacer(modifier = Modifier.height(8.dp))
     MovingTable(list)
@@ -109,6 +117,7 @@ private fun MovingTable(list: List<MovingEntity>) {
         }
         Divider()
         list.forEach { m ->
+            Log.d(TAG, "Γραμμή για μετακίνηση ${'$'}{m.id} με status ${'$'}{m.status}")
             Row(Modifier.fillMaxWidth()) {
                 TableCell(m.routeName.ifBlank { "-" })
                 TableCell(m.driverName.ifBlank { "-" })


### PR DESCRIPTION
## Summary
- add debug logging in moving list screens to inspect category counts and items
- log status classification and grouping for movings

## Testing
- `./gradlew test` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_68c212587ebc8328865fd59688bab5b0