### PR TITLE
Show route selector in passenger search

### DIFF
--- a/app/src/main/java/com/ioannapergamali/mysmartroute/view/ui/screens/FindPassengersScreen.kt
+++ b/app/src/main/java/com/ioannapergamali/mysmartroute/view/ui/screens/FindPassengersScreen.kt
@@ -136,27 +136,44 @@ fun FindPassengersScreen(
                 Text(selectedTimeText)
             }
             Spacer(modifier = Modifier.height(8.dp))
-            if (routeOptions.isNotEmpty()) {
-                ExposedDropdownMenuBox(expanded = routeExpanded, onExpandedChange = { routeExpanded = !routeExpanded }) {
-                    OutlinedTextField(
-                        value = routeOptions[selectedRouteId] ?: "",
-                        onValueChange = {},
-                        label = { Text(stringResource(R.string.route)) },
-                        trailingIcon = { ExposedDropdownMenuDefaults.TrailingIcon(expanded = routeExpanded) },
-                        modifier = Modifier.menuAnchor().fillMaxWidth(),
-                        readOnly = true
-                    )
+            ExposedDropdownMenuBox(
+                expanded = routeExpanded,
+                onExpandedChange = {
+                    if (routeOptions.isNotEmpty()) {
+                        routeExpanded = !routeExpanded
+                    }
+                }
+            ) {
+                OutlinedTextField(
+                    value = routeOptions[selectedRouteId] ?: "",
+                    onValueChange = {},
+                    label = { Text(stringResource(R.string.route)) },
+                    trailingIcon = { ExposedDropdownMenuDefaults.TrailingIcon(expanded = routeExpanded) },
+                    modifier = Modifier.menuAnchor().fillMaxWidth(),
+                    readOnly = true,
+                    enabled = routeOptions.isNotEmpty()
+                )
+                if (routeOptions.isNotEmpty()) {
                     ExposedDropdownMenu(expanded = routeExpanded, onDismissRequest = { routeExpanded = false }) {
                         routeOptions.forEach { (id, name) ->
-                            DropdownMenuItem(text = { Text(name) }, onClick = {
-                                selectedRouteId = id
-                                routeExpanded = false
-                            })
+                            DropdownMenuItem(
+                                text = { Text(name) },
+                                onClick = {
+                                    selectedRouteId = id
+                                    routeExpanded = false
+                                }
+                            )
                         }
                     }
                 }
-                Spacer(modifier = Modifier.height(8.dp))
             }
+            if (routeOptions.isEmpty()) {
+                Text(
+                    text = stringResource(R.string.no_routes_available),
+                    style = MaterialTheme.typography.bodySmall
+                )
+            }
+            Spacer(modifier = Modifier.height(8.dp))
             Button(
                 onClick = { showResults = true },
                 enabled = selectedRouteId != null && selectedDateMillis != null && selectedTimeMillis != null

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -249,6 +249,7 @@
     <string name="request_sent">Request saved</string>
     <string name="view_requests">View Requests</string>
     <string name="no_requests">No requests found</string>
+    <string name="no_routes_available">No routes available</string>
     <string name="view_movings">View Movings</string>
     <string name="no_movings">No movings found</string>
     <string name="active_movings">Active movings</string>


### PR DESCRIPTION
## Summary
- always display route dropdown when searching passengers
- show message when no routes are available

## Testing
- `./gradlew test` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_68c7115616a483289beed41b3c42c290