### PR TITLE
Μεταφορά κουμπιού διαδρομής λεωφορείου

### DIFF
--- a/app/src/main/java/com/ioannapergamali/mysmartroute/view/ui/screens/AnnounceTransportScreen.kt
+++ b/app/src/main/java/com/ioannapergamali/mysmartroute/view/ui/screens/AnnounceTransportScreen.kt
@@ -437,20 +437,6 @@ fun AnnounceTransportScreen(navController: NavController, openDrawer: () -> Unit
 
             Spacer(Modifier.height(16.dp))
 
-            Button(
-                onClick = {
-                    selectedVehicle = VehicleType.BIGBUS
-                    refreshRoute()
-                },
-                enabled = selectedRouteId != null && !calculating
-            ) {
-                Icon(Icons.Default.DirectionsBus, contentDescription = null)
-                Spacer(Modifier.width(8.dp))
-                Text(stringResource(R.string.bus_only))
-            }
-
-            Spacer(Modifier.height(16.dp))
-
             Text(stringResource(R.string.duration_format, duration))
 
             if (calculating) {

--- a/app/src/main/java/com/ioannapergamali/mysmartroute/view/ui/screens/DeclareRouteScreen.kt
+++ b/app/src/main/java/com/ioannapergamali/mysmartroute/view/ui/screens/DeclareRouteScreen.kt
@@ -15,6 +15,7 @@ import androidx.compose.material.icons.filled.MyLocation
 import androidx.compose.material.icons.filled.Refresh
 import androidx.compose.material.icons.filled.Save
 import androidx.compose.material.icons.filled.Close
+import androidx.compose.material.icons.filled.DirectionsBus
 import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.Icon
 import androidx.compose.material3.IconButton
@@ -560,6 +561,30 @@ fun DeclareRouteScreen(navController: NavController, openDrawer: () -> Unit) {
                         }
                     }
                 }) { Icon(Icons.Default.Directions, contentDescription = null) }
+                IconButton(onClick = {
+                    val ids = routePois.map { it.id }
+                    if (ids.size >= 2) {
+                        calculating = true
+                        scope.launch {
+                            val start = LatLng(routePois.first().lat, routePois.first().lng)
+                            val end = LatLng(routePois.last().lat, routePois.last().lng)
+                            val waypoints = routePois.drop(1).dropLast(1).map { LatLng(it.lat, it.lng) }
+                            val data = MapsUtils.fetchDurationAndPath(
+                                start,
+                                end,
+                                apiKey,
+                                VehicleType.BIGBUS,
+                                waypoints
+                            )
+                            if (data.status == "OK") {
+                                pathPoints.clear()
+                                pathPoints.addAll(data.points)
+                                routeSaved = false
+                            }
+                            calculating = false
+                        }
+                    }
+                }) { Icon(Icons.Default.DirectionsBus, contentDescription = stringResource(R.string.bus_only)) }
             }
 
             Spacer(Modifier.height(8.dp))


### PR DESCRIPTION
## Περίληψη
- Αφαιρέθηκε το κουμπί "Διαδρομή με λεωφορείο" από τη δήλωση διαθεσιμότητας μεταφοράς.
- Προστέθηκε αντίστοιχο κουμπί στη δήλωση διαδρομής για υπολογισμό διαδρομής λεωφορείου.

## Έλεγχοι
- `./gradlew test` *(απέτυχε: περιορισμοί περιβάλλοντος)*

------
https://chatgpt.com/codex/tasks/task_e_68c2de92824c8328ab869d2bfecfeb40