### PR TITLE
Διόρθωση κλήσης notifyPassenger

### DIFF
--- a/app/src/main/java/com/ioannapergamali/mysmartroute/view/ui/screens/FindPassengersScreen.kt
+++ b/app/src/main/java/com/ioannapergamali/mysmartroute/view/ui/screens/FindPassengersScreen.kt
@@ -202,7 +202,7 @@ fun FindPassengersScreen(
                             ids.forEach { id ->
                                 val req = filteredRequests.find { it.id == id }
                                 if (req != null) {
-                                    requestViewModel.notifyPassenger(context, id)
+                                    requestViewModel.notifyRoute(context, id)
                                     transferViewModel.notifyDriver(context, req.requestNumber)
                                 }
                             }


### PR DESCRIPTION
## Περίληψη
- Αντικαταστάθηκε η ανύπαρκτη κλήση `notifyPassenger` με την υπάρχουσα `notifyRoute`

## Έλεγχοι
- `./gradlew test` (αποτυχία: SDK location not found)


------
https://chatgpt.com/codex/tasks/task_e_68c7080d6db48328a3f516fd00394232