### PR TITLE
Add TicketActivity for seat reservation printing

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -33,6 +33,7 @@
                 <category android:name="android.intent.category.LAUNCHER" />
             </intent-filter>
         </activity>
+        <activity android:name=".view.TicketActivity" />
     </application>
 
 </manifest>

--- a/app/src/main/java/com/ioannapergamali/mysmartroute/data/local/SeatReservationDao.kt
+++ b/app/src/main/java/com/ioannapergamali/mysmartroute/data/local/SeatReservationDao.kt
@@ -16,6 +16,9 @@ interface SeatReservationDao {
     @Query("SELECT * FROM seat_reservations")
     fun getAll(): Flow<List<SeatReservationEntity>>
 
+    @Query("SELECT * FROM seat_reservations")
+    suspend fun getAllList(): List<SeatReservationEntity>
+
     @Query("DELETE FROM seat_reservations WHERE id = :id")
     suspend fun deleteById(id: String)
 

--- a/app/src/main/java/com/ioannapergamali/mysmartroute/utils/ReservationPrinter.kt
+++ b/app/src/main/java/com/ioannapergamali/mysmartroute/utils/ReservationPrinter.kt
@@ -1,0 +1,24 @@
+package com.ioannapergamali.mysmartroute.utils
+
+import com.ioannapergamali.mysmartroute.data.local.SeatReservationDao
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.withContext
+
+/**
+ * Δημιουργεί κείμενο για εκτύπωση των κρατήσεων.
+ * Builds printable text of seat reservations.
+ */
+class ReservationPrinter(private val dao: SeatReservationDao) {
+    suspend fun buildPrintText(): String = withContext(Dispatchers.IO) {
+        val reservations = dao.getAllList()
+        if (reservations.isEmpty()) {
+            "Δεν βρέθηκαν κρατήσεις."
+        } else {
+            buildString {
+                reservations.forEach { r ->
+                    append("Διαδρομή: ${r.routeId} - Χρήστης: ${r.userId}\n")
+                }
+            }
+        }
+    }
+}

--- a/app/src/main/java/com/ioannapergamali/mysmartroute/view/TicketActivity.kt
+++ b/app/src/main/java/com/ioannapergamali/mysmartroute/view/TicketActivity.kt
@@ -1,0 +1,28 @@
+package com.ioannapergamali.mysmartroute.view
+
+import android.os.Bundle
+import android.widget.TextView
+import androidx.appcompat.app.AppCompatActivity
+import androidx.lifecycle.lifecycleScope
+import com.ioannapergamali.mysmartroute.R
+import com.ioannapergamali.mysmartroute.data.local.MySmartRouteDatabase
+import com.ioannapergamali.mysmartroute.utils.ReservationPrinter
+import kotlinx.coroutines.launch
+
+/**
+ * Απλή δραστηριότητα που εμφανίζει τις κρατήσεις από τη βάση.
+ * Simple activity that prints seat reservations from the database.
+ */
+class TicketActivity : AppCompatActivity() {
+    override fun onCreate(savedInstanceState: Bundle?) {
+        super.onCreate(savedInstanceState)
+        setContentView(R.layout.activity_ticket)
+
+        lifecycleScope.launch {
+            val dao = MySmartRouteDatabase.getInstance(applicationContext).seatReservationDao()
+            val printer = ReservationPrinter(dao)
+            val text = printer.buildPrintText()
+            findViewById<TextView>(R.id.printTextView).text = text
+        }
+    }
+}

--- a/app/src/main/res/layout/activity_ticket.xml
+++ b/app/src/main/res/layout/activity_ticket.xml
@@ -1,0 +1,13 @@
+<?xml version="1.0" encoding="utf-8"?>
+<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent"
+    android:orientation="vertical"
+    android:padding="16dp">
+
+    <TextView
+        android:id="@+id/printTextView"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:text="" />
+</LinearLayout>


### PR DESCRIPTION
## Summary
- extend `SeatReservationDao` with a suspend `getAllList` helper
- add `ReservationPrinter` to build text output from stored reservations
- create `TicketActivity` and layout to display printed reservations and register it in the manifest

## Testing
- `./gradlew test` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_68c700050d88832888a86820eee427c7