### PR TITLE
Εμφάνιση όλων των πινάκων βάσεων δεδομένων

### DIFF
--- a/app/src/main/java/com/ioannapergamali/mysmartroute/data/local/AppDateTimeDao.kt
+++ b/app/src/main/java/com/ioannapergamali/mysmartroute/data/local/AppDateTimeDao.kt
@@ -4,11 +4,15 @@ import androidx.room.Dao
 import androidx.room.Insert
 import androidx.room.OnConflictStrategy
 import androidx.room.Query
+import kotlinx.coroutines.flow.Flow
 
 @Dao
 interface AppDateTimeDao {
     @Query("SELECT * FROM app_datetime WHERE id = 1")
     suspend fun getDateTime(): AppDateTimeEntity?
+
+    @Query("SELECT * FROM app_datetime")
+    fun getAll(): Flow<List<AppDateTimeEntity>>
 
     @Insert(onConflict = OnConflictStrategy.REPLACE)
     suspend fun insert(entity: AppDateTimeEntity)

--- a/app/src/main/java/com/ioannapergamali/mysmartroute/data/local/MovingDetailDao.kt
+++ b/app/src/main/java/com/ioannapergamali/mysmartroute/data/local/MovingDetailDao.kt
@@ -17,6 +17,9 @@ interface MovingDetailDao {
     @Query("SELECT * FROM moving_details WHERE movingId = :movingId")
     fun getForMoving(movingId: String): Flow<List<MovingDetailEntity>>
 
+    @Query("SELECT * FROM moving_details")
+    fun getAll(): Flow<List<MovingDetailEntity>>
+
     @Query("DELETE FROM moving_details WHERE movingId = :movingId")
     suspend fun deleteForMoving(movingId: String)
 }

--- a/app/src/main/java/com/ioannapergamali/mysmartroute/data/local/SeatReservationDetailDao.kt
+++ b/app/src/main/java/com/ioannapergamali/mysmartroute/data/local/SeatReservationDetailDao.kt
@@ -17,6 +17,9 @@ interface SeatReservationDetailDao {
     @Query("SELECT * FROM seat_reservation_details WHERE reservationId = :reservationId")
     fun getForReservation(reservationId: String): Flow<List<SeatReservationDetailEntity>>
 
+    @Query("SELECT * FROM seat_reservation_details")
+    fun getAll(): Flow<List<SeatReservationDetailEntity>>
+
     @Query("DELETE FROM seat_reservation_details WHERE reservationId = :reservationId")
     suspend fun deleteForReservation(reservationId: String)
 }

--- a/app/src/main/java/com/ioannapergamali/mysmartroute/data/local/TransportDeclarationDetailDao.kt
+++ b/app/src/main/java/com/ioannapergamali/mysmartroute/data/local/TransportDeclarationDetailDao.kt
@@ -4,6 +4,7 @@ import androidx.room.Dao
 import androidx.room.Insert
 import androidx.room.OnConflictStrategy
 import androidx.room.Query
+import kotlinx.coroutines.flow.Flow
 
 /** DAO για λεπτομέρειες δηλώσεων μεταφοράς. */
 @Dao
@@ -13,4 +14,7 @@ interface TransportDeclarationDetailDao {
 
     @Query("SELECT * FROM transport_declarations_details WHERE declarationId = :declarationId")
     suspend fun getForDeclaration(declarationId: String): List<TransportDeclarationDetailEntity>
+
+    @Query("SELECT * FROM transport_declarations_details")
+    fun getAll(): Flow<List<TransportDeclarationDetailEntity>>
 }

--- a/app/src/main/java/com/ioannapergamali/mysmartroute/data/local/WalkingDao.kt
+++ b/app/src/main/java/com/ioannapergamali/mysmartroute/data/local/WalkingDao.kt
@@ -16,4 +16,7 @@ interface WalkingDao {
      */
     @Query("SELECT DISTINCT routeId FROM walking WHERE userId = :userId")
     fun getRouteIdsForUser(userId: String): Flow<List<String>>
+
+    @Query("SELECT * FROM walking")
+    fun getAll(): Flow<List<WalkingEntity>>
 }

--- a/app/src/main/java/com/ioannapergamali/mysmartroute/view/ui/screens/FirebaseDatabaseScreen.kt
+++ b/app/src/main/java/com/ioannapergamali/mysmartroute/view/ui/screens/FirebaseDatabaseScreen.kt
@@ -159,6 +159,36 @@ fun FirebaseDatabaseScreen(navController: NavController, openDrawer: () -> Unit)
                     Text("${n.userId} -> ${n.message}")
                 }
                 item { Spacer(modifier = Modifier.padding(8.dp)) }
