### PR TITLE
Προσθήκη πεδίων διαδρομής στο MovingEntity

### DIFF
--- a/app/src/main/java/com/ioannapergamali/mysmartroute/data/local/MovingEntity.kt
+++ b/app/src/main/java/com/ioannapergamali/mysmartroute/data/local/MovingEntity.kt
@@ -27,6 +27,12 @@ data class MovingEntity(
     val date: Long = 0L,
     val cost: Double? = null,
     val durationMinutes: Int = 0,
+    /** Το όχημα που θα εκτελέσει τη μετακίνηση */
+    val vehicleId: String = "",
+    /** Το σημείο εκκίνησης της διαδρομής */
+    val startPoiId: String = "",
+    /** Το σημείο τερματισμού της διαδρομής */
+    val endPoiId: String = "",
     /** Ο οδηγός που ενδιαφέρεται να πραγματοποιήσει τη μεταφορά */
     val driverId: String = "",
     /** Κατάσταση προσφοράς: open, pending, accepted, rejected, completed */
@@ -63,7 +69,10 @@ data class MovingEntity(
         requestNumber: Int = 0,
         driverName: String = "",
         routeName: String = "",
-        vehicleName: String = ""
+        vehicleName: String = "",
+        vehicleId: String = "",
+        startPoiId: String = "",
+        endPoiId: String = ""
     ) : this(
         id,
         routeId,
@@ -71,6 +80,9 @@ data class MovingEntity(
         date,
         cost,
         durationMinutes,
+        vehicleId,
+        startPoiId,
+        endPoiId,
         driverId,
         status,
         requestNumber

--- a/app/src/main/java/com/ioannapergamali/mysmartroute/utils/FirestoreMappers.kt
+++ b/app/src/main/java/com/ioannapergamali/mysmartroute/utils/FirestoreMappers.kt
@@ -307,6 +307,15 @@ fun MovingEntity.toFirestoreMap(): Map<String, Any> {
         "requestNumber" to requestNumber
     )
     cost?.let { map["cost"] = it }
+    if (vehicleId.isNotEmpty()) {
+        map["vehicleId"] = FirebaseFirestore.getInstance().collection("vehicles").document(vehicleId)
+    }
+    if (startPoiId.isNotEmpty()) {
+        map["startPoiId"] = FirebaseFirestore.getInstance().collection("pois").document(startPoiId)
+    }
+    if (endPoiId.isNotEmpty()) {
+        map["endPoiId"] = FirebaseFirestore.getInstance().collection("pois").document(endPoiId)
+    }
     if (createdById.isNotEmpty()) {
         map["createdById"] = FirebaseFirestore.getInstance().collection("users").document(createdById)
         map["createdByName"] = createdByName
@@ -339,6 +348,21 @@ fun DocumentSnapshot.toMovingEntity(): MovingEntity? {
     }
     val costVal = getDouble("cost")
     val durVal = (getLong("durationMinutes") ?: 0L).toInt()
+    val vehicleId = when (val v = get("vehicleId")) {
+        is DocumentReference -> v.id
+        is String -> v
+        else -> getString("vehicleId")
+    } ?: ""
+    val startPoiId = when (val s = get("startPoiId")) {
+        is DocumentReference -> s.id
+        is String -> s
+        else -> getString("startPoiId")
+    } ?: ""
+    val endPoiId = when (val e = get("endPoiId")) {
+        is DocumentReference -> e.id
+        is String -> e
+        else -> getString("endPoiId")
+    } ?: ""
     val createdById = when (val c = get("createdById")) {
         is DocumentReference -> c.id
         is String -> c
@@ -356,20 +380,23 @@ fun DocumentSnapshot.toMovingEntity(): MovingEntity? {
     val routeName = getString("routeName") ?: ""
     val vehicleName = getString("vehicleName") ?: ""
     return MovingEntity(
-        movingId,
-        routeId,
-        userId,
-        dateVal,
-        costVal,
-        durVal,
-        createdById,
-        createdByName,
-        driverId,
-        status,
-        requestNumber,
-        driverName,
-        routeName,
-        vehicleName
+        id = movingId,
+        routeId = routeId,
+        userId = userId,
+        date = dateVal,
+        cost = costVal,
+        durationMinutes = durVal,
+        vehicleId = vehicleId,
+        startPoiId = startPoiId,
+        endPoiId = endPoiId,
+        createdById = createdById,
+        createdByName = createdByName,
+        driverId = driverId,
+        status = status,
+        requestNumber = requestNumber,
+        driverName = driverName,
+        routeName = routeName,
+        vehicleName = vehicleName
     )
 }
 


### PR DESCRIPTION
## Σύνοψη
- Προστέθηκαν τα πεδία `vehicleId`, `startPoiId` και `endPoiId` στην οντότητα `MovingEntity`.
- Ενημερώθηκαν οι συναρτήσεις μετατροπής προς/από Firestore ώστε να χειρίζονται τα νέα πεδία.

## Έλεγχοι
- `./gradlew test` *(απέτυχε: SDK location not found)*
- `./gradlew :app:compileDebugKotlin` *(απέτυχε: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_68c6cd4da7308328b1b86c9ca498e950