### PR TITLE
Ασφαλής ενημέρωση χρηστών χωρίς διαγραφή οχημάτων

### DIFF
--- a/app/src/main/java/com/ioannapergamali/mysmartroute/data/local/UserDao.kt
+++ b/app/src/main/java/com/ioannapergamali/mysmartroute/data/local/UserDao.kt
@@ -6,11 +6,15 @@ import androidx.room.Dao
 import androidx.room.Insert
 import androidx.room.OnConflictStrategy
 import androidx.room.Query
+import androidx.room.Update
 
 @Dao
 interface UserDao {
-    @Insert(onConflict = OnConflictStrategy.REPLACE)
+    @Insert(onConflict = OnConflictStrategy.IGNORE)
     suspend fun insert(user: UserEntity)
+
+    @Update
+    suspend fun update(user: UserEntity)
 
     @Query("SELECT * FROM users WHERE id = :id")
     suspend fun getUser(id: String): UserEntity?

--- a/app/src/main/java/com/ioannapergamali/mysmartroute/data/local/UserOperations.kt
+++ b/app/src/main/java/com/ioannapergamali/mysmartroute/data/local/UserOperations.kt
@@ -1,0 +1,18 @@
+package com.ioannapergamali.mysmartroute.data.local
+
+import androidx.room.Transaction
+
+/**
+ * Εισάγει ή ενημερώνει έναν χρήστη χωρίς να διαγραφούν τα σχετικά οχήματα.
+ */
+@Transaction
+suspend fun insertUserSafely(
+    userDao: UserDao,
+    user: UserEntity
+) {
+    if (userDao.getUser(user.id) == null) {
+        userDao.insert(user)
+    } else {
+        userDao.update(user)
+    }
+}

--- a/app/src/main/java/com/ioannapergamali/mysmartroute/view/ui/screens/ReservationDetailsScreen.kt
+++ b/app/src/main/java/com/ioannapergamali/mysmartroute/view/ui/screens/ReservationDetailsScreen.kt
@@ -23,6 +23,7 @@ import com.ioannapergamali.mysmartroute.data.local.MySmartRouteDatabase
 import com.ioannapergamali.mysmartroute.data.local.SeatReservationEntity
 import com.ioannapergamali.mysmartroute.view.ui.components.TopBar
 import com.ioannapergamali.mysmartroute.utils.toUserEntity
+import com.ioannapergamali.mysmartroute.data.local.insertUserSafely
 import kotlinx.coroutines.tasks.await
 import java.text.SimpleDateFormat
 import java.util.Date
@@ -63,7 +64,7 @@ fun ReservationDetailsScreen(
                         .get()
                         .await()
                         .toUserEntity()
-                        ?.also { db.userDao().insert(it) }
+                        ?.also { insertUserSafely(db.userDao(), it) }
                 user?.let { "${it.name} ${it.surname}" } ?: driverId
             }.orEmpty()
             val localPassenger = db.userDao().getUser(res.userId)
@@ -76,7 +77,7 @@ fun ReservationDetailsScreen(
                     .get()
                     .await()
                     .toUserEntity()
-                    ?.also { db.userDao().insert(it) }
+                    ?.also { insertUserSafely(db.userDao(), it) }
                     ?.let { user ->
                         listOf(user.name, user.surname)
                             .filter { it.isNotBlank() }

--- a/app/src/main/java/com/ioannapergamali/mysmartroute/viewmodel/AuthenticationViewModel.kt
+++ b/app/src/main/java/com/ioannapergamali/mysmartroute/viewmodel/AuthenticationViewModel.kt
@@ -20,6 +20,7 @@ import com.ioannapergamali.mysmartroute.data.local.MenuOptionEntity
 import com.ioannapergamali.mysmartroute.data.local.MenuWithOptions
 import com.ioannapergamali.mysmartroute.repository.VehicleRepository
 import com.ioannapergamali.mysmartroute.data.local.insertMenuSafely
+import com.ioannapergamali.mysmartroute.data.local.insertUserSafely
 import com.ioannapergamali.mysmartroute.data.local.RoleEntity
 import com.ioannapergamali.mysmartroute.model.classes.users.Admin
 import com.ioannapergamali.mysmartroute.model.classes.users.Driver
@@ -186,7 +187,7 @@ class AuthenticationViewModel : ViewModel() {
                     }
 
                     batch.commit().await()
-                    userDao.insert(userEntity.copy(id = uid, roleId = roleId))
+                    insertUserSafely(userDao, userEntity.copy(id = uid, roleId = roleId))
                     _signUpState.value = SignUpState.Success
                     loadCurrentUserRole(context, loadMenus = true)
                 } catch (e: Exception) {
@@ -194,7 +195,7 @@ class AuthenticationViewModel : ViewModel() {
                 }
             } else {
                 val roleId = roleIds[role] ?: "role_passenger"
-                userDao.insert(userEntity.copy(roleId = roleId))
+                insertUserSafely(userDao, userEntity.copy(roleId = roleId))
                 _signUpState.value = SignUpState.Success
             }
         }
@@ -389,7 +390,7 @@ class AuthenticationViewModel : ViewModel() {
                 Log.i(TAG, "Role from Firestore: $roleName")
                 _currentUserRole.value = runCatching { UserRole.valueOf(roleName) }.getOrNull()
                 val current = userDao.getUser(uid) ?: UserEntity(id = uid)
-                userDao.insert(current.copy(role = roleName, roleId = roleId))
+                insertUserSafely(userDao, current.copy(role = roleName, roleId = roleId))
                 if (loadMenus) loadCurrentUserMenus(context)
                 return@launch
             }
@@ -501,7 +502,7 @@ class AuthenticationViewModel : ViewModel() {
                 }
                 val resolvedRoleId = remoteRoleId ?: fallbackRole?.let { roleIds[it] }
                     ?: return@launch
-                user?.let { dbLocal.userDao().insert(it.copy(roleId = resolvedRoleId)) }
+                user?.let { insertUserSafely(dbLocal.userDao(), it.copy(roleId = resolvedRoleId)) }
                 Log.i(TAG, "Fetched roleId from Firestore: $resolvedRoleId")
                 resolvedRoleId
             }

