### PR TITLE
Fix missing brace in LocalDatabaseScreen

### DIFF
--- a/app/src/main/java/com/ioannapergamali/mysmartroute/view/ui/screens/LocalDatabaseScreen.kt
+++ b/app/src/main/java/com/ioannapergamali/mysmartroute/view/ui/screens/LocalDatabaseScreen.kt
@@ -258,3 +258,5 @@ fun LocalDatabaseScreen(navController: NavController, openDrawer: () -> Unit) {
         }
     }
 }
+
+}


### PR DESCRIPTION
## Summary
- add missing closing brace to end of `LocalDatabaseScreen`

## Testing
- `./gradlew test` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_68c2685e35008328b38654c22a9698dd