### PR TITLE
Υποστήριξη null κόστους σε αιτήματα από «Εύρεση τώρα»

### DIFF
--- a/app/src/main/java/com/ioannapergamali/mysmartroute/data/local/MovingEntity.kt
+++ b/app/src/main/java/com/ioannapergamali/mysmartroute/data/local/MovingEntity.kt
@@ -26,7 +26,7 @@ data class MovingEntity(
     val userId: String = "",
     val date: Long = 0L,
     val vehicleId: String = "",
-    val cost: Double = 0.0,
+    val cost: Double? = null,
     val durationMinutes: Int = 0,
     /** Σημείο επιβίβασης */
     val startPoiId: String = "",
@@ -60,7 +60,7 @@ data class MovingEntity(
         userId: String = "",
         date: Long = 0L,
         vehicleId: String = "",
-        cost: Double = 0.0,
+        cost: Double? = null,
         durationMinutes: Int = 0,
         startPoiId: String = "",
         endPoiId: String = "",

--- a/app/src/main/java/com/ioannapergamali/mysmartroute/data/local/TransferRequestEntity.kt
+++ b/app/src/main/java/com/ioannapergamali/mysmartroute/data/local/TransferRequestEntity.kt
@@ -17,7 +17,7 @@ data class TransferRequestEntity(
 
     /** Ημερομηνία σε millis */
     val date: Long = 0L,
-    val cost: Double = 0.0,
+    val cost: Double? = null,
     /** Κατάσταση αιτήματος */
     val status: RequestStatus = RequestStatus.PENDING
 )

--- a/app/src/main/java/com/ioannapergamali/mysmartroute/model/classes/transports/Moving.kt
+++ b/app/src/main/java/com/ioannapergamali/mysmartroute/model/classes/transports/Moving.kt
@@ -9,5 +9,5 @@ data class Moving(
     val id: String,
     val route: Route,
     val date: Int,
-    val cost: Double
+    val cost: Double?
 )

--- a/app/src/main/java/com/ioannapergamali/mysmartroute/model/classes/transports/TransferRequest.kt
+++ b/app/src/main/java/com/ioannapergamali/mysmartroute/model/classes/transports/TransferRequest.kt
@@ -9,6 +9,6 @@ data class TransferRequest(
     val passengerId: String,
     val driverId: String,
     val date: Long,
-    val cost: Double,
+    val cost: Double?,
     val status: RequestStatus
 )

--- a/app/src/main/java/com/ioannapergamali/mysmartroute/utils/FirestoreMappers.kt
+++ b/app/src/main/java/com/ioannapergamali/mysmartroute/utils/FirestoreMappers.kt
@@ -270,13 +270,13 @@ fun MovingEntity.toFirestoreMap(): Map<String, Any> {
         // Αποθηκεύουμε το userId ως αναφορά στο έγγραφο του χρήστη
         "userId" to FirebaseFirestore.getInstance().collection("users").document(userId),
         "date" to date,
-        "cost" to cost,
         "durationMinutes" to durationMinutes,
         "startPoiId" to FirebaseFirestore.getInstance().collection("pois").document(startPoiId),
         "endPoiId" to FirebaseFirestore.getInstance().collection("pois").document(endPoiId),
         "status" to status,
         "requestNumber" to requestNumber
     )
+    cost?.let { map["cost"] = it }
     if (vehicleId.isNotEmpty()) {
         map["vehicleId"] = FirebaseFirestore.getInstance().collection("vehicles").document(vehicleId)
     }
@@ -315,7 +315,7 @@ fun DocumentSnapshot.toMovingEntity(): MovingEntity? {
         is Long -> d
         else -> getLong("date") ?: 0L
     }
-    val costVal = getDouble("cost") ?: 0.0
+    val costVal = getDouble("cost")
     val durVal = (getLong("durationMinutes") ?: 0L).toInt()
     val startPoiId = when (val s = get("startPoiId")) {
         is DocumentReference -> s.id
@@ -501,9 +501,9 @@ fun TransferRequestEntity.toFirestoreMap(): Map<String, Any> {
         "routeId" to db.collection("routes").document(routeId),
         "passengerId" to db.collection("users").document(passengerId),
         "date" to date,
-        "cost" to cost,
         "status" to status.name
     )
+    cost?.let { map["cost"] = it }
 
     if (driverId.isNotBlank()) {
         map["driverId"] = db.collection("users").document(driverId)
@@ -531,7 +531,7 @@ fun DocumentSnapshot.toTransferRequestEntity(): TransferRequestEntity? {
         else -> getString("driverId")
     } ?: ""
     val dateVal = getLong("date") ?: 0L
-    val costVal = getDouble("cost") ?: 0.0
+    val costVal = getDouble("cost")
     val statusStr = getString("status") ?: RequestStatus.PENDING.name
     return TransferRequestEntity(number, routeId, passengerId, driverId, id, dateVal, costVal, enumValueOf(statusStr))
 }

--- a/app/src/main/java/com/ioannapergamali/mysmartroute/view/ui/screens/BookSeatScreen.kt
+++ b/app/src/main/java/com/ioannapergamali/mysmartroute/view/ui/screens/BookSeatScreen.kt
@@ -579,14 +579,14 @@ fun BookSeatScreen(
                                 routeId,
                                 startId,
                                 endId,
-                                Double.MAX_VALUE,
+                                null,
                                 dateMillis
                             )
                             transferRequestViewModel.submitRequest(
                                 context,
                                 routeId,
                                 dateMillis,
-                                Double.MAX_VALUE
+                                null
                             )
                             message = context.getString(R.string.request_sent)
                         }

--- a/app/src/main/java/com/ioannapergamali/mysmartroute/view/ui/screens/FindVehicleScreen.kt
+++ b/app/src/main/java/com/ioannapergamali/mysmartroute/view/ui/screens/FindVehicleScreen.kt
@@ -413,7 +413,7 @@ fun FindVehicleScreen(navController: NavController, openDrawer: () -> Unit) {
                         }
                         val fromId = routePois[fromIdx].id
                         val toId = routePois[toIdx].id
-                        val cost = maxCostText.toDoubleOrNull() ?: Double.MAX_VALUE
+                        val cost = maxCostText.toDoubleOrNull()
                         val routeId = selectedRouteId ?: return@Button
                         val date = System.currentTimeMillis()
 
@@ -422,7 +422,7 @@ fun FindVehicleScreen(navController: NavController, openDrawer: () -> Unit) {
                                 routeId +
                                 "&startId=" + fromId +
                                 "&endId=" + toId +
-                                "&maxCost=" + cost +
+                                "&maxCost=" + (cost?.toString() ?: "") +
                                 "&date="
                         )
                     },
@@ -443,7 +443,7 @@ fun FindVehicleScreen(navController: NavController, openDrawer: () -> Unit) {
                             }
                             val fromId = routePois[fromIdx].id
                             val toId = routePois[toIdx].id
-                            val cost = maxCostText.toDoubleOrNull() ?: Double.MAX_VALUE
+                            val cost = maxCostText.toDoubleOrNull()
                             val date = System.currentTimeMillis()
                             val routeId = saveEditedRouteAsNewRoute()
 

--- a/app/src/main/java/com/ioannapergamali/mysmartroute/view/ui/screens/MovingListScreen.kt
+++ b/app/src/main/java/com/ioannapergamali/mysmartroute/view/ui/screens/MovingListScreen.kt
@@ -52,8 +52,8 @@ private fun formatTime(epochMillis: Long): String =
         .toLocalTime()
         .format(DateTimeFormatter.ofPattern("HH:mm"))
 
-private fun formatCost(cost: Double): String =
-    String.format(Locale.getDefault(), "%.2f€", cost)
+private fun formatCost(cost: Double?): String =
+    cost?.let { String.format(Locale.getDefault(), "%.2f€", it) } ?: "-"
 
 private fun formatDuration(minutes: Int): String {
     val hours = minutes / 60

--- a/app/src/main/java/com/ioannapergamali/mysmartroute/view/ui/screens/PassengerMovingsScreen.kt
+++ b/app/src/main/java/com/ioannapergamali/mysmartroute/view/ui/screens/PassengerMovingsScreen.kt
@@ -158,8 +158,8 @@ private fun formatTime(epochMillis: Long): String =
         .toLocalTime()
         .format(DateTimeFormatter.ofPattern("HH:mm"))
 
-private fun formatCost(cost: Double): String =
-    String.format(Locale.getDefault(), "%.2f€", cost)
+private fun formatCost(cost: Double?): String =
+    cost?.let { String.format(Locale.getDefault(), "%.2f€", it) } ?: "-"
 
 private fun formatDuration(minutes: Int): String {
     val hours = minutes / 60

--- a/app/src/main/java/com/ioannapergamali/mysmartroute/view/ui/screens/RouteModeScreen.kt
+++ b/app/src/main/java/com/ioannapergamali/mysmartroute/view/ui/screens/RouteModeScreen.kt
@@ -444,7 +444,7 @@ fun RouteModeScreen(
                         }
                         val fromId = routePois[fromIdx].id
                         val toId = routePois[toIdx].id
-                        val cost = maxCostText.toDoubleOrNull() ?: Double.MAX_VALUE
+                        val cost = maxCostText.toDoubleOrNull()
                         val routeId = selectedRouteId ?: return@Button
                         val date = datePickerState.selectedDateMillis ?: 0L
 
@@ -453,7 +453,7 @@ fun RouteModeScreen(
                                 routeId +
                                 "&startId=" + fromId +
                                 "&endId=" + toId +
-                                "&maxCost=" + cost +
+                                "&maxCost=" + (cost?.toString() ?: "") +
                                 "&date=" + date
                         )
                     },
@@ -474,7 +474,7 @@ fun RouteModeScreen(
                             }
                             val fromId = routePois[fromIdx].id
                             val toId = routePois[toIdx].id
-                            val cost = maxCostText.toDoubleOrNull() ?: Double.MAX_VALUE
+                            val cost = maxCostText.toDoubleOrNull()
                             val date = datePickerState.selectedDateMillis ?: 0L
                             val routeId = saveEditedRouteAsNewRoute()
 

--- a/app/src/main/java/com/ioannapergamali/mysmartroute/view/ui/screens/ViewRequestsScreen.kt
+++ b/app/src/main/java/com/ioannapergamali/mysmartroute/view/ui/screens/ViewRequestsScreen.kt
@@ -63,7 +63,7 @@ fun ViewRequestsScreen(
     val columnWidth = 150.dp
     val sortOption = remember { mutableStateOf(SortOption.COST) }
     val sortedRequests = when (sortOption.value) {
-        SortOption.COST -> requests.sortedBy { it.cost }
+        SortOption.COST -> requests.sortedBy { it.cost ?: Double.MAX_VALUE }
         SortOption.DATE -> requests.sortedBy { it.date }
     }
 
@@ -155,7 +155,7 @@ fun ViewRequestsScreen(
                                 val timeStr = DateFormat.format("HH:mm", date).toString()
                                 "$dateStr $timeStr"
                             } else ""
-                            val costText = if (req.cost == Double.MAX_VALUE) "-" else req.cost.toString()
+                            val costText = req.cost?.toString() ?: "-"
                             val isExpired = req.date > 0L && System.currentTimeMillis() > req.date && req.status != "completed"
                             val statusText = if (isExpired) stringResource(R.string.request_unsuccessful) else req.status
                             Row(

--- a/app/src/main/java/com/ioannapergamali/mysmartroute/view/ui/screens/ViewTransportRequestsScreen.kt
+++ b/app/src/main/java/com/ioannapergamali/mysmartroute/view/ui/screens/ViewTransportRequestsScreen.kt
@@ -176,7 +176,7 @@ fun ViewTransportRequestsScreen(
                                 )
                                 Text(userName, modifier = Modifier.width(columnWidth))
                                 Text(routeName, modifier = Modifier.width(columnWidth))
-                                val costText = if (req.cost == Double.MAX_VALUE) "∞" else req.cost.toString()
+                                val costText = req.cost?.toString() ?: "∞"
                                 Text(costText, modifier = Modifier.width(columnWidth))
                                 Text(dateTimeText, modifier = Modifier.width(columnWidth))
                                 Text(req.requestNumber.toString(), modifier = Modifier.width(columnWidth))

--- a/app/src/main/java/com/ioannapergamali/mysmartroute/viewmodel/BookingViewModel.kt
+++ b/app/src/main/java/com/ioannapergamali/mysmartroute/viewmodel/BookingViewModel.kt
@@ -61,7 +61,7 @@ class BookingViewModel : ViewModel() {
         declarationId: String = "",
         driverId: String = "",
         vehicleId: String = "",
-        cost: Double = 0.0,
+        cost: Double? = null,
         durationMinutes: Int = 0
     ): Result<Unit> = withContext(Dispatchers.IO) {
         val userId = auth.currentUser?.uid

--- a/app/src/main/java/com/ioannapergamali/mysmartroute/viewmodel/TransferRequestViewModel.kt
+++ b/app/src/main/java/com/ioannapergamali/mysmartroute/viewmodel/TransferRequestViewModel.kt
@@ -34,7 +34,7 @@ class TransferRequestViewModel : ViewModel() {
         context: Context,
         routeId: String,
         date: Long,
-        cost: Double,
+        cost: Double?,
     ) {
         val passengerId = auth.currentUser?.uid ?: return
         val entity = TransferRequestEntity(

--- a/app/src/main/java/com/ioannapergamali/mysmartroute/viewmodel/UserStatsViewModel.kt
+++ b/app/src/main/java/com/ioannapergamali/mysmartroute/viewmodel/UserStatsViewModel.kt
@@ -50,7 +50,7 @@ class UserStatsViewModel(application: Application) : AndroidViewModel(applicatio
             _userSummaries.value = users.map { user ->
                 val userMovings = movingsByUser[user.id]?.filter { it.status == "completed" } ?: emptyList()
                 userMovings.forEach { it.routeName = routeMap[it.routeId]?.name ?: "" }
-                val totalCost = userMovings.sumOf { it.cost }
+                val totalCost = userMovings.sumOf { it.cost ?: 0.0 }
                 val passengerRatings = userMovings.mapNotNull { ratingMap[it.id]?.rating }
                 val passengerAvg = if (passengerRatings.isNotEmpty()) passengerRatings.average() else 0.0
                 val userVehicles = vehiclesByUser[user.id] ?: emptyList()

--- a/app/src/main/java/com/ioannapergamali/mysmartroute/viewmodel/VehicleRequestViewModel.kt
+++ b/app/src/main/java/com/ioannapergamali/mysmartroute/viewmodel/VehicleRequestViewModel.kt
@@ -377,7 +377,7 @@ class VehicleRequestViewModel(
         routeId: String,
         fromPoiId: String,
         toPoiId: String,
-        maxCost: Double,
+        maxCost: Double?,
         date: Long,
         targetUserId: String? = null
     ) {


### PR DESCRIPTION
## Περίληψη
- Μετατροπή των πεδίων κόστους σε nullable ώστε αιτήματα χωρίς τιμή να αποθηκεύονται ως `null`.
- Ενημέρωση ViewModels και οθονών για αποστολή/χειρισμό του προαιρετικού κόστους.
- Προσαρμογή Firestore mappers για παράλειψη του πεδίου όταν δεν υπάρχει τιμή.

## Δοκιμές
- `./gradlew test` *(αποτυχία: missing Android SDK)*

------
https://chatgpt.com/codex/tasks/task_e_68c23c595e908328964fa56efe00f73d