### PR TITLE
Χρήση αποθηκευμένης ημερομηνίας για ταξινόμηση μετακινήσεων

### DIFF
--- a/app/src/main/java/com/ioannapergamali/mysmartroute/view/ui/screens/MovingListScreen.kt
+++ b/app/src/main/java/com/ioannapergamali/mysmartroute/view/ui/screens/MovingListScreen.kt
@@ -17,8 +17,8 @@ import java.util.Locale
  * [com.ioannapergamali.mysmartroute.data.local.MovingStatus].
  */
 @Composable
-fun MovingListScreen(movings: List<MovingEntity>) {
-    val categorized = categorizeMovings(movings)
+fun MovingListScreen(movings: List<MovingEntity>, now: Long = System.currentTimeMillis()) {
+    val categorized = categorizeMovings(movings, now)
     LazyColumn {
         categorized.forEach { (status, list) ->
             item {

--- a/app/src/main/java/com/ioannapergamali/mysmartroute/view/ui/screens/MovingScreen.kt
+++ b/app/src/main/java/com/ioannapergamali/mysmartroute/view/ui/screens/MovingScreen.kt
@@ -6,12 +6,16 @@ import androidx.compose.foundation.lazy.items
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
+import androidx.compose.ui.platform.LocalContext
 import androidx.hilt.navigation.compose.hiltViewModel
+import androidx.lifecycle.viewmodel.compose.viewModel
 import com.ioannapergamali.mysmartroute.viewmodel.MovingViewModel
 import com.ioannapergamali.mysmartroute.data.local.MovingStatus
 import com.ioannapergamali.mysmartroute.data.local.categorizeMovings
+import com.ioannapergamali.mysmartroute.viewmodel.AppDateTimeViewModel
 import java.time.Instant
 import java.time.ZoneId
 import java.time.format.DateTimeFormatter
@@ -24,9 +28,16 @@ private const val TAG = "MovingScreen"
 @Composable
 fun MovingScreen(viewModel: MovingViewModel = hiltViewModel()) {
     val movings by viewModel.state.collectAsState()
+    val context = LocalContext.current
+    val dateViewModel: AppDateTimeViewModel = viewModel()
+    val storedMillis by dateViewModel.dateTime.collectAsState()
+
+    LaunchedEffect(Unit) { dateViewModel.load(context) }
+
+    val now = storedMillis ?: System.currentTimeMillis()
     Log.d(TAG, "Σύνολο μετακινήσεων: ${movings.size}")
 
-    val grouped = categorizeMovings(movings)
+    val grouped = categorizeMovings(movings, now)
 
     LazyColumn {
         listOf(
@@ -62,7 +73,6 @@ private fun titleFor(status: MovingStatus) = when (status) {
     MovingStatus.PENDING -> "Εκκρεμείς μετακινήσεις"
     MovingStatus.UNSUCCESSFUL -> "Ανεπιτυχείς μετακινήσεις"
     MovingStatus.COMPLETED -> "Ολοκληρωμένες μετακινήσεις"
-    else -> ""
 }
 
 private fun formatDate(epochMillis: Long): String =

--- a/app/src/main/java/com/ioannapergamali/mysmartroute/view/ui/screens/PassengerMovingsScreen.kt
+++ b/app/src/main/java/com/ioannapergamali/mysmartroute/view/ui/screens/PassengerMovingsScreen.kt
@@ -31,6 +31,7 @@ import com.ioannapergamali.mysmartroute.data.local.MovingStatus
 import com.ioannapergamali.mysmartroute.data.local.categorizeMovings
 import com.ioannapergamali.mysmartroute.view.ui.components.ScreenContainer
 import com.ioannapergamali.mysmartroute.view.ui.components.TopBar
+import com.ioannapergamali.mysmartroute.viewmodel.AppDateTimeViewModel
 import com.ioannapergamali.mysmartroute.viewmodel.VehicleRequestViewModel
 import com.ioannapergamali.mysmartroute.viewmodel.AuthenticationViewModel
 import com.ioannapergamali.mysmartroute.model.enumerations.UserRole
@@ -48,6 +49,10 @@ fun PassengerMovingsScreen(navController: NavController, openDrawer: () -> Unit)
     val role by authViewModel.currentUserRole.collectAsState()
     val movings by viewModel.movings.collectAsState()
     val context = LocalContext.current
+    val dateViewModel: AppDateTimeViewModel = viewModel()
+    val storedMillis by dateViewModel.dateTime.collectAsState()
+
+    LaunchedEffect(Unit) { dateViewModel.load(context) }
 
     LaunchedEffect(role) {
         val isAdmin = role == UserRole.ADMIN
@@ -55,8 +60,9 @@ fun PassengerMovingsScreen(navController: NavController, openDrawer: () -> Unit)
     }
 
 
+    val now = storedMillis ?: System.currentTimeMillis()
     Log.d(TAG, "Φόρτωση ${movings.size} μετακινήσεων επιβάτη")
-    val grouped = categorizeMovings(movings).also { map ->
+    val grouped = categorizeMovings(movings, now).also { map ->
         map.forEach { (status, list) ->
             Log.d(TAG, "Κατηγορία $status έχει ${list.size} εγγραφές")
 


### PR DESCRIPTION
## Περίληψη
- Αφαίρεση της κατάστασης ACTIVE και καθορισμός τριών καταστάσεων μετακίνησης.
- Ταξινόμηση μετακινήσεων με βάση την αποθηκευμένη ημερομηνία της εφαρμογής.
- Προσθήκη προβολών που αξιοποιούν την αποθηκευμένη ώρα για σωστή κατηγοριοποίηση.

## Έλεγχοι
- `./gradlew test` *(απέτυχε: SDK location not found)*


------
https://chatgpt.com/codex/tasks/task_e_68c7129cb3448328a5bc6235a5c4d466