### PR TITLE
Add notify_selected string resource

### DIFF
--- a/app/src/main/res/values-el/strings.xml
+++ b/app/src/main/res/values-el/strings.xml
@@ -245,6 +245,7 @@
     <string name="sort_by_date">Ταξινόμηση κατά ημερομηνία</string>
     <string name="cancel_request">Ακύρωση αιτήματος</string>
     <string name="notify_route">Ειδοποίηση διαδρομής</string>
+    <string name="notify_selected">Ειδοποίηση επιλεγμένων</string>
     <string name="accept_offer">Αποδοχή</string>
     <string name="reject_offer">Απόρριψη</string>
     <string name="no_notifications">Καμία ειδοποίηση</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -260,6 +260,7 @@
     <string name="cancel_request">Cancel request</string>
     <string name="request_number">Request number</string>
     <string name="notify_route">Notify route</string>
+    <string name="notify_selected">Notify selected</string>
     <string name="request_expired">Request expired</string>
     <string name="request_unsuccessful">Ανεπιτυχής</string>
     <string name="accept_offer">Accept</string>


### PR DESCRIPTION
## Summary
- add missing notify_selected string resource in default and Greek locales

## Testing
- `./gradlew test` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_68c7098a6b6483288059206f381482ae