### PR TITLE
Αποθήκευση app_datetime στο Firestore

### DIFF
--- a/app/src/main/java/com/ioannapergamali/mysmartroute/viewmodel/AppDateTimeViewModel.kt
+++ b/app/src/main/java/com/ioannapergamali/mysmartroute/viewmodel/AppDateTimeViewModel.kt
@@ -3,16 +3,19 @@ package com.ioannapergamali.mysmartroute.viewmodel
 import android.content.Context
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
+import com.google.firebase.firestore.FirebaseFirestore
 import com.ioannapergamali.mysmartroute.data.local.AppDateTimeEntity
 import com.ioannapergamali.mysmartroute.data.local.MySmartRouteDatabase
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.launch
+import kotlinx.coroutines.tasks.await
 
 /** Διαχειρίζεται την αποθηκευμένη ημερομηνία/ώρα. */
 class AppDateTimeViewModel : ViewModel() {
     private val _dateTime = MutableStateFlow<Long?>(null)
     val dateTime: StateFlow<Long?> = _dateTime
+    private val firestore = FirebaseFirestore.getInstance()
 
     fun load(context: Context) {
         viewModelScope.launch {
@@ -26,6 +29,13 @@ class AppDateTimeViewModel : ViewModel() {
             val dao = MySmartRouteDatabase.getInstance(context).appDateTimeDao()
             dao.insert(AppDateTimeEntity(timestamp = millis))
             _dateTime.value = millis
+
+            val data = mapOf("timestamp" to millis)
+            firestore
+                .collection("app_datetime")
+                .document("1")
+                .set(data)
+                .await()
         }
     }
 


### PR DESCRIPTION
## Περίληψη
- Καταχώριση του timestamp και στο Firestore στη συλλογή `app_datetime`

## Δοκιμές
- `./gradlew test` *(αποτυχία: δεν βρέθηκε Android SDK)*

------
https://chatgpt.com/codex/tasks/task_e_68c70bce90048328b28c2ddf3a1976ad