### PR TITLE
Add durationMinutes to transport declaration details

### DIFF
--- a/app/src/main/java/com/ioannapergamali/mysmartroute/data/local/MySmartRouteDatabase.kt
+++ b/app/src/main/java/com/ioannapergamali/mysmartroute/data/local/MySmartRouteDatabase.kt
@@ -79,7 +79,7 @@ import com.ioannapergamali.mysmartroute.data.local.AppDateTimeDao
         AppDateTimeEntity::class
     ],
 
-    version = 74
+    version = 75
 
 )
 @TypeConverters(Converters::class)
@@ -1017,6 +1017,14 @@ abstract class MySmartRouteDatabase : RoomDatabase() {
             }
         }
 
+        private val MIGRATION_74_75 = object : Migration(74, 75) {
+            override fun migrate(database: SupportSQLiteDatabase) {
+                database.execSQL(
+                    "ALTER TABLE `transport_declarations_details` ADD COLUMN `durationMinutes` INTEGER NOT NULL DEFAULT 0"
+                )
+            }
+        }
+
         private fun prepopulate(db: SupportSQLiteDatabase) {
             Log.d(TAG, "Prepopulating database")
             db.execSQL(
@@ -1169,7 +1177,8 @@ abstract class MySmartRouteDatabase : RoomDatabase() {
                     MIGRATION_69_70,
                     MIGRATION_71_72,
                     MIGRATION_72_73,
-                    MIGRATION_73_74
+                    MIGRATION_73_74,
+                    MIGRATION_74_75
 
                 )
                     .addCallback(object : RoomDatabase.Callback() {

--- a/app/src/main/java/com/ioannapergamali/mysmartroute/data/local/TransportDeclarationDetailEntity.kt
+++ b/app/src/main/java/com/ioannapergamali/mysmartroute/data/local/TransportDeclarationDetailEntity.kt
@@ -27,5 +27,6 @@ data class TransportDeclarationDetailEntity(
     val vehicleType: String = "",
     val seats: Int = 0,
     val cost: Double = 0.0,
+    val durationMinutes: Int = 0,
     val startTime: Long = 0L
 )

--- a/app/src/main/java/com/ioannapergamali/mysmartroute/utils/FirestoreMappers.kt
+++ b/app/src/main/java/com/ioannapergamali/mysmartroute/utils/FirestoreMappers.kt
@@ -437,6 +437,7 @@ fun TransportDeclarationDetailEntity.toFirestoreMap(): Map<String, Any> = mapOf(
     "vehicleType" to vehicleType,
     "seats" to seats,
     "cost" to cost,
+    "durationMinutes" to durationMinutes,
     "startTime" to startTime
 )
 
@@ -459,8 +460,9 @@ fun DocumentSnapshot.toTransportDeclarationDetailEntity(declarationId: String): 
     val type = getString("vehicleType") ?: ""
     val seatsVal = (getLong("seats") ?: 0L).toInt()
     val costVal = getDouble("cost") ?: 0.0
+    val durationVal = (getLong("durationMinutes") ?: 0L).toInt()
     val timeVal = getLong("startTime") ?: 0L
-    return TransportDeclarationDetailEntity(id, declarationId, startPoi, endPoi, vehicle, type, seatsVal, costVal, timeVal)
+    return TransportDeclarationDetailEntity(id, declarationId, startPoi, endPoi, vehicle, type, seatsVal, costVal, durationVal, timeVal)
 }
 
 fun AvailabilityEntity.toFirestoreMap(): Map<String, Any> = mapOf(

--- a/app/src/main/java/com/ioannapergamali/mysmartroute/view/ui/screens/AnnounceTransportScreen.kt
+++ b/app/src/main/java/com/ioannapergamali/mysmartroute/view/ui/screens/AnnounceTransportScreen.kt
@@ -571,6 +571,7 @@ fun AnnounceTransportScreen(navController: NavController, openDrawer: () -> Unit
                                 vehicleType = veh.name,
                                 seats = selectedVehicleSeats,
                                 cost = cost,
+                                durationMinutes = segmentDuration,
                                 startTime = detailStartTime
                             )
                             details.add(detail)
@@ -795,6 +796,7 @@ fun AnnounceTransportScreen(navController: NavController, openDrawer: () -> Unit
                                             vehicleType = veh.name,
                                             seats = selectedVehicleSeats,
                                             cost = cost,
+                                            durationMinutes = duration,
                                             startTime = startTime
                                         )
                                     )


### PR DESCRIPTION
## Summary
- track duration per sub-route via `durationMinutes`
- include new field in Firestore mapping and Room migrations

## Testing
- `./gradlew test` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_68c784770d308328a7bc0a64f17416dc