### PR TITLE
feat: duplicate routes with rename option

### DIFF
--- a/app/src/main/res/values-el/strings.xml
+++ b/app/src/main/res/values-el/strings.xml
@@ -291,5 +291,7 @@
     <string name="declare_failure">Αποτυχία αποστολής δήλωσης</string>
     <string name="rating_saved_success">Η βαθμολογία αποθηκεύτηκε</string>
     <string name="rating_save_failed">Αποτυχία αποθήκευσης βαθμολογίας</string>
+    <string name="new_route_name">Νέο όνομα διαδρομής</string>
+    <string name="save_as_new_route">Αποθήκευση ως νέα διαδρομή</string>
 
 </resources>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -317,6 +317,8 @@
     <string name="declare_failure">Failed to declare transport</string>
     <string name="rating_saved_success">Rating saved</string>
     <string name="rating_save_failed">Unable to save rating</string>
+    <string name="new_route_name">New route name</string>
+    <string name="save_as_new_route">Save as new route</string>
     <string name="no_duplicate_pois">No duplicate points found</string>
     <string name="coordinates_label">Coordinates</string>
     <string name="lat">Latitude</string>


### PR DESCRIPTION
## Summary
- allow viewing a route on the map with its stops listed below
- add ability to copy a selected route under a new name while keeping the original
- load map and stop data when selecting a route so the view updates correctly

## Testing
- `./gradlew test` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_68c7513c61708328ab353aa2978022de