### PR TITLE
Allow duplicate POIs in Room database

### DIFF
--- a/app/src/main/java/com/ioannapergamali/mysmartroute/data/local/MySmartRouteDatabase.kt
+++ b/app/src/main/java/com/ioannapergamali/mysmartroute/data/local/MySmartRouteDatabase.kt
@@ -65,7 +65,7 @@ import com.ioannapergamali.mysmartroute.data.local.TripRatingDao
         NotificationEntity::class,
         UserPoiEntity::class
     ],
-    version = 63
+    version = 64
 )
 @TypeConverters(Converters::class)
 abstract class MySmartRouteDatabase : RoomDatabase() {
@@ -819,6 +819,13 @@ abstract class MySmartRouteDatabase : RoomDatabase() {
             }
         }
 
+        private val MIGRATION_63_64 = object : Migration(63, 64) {
+            override fun migrate(database: SupportSQLiteDatabase) {
+                database.execSQL("DROP INDEX IF EXISTS `index_pois_lat_lng`")
+                database.execSQL("CREATE INDEX IF NOT EXISTS `index_pois_lat_lng` ON `pois` (`lat`, `lng`)")
+            }
+        }
+
         private fun prepopulate(db: SupportSQLiteDatabase) {
             Log.d(TAG, "Prepopulating database")
             db.execSQL(
@@ -961,7 +968,8 @@ abstract class MySmartRouteDatabase : RoomDatabase() {
                     MIGRATION_59_60,
                     MIGRATION_60_61,
                     MIGRATION_61_62,
-                    MIGRATION_62_63
+                    MIGRATION_62_63,
+                    MIGRATION_63_64
                 )
                     .addCallback(object : RoomDatabase.Callback() {
                         override fun onCreate(db: SupportSQLiteDatabase) {

--- a/app/src/main/java/com/ioannapergamali/mysmartroute/data/local/PoIDao.kt
+++ b/app/src/main/java/com/ioannapergamali/mysmartroute/data/local/PoIDao.kt
@@ -18,8 +18,8 @@ interface PoIDao {
     @Query("SELECT * FROM pois")
     fun getAll(): kotlinx.coroutines.flow.Flow<List<PoIEntity>>
 
-    @Query("SELECT * FROM pois WHERE lat = :lat AND lng = :lng LIMIT 1")
-    suspend fun findByLocation(lat: Double, lng: Double): PoIEntity?
+    @Query("SELECT * FROM pois WHERE lat = :lat AND lng = :lng")
+    suspend fun findByLocation(lat: Double, lng: Double): List<PoIEntity>
 
     @Query("SELECT * FROM pois WHERE name = :name LIMIT 1")
     suspend fun findByName(name: String): PoIEntity?

--- a/app/src/main/java/com/ioannapergamali/mysmartroute/data/local/PoIEntity.kt
+++ b/app/src/main/java/com/ioannapergamali/mysmartroute/data/local/PoIEntity.kt
@@ -22,7 +22,7 @@ import com.google.android.libraries.places.api.model.Place
         )
     ],
     indices = [
-        Index(value = ["lat", "lng"], unique = true),
+        Index(value = ["lat", "lng"]),
         Index("typeId")
     ]
 )


### PR DESCRIPTION
## Summary
- permit storing different POI names at same coordinates by removing unique index
- expose all POIs for a location via `findByLocation`
- bump Room schema to v64 with migration dropping unique index

## Testing
- `./gradlew test` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_68c2bb690c608328bf91532068c2d5fa