### PR TITLE
Προσθήκη ώρας και κόστους σε λεπτομέρειες κράτησης

### DIFF
--- a/app/src/main/java/com/ioannapergamali/mysmartroute/data/local/MySmartRouteDatabase.kt
+++ b/app/src/main/java/com/ioannapergamali/mysmartroute/data/local/MySmartRouteDatabase.kt
@@ -76,7 +76,7 @@ import com.ioannapergamali.mysmartroute.data.local.TripRatingDao
         UserPoiEntity::class
     ],
 
-    version = 71
+    version = 72
 
 )
 @TypeConverters(Converters::class)
@@ -990,6 +990,17 @@ abstract class MySmartRouteDatabase : RoomDatabase() {
             }
         }
 
+        private val MIGRATION_71_72 = object : Migration(71, 72) {
+            override fun migrate(database: SupportSQLiteDatabase) {
+                database.execSQL(
+                    "ALTER TABLE `seat_reservation_details` ADD COLUMN `cost` REAL NOT NULL DEFAULT 0"
+                )
+                database.execSQL(
+                    "ALTER TABLE `seat_reservation_details` ADD COLUMN `startTime` INTEGER NOT NULL DEFAULT 0"
+                )
+            }
+        }
+
         private fun prepopulate(db: SupportSQLiteDatabase) {
             Log.d(TAG, "Prepopulating database")
             db.execSQL(
@@ -1139,7 +1150,8 @@ abstract class MySmartRouteDatabase : RoomDatabase() {
                     MIGRATION_66_67,
                     MIGRATION_67_68,
                     MIGRATION_68_69,
-                    MIGRATION_69_70
+                    MIGRATION_69_70,
+                    MIGRATION_71_72
 
                 )
                     .addCallback(object : RoomDatabase.Callback() {

--- a/app/src/main/java/com/ioannapergamali/mysmartroute/data/local/SeatReservationDetailEntity.kt
+++ b/app/src/main/java/com/ioannapergamali/mysmartroute/data/local/SeatReservationDetailEntity.kt
@@ -25,5 +25,7 @@ data class SeatReservationDetailEntity(
     @PrimaryKey val id: String = "",
     val reservationId: String = "",
     val startPoiId: String = "",
-    val endPoiId: String = ""
+    val endPoiId: String = "",
+    val cost: Double = 0.0,
+    val startTime: Long = 0L
 )

--- a/app/src/main/java/com/ioannapergamali/mysmartroute/utils/FirestoreMappers.kt
+++ b/app/src/main/java/com/ioannapergamali/mysmartroute/utils/FirestoreMappers.kt
@@ -525,7 +525,9 @@ fun DocumentSnapshot.toSeatReservationEntity(): SeatReservationEntity? {
 fun SeatReservationDetailEntity.toFirestoreMap(): Map<String, Any> = mapOf(
     "id" to id,
     "startPoiId" to FirebaseFirestore.getInstance().collection("pois").document(startPoiId),
-    "endPoiId" to FirebaseFirestore.getInstance().collection("pois").document(endPoiId)
+    "endPoiId" to FirebaseFirestore.getInstance().collection("pois").document(endPoiId),
+    "cost" to cost,
+    "startTime" to startTime
 )
 
 fun DocumentSnapshot.toSeatReservationDetailEntity(reservationId: String): SeatReservationDetailEntity? {
@@ -540,7 +542,9 @@ fun DocumentSnapshot.toSeatReservationDetailEntity(reservationId: String): SeatR
         is String -> e
         else -> return null
     }
-    return SeatReservationDetailEntity(detId, reservationId, start, end)
+    val costVal = getDouble("cost") ?: 0.0
+    val timeVal = getLong("startTime") ?: 0L
+    return SeatReservationDetailEntity(detId, reservationId, start, end, costVal, timeVal)
 }
 
 fun MovingDetailEntity.toFirestoreMap(): Map<String, Any> = mapOf(

--- a/app/src/main/java/com/ioannapergamali/mysmartroute/view/ui/screens/AvailableTransportsScreen.kt
+++ b/app/src/main/java/com/ioannapergamali/mysmartroute/view/ui/screens/AvailableTransportsScreen.kt
@@ -301,7 +301,13 @@ fun AvailableTransportsScreen(
                               grouped.values.forEach { list ->
                                   val decl = list.first().first
                                   val segments = list.map { (_, detail) ->
-                                      ReservationSegment(detail.startPoiId, detail.endPoiId, detail.vehicleId)
+                                      ReservationSegment(
+                                          detail.startPoiId,
+                                          detail.endPoiId,
+                                          detail.vehicleId,
+                                          detail.cost,
+                                          detail.startTime
+                                      )
                                   }
                                   val result = bookingViewModel.reserveSeat(
                                       context = context,

--- a/app/src/main/java/com/ioannapergamali/mysmartroute/viewmodel/BookingViewModel.kt
+++ b/app/src/main/java/com/ioannapergamali/mysmartroute/viewmodel/BookingViewModel.kt
@@ -25,7 +25,9 @@ import java.util.UUID
 data class ReservationSegment(
     val startPoiId: String,
     val endPoiId: String,
-    val vehicleId: String
+    val vehicleId: String,
+    val cost: Double,
+    val startTime: Long
 )
 
 /**
@@ -126,7 +128,9 @@ class BookingViewModel : ViewModel() {
                     id = UUID.randomUUID().toString(),
                     reservationId = reservation.id,
                     startPoiId = seg.startPoiId,
-                    endPoiId = seg.endPoiId
+                    endPoiId = seg.endPoiId,
+                    cost = seg.cost,
+                    startTime = seg.startTime
                 )
                 resDetailDao.insert(resDetail)
                 resRef.collection("details")

--- a/app/src/main/java/com/ioannapergamali/mysmartroute/viewmodel/VehicleRequestViewModel.kt
+++ b/app/src/main/java/com/ioannapergamali/mysmartroute/viewmodel/VehicleRequestViewModel.kt
@@ -544,7 +544,9 @@ class VehicleRequestViewModel(
                         id = UUID.randomUUID().toString(),
                         reservationId = reservation.id,
                         startPoiId = current.startPoiId,
-                        endPoiId = current.endPoiId
+                        endPoiId = current.endPoiId,
+                        cost = declaration?.cost ?: 0.0,
+                        startTime = declaration?.startTime ?: 0L
                     )
                     resDao.insert(reservation)
                     resDetailDao.insert(resDetail)


### PR DESCRIPTION
## Περίληψη
- επεκτάθηκαν οι `SeatReservationDetailEntity` με πεδία κόστους και ώρας
- ενημερώθηκαν οι mappers και τα ViewModels ώστε να αποθηκεύουν/προβάλουν τα νέα πεδία
- προστέθηκε migration και αυξήθηκε η έκδοση της βάσης

## Έλεγχοι
- `./gradlew test` *(αποτυχία: λείπει Android SDK)*

------
https://chatgpt.com/codex/tasks/task_e_68c6eb6674d083288020e69b69aa8395