### PR TITLE
feat: label fields and add edit buttons on admin poi review

### DIFF
--- a/app/src/main/java/com/ioannapergamali/mysmartroute/view/ui/screens/ReviewPoiScreen.kt
+++ b/app/src/main/java/com/ioannapergamali/mysmartroute/view/ui/screens/ReviewPoiScreen.kt
@@ -10,6 +10,8 @@ import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.items
 import androidx.compose.material3.AlertDialog
 import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.Icon
+import androidx.compose.material3.IconButton
 import androidx.compose.material3.Scaffold
 import androidx.compose.material3.Text
 import androidx.compose.material3.TextButton
@@ -26,6 +28,8 @@ import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.unit.dp
 import androidx.lifecycle.viewmodel.compose.viewModel
 import androidx.navigation.NavController
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.Edit
 import com.ioannapergamali.mysmartroute.R
 import com.ioannapergamali.mysmartroute.data.local.PoIEntity
 import com.ioannapergamali.mysmartroute.view.ui.components.ScreenContainer
@@ -53,11 +57,15 @@ fun ReviewPoiScreen(navController: NavController, openDrawer: () -> Unit) {
             } else {
                 LazyColumn(modifier = Modifier.fillMaxSize()) {
                     items(duplicateGroups) { group ->
-                        Column(modifier = Modifier
-                            .fillMaxWidth()
-                            .padding(vertical = 8.dp)) {
+                        Column(
+                            modifier = Modifier
+                                .fillMaxWidth()
+                                .padding(vertical = 8.dp)
+                        ) {
                             val coord = group.first()
-                            Text(text = "(${coord.lat}, ${coord.lng})")
+                            Text(text = stringResource(R.string.coordinates_label))
+                            Text(text = "${stringResource(R.string.lat)}: ${coord.lat}")
+                            Text(text = "${stringResource(R.string.lng)}: ${coord.lng}")
                             group.forEach { poi ->
                                 Row(
                                     modifier = Modifier
@@ -65,13 +73,13 @@ fun ReviewPoiScreen(navController: NavController, openDrawer: () -> Unit) {
                                         .padding(vertical = 4.dp),
                                     horizontalArrangement = Arrangement.SpaceBetween
                                 ) {
-                                    Text(text = poi.name)
-                                    TextButton(onClick = {
+                                    Text(text = "${stringResource(R.string.poi_name)}: ${poi.name}")
+                                    IconButton(onClick = {
                                         selectedGroup = group
                                         keepPoi = poi
                                         editedName = poi.name
                                     }) {
-                                        Text(text = stringResource(R.string.keep))
+                                        Icon(Icons.Filled.Edit, contentDescription = stringResource(R.string.edit))
                                     }
                                 }
                             }

--- a/app/src/main/res/values-el/strings.xml
+++ b/app/src/main/res/values-el/strings.xml
@@ -189,6 +189,10 @@
     <string name="poi_outside_heraklion">Επιλέξτε σημείο εντός Ηρακλείου</string>
     <string name="search_address">Αναζήτηση διεύθυνσης</string>
     <string name="no_duplicate_pois">Δεν βρέθηκαν διπλά σημεία ενδιαφέροντος</string>
+    <string name="coordinates_label">Συντεταγμένες</string>
+    <string name="lat">Πλάτος</string>
+    <string name="lng">Μήκος</string>
+    <string name="edit">Επεξεργασία</string>
     <string name="keep">Κράτησε</string>
     <string name="fill_all_fields">Συμπλήρωσε όλα τα πεδία</string>
     <string name="seat_booked">Η θέση κλείστηκε!</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -303,5 +303,9 @@
     <string name="rating_saved_success">Rating saved</string>
     <string name="rating_save_failed">Unable to save rating</string>
     <string name="no_duplicate_pois">No duplicate points found</string>
+    <string name="coordinates_label">Coordinates</string>
+    <string name="lat">Latitude</string>
+    <string name="lng">Longitude</string>
+    <string name="edit">Edit</string>
     <string name="keep">Keep</string>
 </resources>


### PR DESCRIPTION
## Summary
- show coordinates and names with labels on PoI review screen
- add edit icon button for each PoI in admin duplicates
- provide string resources for labels and edit action

## Testing
- `./gradlew test` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_68c2c2acd36c83289cf90f5e4729d3c4