### PR TITLE
Προσθήκη δυνατότητας αλλαγής ημερομηνίας

### DIFF
--- a/app/src/main/java/com/ioannapergamali/mysmartroute/data/local/AppDateTimeDao.kt
+++ b/app/src/main/java/com/ioannapergamali/mysmartroute/data/local/AppDateTimeDao.kt
@@ -1,0 +1,15 @@
+package com.ioannapergamali.mysmartroute.data.local
+
+import androidx.room.Dao
+import androidx.room.Insert
+import androidx.room.OnConflictStrategy
+import androidx.room.Query
+
+@Dao
+interface AppDateTimeDao {
+    @Query("SELECT * FROM app_datetime WHERE id = 1")
+    suspend fun getDateTime(): AppDateTimeEntity?
+
+    @Insert(onConflict = OnConflictStrategy.REPLACE)
+    suspend fun insert(entity: AppDateTimeEntity)
+}

--- a/app/src/main/java/com/ioannapergamali/mysmartroute/data/local/AppDateTimeEntity.kt
+++ b/app/src/main/java/com/ioannapergamali/mysmartroute/data/local/AppDateTimeEntity.kt
@@ -1,0 +1,11 @@
+package com.ioannapergamali.mysmartroute.data.local
+
+import androidx.room.Entity
+import androidx.room.PrimaryKey
+
+/** Ημερομηνία/ώρα εφαρμογής. */
+@Entity(tableName = "app_datetime")
+data class AppDateTimeEntity(
+    @PrimaryKey val id: Int = 1,
+    val timestamp: Long
+)

--- a/app/src/main/java/com/ioannapergamali/mysmartroute/data/local/MySmartRouteDatabase.kt
+++ b/app/src/main/java/com/ioannapergamali/mysmartroute/data/local/MySmartRouteDatabase.kt
@@ -45,6 +45,8 @@ import androidx.room.TypeConverters
 import com.ioannapergamali.mysmartroute.data.local.Converters
 import com.ioannapergamali.mysmartroute.data.local.TripRatingEntity
 import com.ioannapergamali.mysmartroute.data.local.TripRatingDao
+import com.ioannapergamali.mysmartroute.data.local.AppDateTimeEntity
+import com.ioannapergamali.mysmartroute.data.local.AppDateTimeDao
 
 @Database(
     entities = [
@@ -73,10 +75,11 @@ import com.ioannapergamali.mysmartroute.data.local.TripRatingDao
         TransferRequestEntity::class,
         TripRatingEntity::class,
         NotificationEntity::class,
-        UserPoiEntity::class
+        UserPoiEntity::class,
+        AppDateTimeEntity::class
     ],
 
-    version = 72
+    version = 73
 
 )
 @TypeConverters(Converters::class)
