### PR TITLE
Validate password before Firebase sign up

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -63,10 +63,10 @@ kotlin {
 }
 dependencies {
     // Firebase (BoM για αυτόματες εκδόσεις όλων των modules)
-    implementation(platform("com.google.firebase:firebase-bom:34.0.0"))
-    implementation("com.google.firebase:firebase-auth:24.0.1")
-    implementation("com.google.firebase:firebase-firestore:26.0.0")
-    implementation("com.google.firebase:firebase-storage:22.0.0")
+    implementation(platform("com.google.firebase:firebase-bom:34.2.0"))
+    implementation("com.google.firebase:firebase-auth-ktx")
+    implementation("com.google.firebase:firebase-firestore-ktx")
+    implementation("com.google.firebase:firebase-storage-ktx")
 
 
     // Το Dynamic Links δεν καλύπτεται από το BoM, δηλώνουμε ρητά την έκδοση

--- a/app/src/main/java/com/ioannapergamali/mysmartroute/viewmodel/AuthenticationViewModel.kt
+++ b/app/src/main/java/com/ioannapergamali/mysmartroute/viewmodel/AuthenticationViewModel.kt
@@ -47,6 +47,11 @@ class AuthenticationViewModel : ViewModel() {
     private val gson: Gson = Gson()
     private companion object { const val TAG = "AuthenticationViewModel" }
 
+    private val passwordRegex = Regex(
+        "^(?=.*[a-z])(?=.*[A-Z])(?=.*\\d)(?=.*[@$!%*?&(){}\\[\\]_:;\"'<>.,=+-]).{8,}$"
+    )
+    private fun isPasswordValid(password: String) = passwordRegex.matches(password)
+
     /**
      * Παράδειγμα μετατροπής JSON σε αντικείμενο [UserAddress].
      * Example conversion from JSON to a [UserAddress] object.
@@ -104,6 +109,13 @@ class AuthenticationViewModel : ViewModel() {
                 address.city.isBlank() || address.streetName.isBlank()
             ) {
                 _signUpState.value = SignUpState.Error("All fields are required")
+                return@launch
+            }
+
+            if (!isPasswordValid(password)) {
+                _signUpState.value = SignUpState.Error(
+                    "Ο κωδικός πρέπει να έχει κεφαλαίο, πεζό, αριθμό και ειδικό χαρακτήρα"
+                )
                 return@launch
             }
 


### PR DESCRIPTION
## Summary
- validate user passwords locally before Firebase sign up
- use Firebase BOM 34.2.0 with KTX artifacts

## Testing
- `./gradlew test` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_68c2a55b0f908328a561aa2f00974bdd