### PR TITLE
Add cost field for transport declaration details

### DIFF
--- a/app/src/main/java/com/ioannapergamali/mysmartroute/data/local/TransportDeclarationDetailEntity.kt
+++ b/app/src/main/java/com/ioannapergamali/mysmartroute/data/local/TransportDeclarationDetailEntity.kt
@@ -26,5 +26,6 @@ data class TransportDeclarationDetailEntity(
     val vehicleId: String = "",
     val vehicleType: String = "",
     val seats: Int = 0,
+    val cost: Double = 0.0,
     val startTime: Long = 0L
 )

--- a/app/src/main/java/com/ioannapergamali/mysmartroute/utils/FirestoreMappers.kt
+++ b/app/src/main/java/com/ioannapergamali/mysmartroute/utils/FirestoreMappers.kt
@@ -436,6 +436,7 @@ fun TransportDeclarationDetailEntity.toFirestoreMap(): Map<String, Any> = mapOf(
     "vehicleId" to FirebaseFirestore.getInstance().collection("vehicles").document(vehicleId),
     "vehicleType" to vehicleType,
     "seats" to seats,
+    "cost" to cost,
     "startTime" to startTime
 )
 
@@ -457,8 +458,9 @@ fun DocumentSnapshot.toTransportDeclarationDetailEntity(declarationId: String): 
     }
     val type = getString("vehicleType") ?: ""
     val seatsVal = (getLong("seats") ?: 0L).toInt()
+    val costVal = getDouble("cost") ?: 0.0
     val timeVal = getLong("startTime") ?: 0L
-    return TransportDeclarationDetailEntity(id, declarationId, startPoi, endPoi, vehicle, type, seatsVal, timeVal)
+    return TransportDeclarationDetailEntity(id, declarationId, startPoi, endPoi, vehicle, type, seatsVal, costVal, timeVal)
 }
 
 fun AvailabilityEntity.toFirestoreMap(): Map<String, Any> = mapOf(


### PR DESCRIPTION
## Summary
- include cost in `TransportDeclarationDetailEntity`
- map cost to Firestore and compute total cost from details

## Testing
- `./gradlew test` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_68c6db4562c883288980137f05dcb7f9