### PR TITLE
feat: allow duplicating route during rename

### DIFF
--- a/app/src/main/java/com/ioannapergamali/mysmartroute/view/ui/screens/ReviewRouteScreen.kt
+++ b/app/src/main/java/com/ioannapergamali/mysmartroute/view/ui/screens/ReviewRouteScreen.kt
@@ -142,9 +142,14 @@ fun ReviewRouteScreen(navController: NavController, openDrawer: () -> Unit) {
                     )
                     Spacer(Modifier.height(8.dp))
                     Button(onClick = {
-                        selectedRoute?.let { route ->
-                            val updated = route.copy(name = editedName)
-                            adminViewModel.updateRoute(updated)
+                        selectedRoute?.let {
+                            scope.launch {
+                                routeViewModel.addRoute(
+                                    context,
+                                    pois.map { p -> p.id },
+                                    editedName
+                                )
+                            }
                         }
                         selectedRoute = null
                         editedName = ""


### PR DESCRIPTION
## Summary
- enable αντιγραφή διαδρομής κατά τη μετονομασία στον έλεγχο ονομάτων

## Testing
- `./gradlew test` *(απέτυχε: Plugin [id: 'org.jetbrains.kotlin.plugin.compose'] not found)*

------
https://chatgpt.com/codex/tasks/task_e_68c7484c5e108328bb75c49c1b2aeb86