### PR TITLE
Use stored app time for listings

### DIFF
--- a/app/src/main/java/com/ioannapergamali/mysmartroute/view/ui/screens/PrintScheduledScreen.kt
+++ b/app/src/main/java/com/ioannapergamali/mysmartroute/view/ui/screens/PrintScheduledScreen.kt
@@ -25,6 +25,7 @@ import com.ioannapergamali.mysmartroute.view.ui.components.TopBar
 import com.ioannapergamali.mysmartroute.viewmodel.RouteViewModel
 import com.ioannapergamali.mysmartroute.viewmodel.TransportDeclarationViewModel
 import com.ioannapergamali.mysmartroute.viewmodel.UserViewModel
+import com.ioannapergamali.mysmartroute.viewmodel.AppDateTimeViewModel
 import kotlinx.coroutines.flow.first
 import java.text.SimpleDateFormat
 import java.util.Date
@@ -36,6 +37,7 @@ fun PrintScheduledScreen(navController: NavController, openDrawer: () -> Unit) {
     val declarationViewModel: TransportDeclarationViewModel = viewModel()
     val routeViewModel: RouteViewModel = viewModel()
     val userViewModel: UserViewModel = viewModel()
+    val dateViewModel: AppDateTimeViewModel = viewModel()
     val declarations by declarationViewModel.pendingDeclarations.collectAsState()
     val routes by routeViewModel.routes.collectAsState()
     val passengerNames = remember { mutableStateMapOf<String, List<String>>() }
@@ -49,7 +51,10 @@ fun PrintScheduledScreen(navController: NavController, openDrawer: () -> Unit) {
     }
 
     val routeNames = routes.associate { it.id to it.name }
-    val scheduled = declarations.filter { it.date >= System.currentTimeMillis() }
+    val appTime by dateViewModel.dateTime.collectAsState()
+    LaunchedEffect(Unit) { dateViewModel.load(context) }
+    val now = appTime ?: System.currentTimeMillis()
+    val scheduled = declarations.filter { it.date >= now }
 
     LaunchedEffect(scheduled) {
         val db = MySmartRouteDatabase.getInstance(context)

--- a/app/src/main/java/com/ioannapergamali/mysmartroute/view/ui/screens/ViewRequestsScreen.kt
+++ b/app/src/main/java/com/ioannapergamali/mysmartroute/view/ui/screens/ViewRequestsScreen.kt
@@ -37,6 +37,7 @@ import com.ioannapergamali.mysmartroute.viewmodel.PoIViewModel
 import com.ioannapergamali.mysmartroute.viewmodel.VehicleRequestViewModel
 import com.ioannapergamali.mysmartroute.viewmodel.UserViewModel
 import com.ioannapergamali.mysmartroute.viewmodel.TransferRequestViewModel
+import com.ioannapergamali.mysmartroute.viewmodel.AppDateTimeViewModel
 import com.ioannapergamali.mysmartroute.model.enumerations.RequestStatus
 import android.text.format.DateFormat
 import java.util.Date
@@ -55,6 +56,7 @@ fun ViewRequestsScreen(
     val poiViewModel: PoIViewModel = viewModel()
     val userViewModel: UserViewModel = viewModel()
     val transferViewModel: TransferRequestViewModel = viewModel()
+    val dateViewModel: AppDateTimeViewModel = viewModel()
     val requests by viewModel.requests.collectAsState()
     val pois by poiViewModel.pois.collectAsState()
     val driverNames = remember { mutableStateMapOf<String, String>() }
@@ -90,6 +92,9 @@ fun ViewRequestsScreen(
     }
 
     val poiNames = pois.associate { it.id to it.name }
+    val appTime by dateViewModel.dateTime.collectAsState()
+    LaunchedEffect(Unit) { dateViewModel.load(context) }
+    val now = appTime ?: System.currentTimeMillis()
 
     Scaffold(
         topBar = {
@@ -156,7 +161,7 @@ fun ViewRequestsScreen(
                                 "$dateStr $timeStr"
                             } else ""
                             val costText = req.cost?.toString() ?: "-"
-                            val isExpired = req.date > 0L && System.currentTimeMillis() > req.date && req.status != "completed"
+                            val isExpired = req.date > 0L && now > req.date && req.status != "completed"
                             val statusText = if (isExpired) stringResource(R.string.request_unsuccessful) else req.status
                             Row(
                                 modifier = Modifier.padding(vertical = 8.dp),

--- a/app/src/main/java/com/ioannapergamali/mysmartroute/view/ui/screens/ViewTransportRequestsScreen.kt
+++ b/app/src/main/java/com/ioannapergamali/mysmartroute/view/ui/screens/ViewTransportRequestsScreen.kt
@@ -33,6 +33,7 @@ import com.ioannapergamali.mysmartroute.viewmodel.PoIViewModel
 import com.ioannapergamali.mysmartroute.viewmodel.UserViewModel
 import com.ioannapergamali.mysmartroute.viewmodel.VehicleRequestViewModel
 import com.ioannapergamali.mysmartroute.viewmodel.TransferRequestViewModel
+import com.ioannapergamali.mysmartroute.viewmodel.AppDateTimeViewModel
 import android.text.format.DateFormat
 import java.util.Date
 
@@ -48,6 +49,7 @@ fun ViewTransportRequestsScreen(
     val transferViewModel: TransferRequestViewModel = viewModel()
     val poiViewModel: PoIViewModel = viewModel()
     val userViewModel: UserViewModel = viewModel()
+    val dateViewModel: AppDateTimeViewModel = viewModel()
     val requests by viewModel.requests.collectAsState()
     val pois by poiViewModel.pois.collectAsState()
     val userNames = remember { mutableStateMapOf<String, String>() }
@@ -76,6 +78,9 @@ fun ViewTransportRequestsScreen(
     }
 
     val poiNames = pois.associate { it.id to it.name }
+    val appTime by dateViewModel.dateTime.collectAsState()
+    LaunchedEffect(Unit) { dateViewModel.load(context) }
+    val now = appTime ?: System.currentTimeMillis()
 
     Scaffold(
         topBar = {
@@ -180,7 +185,7 @@ fun ViewTransportRequestsScreen(
                                 Text(costText, modifier = Modifier.width(columnWidth))
                                 Text(dateTimeText, modifier = Modifier.width(columnWidth))
                                 Text(req.requestNumber.toString(), modifier = Modifier.width(columnWidth))
-                                val isExpired = req.date > 0L && System.currentTimeMillis() > req.date && req.status != "completed"
+                                val isExpired = req.date > 0L && now > req.date && req.status != "completed"
                                 if (req.status == "open" && !isExpired) {
                                     Button(
                                         onClick = {


### PR DESCRIPTION
## Summary
- Use `AppDateTimeViewModel` to read stored application time across transport and request screens
- Filter available transports and requests using the stored time instead of the device clock
- Update scheduled printing screen to respect application clock

## Testing
- `./gradlew test` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_68c70859d23c8328865d75f43b04cd9a