### PR TITLE
Προσθήκη υποσυλλογών και ενοποιημένο κλείσιμο θέσεων

### DIFF
--- a/app/src/main/java/com/ioannapergamali/mysmartroute/data/local/MovingDetailDao.kt
+++ b/app/src/main/java/com/ioannapergamali/mysmartroute/data/local/MovingDetailDao.kt
@@ -1,0 +1,22 @@
+package com.ioannapergamali.mysmartroute.data.local
+
+import androidx.room.Dao
+import androidx.room.Insert
+import androidx.room.OnConflictStrategy
+import androidx.room.Query
+import kotlinx.coroutines.flow.Flow
+
+/**
+ * DAO για τις λεπτομέρειες των μετακινήσεων.
+ */
+@Dao
+interface MovingDetailDao {
+    @Insert(onConflict = OnConflictStrategy.REPLACE)
+    suspend fun insert(detail: MovingDetailEntity)
+
+    @Query("SELECT * FROM moving_details WHERE movingId = :movingId")
+    fun getForMoving(movingId: String): Flow<List<MovingDetailEntity>>
+
+    @Query("DELETE FROM moving_details WHERE movingId = :movingId")
+    suspend fun deleteForMoving(movingId: String)
+}

--- a/app/src/main/java/com/ioannapergamali/mysmartroute/data/local/MovingDetailEntity.kt
+++ b/app/src/main/java/com/ioannapergamali/mysmartroute/data/local/MovingDetailEntity.kt
@@ -1,0 +1,30 @@
+package com.ioannapergamali.mysmartroute.data.local
+
+import androidx.room.Entity
+import androidx.room.ForeignKey
+import androidx.room.Index
+import androidx.room.PrimaryKey
+
+/**
+ * Υποσυλλογή για λεπτομέρειες μετακινήσεων.
+ * Αποθηκεύει τα σημεία και το όχημα για κάθε μετακίνηση.
+ */
+@Entity(
+    tableName = "moving_details",
+    foreignKeys = [
+        ForeignKey(
+            entity = MovingEntity::class,
+            parentColumns = ["id"],
+            childColumns = ["movingId"],
+            onDelete = ForeignKey.CASCADE
+        )
+    ],
+    indices = [Index(value = ["movingId"])]
+)
+data class MovingDetailEntity(
+    @PrimaryKey val id: String = "",
+    val movingId: String = "",
+    val startPoiId: String = "",
+    val endPoiId: String = "",
+    val vehicleId: String = ""
+)

