### PR TITLE
Φιλτράρισμα μετακινήσεων σε εκκρεμείς, ανεπιτυχείς και ολοκληρωμένες

### DIFF
--- a/app/src/main/java/com/ioannapergamali/mysmartroute/data/local/MovingStatus.kt
+++ b/app/src/main/java/com/ioannapergamali/mysmartroute/data/local/MovingStatus.kt
@@ -51,7 +51,9 @@ fun categorizeMovings(
     movings: List<MovingEntity>,
     now: Long = System.currentTimeMillis()
 ): Map<MovingStatus, List<MovingEntity>> {
-    val grouped = movings.groupBy { it.movingStatus(now) }
+    val grouped = movings
+        .groupBy { it.movingStatus(now) }
+        .filterKeys { it != MovingStatus.ACTIVE }
     grouped.forEach { (status, list) ->
 
         Log.d(TAG, "Ομαδοποίηση $status -> ${list.size} εγγραφές")

--- a/app/src/main/java/com/ioannapergamali/mysmartroute/view/ui/screens/MovingScreen.kt
+++ b/app/src/main/java/com/ioannapergamali/mysmartroute/view/ui/screens/MovingScreen.kt
@@ -29,7 +29,11 @@ fun MovingScreen(viewModel: MovingViewModel = hiltViewModel()) {
     val grouped = categorizeMovings(movings)
 
     LazyColumn {
-        MovingStatus.values().forEach { status ->
+        listOf(
+            MovingStatus.PENDING,
+            MovingStatus.UNSUCCESSFUL,
+            MovingStatus.COMPLETED
+        ).forEach { status ->
             val list = grouped[status].orEmpty()
 
             Log.d(TAG, "Κατηγορία $status περιέχει ${list.size} εγγραφές")
@@ -55,10 +59,10 @@ fun MovingScreen(viewModel: MovingViewModel = hiltViewModel()) {
 }
 
 private fun titleFor(status: MovingStatus) = when (status) {
-    MovingStatus.ACTIVE -> "Ενεργές μετακινήσεις"
     MovingStatus.PENDING -> "Εκκρεμείς μετακινήσεις"
     MovingStatus.UNSUCCESSFUL -> "Ανεπιτυχείς μετακινήσεις"
     MovingStatus.COMPLETED -> "Ολοκληρωμένες μετακινήσεις"
+    else -> ""
 }
 
 private fun formatDate(epochMillis: Long): String =

--- a/app/src/main/java/com/ioannapergamali/mysmartroute/view/ui/screens/PassengerMovingsScreen.kt
+++ b/app/src/main/java/com/ioannapergamali/mysmartroute/view/ui/screens/PassengerMovingsScreen.kt
@@ -78,10 +78,6 @@ fun PassengerMovingsScreen(navController: NavController, openDrawer: () -> Unit)
                 Text(stringResource(R.string.no_movings))
             } else {
                 MovingCategory(
-                    stringResource(R.string.active_movings),
-                    grouped[MovingStatus.ACTIVE].orEmpty()
-                )
-                MovingCategory(
                     stringResource(R.string.pending_movings),
                     grouped[MovingStatus.PENDING].orEmpty()
                 )


### PR DESCRIPTION
## Περίληψη
- Παραλείπονται οι ενεργές μετακινήσεις από την ομαδοποίηση.
- Η οθόνη επιβάτη εμφανίζει μόνο εκκρεμείς, ανεπιτυχείς και ολοκληρωμένες μετακινήσεις.
- Η γενική οθόνη μετακινήσεων φιλτράρει τις ίδιες τρεις κατηγορίες.

## Έλεγχοι
- `./gradlew test` *(αποτυχία: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_68c710aa4a488328b378a12b31f6ecc1