### PR TITLE
Έλεγχος διπλών σημείων ενδιαφέροντος

### DIFF
--- a/app/src/main/java/com/ioannapergamali/mysmartroute/view/ui/screens/ReviewPoiScreen.kt
+++ b/app/src/main/java/com/ioannapergamali/mysmartroute/view/ui/screens/ReviewPoiScreen.kt
@@ -1,20 +1,15 @@
 package com.ioannapergamali.mysmartroute.view.ui.screens
 
 import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.items
-import androidx.compose.material.icons.Icons
-import androidx.compose.material.icons.filled.Delete
-import androidx.compose.material.icons.filled.Edit
-import androidx.compose.material.icons.filled.Link
 import androidx.compose.material3.AlertDialog
 import androidx.compose.material3.ExperimentalMaterial3Api
-import androidx.compose.material3.Icon
-import androidx.compose.material3.IconButton
 import androidx.compose.material3.Scaffold
 import androidx.compose.material3.Text
 import androidx.compose.material3.TextButton
@@ -27,6 +22,7 @@ import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.unit.dp
 import androidx.lifecycle.viewmodel.compose.viewModel
 import androidx.navigation.NavController
@@ -35,7 +31,6 @@ import com.ioannapergamali.mysmartroute.data.local.PoIEntity
 import com.ioannapergamali.mysmartroute.view.ui.components.ScreenContainer
 import com.ioannapergamali.mysmartroute.view.ui.components.TopBar
 import com.ioannapergamali.mysmartroute.viewmodel.AdminPoiViewModel
