### PR TITLE
Υπολογισμός duration από διαδοχικά startTime

### DIFF
--- a/app/src/main/java/com/ioannapergamali/mysmartroute/viewmodel/BookingViewModel.kt
+++ b/app/src/main/java/com/ioannapergamali/mysmartroute/viewmodel/BookingViewModel.kt
@@ -95,9 +95,8 @@ class BookingViewModel : ViewModel() {
 
         val totalCost = segments.sumOf { it.cost }
         val durationMinutes = if (segments.size > 1) {
-            val minStart = segments.minOf { it.startTime }
-            val maxStart = segments.maxOf { it.startTime }
-            ((maxStart - minStart) / 60000).toInt()
+            val startTimes = segments.map { it.startTime }.sorted()
+            startTimes.zipWithNext { a, b -> ((b - a) / 60000).toInt() }.sum()
         } else 0
 
         val reservation = SeatReservationEntity(


### PR DESCRIPTION
## Περίληψη
- Υπολογισμός `durationMinutes` με άθροισμα διαφορών μεταξύ διαδοχικών `startTime` των τμημάτων κράτησης

## Δοκιμές
- `./gradlew test` *(απέτυχε: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_68c77f8a5c408328b0ddac736c0a7c05