### PR TITLE
Αναβάθμιση Kotlin και ρυθμίσεις Room

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -35,15 +35,14 @@ android {
         compose = true
     }
 
-    buildToolsVersion = "34.0.0"
     compileOptions {
         sourceCompatibility = JavaVersion.VERSION_17
         targetCompatibility = JavaVersion.VERSION_17
     }
 
     composeOptions {
-        // Τελευταία σταθερή έκδοση του compiler για Kotlin 2.0.21
-        kotlinCompilerExtensionVersion = "1.6.11"
+        // Τελευταία σταθερή έκδοση του compiler για Kotlin 2.2.10
+        kotlinCompilerExtensionVersion = "1.7.1"
     }
 
     dependenciesInfo {

--- a/app/src/main/java/com/ioannapergamali/mysmartroute/data/local/MySmartRouteDatabase.kt
+++ b/app/src/main/java/com/ioannapergamali/mysmartroute/data/local/MySmartRouteDatabase.kt
@@ -79,8 +79,8 @@ import com.ioannapergamali.mysmartroute.data.local.AppDateTimeDao
         AppDateTimeEntity::class
     ],
 
-    version = 74
-
+    version = 74,
+    exportSchema = false,
 )
 @TypeConverters(Converters::class)
 abstract class MySmartRouteDatabase : RoomDatabase() {

--- a/app/src/main/java/com/ioannapergamali/mysmartroute/data/local/WalkingRouteDatabase.kt
+++ b/app/src/main/java/com/ioannapergamali/mysmartroute/data/local/WalkingRouteDatabase.kt
@@ -7,7 +7,7 @@ import androidx.room.Database
 import androidx.room.Room
 import androidx.room.RoomDatabase
 
-@Database(entities = [WalkingRouteEntity::class], version = 1)
+@Database(entities = [WalkingRouteEntity::class], version = 1, exportSchema = false)
 abstract class WalkingRouteDatabase : RoomDatabase() {
     abstract fun dao(): WalkingRouteDao
 

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -3,13 +3,13 @@
 plugins {
     id("com.android.application") version "8.12.2" apply false
 
-    // Χρήση της τελευταίας σταθερής έκδοσης 2.0.21 του Kotlin
-    id("org.jetbrains.kotlin.android") version "2.0.21" apply false
+    // Χρήση της τελευταίας σταθερής έκδοσης 2.2.10 του Kotlin
+    id("org.jetbrains.kotlin.android") version "2.2.10" apply false
 
-    // KSP για συμβατότητα με Kotlin 2.0.21
-    id("com.google.devtools.ksp") version "2.0.21-1.0.27" apply false
+    // KSP για συμβατότητα με Kotlin 2.2.10
+    id("com.google.devtools.ksp") version "2.2.10-2.0.2" apply false
 
     id("com.google.gms.google-services") version "4.4.3" apply false
-    id("org.jetbrains.kotlin.plugin.compose") version "2.0.0" // Compose Compiler plugin
+    id("org.jetbrains.kotlin.plugin.compose") version "2.2.0" // Compose Compiler plugin
     id("com.google.dagger.hilt.android") version "2.51.1" apply false
 }

--- a/gradle.properties
+++ b/gradle.properties
@@ -25,4 +25,4 @@ android.nonTransitiveRClass=true
 
 kotlin.jvm.target=17
 # Συγχρονισμός με τη σταθερή έκδοση του Kotlin
-kotlin.version=1.9.23
+kotlin.version=2.2.10


### PR DESCRIPTION
## Περίληψη
- Αναβάθμιση Kotlin και KSP στις νεότερες εκδόσεις και ενημέρωση Compose compiler
- Αφαίρεση buildToolsVersion, ενημέρωση Kotlin compiler extension και προσαρμογή gradle.properties
- Ενημέρωση Room databases με `exportSchema = false`

## Δοκιμές
- `./gradlew assembleDebug` *(απέτυχε: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_68c72e51f75c8328b8916918c7766b94