### PR TITLE
Εμφάνιση όλων των διαδρομών στον admin στη δήλωση διαθεσιμότητας

### DIFF
--- a/app/src/main/java/com/ioannapergamali/mysmartroute/view/ui/screens/AnnounceTransportScreen.kt
+++ b/app/src/main/java/com/ioannapergamali/mysmartroute/view/ui/screens/AnnounceTransportScreen.kt
@@ -141,10 +141,14 @@ fun AnnounceTransportScreen(navController: NavController, openDrawer: () -> Unit
         }
     }
 
-    LaunchedEffect(routes, vehicles, selectedVehicle, selectedRouteId, selectedDriverId) {
-        val driverFiltered = selectedDriverId?.let { id ->
-            routes.filter { it.userId == id }
-        } ?: routes
+    LaunchedEffect(routes, vehicles, selectedVehicle, selectedRouteId, selectedDriverId, role) {
+        val driverFiltered = if (role == UserRole.ADMIN) {
+            routes
+        } else {
+            selectedDriverId?.let { id ->
+                routes.filter { it.userId == id }
+            } ?: routes
+        }
         displayRoutes = if (selectedVehicle == VehicleType.BIGBUS) {
             driverFiltered.filter { route ->
                 val pois = routeViewModel.getRoutePois(context, route.id)
@@ -158,7 +162,6 @@ fun AnnounceTransportScreen(navController: NavController, openDrawer: () -> Unit
         selectedDriverId?.let { id -> list = list.filter { it.userId == id } }
 
         filteredVehicles = list
-
 
         if (selectedRouteId != null && selectedVehicle != null) {
             refreshRoute()


### PR DESCRIPTION
## Περίληψη
- Προσαρμογή λογικής σε AnnounceTransportScreen ώστε ο διαχειριστής να βλέπει όλες τις διαδρομές, ανεξαρτήτως οδηγού.

## Έλεγχοι
- `./gradlew test --console=plain` *(απέτυχε: Starting a Gradle Daemon, 1 busy Daemon could not be reused)*

------
https://chatgpt.com/codex/tasks/task_e_68c2c96baa6483288d77f0ed123c8bfd