+                item { Text("Route Bus Stations", style = MaterialTheme.typography.titleMedium) }
+                items(data!!.routeBusStations) { s ->
+                    Text("${s.routeId} (${s.position}) -> ${s.poiId}")
+                }
+                item { Spacer(modifier = Modifier.padding(8.dp)) }
+                item { Text("Moving Details", style = MaterialTheme.typography.titleMedium) }
+                items(data!!.movingDetails) { d ->
+                    Text("${d.movingId}: ${d.startPoiId}->${d.endPoiId} vehicle:${d.vehicleId}")
+                }
+                item { Spacer(modifier = Modifier.padding(8.dp)) }
+                item { Text("Declaration Details", style = MaterialTheme.typography.titleMedium) }
+                items(data!!.transportDeclarationDetails) { d ->
+                    Text("${d.declarationId}: ${d.startPoiId}->${d.endPoiId} vehicle:${d.vehicleId}")
+                }
+                item { Spacer(modifier = Modifier.padding(8.dp)) }
+                item { Text("Seat Reservation Details", style = MaterialTheme.typography.titleMedium) }
+                items(data!!.seatReservationDetails) { d ->
+                    Text("${d.reservationId}: ${d.startPoiId}->${d.endPoiId}")
+                }
+                item { Spacer(modifier = Modifier.padding(8.dp)) }
+                item { Text("Walking", style = MaterialTheme.typography.titleMedium) }
+                items(data!!.walking) { w ->
+                    Text("${w.id} user:${w.userId} route:${w.routeId}")
+                }
+                item { Spacer(modifier = Modifier.padding(8.dp)) }
+                item { Text("App DateTime", style = MaterialTheme.typography.titleMedium) }
+                items(data!!.appDateTimes) { dt ->
+                    Text("${dt.id} -> ${dt.timestamp}")
+                }
+                item { Spacer(modifier = Modifier.padding(8.dp)) }
                 item { Text("Authentication table δεν είναι διαθέσιμη από το client", color = MaterialTheme.colorScheme.error) }
                 }
             }

--- a/app/src/main/java/com/ioannapergamali/mysmartroute/view/ui/screens/LocalDatabaseScreen.kt
+++ b/app/src/main/java/com/ioannapergamali/mysmartroute/view/ui/screens/LocalDatabaseScreen.kt
@@ -253,6 +253,60 @@ fun LocalDatabaseScreen(navController: NavController, openDrawer: () -> Unit) {
                         Text("${n.userId} -> ${n.message}")
                     }
                 }
+                item { Spacer(modifier = Modifier.padding(8.dp)) }
+                item { Text("Route Bus Stations", style = MaterialTheme.typography.titleMedium) }
+                if (data!!.routeBusStations.isEmpty()) {
+                    item { Text("Ο πίνακας είναι άδειος") }
+                } else {
+                    items(data!!.routeBusStations) { s ->
+                        Text("${s.routeId} (${s.position}) -> ${s.poiId}")
+                    }
+                }
+                item { Spacer(modifier = Modifier.padding(8.dp)) }
+                item { Text("Moving Details", style = MaterialTheme.typography.titleMedium) }
+                if (data!!.movingDetails.isEmpty()) {
+                    item { Text("Ο πίνακας είναι άδειος") }
+                } else {
+                    items(data!!.movingDetails) { d ->
+                        Text("${d.movingId}: ${d.startPoiId}->${d.endPoiId} vehicle:${d.vehicleId}")
+                    }
+                }
+                item { Spacer(modifier = Modifier.padding(8.dp)) }
+                item { Text("Declaration Details", style = MaterialTheme.typography.titleMedium) }
+                if (data!!.transportDeclarationDetails.isEmpty()) {
+                    item { Text("Ο πίνακας είναι άδειος") }
+                } else {
+                    items(data!!.transportDeclarationDetails) { d ->
+                        Text("${d.declarationId}: ${d.startPoiId}->${d.endPoiId} vehicle:${d.vehicleId}")
+                    }
+                }
+                item { Spacer(modifier = Modifier.padding(8.dp)) }
+                item { Text("Seat Reservation Details", style = MaterialTheme.typography.titleMedium) }
+                if (data!!.seatReservationDetails.isEmpty()) {
+                    item { Text("Ο πίνακας είναι άδειος") }
+                } else {
+                    items(data!!.seatReservationDetails) { d ->
+                        Text("${d.reservationId}: ${d.startPoiId}->${d.endPoiId}")
+                    }
+                }
+                item { Spacer(modifier = Modifier.padding(8.dp)) }
+                item { Text("Walking", style = MaterialTheme.typography.titleMedium) }
+                if (data!!.walking.isEmpty()) {
+                    item { Text("Ο πίνακας είναι άδειος") }
+                } else {
+                    items(data!!.walking) { w ->
+                        Text("${w.id} user:${w.userId} route:${w.routeId}")
+                    }
+                }
+                item { Spacer(modifier = Modifier.padding(8.dp)) }
+                item { Text("App DateTime", style = MaterialTheme.typography.titleMedium) }
+                if (data!!.appDateTimes.isEmpty()) {
+                    item { Text("Ο πίνακας είναι άδειος") }
+                } else {
+                    items(data!!.appDateTimes) { dt ->
+                        Text("${dt.id} -> ${dt.timestamp}")
+                    }
+                }
                 }
             }
         }


### PR DESCRIPTION
## Περίληψη
- Προστέθηκαν μέθοδοι `getAll` στα DAO για λεπτομέρειες και βοηθητικούς πίνακες.
- Ο `DatabaseViewModel` φορτώνει πλέον όλους τους πίνακες από την τοπική βάση και το Firestore και ενημερώνει τη νέα δομή `DatabaseData`.
- Οι οθόνες `LocalDatabaseScreen` και `FirebaseDatabaseScreen` εμφανίζουν όλα τα διαθέσιμα δεδομένα.

## Δοκιμές
- `./gradlew test` (απέτυχε: SDK location not found)


------
https://chatgpt.com/codex/tasks/task_e_68c72efec6ec83289c75dccdf31f16de