### PR TITLE
Προσθήκη κατάστασης OPEN στα αιτήματα μεταφοράς

### DIFF
--- a/app/src/main/java/com/ioannapergamali/mysmartroute/data/local/TransferRequestEntity.kt
+++ b/app/src/main/java/com/ioannapergamali/mysmartroute/data/local/TransferRequestEntity.kt
@@ -19,5 +19,5 @@ data class TransferRequestEntity(
     val date: Long = 0L,
     val cost: Double? = null,
     /** Κατάσταση αιτήματος */
-    val status: RequestStatus = RequestStatus.PENDING
+    val status: RequestStatus = RequestStatus.OPEN
 )

--- a/app/src/main/java/com/ioannapergamali/mysmartroute/model/enumerations/RequestStatus.kt
+++ b/app/src/main/java/com/ioannapergamali/mysmartroute/model/enumerations/RequestStatus.kt
@@ -5,9 +5,10 @@ package com.ioannapergamali.mysmartroute.model.enumerations
  * English: Possible states of a transport request.
  */
 enum class RequestStatus {
+    OPEN,
+    PENDING,
     ACCEPTED,
     REJECTED,
     CANCELED,
-    PENDING,
     COMPLETED
 }

--- a/app/src/main/java/com/ioannapergamali/mysmartroute/utils/FirestoreMappers.kt
+++ b/app/src/main/java/com/ioannapergamali/mysmartroute/utils/FirestoreMappers.kt
@@ -631,7 +631,7 @@ fun DocumentSnapshot.toTransferRequestEntity(): TransferRequestEntity? {
     } ?: ""
     val dateVal = getLong("date") ?: 0L
     val costVal = getDouble("cost")
-    val statusStr = getString("status") ?: RequestStatus.PENDING.name
+    val statusStr = getString("status") ?: RequestStatus.OPEN.name
     return TransferRequestEntity(number, routeId, passengerId, driverId, id, dateVal, costVal, enumValueOf(statusStr))
 }
 

--- a/app/src/main/java/com/ioannapergamali/mysmartroute/view/ui/screens/ViewRequestsScreen.kt
+++ b/app/src/main/java/com/ioannapergamali/mysmartroute/view/ui/screens/ViewRequestsScreen.kt
@@ -171,7 +171,7 @@ fun ViewRequestsScreen(
                                 Text(routeName, modifier = Modifier.width(columnWidth))
                                 Text(costText, modifier = Modifier.width(columnWidth))
                                 Text(dateTimeText, modifier = Modifier.width(columnWidth))
-                                if (req.status == "pending" && !isExpired) {
+                                if (req.status == "pending" && req.driverId.isNotBlank() && !isExpired) {
                                     val dName = driverNames[req.driverId] ?: ""
                                     Text(dName, modifier = Modifier.width(columnWidth))
                                     Button(onClick = {

--- a/app/src/main/java/com/ioannapergamali/mysmartroute/viewmodel/TransferRequestViewModel.kt
+++ b/app/src/main/java/com/ioannapergamali/mysmartroute/viewmodel/TransferRequestViewModel.kt
@@ -34,7 +34,7 @@ class TransferRequestViewModel : ViewModel() {
         context: Context,
         routeId: String,
         date: Long,
-        cost: Double?,
+            cost: Double?,
     ) {
         val passengerId = auth.currentUser?.uid ?: return
         val entity = TransferRequestEntity(
@@ -43,7 +43,7 @@ class TransferRequestViewModel : ViewModel() {
             driverId = "",
             date = date,
             cost = cost,
-            status = RequestStatus.PENDING
+            status = RequestStatus.OPEN
         )
         viewModelScope.launch(Dispatchers.IO) {
             val dao = MySmartRouteDatabase.getInstance(context).transferRequestDao()


### PR DESCRIPTION
## Περίληψη
- Προστέθηκε νέα κατάσταση `OPEN` στα αιτήματα μεταφοράς και χρησιμοποιείται ως αρχική τιμή.
- Ενημερώθηκε ο συγχρονισμός με το Firestore ώστε να χειρίζεται την κατάσταση `OPEN`.
- Τα κουμπιά αποδοχής/απόρριψης εμφανίζονται μόνο όταν υπάρχει οδηγός.

## Δοκιμές
- `./gradlew test` *(αποτυχία: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_68c718906de4832881a96665060944f1