### PR TITLE
Add cost per association and compute total route cost

### DIFF
--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -226,6 +226,7 @@
     <string name="boarding_stop">Boarding stop</string>
     <string name="dropoff_stop">Drop-off stop</string>
     <string name="invalid_stop_order">Drop-off stop must be after boarding stop.</string>
+    <string name="invalid_cost">Invalid cost</string>
     <string name="bus_required">Bus station links require a bus vehicle.</string>
     <string name="clear_selection">Clear selection</string>
     <string name="passenger">Passenger</string>


### PR DESCRIPTION
## Summary
- add cost input and display per transport association
- compute total route cost as sum of association costs
- validate segment costs and keep automatic start times

## Testing
- `./gradlew test` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_68c6dc869070832892e86e595431ac29