### PR TITLE
Use Flow for vehicles and ensure singleton DB

### DIFF
--- a/app/src/main/java/com/ioannapergamali/mysmartroute/data/local/VehicleDao.kt
+++ b/app/src/main/java/com/ioannapergamali/mysmartroute/data/local/VehicleDao.kt
@@ -17,7 +17,7 @@ interface VehicleDao {
     fun getVehiclesForUser(userId: String): Flow<List<VehicleEntity>>
 
     @Query("SELECT * FROM vehicles")
-    fun getAllVehicles(): Flow<List<VehicleEntity>>
+    fun getVehicles(): Flow<List<VehicleEntity>>
 
     @Query("SELECT * FROM vehicles WHERE id = :id LIMIT 1")
     suspend fun getVehicle(id: String): VehicleEntity?

--- a/app/src/main/java/com/ioannapergamali/mysmartroute/repository/VehicleRepository.kt
+++ b/app/src/main/java/com/ioannapergamali/mysmartroute/repository/VehicleRepository.kt
@@ -59,8 +59,8 @@ class VehicleRepository @Inject constructor(
     }
 
     /** Ροή με όλα τα οχήματα. Αν η Room είναι κενή, τα φέρνει από το Firestore. */
-    val vehicles: Flow<List<VehicleEntity>> = vehicleDao.getAllVehicles().onStart {
-        val local = vehicleDao.getAllVehicles().first()
+    val vehicles: Flow<List<VehicleEntity>> = vehicleDao.getVehicles().onStart {
+        val local = vehicleDao.getVehicles().first()
         if (local.isEmpty()) {
             Log.d(TAG, "Τοπικά οχήματα κενά, ανάκτηση από Firestore")
             val remote = firestore.collection("vehicles").get().await()

--- a/app/src/main/java/com/ioannapergamali/mysmartroute/viewmodel/DatabaseViewModel.kt
+++ b/app/src/main/java/com/ioannapergamali/mysmartroute/viewmodel/DatabaseViewModel.kt
@@ -109,7 +109,7 @@ class DatabaseViewModel : ViewModel() {
             Log.d(TAG, "Loading local data")
             kotlinx.coroutines.flow.combine(
                 db.userDao().getAllUsers(),
-                db.vehicleDao().getAllVehicles(),
+                db.vehicleDao().getVehicles(),
                 db.poIDao().getAll(),
                 db.poiTypeDao().getAll(),
                 db.settingsDao().getAllSettings(),
@@ -522,7 +522,7 @@ class DatabaseViewModel : ViewModel() {
                     Log.d(TAG, "Local database is newer, uploading data")
                     val users = db.userDao().getAllUsers().first()
                     Log.d(TAG, "Fetched ${users.size} local users")
-                    val vehicles = db.vehicleDao().getAllVehicles().first()
+                    val vehicles = db.vehicleDao().getVehicles().first()
                     Log.d(TAG, "Fetched ${vehicles.size} local vehicles")
                     val pois = db.poIDao().getAll().first()
                     Log.d(TAG, "Fetched ${pois.size} local pois")

--- a/app/src/main/java/com/ioannapergamali/mysmartroute/viewmodel/UserStatsViewModel.kt
+++ b/app/src/main/java/com/ioannapergamali/mysmartroute/viewmodel/UserStatsViewModel.kt
@@ -38,7 +38,7 @@ class UserStatsViewModel(application: Application) : AndroidViewModel(applicatio
             val users = db.userDao().getAllUsers().first()
             val movings = db.movingDao().getAll().first()
             val ratings = db.tripRatingDao().getAll().first()
-            val vehicles = db.vehicleDao().getAllVehicles().first()
+            val vehicles = db.vehicleDao().getVehicles().first()
             val routes = db.routeDao().getAll().first()
 
             val ratingMap = ratings.associateBy { it.movingId }

--- a/app/src/main/java/com/ioannapergamali/mysmartroute/viewmodel/VehicleViewModel.kt
+++ b/app/src/main/java/com/ioannapergamali/mysmartroute/viewmodel/VehicleViewModel.kt
@@ -176,7 +176,7 @@ class VehicleViewModel : ViewModel() {
             if (vehicleId.isBlank()) return@launch
             if (_vehicles.value.any { it.id == vehicleId }) return@launch
 
-            val dbLocal = MySmartRouteDatabase.getInstance(context)
+            val dbLocal = MySmartRouteDatabase.getInstance(context.applicationContext)
             val vehicleDao = dbLocal.vehicleDao()
 
             val local = vehicleDao.getVehicle(vehicleId)
@@ -204,7 +204,7 @@ class VehicleViewModel : ViewModel() {
     private fun getRepository(context: Context): VehicleRepository {
         val existing = repository
         if (existing != null) return existing
-        val dbLocal = MySmartRouteDatabase.getInstance(context)
+        val dbLocal = MySmartRouteDatabase.getInstance(context.applicationContext)
         return VehicleRepository(dbLocal, db).also { repo ->
             repository = repo
             repo.startSync(viewModelScope)


### PR DESCRIPTION
## Summary
- Rename VehicleDao.getAllVehicles to getVehicles returning Flow
- Use application context when retrieving MySmartRouteDatabase
- Update view models and repository to use Flow-based DAO

## Testing
- `./gradlew test` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_68c27868305883289be46e93a38cf329