### PR TITLE
Add date, time, cost and duration to movement views

### DIFF
--- a/app/src/main/java/com/ioannapergamali/mysmartroute/view/ui/screens/MovingListScreen.kt
+++ b/app/src/main/java/com/ioannapergamali/mysmartroute/view/ui/screens/MovingListScreen.kt
@@ -10,6 +10,7 @@ import com.ioannapergamali.mysmartroute.data.local.categorizeMovings
 import java.time.Instant
 import java.time.ZoneId
 import java.time.format.DateTimeFormatter
+import java.util.Locale
 
 /**
  * Εμφανίζει τις μετακινήσεις κατηγοριοποιημένες ανάλογα με την
@@ -27,7 +28,13 @@ fun MovingListScreen(movings: List<MovingEntity>) {
                 )
             }
             items(list) { moving ->
-                Text("Μετακίνηση ${moving.id} – ${formatDate(moving.date)}")
+                Text(
+                    "Μετακίνηση ${moving.id} – " +
+                        "Ημερομηνία: ${formatDate(moving.date)} – " +
+                        "Ώρα: ${formatTime(moving.date)} – " +
+                        "Κόστος: ${formatCost(moving.cost)} – " +
+                        "Διάρκεια: ${formatDuration(moving.durationMinutes)}"
+                )
             }
         }
     }
@@ -36,4 +43,21 @@ fun MovingListScreen(movings: List<MovingEntity>) {
 private fun formatDate(epochMillis: Long): String =
     Instant.ofEpochMilli(epochMillis)
         .atZone(ZoneId.systemDefault())
-        .format(DateTimeFormatter.ofPattern("yyyy-MM-dd HH:mm"))
+        .toLocalDate()
+        .format(DateTimeFormatter.ofPattern("yyyy-MM-dd"))
+
+private fun formatTime(epochMillis: Long): String =
+    Instant.ofEpochMilli(epochMillis)
+        .atZone(ZoneId.systemDefault())
+        .toLocalTime()
+        .format(DateTimeFormatter.ofPattern("HH:mm"))
+
+private fun formatCost(cost: Double): String =
+    String.format(Locale.getDefault(), "%.2f€", cost)
+
+private fun formatDuration(minutes: Int): String {
+    val hours = minutes / 60
+    val mins = minutes % 60
+    return if (hours > 0) String.format(Locale.getDefault(), "%d:%02d", hours, mins)
+    else String.format(Locale.getDefault(), "0:%02d", mins)
+}

--- a/app/src/main/java/com/ioannapergamali/mysmartroute/view/ui/screens/PassengerMovingsScreen.kt
+++ b/app/src/main/java/com/ioannapergamali/mysmartroute/view/ui/screens/PassengerMovingsScreen.kt
@@ -32,6 +32,10 @@ import com.ioannapergamali.mysmartroute.data.local.categorizeMovings
 import com.ioannapergamali.mysmartroute.view.ui.components.ScreenContainer
 import com.ioannapergamali.mysmartroute.view.ui.components.TopBar
 import com.ioannapergamali.mysmartroute.viewmodel.VehicleRequestViewModel
+import java.time.Instant
+import java.time.ZoneId
+import java.time.format.DateTimeFormatter
+import java.util.Locale
 
 private const val TAG = "PassengerMovingsScreen"
 @OptIn(ExperimentalMaterial3Api::class)
@@ -116,6 +120,10 @@ private fun MovingTable(list: List<MovingEntity>) {
                 TableHeaderCell(stringResource(R.string.driver))
                 TableHeaderCell(stringResource(R.string.vehicle_name))
                 TableHeaderCell(stringResource(R.string.passenger))
+                TableHeaderCell(stringResource(R.string.date))
+                TableHeaderCell(stringResource(R.string.time))
+                TableHeaderCell(stringResource(R.string.cost))
+                TableHeaderCell(stringResource(R.string.duration))
             }
             Divider()
             list.forEach { m ->
@@ -127,11 +135,37 @@ private fun MovingTable(list: List<MovingEntity>) {
                     TableCell(m.driverName.ifBlank { "-" })
                     TableCell(m.vehicleName.ifBlank { "-" })
                     TableCell(m.createdByName.ifBlank { "-" })
+                    TableCell(formatDate(m.date))
+                    TableCell(formatTime(m.date))
+                    TableCell(formatCost(m.cost))
+                    TableCell(formatDuration(m.durationMinutes))
                 }
                 Divider()
             }
         }
     }
+}
+
+private fun formatDate(epochMillis: Long): String =
+    Instant.ofEpochMilli(epochMillis)
+        .atZone(ZoneId.systemDefault())
+        .toLocalDate()
+        .format(DateTimeFormatter.ofPattern("yyyy-MM-dd"))
+
+private fun formatTime(epochMillis: Long): String =
+    Instant.ofEpochMilli(epochMillis)
+        .atZone(ZoneId.systemDefault())
+        .toLocalTime()
+        .format(DateTimeFormatter.ofPattern("HH:mm"))
+
+private fun formatCost(cost: Double): String =
+    String.format(Locale.getDefault(), "%.2f€", cost)
+
+private fun formatDuration(minutes: Int): String {
+    val hours = minutes / 60
+    val mins = minutes % 60
+    return if (hours > 0) String.format(Locale.getDefault(), "%d:%02d", hours, mins)
+    else String.format(Locale.getDefault(), "0:%02d", mins)
 }
 
 @Composable


### PR DESCRIPTION
## Summary
- display date, time, cost and duration columns in passenger moving list
- show the same information in simple moving list

## Testing
- `./gradlew test` *(fails: Starting a Gradle Daemon, 3 busy Daemons could not be reused, use --status for details)*

------
https://chatgpt.com/codex/tasks/task_e_68c231b129908328acf94aac9d60deef