### PR TITLE
Δημιουργία migration 62→63 και αφαίρεση fallback από Room

### DIFF
--- a/app/src/main/java/com/ioannapergamali/mysmartroute/data/local/MySmartRouteDatabase.kt
+++ b/app/src/main/java/com/ioannapergamali/mysmartroute/data/local/MySmartRouteDatabase.kt
@@ -813,6 +813,12 @@ abstract class MySmartRouteDatabase : RoomDatabase() {
             }
         }
 
+        private val MIGRATION_62_63 = object : Migration(62, 63) {
+            override fun migrate(database: SupportSQLiteDatabase) {
+                // Καμία αλλαγή στο schema αλλά απαιτείται migration για να διατηρηθούν τα δεδομένα
+            }
+        }
+
         private fun prepopulate(db: SupportSQLiteDatabase) {
             Log.d(TAG, "Prepopulating database")
             db.execSQL(
@@ -954,9 +960,9 @@ abstract class MySmartRouteDatabase : RoomDatabase() {
                     MIGRATION_57_58,
                     MIGRATION_59_60,
                     MIGRATION_60_61,
-                    MIGRATION_61_62
+                    MIGRATION_61_62,
+                    MIGRATION_62_63
                 )
-                    .fallbackToDestructiveMigration()
                     .addCallback(object : RoomDatabase.Callback() {
                         override fun onCreate(db: SupportSQLiteDatabase) {
                             prepopulate(db)


### PR DESCRIPTION
## Περίληψη
- Προστέθηκε κενό migration 62→63 ώστε να μην διαγράφονται τα δεδομένα όταν αυξάνεται η έκδοση της βάσης.
- Αφαιρέθηκε το `fallbackToDestructiveMigration` και δηλώθηκε το νέο migration στον builder της βάσης.

## Έλεγχοι
- `./gradlew test` *(αποτυχία: missing Android SDK)*

------
https://chatgpt.com/codex/tasks/task_e_68c246252a548328a8c49e8562f1385f