### PR TITLE
Βελτίωση συγχρονισμού POI από το Firestore

### DIFF
--- a/app/src/main/java/com/ioannapergamali/mysmartroute/data/local/PoIDao.kt
+++ b/app/src/main/java/com/ioannapergamali/mysmartroute/data/local/PoIDao.kt
@@ -9,10 +9,10 @@ import androidx.room.Query
 
 @Dao
 interface PoIDao {
-    @Insert(onConflict = OnConflictStrategy.IGNORE)
+    @Insert(onConflict = OnConflictStrategy.REPLACE)
     suspend fun insertAll(pois: List<PoIEntity>)
 
-    @Insert(onConflict = OnConflictStrategy.IGNORE)
+    @Insert(onConflict = OnConflictStrategy.REPLACE)
     suspend fun insert(poi: PoIEntity)
 
     @Query("SELECT * FROM pois")

--- a/app/src/main/java/com/ioannapergamali/mysmartroute/viewmodel/PoIViewModel.kt
+++ b/app/src/main/java/com/ioannapergamali/mysmartroute/viewmodel/PoIViewModel.kt
@@ -38,14 +38,15 @@ class PoIViewModel : ViewModel() {
         viewModelScope.launch {
             val dao = MySmartRouteDatabase.getInstance(context).poIDao()
             _pois.value = dao.getAll().first()
-            db.collection("pois").get()
-                .addOnSuccessListener { snapshot ->
-                    val list = snapshot.documents.mapNotNull { doc ->
-                        doc.toPoIEntity()
-                    }
-                    _pois.value = list
-                    viewModelScope.launch { dao.insertAll(list) }
+            try {
+                val snapshot = db.collection("pois").get().await()
+                val list = snapshot.documents.mapNotNull { doc ->
+                    doc.toPoIEntity()
                 }
+                _pois.value = list
+                dao.insertAll(list)
+            } catch (_: Exception) {
+            }
         }
     }
 


### PR DESCRIPTION
## Summary
- αντικατάσταση στρατηγικής σύγκρουσης στο PoIDao με REPLACE ώστε να ενημερώνονται υπάρχουσες εγγραφές
- χρήση του await στο PoIViewModel για φόρτωση POI και αποθήκευση στη βάση χωρίς πρόσθετο coroutine

## Testing
- `./gradlew test` *(απέτυχε: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_68c2cb82ec3c8328aab66f20e5e06ebc