### PR TITLE
feat: duplicate routes with rename option

### DIFF
--- a/app/src/main/java/com/ioannapergamali/mysmartroute/view/ui/screens/ViewRoutesScreen.kt
+++ b/app/src/main/java/com/ioannapergamali/mysmartroute/view/ui/screens/ViewRoutesScreen.kt
@@ -47,6 +47,7 @@ fun ViewRoutesScreen(navController: NavController, openDrawer: () -> Unit) {
     var pois by remember { mutableStateOf<List<PoIEntity>>(emptyList()) }
     var pathPoints by remember { mutableStateOf<List<LatLng>>(emptyList()) }
     var expanded by remember { mutableStateOf(false) }
+    var newRouteName by remember { mutableStateOf("") }
 
     val cameraPositionState = rememberCameraPositionState()
     val apiKey = MapsUtils.getApiKey(context)
@@ -118,6 +119,7 @@ fun ViewRoutesScreen(navController: NavController, openDrawer: () -> Unit) {
                                     )
                                     pathPoints = path
                                     pois = routeViewModel.getRoutePois(context, route.id)
+                                    newRouteName = route.name
                                     path.firstOrNull()?.let {
                                         cameraPositionState.move(
                                             CameraUpdateFactory.newLatLngZoom(it, 13f)
@@ -176,6 +178,40 @@ fun ViewRoutesScreen(navController: NavController, openDrawer: () -> Unit) {
                             Text(poi.type.name, modifier = Modifier.weight(1f))
                         }
                     }
+                }
+            }
+
+            Spacer(Modifier.height(16.dp))
+
+            if (selectedRoute != null && pois.isNotEmpty()) {
+                OutlinedTextField(
+                    value = newRouteName,
+                    onValueChange = { newRouteName = it },
+                    label = { Text(stringResource(R.string.new_route_name)) },
+                    modifier = Modifier.fillMaxWidth()
+                )
+                Spacer(Modifier.height(8.dp))
+                Button(
+                    onClick = {
+                        scope.launch {
+                            val ids = pois.map { it.id }
+                            val result = routeViewModel.addRoute(context, ids, newRouteName)
+                            val msg = if (result != null) {
+                                routeViewModel.loadRoutes(context, includeAll = true)
+                                R.string.route_saved
+                            } else {
+                                R.string.route_save_failed
+                            }
+                            Toast.makeText(
+                                context,
+                                context.getString(msg),
+                                Toast.LENGTH_SHORT
+                            ).show()
+                        }
+                    },
+                    enabled = newRouteName.isNotBlank()
+                ) {
+                    Text(stringResource(R.string.save_as_new_route))
                 }
             }
         }

--- a/app/src/main/res/values-el/strings.xml
+++ b/app/src/main/res/values-el/strings.xml
@@ -291,5 +291,7 @@
     <string name="declare_failure">Αποτυχία αποστολής δήλωσης</string>
     <string name="rating_saved_success">Η βαθμολογία αποθηκεύτηκε</string>
     <string name="rating_save_failed">Αποτυχία αποθήκευσης βαθμολογίας</string>
+    <string name="new_route_name">Νέο όνομα διαδρομής</string>
+    <string name="save_as_new_route">Αποθήκευση ως νέα διαδρομή</string>
 
 </resources>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -317,6 +317,8 @@
     <string name="declare_failure">Failed to declare transport</string>
     <string name="rating_saved_success">Rating saved</string>
     <string name="rating_save_failed">Unable to save rating</string>
+    <string name="new_route_name">New route name</string>
+    <string name="save_as_new_route">Save as new route</string>
     <string name="no_duplicate_pois">No duplicate points found</string>
     <string name="coordinates_label">Coordinates</string>
     <string name="lat">Latitude</string>


### PR DESCRIPTION
## Summary
- allow viewing a route on the map with its stops listed below
- add ability to copy a selected route under a new name while keeping the original

## Testing
- `./gradlew test` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_68c7513c61708328ab353aa2978022de