### PR TITLE
Αποθήκευση vehicleId ως αναφορά στις δηλώσεις μεταφοράς

### DIFF
--- a/app/src/main/java/com/ioannapergamali/mysmartroute/utils/FirestoreMappers.kt
+++ b/app/src/main/java/com/ioannapergamali/mysmartroute/utils/FirestoreMappers.kt
@@ -369,7 +369,8 @@ fun TransportDeclarationEntity.toFirestoreMap(): Map<String, Any> = mapOf(
     // Χρησιμοποιούμε αναφορές εγγράφων για οδηγό και διαδρομή
     "routeId" to FirebaseFirestore.getInstance().collection("routes").document(routeId),
     "driverId" to FirebaseFirestore.getInstance().collection("users").document(driverId),
-    "vehicleId" to vehicleId,
+    // Αποθηκεύουμε το όχημα ως αναφορά στο έγγραφο του οχήματος
+    "vehicleId" to FirebaseFirestore.getInstance().collection("vehicles").document(vehicleId),
     "vehicleType" to vehicleType,
     "cost" to cost,
     "durationMinutes" to durationMinutes,


### PR DESCRIPTION
## Περίληψη
- Το πεδίο `vehicleId` στο Firestore map των δηλώσεων μεταφοράς αποθηκεύεται πλέον ως αναφορά στο έγγραφο οχήματος.

## Έλεγχοι
- `./gradlew test` (απέτυχε: SDK location not found)


------
https://chatgpt.com/codex/tasks/task_e_68c29f036b2883288a37286058583777