### PR TITLE
Φιλτράρισμα οχημάτων ανά χρήστη και διακοπή συγχρονισμού στο logout

### DIFF
--- a/app/src/main/java/com/ioannapergamali/mysmartroute/view/ui/components/NavigationDrawer.kt
+++ b/app/src/main/java/com/ioannapergamali/mysmartroute/view/ui/components/NavigationDrawer.kt
@@ -35,6 +35,8 @@ import androidx.compose.ui.res.stringResource
 import kotlinx.coroutines.launch
 import com.google.firebase.firestore.FirebaseFirestore
 import com.ioannapergamali.mysmartroute.R
+import androidx.lifecycle.viewmodel.compose.viewModel
+import com.ioannapergamali.mysmartroute.viewmodel.AuthenticationViewModel
 
 @Composable
 fun DrawerMenu(navController: NavController, closeDrawer: () -> Unit) {
@@ -43,6 +45,8 @@ fun DrawerMenu(navController: NavController, closeDrawer: () -> Unit) {
         drawerContentColor = MaterialTheme.colorScheme.onSurface,
         drawerTonalElevation = 4.dp
     ) {
+        val context = LocalContext.current
+        val authViewModel: AuthenticationViewModel = viewModel()
         val userState = remember { mutableStateOf(FirebaseAuth.getInstance().currentUser) }
         val username = remember { mutableStateOf<String?>(null) }
         val role = remember { mutableStateOf<String?>(null) }
@@ -158,7 +162,7 @@ fun DrawerMenu(navController: NavController, closeDrawer: () -> Unit) {
                 label = { Text(stringResource(R.string.logout)) },
                 selected = false,
                 onClick = {
-                    FirebaseAuth.getInstance().signOut()
+                    authViewModel.signOut(context)
                     navController.navigate("home") {
                         popUpTo("home") { inclusive = true }
                     }

--- a/app/src/main/java/com/ioannapergamali/mysmartroute/view/ui/components/TopBar.kt
+++ b/app/src/main/java/com/ioannapergamali/mysmartroute/view/ui/components/TopBar.kt
@@ -55,12 +55,7 @@ fun TopBar(
     showLanguageToggle: Boolean = true,
     showNotifications: Boolean = true,
     onMenuClick: () -> Unit = {},
-    onLogout: () -> Unit = {
-        FirebaseAuth.getInstance().signOut()
-        navController.navigate("home") {
-            popUpTo("home") { inclusive = true }
-        }
-    }
+    onLogout: (() -> Unit)? = null
 ) {
     // Γραμμή εφαρμογής με δυνατότητες πλοήγησης, γλώσσας και ειδοποιήσεων
     // App bar providing navigation, language toggle, and notifications
@@ -84,6 +79,14 @@ fun TopBar(
 
     val userId = FirebaseAuth.getInstance().currentUser?.uid
     val isLoggedIn = userId != null
+
+    val logoutAction = {
+        authViewModel.signOut(context)
+        onLogout?.invoke()
+        navController.navigate("home") {
+            popUpTo("home") { inclusive = true }
+        }
+    }
 
     Box(modifier = Modifier.statusBarsPadding()) {
         TopAppBar(
@@ -175,7 +178,7 @@ fun TopBar(
                 }
             }
             if (showLogout) {
-                IconButton(onClick = onLogout) {
+                IconButton(onClick = logoutAction) {
                     Icon(
                         Icons.Filled.Logout,
                         contentDescription = "logout",

--- a/app/src/main/java/com/ioannapergamali/mysmartroute/view/ui/screens/HomeScreen.kt
+++ b/app/src/main/java/com/ioannapergamali/mysmartroute/view/ui/screens/HomeScreen.kt
@@ -84,7 +84,7 @@ fun HomeScreen(
                         onLogin = { viewModel.login(context, email, password) },
                         onNavigateToSignUp = onNavigateToSignUp,
                         onForgotPassword = { navController.navigate("resetPassword") },
-                        onLogout = { viewModel.signOut() },
+                        onLogout = { viewModel.signOut(context) },
                         modifier = Modifier.weight(1f)
                     )
                 }
@@ -107,7 +107,7 @@ fun HomeScreen(
                         onLogin = { viewModel.login(context, email, password) },
                         onNavigateToSignUp = onNavigateToSignUp,
                         onForgotPassword = { navController.navigate("resetPassword") },
-                        onLogout = { viewModel.signOut() }
+                        onLogout = { viewModel.signOut(context) }
                     )
                 }
             }

--- a/app/src/main/java/com/ioannapergamali/mysmartroute/view/ui/screens/MenuScreen.kt
+++ b/app/src/main/java/com/ioannapergamali/mysmartroute/view/ui/screens/MenuScreen.kt
@@ -57,11 +57,7 @@ fun MenuScreen(navController: NavController, openDrawer: () -> Unit) {
                 showMenu = true,
                 onMenuClick = openDrawer,
                 onLogout = {
-                    viewModel.signOut()
                     Toast.makeText(context, "Logged out", Toast.LENGTH_SHORT).show()
-                    navController.navigate("home") {
-                        popUpTo("menu") { inclusive = true }
-                    }
                 }
             )
         }

--- a/app/src/main/java/com/ioannapergamali/mysmartroute/viewmodel/AuthenticationViewModel.kt
+++ b/app/src/main/java/com/ioannapergamali/mysmartroute/viewmodel/AuthenticationViewModel.kt
@@ -18,6 +18,7 @@ import com.ioannapergamali.mysmartroute.data.local.UserEntity
 import com.ioannapergamali.mysmartroute.data.local.MenuEntity
 import com.ioannapergamali.mysmartroute.data.local.MenuOptionEntity
 import com.ioannapergamali.mysmartroute.data.local.MenuWithOptions
+import com.ioannapergamali.mysmartroute.repository.VehicleRepository
 import com.ioannapergamali.mysmartroute.data.local.insertMenuSafely
 import com.ioannapergamali.mysmartroute.data.local.RoleEntity
 import com.ioannapergamali.mysmartroute.model.classes.users.Admin
@@ -560,7 +561,11 @@ class AuthenticationViewModel : ViewModel() {
      * Αποσυνδέει τον χρήστη και καθαρίζει τις τοπικές καταστάσεις.
      * Signs the user out and clears local states.
      */
-    fun signOut() {
+    fun signOut(context: Context) {
+        VehicleRepository(
+            MySmartRouteDatabase.getInstance(context.applicationContext),
+            FirebaseFirestore.getInstance()
+        ).stopSync()
         auth.signOut()
         _currentUserRole.value = null
         _currentMenus.value = emptyList()


### PR DESCRIPTION
## Περίληψη
- Συγχρονισμός οχημάτων μόνο για τον τρέχοντα χρήστη στο Firestore listener και στην αρχική φόρτωση.
- Προσθήκη `signOut(context)` στο AuthenticationViewModel που διακόπτει τον συγχρονισμό πριν την αποσύνδεση.
- Ενημέρωση TopBar και NavigationDrawer ώστε το logout να χρησιμοποιεί το AuthenticationViewModel και να οδηγεί στην αρχική οθόνη.

## Έλεγχοι
- `./gradlew test` *(αποτυχία: λείπει το Android SDK)*


------
https://chatgpt.com/codex/tasks/task_e_68c27ec48ff08328819864648c200c71