### PR TITLE
Add route segment models for bus driver availability

### DIFF
--- a/app/src/main/java/com/ioannapergamali/mysmartroute/model/classes/routes/RouteSegment.kt
+++ b/app/src/main/java/com/ioannapergamali/mysmartroute/model/classes/routes/RouteSegment.kt
@@ -1,0 +1,42 @@
+package com.ioannapergamali.mysmartroute.model.classes.routes
+
+/**
+ * Αντιπροσώπευση τμημάτων διαδρομής.
+ * Κάθε τμήμα μπορεί να είναι πεζό ή λεωφορείο.
+ */
+sealed class RouteSegment {
+    data class Walk(
+        val start: String,
+        val end: String
+    ) : RouteSegment()
+
+    data class Bus(
+        val start: String,
+        val end: String,
+        val driver: DriverInfo
+    ) : RouteSegment()
+}
+
+/**
+ * Βασικές πληροφορίες οδηγού για τα τμήματα λεωφορείου.
+ */
+data class DriverInfo(
+    val id: String,
+    val name: String
+)
+
+/**
+ * Διαδρομή αποτελούμενη από πολλαπλά τμήματα.
+ */
+data class ComplexRoute(
+    val segments: List<RouteSegment>
+)
+
+/**
+ * Έλεγχος αν ο οδηγός είναι διαθέσιμος για κάποιο τμήμα λεωφορείου.
+ */
+fun isDriverAvailable(driverId: String, route: ComplexRoute): Boolean {
+    return route.segments
+        .filterIsInstance<RouteSegment.Bus>()
+        .any { it.driver.id == driverId }
+}


### PR DESCRIPTION
## Summary
- define `RouteSegment` sealed class with walk and bus variants
- add `DriverInfo`, `ComplexRoute` and `isDriverAvailable` helper

## Testing
- `./gradlew test` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_68c30ecede908328a431aeeb090e4a07