### PR TITLE
Allow horizontal scroll for POI review rows

### DIFF
--- a/app/src/main/java/com/ioannapergamali/mysmartroute/view/ui/screens/ReviewPoiScreen.kt
+++ b/app/src/main/java/com/ioannapergamali/mysmartroute/view/ui/screens/ReviewPoiScreen.kt
@@ -1,5 +1,6 @@
 package com.ioannapergamali.mysmartroute.view.ui.screens
 
+import androidx.compose.foundation.horizontalScroll
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
@@ -8,6 +9,7 @@ import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.items
+import androidx.compose.foundation.rememberScrollState
 import androidx.compose.material3.AlertDialog
 import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.Icon
@@ -70,6 +72,7 @@ fun ReviewPoiScreen(navController: NavController, openDrawer: () -> Unit) {
                                 Row(
                                     modifier = Modifier
                                         .fillMaxWidth()
+                                        .horizontalScroll(rememberScrollState())
                                         .padding(vertical = 4.dp),
                                     horizontalArrangement = Arrangement.SpaceBetween
                                 ) {


### PR DESCRIPTION
## Summary
- enable οριζόντιο scroll στην οθόνη ελέγχου ονομάτων PoI ώστε τα κουμπιά να είναι πάντα ορατά

## Testing
- `./gradlew test` *(απέτυχε: Starting a Gradle Daemon, 1 busy Daemon could not be reused)*

------
https://chatgpt.com/codex/tasks/task_e_68c2c9015408832895f58705f70a75ed