### PR TITLE
Fix date picker selectable dates implementation

### DIFF
--- a/app/src/main/java/com/ioannapergamali/mysmartroute/view/ui/screens/AnnounceTransportScreen.kt
+++ b/app/src/main/java/com/ioannapergamali/mysmartroute/view/ui/screens/AnnounceTransportScreen.kt
@@ -116,7 +116,7 @@ fun AnnounceTransportScreen(navController: NavController, openDrawer: () -> Unit
     }
     val datePickerState = rememberDatePickerState(
         initialSelectedDateMillis = todayMillis,
-        selectableDates = object : DatePickerState.SelectableDates {
+        selectableDates = object : SelectableDates {
             override fun isSelectableDate(utcTimeMillis: Long): Boolean =
                 utcTimeMillis >= todayMillis
         }


### PR DESCRIPTION
## Summary
- use the proper `SelectableDates` interface in `AnnounceTransportScreen`

## Testing
- `./gradlew test` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_68c313c9ac40832889e585c42ce4425b