### PR TITLE
Add keep and keep all options for duplicate routes

### DIFF
--- a/app/src/main/res/values-el/strings.xml
+++ b/app/src/main/res/values-el/strings.xml
@@ -201,6 +201,7 @@
     <string name="lng">Μήκος</string>
     <string name="edit">Επεξεργασία</string>
     <string name="keep">Κράτησε</string>
+    <string name="keep_all">Κράτησε όλα</string>
     <string name="fill_all_fields">Συμπλήρωσε όλα τα πεδία</string>
     <string name="seat_booked">Η θέση κλείστηκε!</string>
     <string name="seat_unavailable">Δεν υπάρχουν διαθέσιμες θέσεις.</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -325,4 +325,5 @@
     <string name="lng">Longitude</string>
     <string name="edit">Edit</string>
     <string name="keep">Keep</string>
+    <string name="keep_all">Keep all</string>
 </resources>


### PR DESCRIPTION
## Summary
- allow admins to keep one or all duplicate routes with new buttons
- add `keep_all` string resources in English and Greek

## Testing
- `./gradlew test` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_68c7629c4a58832891104993f42f8c40