### PR TITLE
Αποφυγή αιτημάτων στο "Εύρεση τώρα"

### DIFF
--- a/app/src/main/java/com/ioannapergamali/mysmartroute/view/ui/screens/BookSeatScreen.kt
+++ b/app/src/main/java/com/ioannapergamali/mysmartroute/view/ui/screens/BookSeatScreen.kt
@@ -551,14 +551,6 @@ fun BookSeatScreen(
                         val dateMillis = datePickerState.selectedDateMillis ?: return@Button
                         val startId = startIndex?.let { pois[it].id } ?: return@Button
                         val endId = endIndex?.let { pois[it].id } ?: return@Button
-                        requestViewModel.requestTransport(
-                            context,
-                            r.id,
-                            startId,
-                            endId,
-                            Double.MAX_VALUE,
-                            dateMillis
-                        )
                         navController.navigate(
                             "availableTransports?routeId=" +
                                     r.id +

--- a/app/src/main/java/com/ioannapergamali/mysmartroute/view/ui/screens/FindVehicleScreen.kt
+++ b/app/src/main/java/com/ioannapergamali/mysmartroute/view/ui/screens/FindVehicleScreen.kt
@@ -417,7 +417,6 @@ fun FindVehicleScreen(navController: NavController, openDrawer: () -> Unit) {
                         val routeId = selectedRouteId ?: return@Button
                         val date = System.currentTimeMillis()
 
-                        requestViewModel.requestTransport(context, routeId, fromId, toId, cost, date)
                         navController.navigate(
                             "availableTransports?routeId=" +
                                 routeId +

--- a/app/src/main/java/com/ioannapergamali/mysmartroute/view/ui/screens/RouteModeScreen.kt
+++ b/app/src/main/java/com/ioannapergamali/mysmartroute/view/ui/screens/RouteModeScreen.kt
@@ -448,7 +448,6 @@ fun RouteModeScreen(
                         val routeId = selectedRouteId ?: return@Button
                         val date = datePickerState.selectedDateMillis ?: 0L
 
-                        requestViewModel.requestTransport(context, routeId, fromId, toId, cost, date)
                         navController.navigate(
                             "availableTransports?routeId=" +
                                 routeId +


### PR DESCRIPTION
## Περίληψη
- Αφαίρεση της κλήσης `requestTransport` από τα κουμπιά "Εύρεση τώρα" ώστε να μην δημιουργείται αίτημα κατά την άμεση κράτηση.
- Εφαρμογή σε οθόνες BookSeat, RouteMode και FindVehicle.

## Δοκιμές
- `timeout 5 ./gradlew test --console=plain` *(απέτυχε: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_68c215b9c61c8328a14b87032c3d9539