### PR TITLE
Απλοποίηση αποθήκευσης οχημάτων

### DIFF
--- a/app/src/main/java/com/ioannapergamali/mysmartroute/repository/VehicleRepository.kt
+++ b/app/src/main/java/com/ioannapergamali/mysmartroute/repository/VehicleRepository.kt
@@ -35,7 +35,7 @@ class VehicleRepository @Inject constructor(
     private val vehicleDao = db.vehicleDao()
 
     /**
-     * Αποθηκεύει όχημα στο Firestore και τοπικά στη Room.
+     * Αποθηκεύει όχημα στη Room και στη συνέχεια στο Firestore.
      */
     suspend fun addVehicle(vehicle: VehicleEntity) = withContext(Dispatchers.IO) {
         val uid = FirebaseAuth.getInstance().currentUser?.uid
@@ -43,6 +43,10 @@ class VehicleRepository @Inject constructor(
         val entity = vehicle.copy(userId = vehicle.userId.ifBlank { uid })
 
         Log.d(TAG, "Καταχώρηση οχήματος ${entity.id}")
+
+        insertVehicleSafely(db, entity)
+        Log.d(TAG, "Το όχημα ${entity.id} αποθηκεύτηκε τοπικά")
+
         try {
             firestore.collection("vehicles")
                 .document(entity.id)
@@ -51,9 +55,6 @@ class VehicleRepository @Inject constructor(
             Log.d(TAG, "Αποθήκευση οχήματος ${entity.id} στο Firestore επιτυχής")
         } catch (e: Exception) {
             Log.e(TAG, "Αποτυχία αποθήκευσης οχήματος ${entity.id} στο Firestore", e)
-        } finally {
-            insertVehicleSafely(db, entity)
-            Log.d(TAG, "Το όχημα ${entity.id} αποθηκεύτηκε τοπικά")
         }
     }
 

--- a/app/src/main/java/com/ioannapergamali/mysmartroute/viewmodel/VehicleViewModel.kt
+++ b/app/src/main/java/com/ioannapergamali/mysmartroute/viewmodel/VehicleViewModel.kt
@@ -20,6 +20,7 @@ import com.ioannapergamali.mysmartroute.repository.VehicleRepository
 import kotlinx.coroutines.tasks.await
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.Job
@@ -123,6 +124,8 @@ class VehicleViewModel : ViewModel() {
             val repo = getRepository(context)
             try {
                 repo.addVehicle(entity)
+                val vehicles = repo.vehiclesForUser(userId).first()
+                Log.d(TAG, "Βρέθηκαν ${vehicles.size} οχήματα")
                 Log.d(TAG, "Το όχημα ${entity.id} αποθηκεύτηκε επιτυχώς")
                 _registerState.value = RegisterState.Success
             } catch (e: Exception) {
@@ -191,6 +194,11 @@ class VehicleViewModel : ViewModel() {
                 }
             }
         }
+    }
+
+    override fun onCleared() {
+        repository?.stopSync()
+        super.onCleared()
     }
 
     private fun getRepository(context: Context): VehicleRepository {


### PR DESCRIPTION
## Περίληψη
- Καταχώρηση οχημάτων πρώτα στη Room και έπειτα στο Firestore για αποφυγή διπλών εισαγωγών
- Επαλήθευση μετά την αποθήκευση με άμεση ανάγνωση από τη Room
- Διακοπή του συγχρονισμού Firestore όταν καταστρέφεται το ViewModel

## Έλεγχοι
- `./gradlew test` *(απέτυχε: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_68c2725ddcd08328a369b475a4e33a73