### PR TITLE
feat: add route rename with map view

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -114,7 +114,7 @@ dependencies {
 
     // Google Maps
     implementation("com.google.android.gms:play-services-maps:19.2.0")
-    implementation("com.google.maps.android:maps-compose:6.6.0")
+    implementation("com.google.maps.android:maps-compose:6.10.0")
     implementation("com.google.maps.android:maps-ktx:5.2.0")
     implementation("com.google.maps.android:maps-utils-ktx:5.2.0")
     implementation("com.google.android.gms:play-services-location:21.3.0")

--- a/app/src/main/java/com/ioannapergamali/mysmartroute/view/ui/screens/ViewRoutesScreen.kt
+++ b/app/src/main/java/com/ioannapergamali/mysmartroute/view/ui/screens/ViewRoutesScreen.kt
@@ -47,6 +47,8 @@ fun ViewRoutesScreen(navController: NavController, openDrawer: () -> Unit) {
     var pois by remember { mutableStateOf<List<PoIEntity>>(emptyList()) }
     var pathPoints by remember { mutableStateOf<List<LatLng>>(emptyList()) }
     var expanded by remember { mutableStateOf(false) }
+    var renameDialog by remember { mutableStateOf(false) }
+    var newName by remember { mutableStateOf("") }
 
     val cameraPositionState = rememberCameraPositionState()
     val apiKey = MapsUtils.getApiKey(context)
@@ -177,6 +179,53 @@ fun ViewRoutesScreen(navController: NavController, openDrawer: () -> Unit) {
                         }
                     }
                 }
+                Spacer(Modifier.height(16.dp))
+                Button(onClick = {
+                    newName = selectedRoute?.name ?: ""
+                    renameDialog = true
+                }) {
+                    Text(stringResource(R.string.rename_route))
+                }
+            }
+
+            if (renameDialog) {
+                AlertDialog(
+                    onDismissRequest = { renameDialog = false },
+                    title = { Text(stringResource(R.string.rename_route)) },
+                    text = {
+                        TextField(
+                            value = newName,
+                            onValueChange = { newName = it },
+                            label = { Text(stringResource(R.string.new_route_name)) }
+                        )
+                    },
+                    confirmButton = {
+                        TextButton(onClick = {
+                            scope.launch {
+                                selectedRoute?.let {
+                                    routeViewModel.addRoute(
+                                        context,
+                                        pois.map { p -> p.id },
+                                        newName
+                                    )
+                                    routeViewModel.loadRoutes(context, includeAll = true)
+                                }
+                            }
+                            renameDialog = false
+                            newName = ""
+                            selectedRoute = null
+                            pois = emptyList()
+                            pathPoints = emptyList()
+                        }) {
+                            Text(stringResource(R.string.ok))
+                        }
+                    },
+                    dismissButton = {
+                        TextButton(onClick = { renameDialog = false }) {
+                            Text(stringResource(R.string.cancel))
+                        }
+                    }
+                )
             }
         }
     }

--- a/app/src/main/res/values-el/strings.xml
+++ b/app/src/main/res/values-el/strings.xml
@@ -193,6 +193,8 @@
     <string name="save_route">Αποθήκευση διαδρομής</string>
     <string name="route_name">Όνομα διαδρομής</string>
     <string name="stops_header">Στάσεις</string>
+    <string name="rename_route">Μετονομασία διαδρομής</string>
+    <string name="new_route_name">Νέο όνομα διαδρομής</string>
     <string name="poi_outside_heraklion">Επιλέξτε σημείο εντός Ηρακλείου</string>
     <string name="search_address">Αναζήτηση διεύθυνσης</string>
     <string name="no_duplicate_pois">Δεν βρέθηκαν διπλά σημεία ενδιαφέροντος</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -196,6 +196,8 @@
     <string name="save_route">Save route</string>
     <string name="route_name">Route name</string>
     <string name="stops_header">Stops</string>
+    <string name="rename_route">Rename route</string>
+    <string name="new_route_name">New route name</string>
     <!-- Legend texts -->
     <string name="legend_header">ΣΗΜΕΙΑ ΔΙΑΔΡΟΜΗΣ</string>
     <string name="legend_unsaved_point">Μη αποθηκευμένο εκτός διαδρομής</string>


### PR DESCRIPTION
## Summary
- allow route rename while viewing path and stops
- update maps compose dependency

## Testing
- `./gradlew test` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_68c729630ef0832885fb02728892f217