### PR TITLE
Fix missing closing brace in FirebaseDatabaseScreen

### DIFF
--- a/app/src/main/java/com/ioannapergamali/mysmartroute/view/ui/screens/FirebaseDatabaseScreen.kt
+++ b/app/src/main/java/com/ioannapergamali/mysmartroute/view/ui/screens/FirebaseDatabaseScreen.kt
@@ -163,5 +163,6 @@ fun FirebaseDatabaseScreen(navController: NavController, openDrawer: () -> Unit)
                 }
             }
         }
+        }
     }
 }


### PR DESCRIPTION
## Summary
- close `else` block in FirebaseDatabaseScreen to fix compilation error

## Testing
- `./gradlew lint` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_68c2644784b8832882d3ceac426983ce