### PR TITLE
Έλεγχος movings πριν την ολοκλήρωση διαδρομής

### DIFF
--- a/app/src/main/java/com/ioannapergamali/mysmartroute/data/local/MovingDao.kt
+++ b/app/src/main/java/com/ioannapergamali/mysmartroute/data/local/MovingDao.kt
@@ -31,6 +31,11 @@ interface MovingDao {
     suspend fun countForRoute(routeId: String, date: Long): Int
 
     @Query(
+        "SELECT COUNT(*) FROM movings WHERE routeId = :routeId AND date = :date AND status IN ('pending','open')"
+    )
+    suspend fun countPendingOrOpenForRoute(routeId: String, date: Long): Int
+
+    @Query(
         "SELECT COUNT(*) FROM movings WHERE routeId = :routeId AND date = :date AND status = 'completed'"
     )
     suspend fun countCompletedForRoute(routeId: String, date: Long): Int


### PR DESCRIPTION
## Περίληψη
- Προστέθηκε έλεγχος στη βάση `movings` για διαδρομές με κατάσταση pending/open πριν φορτωθούν οι κρατήσεις.
- Αφαιρέθηκαν τα πεδία ώρας και τύπου οχήματος από την οθόνη προετοιμασίας ολοκλήρωσης διαδρομής.

## Δοκιμές
- `./gradlew test` *(αποτυχία: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_68c6e88df6888328bbe2b0f124e521b8