### PR TITLE
Make notification items open request screen

### DIFF
--- a/app/src/main/java/com/ioannapergamali/mysmartroute/view/ui/screens/NotificationsScreen.kt
+++ b/app/src/main/java/com/ioannapergamali/mysmartroute/view/ui/screens/NotificationsScreen.kt
@@ -1,5 +1,7 @@
 package com.ioannapergamali.mysmartroute.view.ui.screens
 
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.items
@@ -99,6 +101,10 @@ fun NotificationsScreen(navController: NavController, openDrawer: () -> Unit) {
     }
 
     val messages = systemNotifications.map { it.message } + requestMessages
+    val requestScreen = when (role) {
+        UserRole.DRIVER -> "viewTransportRequests"
+        else -> "viewRequests"
+    }
 
     Scaffold(
         topBar = {
@@ -116,7 +122,12 @@ fun NotificationsScreen(navController: NavController, openDrawer: () -> Unit) {
             } else {
                 LazyColumn {
                     items(messages) { msg ->
-                        Text(msg)
+                        Text(
+                            msg,
+                            modifier = Modifier
+                                .fillMaxWidth()
+                                .clickable { navController.navigate(requestScreen) }
+                        )
                         Divider()
                     }
                 }


### PR DESCRIPTION
## Summary
- Make every notification entry clickable and navigate to the appropriate request screen.

## Testing
- ⚠️ `./gradlew test` *(Android SDK missing)*

------
https://chatgpt.com/codex/tasks/task_e_68c27a828e948328bc52588106b04bd8