### PR TITLE
Αποφυγή ειδοποίησης χωρίς επιβεβαίωση οδηγού

### DIFF
--- a/app/src/main/java/com/ioannapergamali/mysmartroute/view/ui/screens/NotificationsScreen.kt
+++ b/app/src/main/java/com/ioannapergamali/mysmartroute/view/ui/screens/NotificationsScreen.kt
@@ -85,7 +85,9 @@ fun NotificationsScreen(navController: NavController, openDrawer: () -> Unit) {
             }
         }
 
-        UserRole.PASSENGER -> requests.filter { it.status == "pending" }.map { req ->
+        UserRole.PASSENGER -> requests.filter {
+            it.status == "pending" && it.driverId.isNotBlank()
+        }.map { req ->
             stringResource(
                 R.string.driver_offer_notification,
                 req.driverName,

--- a/app/src/main/java/com/ioannapergamali/mysmartroute/viewmodel/VehicleRequestViewModel.kt
+++ b/app/src/main/java/com/ioannapergamali/mysmartroute/viewmodel/VehicleRequestViewModel.kt
@@ -171,7 +171,7 @@ class VehicleRequestViewModel(
                         (it.driverId == userId && it.status == "accepted")
                 }
             } else {
-                _requests.value.filter { it.status == "pending" }
+                _requests.value.filter { it.status == "pending" && it.driverId.isNotBlank() }
             }
             _hasUnreadNotifications.value = notifications.any { it.id !in readNotificationIds }
 
@@ -338,7 +338,7 @@ class VehicleRequestViewModel(
                     (it.driverId == userId && it.status == "accepted")
             }
         } else {
-            _requests.value.filter { it.status == "pending" }
+            _requests.value.filter { it.status == "pending" && it.driverId.isNotBlank() }
         }
         readNotificationIds.addAll(notifications.map { it.id })
         _hasUnreadNotifications.value = false
@@ -623,7 +623,9 @@ class VehicleRequestViewModel(
     }
 
     private suspend fun showPendingNotifications(context: Context) {
-        _requests.value.filter { it.status == "pending" && it.id !in notifiedRequests }.forEach { req ->
+        _requests.value.filter {
+            it.status == "pending" && it.driverId.isNotBlank() && it.id !in notifiedRequests
+        }.forEach { req ->
             val driverName = if (req.driverName.isNotBlank()) {
                 req.driverName
             } else {


### PR DESCRIPTION
## Περιγραφή
- Εμφάνιση ειδοποιήσεων "ο οδηγός προσφέρθηκε" μόνο όταν έχει οριστεί driverId
- Φιλτράρισμα αιτημάτων χωρίς οδηγό σε προβολή και ειδοποιήσεις

## Έλεγχοι
- `./gradlew test` *(αποτυχία: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_68c275e69b988328a371588f59862301