### PR TITLE
Αφαίρεση αποθήκευσης κωδικού χρήστη

### DIFF
--- a/app/src/main/java/com/ioannapergamali/mysmartroute/data/local/UserEntity.kt
+++ b/app/src/main/java/com/ioannapergamali/mysmartroute/data/local/UserEntity.kt
@@ -14,7 +14,6 @@ data class UserEntity(
     var email: String = "",
     var phoneNum: String = "",
     var photoUrl: String? = null,
-    var password: String = "",
     var role: String = "",
     var roleId: String = "",
     var city: String = "",

--- a/app/src/main/java/com/ioannapergamali/mysmartroute/model/classes/users/Admin.kt
+++ b/app/src/main/java/com/ioannapergamali/mysmartroute/model/classes/users/Admin.kt
@@ -9,8 +9,7 @@ class Admin(
     surname: String,
     address: UserAddress,
     phoneNum: String,
-    username: String,
-    password: String
-) : Driver(id, name, email, surname, address, phoneNum, username, password) {
+    username: String
+) : Driver(id, name, email, surname, address, phoneNum, username) {
     override fun getRole() = UserRole.ADMIN
 }

--- a/app/src/main/java/com/ioannapergamali/mysmartroute/model/classes/users/Driver.kt
+++ b/app/src/main/java/com/ioannapergamali/mysmartroute/model/classes/users/Driver.kt
@@ -9,8 +9,7 @@ open class Driver(
     surname: String,
     address: UserAddress,
     phoneNum: String,
-    username: String,
-    password: String
-) : Passenger(id, name, email, surname, address, phoneNum, username, password) {
+    username: String
+) : Passenger(id, name, email, surname, address, phoneNum, username) {
     override fun getRole() = UserRole.DRIVER
 }

--- a/app/src/main/java/com/ioannapergamali/mysmartroute/model/classes/users/Passenger.kt
+++ b/app/src/main/java/com/ioannapergamali/mysmartroute/model/classes/users/Passenger.kt
@@ -10,8 +10,7 @@ open class Passenger(
     override val surname: String,
     override val address: UserAddress,
     override val phoneNum: String,
-    override val username: String,
-    override val password: String
+    override val username: String
 ) : User {
     override fun getRole() = UserRole.PASSENGER
 }

--- a/app/src/main/java/com/ioannapergamali/mysmartroute/model/interfaces/User.kt
+++ b/app/src/main/java/com/ioannapergamali/mysmartroute/model/interfaces/User.kt
@@ -12,7 +12,6 @@ interface User {
     val address: UserAddress
     val phoneNum: String
     val username: String
-    val password: String
 
     fun getRole(): UserRole
 }

--- a/app/src/main/java/com/ioannapergamali/mysmartroute/utils/FirestoreMappers.kt
+++ b/app/src/main/java/com/ioannapergamali/mysmartroute/utils/FirestoreMappers.kt
@@ -51,7 +51,6 @@ fun UserEntity.toFirestoreMap(): Map<String, Any> = buildMap {
     } else {
         Log.d("FirestoreMappers", "photoUrl κενό - δεν προστέθηκε")
     }
-    put("password", password)
     put("role", role)
     put("roleId", roleId)
     put("city", city)
@@ -158,7 +157,6 @@ fun DocumentSnapshot.toUserEntity(): UserEntity? {
         email = email,
         phoneNum = phoneNum,
         photoUrl = photo,
-        password = getString("password") ?: "",
         role = getString("role") ?: "",
         roleId = when (val rawRole = get("roleId")) {
             is DocumentReference -> rawRole.id

--- a/app/src/main/java/com/ioannapergamali/mysmartroute/viewmodel/AuthenticationViewModel.kt
+++ b/app/src/main/java/com/ioannapergamali/mysmartroute/viewmodel/AuthenticationViewModel.kt
@@ -22,9 +22,6 @@ import com.ioannapergamali.mysmartroute.repository.VehicleRepository
 import com.ioannapergamali.mysmartroute.data.local.insertMenuSafely
 import com.ioannapergamali.mysmartroute.data.local.insertUserSafely
 import com.ioannapergamali.mysmartroute.data.local.RoleEntity
-import com.ioannapergamali.mysmartroute.model.classes.users.Admin
-import com.ioannapergamali.mysmartroute.model.classes.users.Driver
-import com.ioannapergamali.mysmartroute.model.classes.users.Passenger
 import com.ioannapergamali.mysmartroute.model.classes.users.UserAddress
 import com.ioannapergamali.mysmartroute.model.enumerations.UserRole
 import com.ioannapergamali.mysmartroute.utils.NetworkUtils
@@ -118,7 +115,6 @@ class AuthenticationViewModel : ViewModel() {
                 username = username,
                 email = email,
                 phoneNum = phoneNum,
-                password = password,
                 role = role.name,
                 roleId = "",
                 city = address.city,
@@ -128,12 +124,6 @@ class AuthenticationViewModel : ViewModel() {
             )
             val dbLocal = MySmartRouteDatabase.getInstance(context)
             val userDao = dbLocal.userDao()
-
-            val user = when (role) {
-                UserRole.DRIVER -> Driver(userIdLocal, name, email, surname, address, phoneNum, username, password)
-                UserRole.PASSENGER -> Passenger(userIdLocal, name, email, surname, address, phoneNum, username, password)
-                UserRole.ADMIN -> Admin(userIdLocal, name, email, surname, address, phoneNum, username, password)
-            }
 
             if (NetworkUtils.isInternetAvailable(context)) {
                 try {
@@ -155,7 +145,6 @@ class AuthenticationViewModel : ViewModel() {
                         "username" to username,
                         "email" to email,
                         "phoneNum" to phoneNum,
-                        "password" to password,
                         "role" to role.name,
                         "roleId" to roleId,
                         "city" to address.city,


### PR DESCRIPTION
## Σκοπός
- Να μην αποθηκεύεται ο κωδικός χρήστη στον πίνακα `users` της Room και στο Firestore.

## Αλλαγές
- Αφαιρέθηκε το πεδίο `password` από `UserEntity` και τις αντίστοιχες κλάσεις χρηστών.
- Ενημερώθηκαν οι map συναρτήσεις του Firestore ώστε να μην διαχειρίζονται τον κωδικό.
- Η διαδικασία εγγραφής δεν αποθηκεύει πλέον τον κωδικό στο Firestore.

## Έλεγχοι
- `./gradlew test` *(απέτυχε: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_68c29e6ea3588328a729834195fb6675