### PR TITLE
Add ticket header to reservation details

### DIFF
--- a/app/src/main/java/com/ioannapergamali/mysmartroute/view/ui/screens/ReservationDetailsScreen.kt
+++ b/app/src/main/java/com/ioannapergamali/mysmartroute/view/ui/screens/ReservationDetailsScreen.kt
@@ -2,6 +2,9 @@ package com.ioannapergamali.mysmartroute.view.ui.screens
 
 import android.net.Uri
 import androidx.compose.foundation.layout.*
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.ConfirmationNumber
+import androidx.compose.material3.Icon
 import androidx.compose.material3.Card
 import androidx.compose.material3.CardDefaults
 import androidx.compose.material3.Scaffold
@@ -108,6 +111,15 @@ fun ReservationDetailsScreen(
                 elevation = CardDefaults.cardElevation(defaultElevation = 4.dp)
             ) {
                 Column(Modifier.padding(16.dp)) {
+                    Row(verticalAlignment = Alignment.CenterVertically) {
+                        Icon(
+                            imageVector = Icons.Filled.ConfirmationNumber,
+                            contentDescription = null
+                        )
+                        Spacer(modifier = Modifier.width(8.dp))
+                        Text(stringResource(R.string.ticket))
+                    }
+                    Spacer(modifier = Modifier.height(8.dp))
                     Text("${stringResource(R.string.date)}: ${formatter.format(Date(res.date))}")
                     Text("${stringResource(R.string.route)}: $routeName")
                     Text("${stringResource(R.string.start_point)}: $startPoiName")

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -291,6 +291,7 @@
     <string name="save">Save</string>
     <string name="no_completed_transports">No completed transports</string>
     <string name="view_details">View details</string>
+    <string name="ticket">Εισιτήριο</string>
     <string name="reservation_details">Reservation details</string>
     <string name="no_reservation_found">No reservation found</string>
     <string name="favorite_routes_saved">Routes saved</string>


### PR DESCRIPTION
## Summary
- show ticket title with icon on reservation details card
- add string resource for ticket label

## Testing
- `./gradlew test --console=plain` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_68c21b11850883288a8ed4f2a0a9e6e2