@@ -107,6 +110,7 @@ abstract class MySmartRouteDatabase : RoomDatabase() {
     abstract fun tripRatingDao(): TripRatingDao
     abstract fun notificationDao(): NotificationDao
     abstract fun userPoiDao(): UserPoiDao
+    abstract fun appDateTimeDao(): AppDateTimeDao
 
     companion object {
         @Volatile
@@ -1001,6 +1005,13 @@ abstract class MySmartRouteDatabase : RoomDatabase() {
             }
         }
 
+        private val MIGRATION_72_73 = object : Migration(72, 73) {
+            override fun migrate(database: SupportSQLiteDatabase) {
+                database.execSQL("CREATE TABLE IF NOT EXISTS `app_datetime` (`id` INTEGER NOT NULL, `timestamp` INTEGER NOT NULL, PRIMARY KEY(`id`))")
+                database.execSQL("INSERT OR IGNORE INTO app_datetime (id, timestamp) VALUES (1, strftime('%s','now')*1000)")
+            }
+        }
+
         private fun prepopulate(db: SupportSQLiteDatabase) {
             Log.d(TAG, "Prepopulating database")
             db.execSQL(
@@ -1084,6 +1095,7 @@ abstract class MySmartRouteDatabase : RoomDatabase() {
             insertOption("opt_admin_13", adminMenuId, "view_pois", "viewPois")
             Log.d(TAG, "Prepopulate complete")
             db.execSQL("INSERT INTO app_language (id, language) VALUES (1, 'el')")
+            db.execSQL("INSERT INTO app_datetime (id, timestamp) VALUES (1, strftime('%s', 'now')*1000)")
         }
 
         fun getInstance(context: Context): MySmartRouteDatabase {
@@ -1151,7 +1163,8 @@ abstract class MySmartRouteDatabase : RoomDatabase() {
                     MIGRATION_67_68,
                     MIGRATION_68_69,
                     MIGRATION_69_70,
-                    MIGRATION_71_72
+                    MIGRATION_71_72,
+                    MIGRATION_72_73
 
                 )
                     .addCallback(object : RoomDatabase.Callback() {

--- a/app/src/main/java/com/ioannapergamali/mysmartroute/model/navigation/NavigationHost.kt
+++ b/app/src/main/java/com/ioannapergamali/mysmartroute/model/navigation/NavigationHost.kt
@@ -29,6 +29,7 @@ import com.ioannapergamali.mysmartroute.view.ui.screens.LocalDatabaseScreen
 import com.ioannapergamali.mysmartroute.view.ui.screens.FirebaseDatabaseScreen
 import com.ioannapergamali.mysmartroute.view.ui.screens.AdminSignUpScreen
 import com.ioannapergamali.mysmartroute.view.ui.screens.EditPrivilegesScreen
+import com.ioannapergamali.mysmartroute.view.ui.screens.AdvanceDateScreen
 import com.ioannapergamali.mysmartroute.view.ui.screens.DatabaseSyncScreen
 import com.ioannapergamali.mysmartroute.view.ui.screens.RolesScreen
 import com.ioannapergamali.mysmartroute.view.ui.screens.ProfileScreen
@@ -407,6 +408,10 @@ fun NavigationHost(
 
         composable("userPoints") {
             UserPointsScreen(navController = navController, openDrawer = openDrawer)
+        }
+
+        composable("advanceDate") {
+            AdvanceDateScreen(navController = navController, openDrawer = openDrawer)
         }
 
 

--- a/app/src/main/java/com/ioannapergamali/mysmartroute/view/ui/components/TopBar.kt
+++ b/app/src/main/java/com/ioannapergamali/mysmartroute/view/ui/components/TopBar.kt
@@ -9,6 +9,7 @@ import androidx.compose.material.icons.filled.Home
 import androidx.compose.material.icons.filled.Notifications
 import android.util.Log
 import androidx.compose.foundation.layout.Row
+import Column
 import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.Icon
 import androidx.compose.material3.IconButton
@@ -33,6 +34,10 @@ import com.ioannapergamali.mysmartroute.utils.LocaleUtils
 import com.ioannapergamali.mysmartroute.model.AppLanguage
 import kotlinx.coroutines.launch
 import com.google.firebase.auth.FirebaseAuth
+import com.ioannapergamali.mysmartroute.viewmodel.AppDateTimeViewModel
+import java.text.SimpleDateFormat
+import java.util.Date
+import java.util.Locale
 import androidx.lifecycle.viewmodel.compose.viewModel
 import com.ioannapergamali.mysmartroute.viewmodel.SettingsViewModel
 import com.ioannapergamali.mysmartroute.viewmodel.AuthenticationViewModel
@@ -67,6 +72,12 @@ fun TopBar(
     val currentLanguage by LanguagePreferenceManager.languageFlow(context).collectAsState(initial = AppLanguage.Greek.code)
     val role by authViewModel.currentUserRole.collectAsState()
     val hasUnreadNotifications by requestViewModel.hasUnreadNotifications.collectAsState()
+    val dateTimeViewModel: AppDateTimeViewModel = viewModel()
+    val storedMillis by dateTimeViewModel.dateTime.collectAsState()
+    LaunchedEffect(Unit) {
+        dateTimeViewModel.load(context)
+    }
+    val formattedDate = storedMillis?.let { SimpleDateFormat("dd/MM/yyyy HH:mm", Locale.getDefault()).format(Date(it)) } ?: ""
 
     LaunchedEffect(Unit) {
         authViewModel.loadCurrentUserRole(context)
@@ -98,7 +109,7 @@ fun TopBar(
                 actionIconContentColor = MaterialTheme.colorScheme.primary,
                 titleContentColor = MaterialTheme.colorScheme.primary
             ),
-        title = { Text(title) },
+        title = { if (formattedDate.isNotEmpty()) { Column { Text(title); Text(formattedDate, style = MaterialTheme.typography.labelSmall) } } else { Text(title) } },
         navigationIcon = {
             Row {
                 IconButton(onClick = {

--- a/app/src/main/java/com/ioannapergamali/mysmartroute/view/ui/screens/AdvanceDateScreen.kt
+++ b/app/src/main/java/com/ioannapergamali/mysmartroute/view/ui/screens/AdvanceDateScreen.kt
@@ -1,0 +1,66 @@
+@file:OptIn(ExperimentalMaterial3Api::class)
+package com.ioannapergamali.mysmartroute.view.ui.screens
+
+import android.app.DatePickerDialog
+import android.app.TimePickerDialog
+import androidx.compose.foundation.layout.*
+import androidx.compose.material3.Button
+import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.Scaffold
+import androidx.compose.material3.Text
+import androidx.compose.runtime.*
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.unit.dp
+import androidx.lifecycle.viewmodel.compose.viewModel
+import androidx.navigation.NavController
+import com.ioannapergamali.mysmartroute.R
+import com.ioannapergamali.mysmartroute.view.ui.components.ScreenContainer
+import com.ioannapergamali.mysmartroute.view.ui.components.TopBar
+import com.ioannapergamali.mysmartroute.viewmodel.AppDateTimeViewModel
+import java.text.SimpleDateFormat
+import java.util.*
+
+@Composable
+fun AdvanceDateScreen(navController: NavController, openDrawer: () -> Unit) {
+    val context = LocalContext.current
+    val dateViewModel: AppDateTimeViewModel = viewModel()
+    val storedMillis by dateViewModel.dateTime.collectAsState()
+    val format = remember { SimpleDateFormat("dd/MM/yyyy HH:mm", Locale.getDefault()) }
+
+    LaunchedEffect(Unit) { dateViewModel.load(context) }
+
+    Scaffold(
+        topBar = {
+            TopBar(
+                title = stringResource(R.string.advance_date),
+                navController = navController,
+                showMenu = true,
+                onMenuClick = openDrawer
+            )
+        }
+    ) { padding ->
+        ScreenContainer(modifier = Modifier.padding(padding), scrollable = false) {
+            val systemText = format.format(Date())
+            val storedText = storedMillis?.let { format.format(Date(it)) } ?: ""
+            Text(stringResource(R.string.system_datetime) + ": " + systemText)
+            Spacer(Modifier.height(8.dp))
+            Text(stringResource(R.string.stored_datetime) + ": " + storedText)
+            Spacer(Modifier.height(16.dp))
+            Button(onClick = {
+                val cal = Calendar.getInstance()
+                DatePickerDialog(context, { _, y, m, d ->
+                    TimePickerDialog(context, { _, h, min ->
+                        val newCal = Calendar.getInstance().apply { set(y, m, d, h, min) }
+                        dateViewModel.save(context, newCal.timeInMillis)
+                    }, cal.get(Calendar.HOUR_OF_DAY), cal.get(Calendar.MINUTE), true).show()
+                }, cal.get(Calendar.YEAR), cal.get(Calendar.MONTH), cal.get(Calendar.DAY_OF_MONTH)).show()
+            }) { Text(stringResource(R.string.edit)) }
+            Spacer(Modifier.height(8.dp))
+            Button(onClick = { dateViewModel.reset(context) }) {
+                Text(stringResource(R.string.reset_time))
+            }
+        }
+    }
+}

--- a/app/src/main/java/com/ioannapergamali/mysmartroute/viewmodel/AppDateTimeViewModel.kt
+++ b/app/src/main/java/com/ioannapergamali/mysmartroute/viewmodel/AppDateTimeViewModel.kt
@@ -1,0 +1,35 @@
+package com.ioannapergamali.mysmartroute.viewmodel
+
+import android.content.Context
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.viewModelScope
+import com.ioannapergamali.mysmartroute.data.local.AppDateTimeEntity
+import com.ioannapergamali.mysmartroute.data.local.MySmartRouteDatabase
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.launch
+
+/** Διαχειρίζεται την αποθηκευμένη ημερομηνία/ώρα. */
+class AppDateTimeViewModel : ViewModel() {
+    private val _dateTime = MutableStateFlow<Long?>(null)
+    val dateTime: StateFlow<Long?> = _dateTime
+
+    fun load(context: Context) {
+        viewModelScope.launch {
+            val dao = MySmartRouteDatabase.getInstance(context).appDateTimeDao()
+            _dateTime.value = dao.getDateTime()?.timestamp
+        }
+    }
+
+    fun save(context: Context, millis: Long) {
+        viewModelScope.launch {
+            val dao = MySmartRouteDatabase.getInstance(context).appDateTimeDao()
+            dao.insert(AppDateTimeEntity(timestamp = millis))
+            _dateTime.value = millis
+        }
+    }
+
+    fun reset(context: Context) {
+        save(context, System.currentTimeMillis())
+    }
+}

--- a/app/src/main/res/values-el/strings.xml
+++ b/app/src/main/res/values-el/strings.xml
@@ -147,6 +147,9 @@
     <string name="passenger_avg_rating_label">Ικανοποίηση επιβατών: %1$.1f/5</string>
     <string name="no_completed_movings">Δεν υπάρχουν ολοκληρωμένες μετακινήσεις</string>
     <string name="advance_date">Μεταφορά ημερομηνίας</string>
+    <string name="system_datetime">Ημερομηνία/ώρα συστήματος</string>
+    <string name="stored_datetime">Αποθηκευμένη ημερομηνία/ώρα</string>
+    <string name="reset_time">Επαναφορά στην τρέχουσα</string>
     <string name="declare_route">Δήλωση διαδρομής</string>
     <string name="announce_transport">Δήλωση μεταφοράς</string>
     <string name="from">Από</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -145,6 +145,9 @@
     <string name="passenger_avg_rating_label">Passenger satisfaction: %1$.1f/5</string>
     <string name="no_completed_movings">No completed movings</string>
     <string name="advance_date">Advance Date</string>
+    <string name="system_datetime">System date/time</string>
+    <string name="stored_datetime">Stored date/time</string>
+    <string name="reset_time">Reset to now</string>
     <string name="declare_route">Declare Route</string>
     <string name="announce_transport">Announce Transport</string>
     <string name="from">From</string>


### PR DESCRIPTION
## Περίληψη
- Αποθηκεύεται η ημερομηνία/ώρα της εφαρμογής σε νέο πίνακα Room και εμφανίζεται στη γραμμή τίτλου.
- Προστέθηκε οθόνη «Μεταφορά ημερομηνίας» με επιλογή επεξεργασίας μέσω Date/Time picker και δυνατότητα επαναφοράς.
- Ενημερώθηκε η βάση δεδομένων με νέα οντότητα, migration και προεπιλεγμένη εγγραφή.

## Έλεγχοι
- `./gradlew test` *(αποτυχία: δεν βρέθηκε Android SDK)*

------
https://chatgpt.com/codex/tasks/task_e_68c702f4bcdc8328992a261388a9e44f