### PR TITLE
Αυτόματη σήμανση ληγμένων μετακινήσεων ως ανεπιτυχείς

### DIFF
--- a/app/src/main/java/com/ioannapergamali/mysmartroute/data/local/MovingStatus.kt
+++ b/app/src/main/java/com/ioannapergamali/mysmartroute/data/local/MovingStatus.kt
@@ -7,9 +7,9 @@ import android.util.Log
 /**
  * Περιγράφει την κατάσταση μιας μετακίνησης όπως εμφανίζεται στην εφαρμογή.
  *
- * - [ACTIVE]    Μετακινήσεις "accepted" που δεν έχουν ολοκληρωθεί ακόμη.
+ * - [ACTIVE]    Μετακινήσεις "accepted" με μελλοντική ημερομηνία.
  * - [PENDING]   Μετακινήσεις "open" που ακόμη δεν έχει παρέλθει η προγραμματισμένη ώρα.
- * - [UNSUCCESSFUL] Μετακινήσεις "open" των οποίων έχει λήξει ο χρόνος χωρίς να γίνουν αποδεκτές.
+ * - [UNSUCCESSFUL] Μετακινήσεις "open" ή "accepted" των οποίων έχει λήξει ο χρόνος χωρίς να γίνουν αποδεκτές/ολοκληρωθούν.
  * - [COMPLETED] Μετακινήσεις με status "completed", δηλαδή όταν ο οδηγός έχει πατήσει ολοκλήρωση.
  */
 enum class MovingStatus {
@@ -28,7 +28,12 @@ private const val TAG = "MovingStatus"
 fun MovingEntity.movingStatus(now: Long = System.currentTimeMillis()): MovingStatus {
     val result = when (status.lowercase()) {
         "completed" -> MovingStatus.COMPLETED
-        "accepted" -> MovingStatus.ACTIVE
+        // Οι "accepted" μετακινήσεις θεωρούνται ενεργές μόνο εφόσον δεν έχει παρέλθει η ημερομηνία.
+        "accepted" -> if (date > now) {
+            MovingStatus.ACTIVE
+        } else {
+            MovingStatus.UNSUCCESSFUL
+        }
         // Τα statuses "open" και "pending" αντιμετωπίζονται το ίδιο:
         // αν η ημερομηνία είναι μελλοντική θεωρούνται εκκρεμείς, αλλιώς ανεπιτυχείς.
         "open", "pending" -> if (date > now) {


### PR DESCRIPTION
## Περίληψη
- Τα "accepted" δρομολόγια με παρελθούσα ημερομηνία ταξινομούνται πλέον ως ανεπιτυχείς.
- Ενοποιήθηκε ο έλεγχος ημερομηνίας για accepted/open/pending μετακινήσεις.

## Δοκιμές
- `./gradlew test` *(αποτυχία: λείπει Android SDK)*

------
https://chatgpt.com/codex/tasks/task_e_68c70c6b7c8c8328a45743c175061710