### PR TITLE
Προσθήκη πεδίων κόστους και ώρας στις λεπτομέρειες μεταφοράς

### DIFF
--- a/app/src/main/java/com/ioannapergamali/mysmartroute/data/local/MySmartRouteDatabase.kt
+++ b/app/src/main/java/com/ioannapergamali/mysmartroute/data/local/MySmartRouteDatabase.kt
@@ -76,7 +76,7 @@ import com.ioannapergamali.mysmartroute.data.local.TripRatingDao
         UserPoiEntity::class
     ],
 
-    version = 69
+    version = 70
 
 )
 @TypeConverters(Converters::class)
@@ -979,6 +979,17 @@ abstract class MySmartRouteDatabase : RoomDatabase() {
             }
         }
 
+        private val MIGRATION_69_70 = object : Migration(69, 70) {
+            override fun migrate(database: SupportSQLiteDatabase) {
+                database.execSQL(
+                    "ALTER TABLE `transport_declarations_details` ADD COLUMN `cost` REAL NOT NULL DEFAULT 0"
+                )
+                database.execSQL(
+                    "ALTER TABLE `transport_declarations_details` ADD COLUMN `startTime` INTEGER NOT NULL DEFAULT 0"
+                )
+            }
+        }
+
         private fun prepopulate(db: SupportSQLiteDatabase) {
             Log.d(TAG, "Prepopulating database")
             db.execSQL(
@@ -1127,7 +1138,8 @@ abstract class MySmartRouteDatabase : RoomDatabase() {
                     MIGRATION_65_66,
                     MIGRATION_66_67,
                     MIGRATION_67_68,
-                    MIGRATION_68_69
+                    MIGRATION_68_69,
+                    MIGRATION_69_70
 
                 )
                     .addCallback(object : RoomDatabase.Callback() {

--- a/app/src/main/java/com/ioannapergamali/mysmartroute/data/local/TransportDeclarationDetailEntity.kt
+++ b/app/src/main/java/com/ioannapergamali/mysmartroute/data/local/TransportDeclarationDetailEntity.kt
@@ -25,5 +25,7 @@ data class TransportDeclarationDetailEntity(
     val endPoiId: String = "",
     val vehicleId: String = "",
     val vehicleType: String = "",
-    val seats: Int = 0
+    val seats: Int = 0,
+    val cost: Double = 0.0,
+    val startTime: Long = 0L
 )

--- a/app/src/main/java/com/ioannapergamali/mysmartroute/utils/FirestoreMappers.kt
+++ b/app/src/main/java/com/ioannapergamali/mysmartroute/utils/FirestoreMappers.kt
@@ -408,7 +408,9 @@ fun TransportDeclarationDetailEntity.toFirestoreMap(): Map<String, Any> = mapOf(
     "endPoiId" to FirebaseFirestore.getInstance().collection("pois").document(endPoiId),
     "vehicleId" to FirebaseFirestore.getInstance().collection("vehicles").document(vehicleId),
     "vehicleType" to vehicleType,
-    "seats" to seats
+    "seats" to seats,
+    "cost" to cost,
+    "startTime" to startTime
 )
 
 fun DocumentSnapshot.toTransportDeclarationDetailEntity(declarationId: String): TransportDeclarationDetailEntity? {
@@ -429,7 +431,9 @@ fun DocumentSnapshot.toTransportDeclarationDetailEntity(declarationId: String): 
     }
     val type = getString("vehicleType") ?: ""
     val seatsVal = (getLong("seats") ?: 0L).toInt()
-    return TransportDeclarationDetailEntity(id, declarationId, startPoi, endPoi, vehicle, type, seatsVal)
+    val costVal = getDouble("cost") ?: 0.0
+    val timeVal = getLong("startTime") ?: 0L
+    return TransportDeclarationDetailEntity(id, declarationId, startPoi, endPoi, vehicle, type, seatsVal, costVal, timeVal)
 }
 
 fun AvailabilityEntity.toFirestoreMap(): Map<String, Any> = mapOf(


### PR DESCRIPTION
## Περίληψη
- Προσθήκη πεδίων `cost` και `startTime` στην οντότητα TransportDeclarationDetail
- Ενημέρωση Firestore mappers για αποθήκευση/φόρτωση των νέων πεδίων
- Αναβάθμιση βάσης σε έκδοση 70 με νέα migration για τα επιπλέον πεδία

## Έλεγχοι
- `./gradlew test` *(αποτυχία: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_68c6cc9591248328a346e25837b74066