### PR TITLE
Ενεργοποίηση αποστολής με συσχέτιση πρώτου-τελευταίου

### DIFF
--- a/app/src/main/java/com/ioannapergamali/mysmartroute/view/ui/screens/AnnounceTransportScreen.kt
+++ b/app/src/main/java/com/ioannapergamali/mysmartroute/view/ui/screens/AnnounceTransportScreen.kt
@@ -103,7 +103,15 @@ private fun canSend(
     calculating: Boolean
 ): Boolean {
     if (!routeSelected || cost.isBlank() || !dateSelected || !timeSelected || calculating) return false
-    if (details.isNotEmpty()) return arePoisSequential(pois, details)
+    if (details.isNotEmpty()) {
+        if (arePoisSequential(pois, details)) return true
+        val firstId = pois.firstOrNull()?.id
+        val lastId = pois.lastOrNull()?.id
+        if (firstId != null && lastId != null) {
+            return details.any { it.startPoiId == firstId && it.endPoiId == lastId }
+        }
+        return false
+    }
     return startIndex == 0 && endIndex == pois.lastIndex
 }
 


### PR DESCRIPTION
## Περιγραφή
- Ενεργοποίηση του κουμπιού αποστολής όταν υπάρχει συσχέτιση πρώτου-τελευταίου POI
- Διατήρηση ελέγχου για διαδοχικές συσχετίσεις όλων των POIs

## Έλεγχοι
- `./gradlew test` *(απέτυχε: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_68c37fadff98832893141e8c33f024e2