--- a/app/src/main/java/com/ioannapergamali/mysmartroute/viewmodel/DatabaseViewModel.kt
+++ b/app/src/main/java/com/ioannapergamali/mysmartroute/viewmodel/DatabaseViewModel.kt
@@ -14,6 +14,7 @@ import com.ioannapergamali.mysmartroute.data.local.PoIEntity
 import com.ioannapergamali.mysmartroute.data.local.PoiTypeEntity
 import com.ioannapergamali.mysmartroute.data.local.SettingsEntity
 import com.ioannapergamali.mysmartroute.data.local.insertSettingsSafely
+import com.ioannapergamali.mysmartroute.data.local.insertUserSafely
 import com.ioannapergamali.mysmartroute.data.local.insertVehicleSafely
 import com.ioannapergamali.mysmartroute.data.local.insertMenuSafely
 import com.ioannapergamali.mysmartroute.data.local.RoleEntity
@@ -498,7 +499,7 @@ class DatabaseViewModel : ViewModel() {
                         TAG,
                         "Remote data -> users:${users.size} vehicles:${vehicles.size} pois:${pois.size} poiTypes:${poiTypes.size} settings:${settings.size} roles:${roles.size} menus:${menus.size} options:${menuOptions.size} routes:${routes.size} movings:${movings.size} declarations:${declarations.size} availabilities:${availabilities.size} favorites:${favorites.size} seatRes:${seatReservations.size} transferReq:${transferRequests.size} tripRatings:${tripRatings.size}"
                     )
-                    users.forEach { db.userDao().insert(it) }
+                    users.forEach { insertUserSafely(db.userDao(), it) }
                     vehicles.forEach { insertVehicleSafely(db, it) }
                     pois.forEach { db.poIDao().insert(it) }
                     db.poiTypeDao().insertAll(poiTypes)

--- a/app/src/main/java/com/ioannapergamali/mysmartroute/viewmodel/UserViewModel.kt
+++ b/app/src/main/java/com/ioannapergamali/mysmartroute/viewmodel/UserViewModel.kt
@@ -11,6 +11,7 @@ import com.ioannapergamali.mysmartroute.data.local.UserEntity
 import com.ioannapergamali.mysmartroute.data.local.NotificationEntity
 import com.ioannapergamali.mysmartroute.data.local.demoteDriverToPassenger
 import com.ioannapergamali.mysmartroute.data.local.promotePassengerToDriver
+import com.ioannapergamali.mysmartroute.data.local.insertUserSafely
 import com.ioannapergamali.mysmartroute.utils.toFirestoreMap
 import com.ioannapergamali.mysmartroute.model.enumerations.UserRole
 import com.ioannapergamali.mysmartroute.utils.NetworkUtils
@@ -156,7 +157,7 @@ class UserViewModel : ViewModel() {
                 UserRole.ADMIN -> "role_admin"
             }
             user.roleId = newRoleId
-            userDao.insert(user)
+            insertUserSafely(userDao, user)
             runCatching {
                 db.collection("users").document(userId)
                     .update("role", newRole.name, "roleId", newRoleId)


### PR DESCRIPTION
## Περίληψη
- Προστέθηκε `insertUserSafely` για ενημέρωση χρηστών χωρίς να διαγράφονται τα σχετικά οχήματα.
- Τροποποιήθηκαν τα ViewModels ώστε να χρησιμοποιούν τη νέα βοηθητική συνάρτηση.
- Ρυθμίστηκε το `UserDao` να αγνοεί συγκρούσεις και να παρέχει μέθοδο `update`.

## Δοκιμές
- `./gradlew test` *(απέτυχε: SDK location not found)*


------
https://chatgpt.com/codex/tasks/task_e_68c29aec39448328b4f367efeb86dac1