### PR TITLE
Rename unassigned routes option

### DIFF
--- a/app/src/main/res/values-el/strings.xml
+++ b/app/src/main/res/values-el/strings.xml
@@ -127,7 +127,7 @@
     <string name="edit_privileges">Αλλαγή δικαιωμάτων χρήστη</string>
     <string name="define_poi">Ορισμός σημείου ενδιαφέροντος</string>
     <string name="define_duration">Ορισμός διάρκειας μετακίνησης με τα πόδια</string>
-    <string name="view_unassigned">Προβολή μη εκχωρημένων διαδρομών</string>
+    <string name="view_unassigned">Προβολή μη εκχωρημένων διαδρομών για περπάτημα</string>
     <string name="no_unassigned_routes">Δεν υπάρχουν διαδρομές χωρίς διάρκεια περπατήματος</string>
     <string name="review_poi">Έλεγχος ονομάτων σημείων ενδιαφέροντος</string>
     <string name="rank_drivers">Προβολή 10 καλύτερων και χειρότερων οδηγών</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -125,7 +125,7 @@
     <string name="edit_privileges">Promote or Demote User</string>
     <string name="define_poi">Define Point of Interest</string>
     <string name="define_duration">Define Duration of Travel by Foot</string>
-    <string name="view_unassigned">View List of Unassigned Routes</string>
+    <string name="view_unassigned">View Unassigned Routes for Walking</string>
     <string name="no_unassigned_routes">No routes without walking duration</string>
     <string name="review_poi">Review Point of Interest Names</string>
     <string name="rank_drivers">Show 10 Best and Worst Drivers</string>


### PR DESCRIPTION
## Summary
- rename admin option text to show unassigned walking routes

## Testing
- `./gradlew test` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_68c2da6f38b083288d56b5cced8ad6fe