-import androidx.compose.ui.res.stringResource
 
 /**
  * Οθόνη ελέγχου και διαχείρισης ονομάτων PoI από τον διαχειριστή.
@@ -45,49 +40,40 @@ import androidx.compose.ui.res.stringResource
 fun ReviewPoiScreen(navController: NavController, openDrawer: () -> Unit) {
     val context = LocalContext.current
     val viewModel: AdminPoiViewModel = viewModel(factory = AdminPoiViewModel.Factory(context))
-    val pois by viewModel.pois.collectAsState()
+    val duplicateGroups by viewModel.duplicatePois.collectAsState()
 
-    var editPoi by remember { mutableStateOf<PoIEntity?>(null) }
+    var selectedGroup by remember { mutableStateOf<List<PoIEntity>?>(null) }
+    var keepPoi by remember { mutableStateOf<PoIEntity?>(null) }
     var editedName by remember { mutableStateOf("") }
-    var mergeKeepId by remember { mutableStateOf<String?>(null) }
 
     Scaffold(topBar = { TopBar(title = stringResource(R.string.review_poi), navController = navController, showMenu = true, onMenuClick = openDrawer) }) { padding ->
         ScreenContainer(modifier = Modifier.padding(padding), scrollable = false) {
-            LazyColumn(modifier = Modifier.fillMaxSize()) {
-                items(pois) { poi ->
-                    Row(
-                        modifier = Modifier
+            if (duplicateGroups.isEmpty()) {
+                Text(text = stringResource(R.string.no_duplicate_pois), modifier = Modifier.padding(16.dp))
+            } else {
+                LazyColumn(modifier = Modifier.fillMaxSize()) {
+                    items(duplicateGroups) { group ->
+                        Column(modifier = Modifier
                             .fillMaxWidth()
-                            .padding(vertical = 4.dp),
-                        horizontalArrangement = Arrangement.SpaceBetween
-                    ) {
-                        Text(text = "${poi.name} (${poi.lat}, ${poi.lng})")
-                        Row {
-                            IconButton(onClick = {
-                                editPoi = poi
-                                editedName = poi.name
-                            }) {
-                                Icon(Icons.Default.Edit, contentDescription = "Επεξεργασία")
-                            }
-                            IconButton(onClick = {
-                                mergeKeepId?.let { keep ->
-                                    if (keep != poi.id) {
-                                        viewModel.mergePois(keep, poi.id)
+                            .padding(vertical = 8.dp)) {
+                            val coord = group.first()
+                            Text(text = "(${coord.lat}, ${coord.lng})")
+                            group.forEach { poi ->
+                                Row(
+                                    modifier = Modifier
+                                        .fillMaxWidth()
+                                        .padding(vertical = 4.dp),
+                                    horizontalArrangement = Arrangement.SpaceBetween
+                                ) {
+                                    Text(text = poi.name)
+                                    TextButton(onClick = {
+                                        selectedGroup = group
+                                        keepPoi = poi
+                                        editedName = poi.name
+                                    }) {
+                                        Text(text = stringResource(R.string.keep))
                                     }
-                                    mergeKeepId = null
-                                } ?: run {
-                                    mergeKeepId = poi.id
                                 }
-                            }) {
-                                Icon(
-                                    imageVector = Icons.Default.Link,
-                                    contentDescription = "Συγχώνευση",
-                                    tint = if (mergeKeepId == poi.id)
-                                        androidx.compose.material3.MaterialTheme.colorScheme.primary else androidx.compose.material3.MaterialTheme.colorScheme.onSurface
-                                )
-                            }
-                            IconButton(onClick = { viewModel.deletePoi(poi.id) }) {
-                                Icon(Icons.Default.Delete, contentDescription = "Διαγραφή")
                             }
                         }
                     }
@@ -96,21 +82,30 @@ fun ReviewPoiScreen(navController: NavController, openDrawer: () -> Unit) {
         }
     }
 
-    editPoi?.let { poi ->
+    if (keepPoi != null && selectedGroup != null) {
         AlertDialog(
-            onDismissRequest = { editPoi = null },
-            title = { Text(stringResource(R.string.poi_name)) },
-            text = {
-                TextField(value = editedName, onValueChange = { editedName = it })
+            onDismissRequest = {
+                keepPoi = null
+                selectedGroup = null
             },
+            title = { Text(stringResource(R.string.poi_name)) },
+            text = { TextField(value = editedName, onValueChange = { editedName = it }) },
             confirmButton = {
                 TextButton(onClick = {
-                    viewModel.updatePoi(poi.copy(name = editedName))
-                    editPoi = null
-                }) { Text(stringResource(android.R.string.ok)) }
+                    val updatedPoi = keepPoi!!.copy(name = editedName)
+                    viewModel.updatePoi(updatedPoi)
+                    selectedGroup!!.filter { it.id != updatedPoi.id }.forEach { other ->
+                        viewModel.mergePois(updatedPoi.id, other.id)
+                    }
+                    keepPoi = null
+                    selectedGroup = null
+                }) { Text(stringResource(R.string.ok)) }
             },
             dismissButton = {
-                TextButton(onClick = { editPoi = null }) { Text(stringResource(android.R.string.cancel)) }
+                TextButton(onClick = {
+                    keepPoi = null
+                    selectedGroup = null
+                }) { Text(stringResource(R.string.cancel)) }
             }
         )
     }

--- a/app/src/main/res/values-el/strings.xml
+++ b/app/src/main/res/values-el/strings.xml
@@ -188,6 +188,8 @@
     <string name="stops_header">Στάσεις</string>
     <string name="poi_outside_heraklion">Επιλέξτε σημείο εντός Ηρακλείου</string>
     <string name="search_address">Αναζήτηση διεύθυνσης</string>
+    <string name="no_duplicate_pois">Δεν βρέθηκαν διπλά σημεία ενδιαφέροντος</string>
+    <string name="keep">Κράτησε</string>
     <string name="fill_all_fields">Συμπλήρωσε όλα τα πεδία</string>
     <string name="seat_booked">Η θέση κλείστηκε!</string>
     <string name="seat_unavailable">Δεν υπάρχουν διαθέσιμες θέσεις.</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -302,4 +302,6 @@
     <string name="declare_failure">Failed to declare transport</string>
     <string name="rating_saved_success">Rating saved</string>
     <string name="rating_save_failed">Unable to save rating</string>
+    <string name="no_duplicate_pois">No duplicate points found</string>
+    <string name="keep">Keep</string>
 </resources>


### PR DESCRIPTION
## Περίληψη
- Προσθήκη οθόνης ελέγχου που εμφανίζει ομάδες POI με ίδιες συντεταγμένες και επιτρέπει την επιλογή ενός για διατήρηση
- Δυνατότητα μετονομασίας του επιλεγμένου POI και συγχώνευση των υπολοίπων
- Νέα κείμενα "No duplicate points found" και "Keep" σε en/el

## Δοκιμές
- `./gradlew test` *(απέτυχε: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_68c2b6f8a6f48328a2287d7ac97d0026