### PR TITLE
Διόρθωση import για Column στο TopBar

### DIFF
--- a/app/src/main/java/com/ioannapergamali/mysmartroute/view/ui/components/TopBar.kt
+++ b/app/src/main/java/com/ioannapergamali/mysmartroute/view/ui/components/TopBar.kt
@@ -9,7 +9,7 @@ import androidx.compose.material.icons.filled.Home
 import androidx.compose.material.icons.filled.Notifications
 import android.util.Log
 import androidx.compose.foundation.layout.Row
-import Column
+import androidx.compose.foundation.layout.Column
 import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.Icon
 import androidx.compose.material3.IconButton


### PR DESCRIPTION
## Σύνοψη
- Εισαγωγή του σωστού `Column` από το Jetpack Compose στο TopBar

## Έλεγχοι
- `./gradlew test` (απέτυχε: SDK location not found)

------
https://chatgpt.com/codex/tasks/task_e_68c70664bd3483288c1f582265b28a44