### PR TITLE
Αποφυγή δημιουργίας νέας διαδρομής χωρίς αλλαγές στάσεων

### DIFF
--- a/app/src/main/java/com/ioannapergamali/mysmartroute/view/ui/screens/BookSeatScreen.kt
+++ b/app/src/main/java/com/ioannapergamali/mysmartroute/view/ui/screens/BookSeatScreen.kt
@@ -183,7 +183,9 @@ fun BookSeatScreen(
     }
 
     suspend fun saveEditedRouteIfChanged(): String {
-        if (poiIds == originalPoiIds) return selectedRouteId ?: ""
+        val current = poiIds.toSet()
+        val original = originalPoiIds.toSet()
+        if (current == original) return selectedRouteId ?: ""
         val uid = FirebaseAuth.getInstance().currentUser?.uid ?: return selectedRouteId ?: ""
         val username = FirebaseFirestore.getInstance()
             .collection("users")

--- a/app/src/main/java/com/ioannapergamali/mysmartroute/view/ui/screens/RouteModeScreen.kt
+++ b/app/src/main/java/com/ioannapergamali/mysmartroute/view/ui/screens/RouteModeScreen.kt
@@ -147,7 +147,9 @@ fun RouteModeScreen(
         }
     }
     suspend fun saveEditedRouteAsNewRoute(): String {
-        if (routePoiIds == originalPoiIds) return selectedRouteId ?: ""
+        val current = routePoiIds.toSet()
+        val original = originalPoiIds.toSet()
+        if (current == original) return selectedRouteId ?: ""
         val uid = FirebaseAuth.getInstance().currentUser?.uid ?: return selectedRouteId ?: ""
         val username = FirebaseFirestore.getInstance()
             .collection("users")


### PR DESCRIPTION
## Περίληψη
- Αποτρέπεται η δημιουργία νέας διαδρομής κατά την αποθήκευση αιτημάτων όταν δεν έχουν αλλάξει στάσεις
- Παρόμοιος έλεγχος προστέθηκε και στη λειτουργία αποθήκευσης διαδρομής ως νέας

## Έλεγχοι
- `./gradlew test --console=plain` *(απέτυχε να ολοκληρωθεί λόγω περιορισμών περιβάλλοντος)*

------
https://chatgpt.com/codex/tasks/task_e_68c722b079fc8328a9b894f570faef25