### PR TITLE
Fix duplicate advance date entry in admin menu

### DIFF
--- a/app/src/main/java/com/ioannapergamali/mysmartroute/data/local/MySmartRouteDatabase.kt
+++ b/app/src/main/java/com/ioannapergamali/mysmartroute/data/local/MySmartRouteDatabase.kt
@@ -317,7 +317,6 @@ abstract class MySmartRouteDatabase : RoomDatabase() {
                 insertOption("opt_admin_8", adminMenuId, "rank_passengers", "rankPassengers")
             insertOption("opt_admin_9", adminMenuId, "view_vehicles", "viewVehicles")
             insertOption("opt_admin_10", adminMenuId, "view_users", "viewUsers")
-            insertOption("opt_admin_11", adminMenuId, "advance_date", "advanceDate")
         }
         }
 


### PR DESCRIPTION
## Summary
- remove duplicate advance date option from admin menu population

## Testing
- `./gradlew test` *(failed: environment limitation)*

------
https://chatgpt.com/codex/tasks/task_e_68c75aa46b7c8328bf374bd29754f8d2