### PR TITLE
Προσθήκη debug log για επαλήθευση τοπικής αποθήκευσης οχημάτων

### DIFF
--- a/app/src/main/java/com/ioannapergamali/mysmartroute/viewmodel/VehicleViewModel.kt
+++ b/app/src/main/java/com/ioannapergamali/mysmartroute/viewmodel/VehicleViewModel.kt
@@ -124,6 +124,9 @@ class VehicleViewModel : ViewModel() {
             val repo = getRepository(context)
             try {
                 repo.addVehicle(entity)
+                val dbLocal = MySmartRouteDatabase.getInstance(context.applicationContext)
+                val vehiclesLocal = dbLocal.vehicleDao().getVehiclesForUser(userId).first()
+                Log.d(TAG, "Τοπικά βρέθηκαν ${vehiclesLocal.size} οχήματα")
                 val vehicles = repo.vehiclesForUser(userId).first()
                 Log.d(TAG, "Βρέθηκαν ${vehicles.size} οχήματα")
                 Log.d(TAG, "Το όχημα ${entity.id} αποθηκεύτηκε επιτυχώς")


### PR DESCRIPTION
## Περίληψη
- Καταγραφή του αριθμού οχημάτων στη Room αμέσως μετά την προσθήκη για επιβεβαίωση τοπικής αποθήκευσης.

## Έλεγχοι
- `./gradlew test` *(απέτυχε: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_68c27d39593c83288304f8e796a78d8f