### PR TITLE
Προσθήκη επιλογής διαδρομής λεωφορείου

### DIFF
--- a/app/src/main/java/com/ioannapergamali/mysmartroute/utils/MapsUtils.kt
+++ b/app/src/main/java/com/ioannapergamali/mysmartroute/utils/MapsUtils.kt
@@ -96,10 +96,11 @@ object MapsUtils {
         val originParam = "${origin.latitude},${origin.longitude}"
         val destParam = "${destination.latitude},${destination.longitude}"
         val modeParam = vehicleToMode(vehicleType)
+        val transitParam = if (modeParam == "transit") "&transit_mode=bus" else ""
         val waypointParam = if (waypoints.isNotEmpty()) {
             "&waypoints=" + waypoints.joinToString("|") { "${it.latitude},${it.longitude}" }
         } else ""
-        return "https://maps.googleapis.com/maps/api/directions/json?origin=$originParam&destination=$destParam&mode=$modeParam$waypointParam&key=$apiKey"
+        return "https://maps.googleapis.com/maps/api/directions/json?origin=$originParam&destination=$destParam&mode=$modeParam$transitParam$waypointParam&key=$apiKey"
     }
 
     private fun buildWalkingDirectionsUrl(

--- a/app/src/main/java/com/ioannapergamali/mysmartroute/view/ui/screens/AnnounceTransportScreen.kt
+++ b/app/src/main/java/com/ioannapergamali/mysmartroute/view/ui/screens/AnnounceTransportScreen.kt
@@ -437,6 +437,20 @@ fun AnnounceTransportScreen(navController: NavController, openDrawer: () -> Unit
 
             Spacer(Modifier.height(16.dp))
 
+            Button(
+                onClick = {
+                    selectedVehicle = VehicleType.BIGBUS
+                    refreshRoute()
+                },
+                enabled = selectedRouteId != null && !calculating
+            ) {
+                Icon(Icons.Default.DirectionsBus, contentDescription = null)
+                Spacer(Modifier.width(8.dp))
+                Text(stringResource(R.string.bus_only))
+            }
+
+            Spacer(Modifier.height(16.dp))
+
             Text(stringResource(R.string.duration_format, duration))
 
             if (calculating) {

--- a/app/src/main/res/values-el/strings.xml
+++ b/app/src/main/res/values-el/strings.xml
@@ -164,6 +164,7 @@
     <string name="announce">Αποστολή</string>
     <string name="register">Καταχώρηση</string>
     <string name="duration_format">Διάρκεια: %1$d λεπτά</string>
+    <string name="bus_only">Διαδρομή με λεωφορείο</string>
     <string name="app_language">Γλώσσα εφαρμογής</string>
     <string name="poi_name">Όνομα POI</string>
     <string name="poi_description">Περιγραφή</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -163,6 +163,7 @@
     <string name="announce">Announce</string>
     <string name="register">Register</string>
     <string name="duration_format">Duration: %1$d min</string>
+    <string name="bus_only">Bus-only route</string>
     <string name="app_language">App Language</string>
     <string name="poi_name">PoI Name</string>
     <string name="poi_description">Description</string>


### PR DESCRIPTION
## Περίληψη
- Προσθήκη κουμπιού στη δήλωση διαδρομής οδηγού για υπολογισμό διαδρομών λεωφορείου
- Υποστήριξη παραμέτρου `transit_mode=bus` στις κλήσεις του Directions API
- Νέα μηνύματα διεπαφής για την επιλογή διαδρομής λεωφορείου

## Έλεγχοι
- `./gradlew test` *(αποτυχία: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_68c2d96d96ec8328829b71a25b02ea49