### PR TITLE
Υπολογισμός κόστους από λεπτομέρειες διαδρομής

### DIFF
--- a/app/src/main/java/com/ioannapergamali/mysmartroute/view/ui/screens/AnnounceTransportScreen.kt
+++ b/app/src/main/java/com/ioannapergamali/mysmartroute/view/ui/screens/AnnounceTransportScreen.kt
@@ -773,16 +773,17 @@ fun AnnounceTransportScreen(navController: NavController, openDrawer: () -> Unit
                                 } else emptyList()
                             }
                             val minSeatsValue = if (details.isNotEmpty()) minSeats else selectedVehicleSeats
+                            val costPerDetail = if (detailList.isNotEmpty()) cost / detailList.size else 0.0
+                            val detailedCosts = detailList.map { it.copy(cost = costPerDetail) }
                             val success = declarationViewModel.declareTransport(
                                 context,
                                 routeId,
                                 driverId,
                                 if (minSeatsValue == Int.MAX_VALUE) 0 else minSeatsValue,
-                                cost,
                                 duration,
                                 date,
                                 startTime,
-                                detailList
+                                detailedCosts
                             )
                             Toast.makeText(
                                 context,

--- a/app/src/main/java/com/ioannapergamali/mysmartroute/viewmodel/TransportDeclarationViewModel.kt
+++ b/app/src/main/java/com/ioannapergamali/mysmartroute/viewmodel/TransportDeclarationViewModel.kt
@@ -106,7 +106,6 @@ class TransportDeclarationViewModel : ViewModel() {
         routeId: String,
         driverId: String,
         seats: Int,
-        cost: Double,
         durationMinutes: Int,
         date: Long,
         startTime: Long = 0L,
@@ -116,7 +115,8 @@ class TransportDeclarationViewModel : ViewModel() {
         val declDao = db.transportDeclarationDao()
         val detailDao = db.transportDeclarationDetailDao()
         val id = UUID.randomUUID().toString()
-        val entity = TransportDeclarationEntity(id, routeId, driverId, cost, durationMinutes, date, startTime)
+        val totalCost = details.sumOf { it.cost }
+        val entity = TransportDeclarationEntity(id, routeId, driverId, totalCost, durationMinutes, date, startTime)
         entity.seats = seats
         if (details.isNotEmpty()) {
             entity.vehicleId = details.first().vehicleId


### PR DESCRIPTION
## Περίληψη
- Υπολογισμός του συνολικού κόστους δήλωσης από τα επιμέρους κόστη των λεπτομερειών
- Κατανομή κόστους σε κάθε detail κατά την καταχώριση διαδρομής

## Δοκιμές
- `timeout 60 ./gradlew test --console=plain` *(απέτυχε: έληξε ο χρόνος στο περιβάλλον εργασίας)*

------
https://chatgpt.com/codex/tasks/task_e_68c6d61ee22c8328bbda01e7b48f5176