### PR TITLE
Ενημέρωση moving details με κόστος και ώρα

### DIFF
--- a/app/src/main/java/com/ioannapergamali/mysmartroute/view/ui/screens/AvailableTransportsScreen.kt
+++ b/app/src/main/java/com/ioannapergamali/mysmartroute/view/ui/screens/AvailableTransportsScreen.kt
@@ -320,8 +320,6 @@ fun AvailableTransportsScreen(
                                                     segments = segments,
                                                     declarationId = decl.id,
                                                     driverId = decl.driverId,
-                                                    cost = decl.cost,
-                                                    durationMinutes = decl.durationMinutes,
                                                 )
                                                 result.onSuccess {
                                                     val map = detailReservationCounts.getOrPut(decl.id) { mutableMapOf() }


### PR DESCRIPTION
## Περίληψη
- Υπολογισμός συνολικού κόστους και διάρκειας κατά την κράτηση θέσης
- Αποθήκευση cost και startTime στα έγγραφα της υποσυλλογής `movings/{id}/details`
- Απλούστευση κλήσης κράτησης θέσης χωρίς εξωτερικά ορίσματα κόστους/διάρκειας

## Έλεγχοι
- `./gradlew test` *(αποτυχία: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_68c776305dfc8328906f994d17e5b307