### PR TITLE
Fix route and duration display on announce screen

### DIFF
--- a/app/src/main/java/com/ioannapergamali/mysmartroute/view/ui/screens/AnnounceTransportScreen.kt
+++ b/app/src/main/java/com/ioannapergamali/mysmartroute/view/ui/screens/AnnounceTransportScreen.kt
@@ -128,11 +128,12 @@ fun AnnounceTransportScreen(navController: NavController, openDrawer: () -> Unit
         if (rId != null && vehicle != null) {
             scope.launch {
                 calculating = true
-                val (_, path) = routeViewModel.getRouteDirections(context, rId, vehicle)
-                pathPoints = path
-                pois = routeViewModel.getRoutePois(context, rId)
-                duration = routeViewModel.getRouteDuration(context, rId, vehicle)
-                path.firstOrNull()?.let { first ->
+                val poisList = routeViewModel.getRoutePois(context, rId)
+                pois = poisList
+                val (dur, path) = routeViewModel.getRouteDirections(context, rId, vehicle)
+                duration = dur
+                pathPoints = if (path.isNotEmpty()) path else poisList.map { LatLng(it.lat, it.lng) }
+                pathPoints.firstOrNull()?.let { first ->
                     cameraPositionState.move(CameraUpdateFactory.newLatLngZoom(first, 13f))
                 }
                 calculating = false


### PR DESCRIPTION
## Summary
- Fetch both duration and path in one call and fall back to POI positions when no path is returned.
- Move camera based on resulting path to keep map centered.

## Testing
- `./gradlew test` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_68c221e817d4832881c3cb2ab96cd9ed