### PR TITLE
Add userId field to vehicle tables and enable horizontal scrolling

### DIFF
--- a/app/src/main/java/com/ioannapergamali/mysmartroute/view/ui/screens/FirebaseDatabaseScreen.kt
+++ b/app/src/main/java/com/ioannapergamali/mysmartroute/view/ui/screens/FirebaseDatabaseScreen.kt
@@ -1,10 +1,13 @@
 package com.ioannapergamali.mysmartroute.view.ui.screens
 
+import androidx.compose.foundation.horizontalScroll
+import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Spacer
-import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.items
+import androidx.compose.foundation.rememberScrollState
 import androidx.compose.material3.CircularProgressIndicator
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Scaffold
@@ -48,7 +51,9 @@ fun FirebaseDatabaseScreen(navController: NavController, openDrawer: () -> Unit)
             }
         } else {
             ScreenContainer(modifier = Modifier.padding(padding), scrollable = false) {
-                LazyColumn(modifier = Modifier.fillMaxSize()) {
+                val scrollState = rememberScrollState()
+                Box(modifier = Modifier.horizontalScroll(scrollState)) {
+                    LazyColumn(modifier = Modifier.fillMaxWidth()) {
                 item { Text("Users", style = MaterialTheme.typography.titleMedium) }
                 items(data!!.users) { user ->
                     Text("ID: ${user.id}, ${user.name} ${user.surname}, ${user.username}")
@@ -56,7 +61,10 @@ fun FirebaseDatabaseScreen(navController: NavController, openDrawer: () -> Unit)
                 item { Spacer(modifier = Modifier.padding(8.dp)) }
                 item { Text("Vehicles", style = MaterialTheme.typography.titleMedium) }
                 items(data!!.vehicles) { vehicle ->
-                    Text("${vehicle.description}, τύπος ${vehicle.type}, θέσεις ${vehicle.seat}")
+                    Text(
+                        "${vehicle.description}, τύπος ${vehicle.type}, θέσεις ${vehicle.seat}, user:${vehicle.userId}",
+                        softWrap = false
+                    )
                 }
                 item { Spacer(modifier = Modifier.padding(8.dp)) }
                 item { Text("Poi Types", style = MaterialTheme.typography.titleMedium) }

--- a/app/src/main/java/com/ioannapergamali/mysmartroute/view/ui/screens/LocalDatabaseScreen.kt
+++ b/app/src/main/java/com/ioannapergamali/mysmartroute/view/ui/screens/LocalDatabaseScreen.kt
@@ -1,10 +1,13 @@
 package com.ioannapergamali.mysmartroute.view.ui.screens
 
+import androidx.compose.foundation.horizontalScroll
+import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Spacer
-import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.items
+import androidx.compose.foundation.rememberScrollState
 import androidx.compose.material3.CircularProgressIndicator
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Scaffold
@@ -50,7 +53,9 @@ fun LocalDatabaseScreen(navController: NavController, openDrawer: () -> Unit) {
             }
         } else {
             ScreenContainer(modifier = Modifier.padding(padding), scrollable = false) {
-                LazyColumn(modifier = Modifier.fillMaxSize()) {
+                val scrollState = rememberScrollState()
+                Box(modifier = Modifier.horizontalScroll(scrollState)) {
+                    LazyColumn(modifier = Modifier.fillMaxWidth()) {
                 item { Text("Users", style = MaterialTheme.typography.titleMedium) }
                 if (data!!.users.isEmpty()) {
                     item { Text("Ο πίνακας είναι άδειος") }
@@ -65,7 +70,10 @@ fun LocalDatabaseScreen(navController: NavController, openDrawer: () -> Unit) {
                     item { Text("Ο πίνακας είναι άδειος") }
                 } else {
                     items(data!!.vehicles) { vehicle ->
-                        Text("${vehicle.description}, τύπος ${vehicle.type}, θέσεις ${vehicle.seat}")
+                        Text(
+                            "${vehicle.description}, τύπος ${vehicle.type}, θέσεις ${vehicle.seat}, user:${vehicle.userId}",
+                            softWrap = false
+                        )
                     }
                 }
                 item { Spacer(modifier = Modifier.padding(8.dp)) }


### PR DESCRIPTION
## Summary
- εμφανίζει το userId για κάθε όχημα στους πίνακες Local και Firebase DB
- προστέθηκε οριζόντια κύλιση για καλύτερη προβολή των πινάκων

## Testing
- `./gradlew test` *(απέτυχε: δεν ολοκληρώθηκε στο περιβάλλον)*

------
https://chatgpt.com/codex/tasks/task_e_68c25f787ff88328ac3478b8060e1989