--- a/app/src/main/java/com/ioannapergamali/mysmartroute/data/local/MovingEntity.kt
+++ b/app/src/main/java/com/ioannapergamali/mysmartroute/data/local/MovingEntity.kt
@@ -25,13 +25,8 @@ data class MovingEntity(
     val routeId: String = "",
     val userId: String = "",
     val date: Long = 0L,
-    val vehicleId: String = "",
     val cost: Double? = null,
     val durationMinutes: Int = 0,
-    /** Σημείο επιβίβασης */
-    val startPoiId: String = "",
-    /** Σημείο αποβίβασης */
-    val endPoiId: String = "",
     /** Ο οδηγός που ενδιαφέρεται να πραγματοποιήσει τη μεταφορά */
     val driverId: String = "",
     /** Κατάσταση προσφοράς: open, pending, accepted, rejected, completed */
@@ -59,11 +54,8 @@ data class MovingEntity(
         routeId: String = "",
         userId: String = "",
         date: Long = 0L,
-        vehicleId: String = "",
         cost: Double? = null,
         durationMinutes: Int = 0,
-        startPoiId: String = "",
-        endPoiId: String = "",
         createdById: String = "",
         createdByName: String = "",
         driverId: String = "",
@@ -77,11 +69,8 @@ data class MovingEntity(
         routeId,
         userId,
         date,
-        vehicleId,
         cost,
         durationMinutes,
-        startPoiId,
-        endPoiId,
         driverId,
         status,
         requestNumber

--- a/app/src/main/java/com/ioannapergamali/mysmartroute/data/local/SeatReservationDetailDao.kt
+++ b/app/src/main/java/com/ioannapergamali/mysmartroute/data/local/SeatReservationDetailDao.kt
@@ -1,0 +1,22 @@
+package com.ioannapergamali.mysmartroute.data.local
+
+import androidx.room.Dao
+import androidx.room.Insert
+import androidx.room.OnConflictStrategy
+import androidx.room.Query
+import kotlinx.coroutines.flow.Flow
+
+/**
+ * DAO για πρόσβαση στις λεπτομέρειες των κρατήσεων θέσεων.
+ */
+@Dao
+interface SeatReservationDetailDao {
+    @Insert(onConflict = OnConflictStrategy.REPLACE)
+    suspend fun insert(detail: SeatReservationDetailEntity)
+
+    @Query("SELECT * FROM seat_reservation_details WHERE reservationId = :reservationId")
+    fun getForReservation(reservationId: String): Flow<List<SeatReservationDetailEntity>>
+
+    @Query("DELETE FROM seat_reservation_details WHERE reservationId = :reservationId")
+    suspend fun deleteForReservation(reservationId: String)
+}

--- a/app/src/main/java/com/ioannapergamali/mysmartroute/data/local/SeatReservationDetailEntity.kt
+++ b/app/src/main/java/com/ioannapergamali/mysmartroute/data/local/SeatReservationDetailEntity.kt
@@ -1,0 +1,29 @@
+package com.ioannapergamali.mysmartroute.data.local
+
+import androidx.room.Entity
+import androidx.room.ForeignKey
+import androidx.room.Index
+import androidx.room.PrimaryKey
+
+/**
+ * Υποσυλλογή για λεπτομέρειες κράτησης θέσης.
+ * Αποθηκεύει τα σημεία επιβίβασης και αποβίβασης για κάθε κράτηση.
+ */
+@Entity(
+    tableName = "seat_reservation_details",
+    foreignKeys = [
+        ForeignKey(
+            entity = SeatReservationEntity::class,
+            parentColumns = ["id"],
+            childColumns = ["reservationId"],
+            onDelete = ForeignKey.CASCADE
+        )
+    ],
+    indices = [Index(value = ["reservationId"])]
+)
+data class SeatReservationDetailEntity(
+    @PrimaryKey val id: String = "",
+    val reservationId: String = "",
+    val startPoiId: String = "",
+    val endPoiId: String = ""
+)

--- a/app/src/main/java/com/ioannapergamali/mysmartroute/data/local/SeatReservationEntity.kt
+++ b/app/src/main/java/com/ioannapergamali/mysmartroute/data/local/SeatReservationEntity.kt
@@ -16,9 +16,5 @@ data class SeatReservationEntity(
     /** Ημερομηνία κράτησης σε millis */
     val date: Long = 0L,
     /** Ώρα έναρξης της διαδρομής σε millis από τα μεσάνυχτα */
-    val startTime: Long = 0L,
-    /** Σημείο επιβίβασης */
-    val startPoiId: String = "",
-    /** Σημείο αποβίβασης */
-    val endPoiId: String = ""
+    val startTime: Long = 0L
 )

--- a/app/src/main/java/com/ioannapergamali/mysmartroute/view/ui/screens/ReservationDetailsScreen.kt
+++ b/app/src/main/java/com/ioannapergamali/mysmartroute/view/ui/screens/ReservationDetailsScreen.kt
@@ -21,6 +21,7 @@ import com.google.firebase.firestore.FirebaseFirestore
 import com.ioannapergamali.mysmartroute.R
 import com.ioannapergamali.mysmartroute.data.local.MySmartRouteDatabase
 import com.ioannapergamali.mysmartroute.data.local.SeatReservationEntity
+import kotlinx.coroutines.flow.firstOrNull
 import com.ioannapergamali.mysmartroute.view.ui.components.TopBar
 import com.ioannapergamali.mysmartroute.utils.toUserEntity
 import com.ioannapergamali.mysmartroute.data.local.insertUserSafely
@@ -52,8 +53,9 @@ fun ReservationDetailsScreen(
         reservation?.let { res ->
             val db = MySmartRouteDatabase.getInstance(context)
             routeName = db.routeDao().findById(res.routeId)?.name ?: res.routeId
-            startPoiName = db.poIDao().findById(res.startPoiId)?.name ?: res.startPoiId
-            endPoiName = db.poIDao().findById(res.endPoiId)?.name ?: res.endPoiId
+            val det = db.seatReservationDetailDao().getForReservation(res.id).firstOrNull()
+            startPoiName = det?.startPoiId?.let { db.poIDao().findById(it)?.name ?: it } ?: ""
+            endPoiName = det?.endPoiId?.let { db.poIDao().findById(it)?.name ?: it } ?: ""
             val decl = db.transportDeclarationDao().getById(res.declarationId)
             cost = decl?.cost
             driverName = decl?.driverId?.let { driverId ->

--- a/app/src/main/java/com/ioannapergamali/mysmartroute/viewmodel/ReservationViewModel.kt
+++ b/app/src/main/java/com/ioannapergamali/mysmartroute/viewmodel/ReservationViewModel.kt
@@ -6,15 +6,19 @@ import androidx.lifecycle.viewModelScope
 import com.google.firebase.firestore.FirebaseFirestore
 import com.ioannapergamali.mysmartroute.data.local.MySmartRouteDatabase
 import com.ioannapergamali.mysmartroute.data.local.SeatReservationEntity
+import com.ioannapergamali.mysmartroute.data.local.SeatReservationDetailEntity
 import com.ioannapergamali.mysmartroute.data.local.MovingEntity
+import com.ioannapergamali.mysmartroute.data.local.MovingDetailEntity
 import com.ioannapergamali.mysmartroute.data.local.TransportDeclarationEntity
 import com.ioannapergamali.mysmartroute.utils.NetworkUtils
 import com.ioannapergamali.mysmartroute.utils.toSeatReservationEntity
+import com.ioannapergamali.mysmartroute.utils.toSeatReservationDetailEntity
 import com.ioannapergamali.mysmartroute.utils.toFirestoreMap
 import com.ioannapergamali.mysmartroute.model.enumerations.RequestStatus
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.first
+import kotlinx.coroutines.flow.firstOrNull
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.tasks.await
 import kotlinx.coroutines.Dispatchers
@@ -42,7 +46,9 @@ class ReservationViewModel : ViewModel() {
                 return@launch
             }
 
-            val dao = MySmartRouteDatabase.getInstance(context).seatReservationDao()
+            val dbLocal = MySmartRouteDatabase.getInstance(context)
+            val dao = dbLocal.seatReservationDao()
+            val detailDao = dbLocal.seatReservationDetailDao()
             _reservations.value = dao.getReservationsForDeclaration(declarationId).first()
 
             if (NetworkUtils.isInternetAvailable(context)) {
@@ -59,6 +65,12 @@ class ReservationViewModel : ViewModel() {
                 if (list.isNotEmpty()) {
                     _reservations.value = list
                     list.forEach { dao.insert(it) }
+                    remote.documents.forEach { doc ->
+                        val resId = doc.getString("id") ?: doc.id
+                        val dets = doc.reference.collection("details").get().await()
+                        dets.documents.mapNotNull { it.toSeatReservationDetailEntity(resId) }
+                            .forEach { detailDao.insert(it) }
+                    }
                 }
             }
         }
@@ -71,7 +83,9 @@ class ReservationViewModel : ViewModel() {
     suspend fun getReservationCount(context: Context, declarationId: String): Int {
         if (declarationId.isBlank()) return 0
 
-        val dao = MySmartRouteDatabase.getInstance(context).seatReservationDao()
+        val dbLocal = MySmartRouteDatabase.getInstance(context)
+        val dao = dbLocal.seatReservationDao()
+        val detailDao = dbLocal.seatReservationDetailDao()
 
         val localCount = withContext(Dispatchers.IO) {
             dao.getReservationsForDeclaration(declarationId).first().size
@@ -85,7 +99,15 @@ class ReservationViewModel : ViewModel() {
                 .await()
             val list = remote.documents.mapNotNull { it.toSeatReservationEntity() }
             if (list.isNotEmpty()) {
-                withContext(Dispatchers.IO) { list.forEach { dao.insert(it) } }
+                withContext(Dispatchers.IO) {
+                    list.forEach { dao.insert(it) }
+                    remote.documents.forEach { doc ->
+                        val resId = doc.getString("id") ?: doc.id
+                        val dets = doc.reference.collection("details").get().await()
+                        dets.documents.mapNotNull { it.toSeatReservationDetailEntity(resId) }
+                            .forEach { detailDao.insert(it) }
+                    }
+                }
                 return list.size
             }
         }
@@ -105,26 +127,34 @@ class ReservationViewModel : ViewModel() {
     ): Int {
         if (declarationId.isBlank()) return 0
 
-        val dao = MySmartRouteDatabase.getInstance(context).seatReservationDao()
+        val dbLocal = MySmartRouteDatabase.getInstance(context)
+        val resDao = dbLocal.seatReservationDao()
+        val detailDao = dbLocal.seatReservationDetailDao()
 
         val localCount = withContext(Dispatchers.IO) {
-            dao.getReservationsForDeclaration(declarationId).first()
-                .count { it.startPoiId == startPoiId && it.endPoiId == endPoiId }
+            resDao.getReservationsForDeclaration(declarationId).first().count { res ->
+                detailDao.getForReservation(res.id).first().any {
+                    it.startPoiId == startPoiId && it.endPoiId == endPoiId
+                }
+            }
         }
 
         if (NetworkUtils.isInternetAvailable(context)) {
             val declRef = db.collection("transport_declarations").document(declarationId)
             val remote = db.collection("seat_reservations")
                 .whereEqualTo("declarationId", declRef)
-                .whereEqualTo("startPoiId", startPoiId)
-                .whereEqualTo("endPoiId", endPoiId)
                 .get()
                 .await()
-            val list = remote.documents.mapNotNull { it.toSeatReservationEntity() }
-            if (list.isNotEmpty()) {
-                withContext(Dispatchers.IO) { list.forEach { dao.insert(it) } }
-                return list.size
+            var remoteCount = 0
+            remote.documents.forEach { doc ->
+                val dets = doc.reference.collection("details")
+                    .whereEqualTo("startPoiId", startPoiId)
+                    .whereEqualTo("endPoiId", endPoiId)
+                    .get()
+                    .await()
+                if (!dets.isEmpty) remoteCount++
             }
+            return maxOf(localCount, remoteCount)
         }
 
         return localCount
@@ -145,7 +175,9 @@ class ReservationViewModel : ViewModel() {
         viewModelScope.launch {
             val db = MySmartRouteDatabase.getInstance(context)
             val resDao = db.seatReservationDao()
+            val resDetailDao = db.seatReservationDetailDao()
             val movingDao = db.movingDao()
+            val movingDetailDao = db.movingDetailDao()
             val transferDao = db.transferRequestDao()
             val hasInternet = NetworkUtils.isInternetAvailable(context)
             val existing = movingDao.countCompletedForRoute(routeId, date)
@@ -156,16 +188,14 @@ class ReservationViewModel : ViewModel() {
             val reservations = resDao.getReservationsForRouteAndDateTime(routeId, date, startTime).first()
             val currentMovings = movingDao.getAll().first()
             reservations.forEach { res ->
+                val detail = resDetailDao.getForReservation(res.id).firstOrNull() ?: return@forEach
                 val found = currentMovings.find {
                     it.routeId == routeId &&
                         it.userId == res.userId &&
-                        it.startPoiId == res.startPoiId &&
-                        it.endPoiId == res.endPoiId &&
                         it.date == date
                 }
                 val moving = if (found != null) {
                     found.copy(
-                        vehicleId = declaration.vehicleId,
                         cost = declaration.cost,
                         durationMinutes = declaration.durationMinutes,
                         driverId = declaration.driverId,
@@ -177,24 +207,32 @@ class ReservationViewModel : ViewModel() {
                         routeId = routeId,
                         userId = res.userId,
                         date = date,
-                        vehicleId = declaration.vehicleId,
                         cost = declaration.cost,
                         durationMinutes = declaration.durationMinutes,
-                        startPoiId = res.startPoiId,
-                        endPoiId = res.endPoiId,
                         driverId = declaration.driverId,
                         status = "completed"
                     )
                 }
                 movingDao.insert(moving)
+                val movingDetail = MovingDetailEntity(
+                    id = UUID.randomUUID().toString(),
+                    movingId = moving.id,
+                    startPoiId = detail.startPoiId,
+                    endPoiId = detail.endPoiId,
+                    vehicleId = declaration.vehicleId
+                )
+                movingDetailDao.insert(movingDetail)
                 if (moving.requestNumber != 0) {
                     transferDao.updateStatus(moving.requestNumber, RequestStatus.COMPLETED)
                 }
                 if (hasInternet) {
-                    FirebaseFirestore.getInstance()
+                    val movingRef = FirebaseFirestore.getInstance()
                         .collection("movings")
                         .document(moving.id)
-                        .set(moving.toFirestoreMap())
+                    movingRef.set(moving.toFirestoreMap()).await()
+                    movingRef.collection("details")
+                        .document(movingDetail.id)
+                        .set(movingDetail.toFirestoreMap())
                         .await()
                     if (moving.requestNumber != 0) {
                         transferDao.getRequestByNumber(moving.requestNumber)


### PR DESCRIPTION
## Περίληψη
- Ανάγνωση και εγγραφή λεπτομερειών θέσεων/μετακινήσεων στις υποσυλλογές Firestore
- Ενημέρωση ViewModel συγχρονισμού για πλήρη μεταφορά των πεδίων startPoiId/endPoiId/vehicleId από τις κύριες συλλογές

## Δοκιμές
- `./gradlew test` *(απέτυχε: στάθηκε στην επίλυση εξαρτήσεων λόγω απουσίας Android SDK)*

------
https://chatgpt.com/codex/tasks/task_e_68c6c25552348328a04644ff047ee3f7