### PR TITLE
Αφαίρεση horizontalScroll από MovingTable

### DIFF
--- a/app/src/main/java/com/ioannapergamali/mysmartroute/view/ui/screens/PassengerMovingsScreen.kt
+++ b/app/src/main/java/com/ioannapergamali/mysmartroute/view/ui/screens/PassengerMovingsScreen.kt
@@ -1,7 +1,6 @@
 package com.ioannapergamali.mysmartroute.view.ui.screens
 
 import android.util.Log
-import androidx.compose.foundation.horizontalScroll
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.RowScope
@@ -9,8 +8,7 @@ import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
-import androidx.compose.foundation.layout.weight
-import androidx.compose.foundation.rememberScrollState
+import androidx.compose.foundation.layout.width
 import androidx.compose.material3.Divider
 import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.MaterialTheme
@@ -20,8 +18,8 @@ import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
-import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.unit.dp
 import androidx.lifecycle.viewmodel.compose.viewModel
@@ -107,11 +105,8 @@ private fun MovingCategory(title: String, list: List<MovingEntity>) {
 
 @Composable
 private fun MovingTable(list: List<MovingEntity>) {
-    val scrollState = rememberScrollState()
     Column(
-        modifier = Modifier
-            .fillMaxWidth()
-            .horizontalScroll(scrollState)
+        modifier = Modifier.fillMaxWidth()
     ) {
         Row(Modifier.fillMaxWidth()) {
             TableHeaderCell(stringResource(R.string.route))
@@ -140,7 +135,7 @@ private fun RowScope.TableHeaderCell(text: String) {
     Text(
         text,
         modifier = Modifier
-            .weight(1f)
+            .width(120.dp)
             .padding(4.dp),
         style = MaterialTheme.typography.titleSmall
     )
@@ -151,7 +146,7 @@ private fun RowScope.TableCell(text: String) {
     Text(
         text,
         modifier = Modifier
-            .weight(1f)
+            .width(120.dp)
             .padding(4.dp)
     )
 }


### PR DESCRIPTION
## Περίληψη
- Απλοποιήθηκε ο πίνακας μετακινήσεων αφαιρώντας το horizontalScroll
- Τα κελιά απέκτησαν σταθερό πλάτος για σωστή εμφάνιση δεδομένων

## Έλεγχοι
- `./gradlew test` (απέτυχε: SDK location not found)


------
https://chatgpt.com/codex/tasks/task_e_68c21a5cf5048328a245b887d9b21272