### PR TITLE
Προσθήκη πεδίου διάρκειας στις λεπτομέρειες κρατήσεων και μετακινήσεων

### DIFF
--- a/app/src/main/java/com/ioannapergamali/mysmartroute/data/local/MovingDetailEntity.kt
+++ b/app/src/main/java/com/ioannapergamali/mysmartroute/data/local/MovingDetailEntity.kt
@@ -26,5 +26,6 @@ data class MovingDetailEntity(
     val movingId: String = "",
     val startPoiId: String = "",
     val endPoiId: String = "",
+    val durationMinutes: Int = 0,
     val vehicleId: String = ""
 )

--- a/app/src/main/java/com/ioannapergamali/mysmartroute/data/local/MySmartRouteDatabase.kt
+++ b/app/src/main/java/com/ioannapergamali/mysmartroute/data/local/MySmartRouteDatabase.kt
@@ -79,7 +79,7 @@ import com.ioannapergamali.mysmartroute.data.local.AppDateTimeDao
         AppDateTimeEntity::class
     ],
 
-    version = 75
+    version = 76
 
 )
 @TypeConverters(Converters::class)
@@ -1025,6 +1025,17 @@ abstract class MySmartRouteDatabase : RoomDatabase() {
             }
         }
 
+        private val MIGRATION_75_76 = object : Migration(75, 76) {
+            override fun migrate(database: SupportSQLiteDatabase) {
+                database.execSQL(
+                    "ALTER TABLE `seat_reservation_details` ADD COLUMN `durationMinutes` INTEGER NOT NULL DEFAULT 0"
+                )
+                database.execSQL(
+                    "ALTER TABLE `moving_details` ADD COLUMN `durationMinutes` INTEGER NOT NULL DEFAULT 0"
+                )
+            }
+        }
+
         private fun prepopulate(db: SupportSQLiteDatabase) {
             Log.d(TAG, "Prepopulating database")
             db.execSQL(
@@ -1178,7 +1189,8 @@ abstract class MySmartRouteDatabase : RoomDatabase() {
                     MIGRATION_71_72,
                     MIGRATION_72_73,
                     MIGRATION_73_74,
-                    MIGRATION_74_75
+                    MIGRATION_74_75,
+                    MIGRATION_75_76
 
                 )
                     .addCallback(object : RoomDatabase.Callback() {

--- a/app/src/main/java/com/ioannapergamali/mysmartroute/data/local/SeatReservationDetailEntity.kt
+++ b/app/src/main/java/com/ioannapergamali/mysmartroute/data/local/SeatReservationDetailEntity.kt
@@ -27,5 +27,6 @@ data class SeatReservationDetailEntity(
     val startPoiId: String = "",
     val endPoiId: String = "",
     val cost: Double = 0.0,
+    val durationMinutes: Int = 0,
     val startTime: Long = 0L
 )

--- a/app/src/main/java/com/ioannapergamali/mysmartroute/utils/FirestoreMappers.kt
+++ b/app/src/main/java/com/ioannapergamali/mysmartroute/utils/FirestoreMappers.kt
@@ -529,6 +529,7 @@ fun SeatReservationDetailEntity.toFirestoreMap(): Map<String, Any> = mapOf(
     "startPoiId" to FirebaseFirestore.getInstance().collection("pois").document(startPoiId),
     "endPoiId" to FirebaseFirestore.getInstance().collection("pois").document(endPoiId),
     "cost" to cost,
+    "durationMinutes" to durationMinutes,
     "startTime" to startTime
 )
 
@@ -545,14 +546,16 @@ fun DocumentSnapshot.toSeatReservationDetailEntity(reservationId: String): SeatR
         else -> return null
     }
     val costVal = getDouble("cost") ?: 0.0
+    val durationVal = getLong("durationMinutes")?.toInt() ?: 0
     val timeVal = getLong("startTime") ?: 0L
-    return SeatReservationDetailEntity(detId, reservationId, start, end, costVal, timeVal)
+    return SeatReservationDetailEntity(detId, reservationId, start, end, costVal, durationVal, timeVal)
 }
 
 fun MovingDetailEntity.toFirestoreMap(): Map<String, Any> = mapOf(
     "id" to id,
     "startPoiId" to FirebaseFirestore.getInstance().collection("pois").document(startPoiId),
     "endPoiId" to FirebaseFirestore.getInstance().collection("pois").document(endPoiId),
+    "durationMinutes" to durationMinutes,
     "vehicleId" to FirebaseFirestore.getInstance().collection("vehicles").document(vehicleId)
 )
 
@@ -573,7 +576,8 @@ fun DocumentSnapshot.toMovingDetailEntity(movingId: String): MovingDetailEntity?
         is String -> v
         else -> ""
     }
-    return MovingDetailEntity(detId, movingId, start, end, vehicle)
+    val durationVal = getLong("durationMinutes")?.toInt() ?: 0
+    return MovingDetailEntity(detId, movingId, start, end, durationVal, vehicle)
 }
 
 fun FavoriteEntity.toFirestoreMap(): Map<String, Any> = mapOf(

--- a/app/src/main/java/com/ioannapergamali/mysmartroute/view/ui/screens/AvailableTransportsScreen.kt
+++ b/app/src/main/java/com/ioannapergamali/mysmartroute/view/ui/screens/AvailableTransportsScreen.kt
@@ -309,7 +309,8 @@ fun AvailableTransportsScreen(
                                                         detail.endPoiId,
                                                         detail.vehicleId,
                                                         detail.cost,
-                                                        detail.startTime
+                                                        detail.startTime,
+                                                        detail.durationMinutes
                                                     )
                                                 }
                                                 val result = bookingViewModel.reserveSeat(

--- a/app/src/main/java/com/ioannapergamali/mysmartroute/viewmodel/ReservationViewModel.kt
+++ b/app/src/main/java/com/ioannapergamali/mysmartroute/viewmodel/ReservationViewModel.kt
@@ -222,6 +222,7 @@ class ReservationViewModel : ViewModel() {
                     movingId = moving.id,
                     startPoiId = detail.startPoiId,
                     endPoiId = detail.endPoiId,
+                    durationMinutes = declaration.durationMinutes,
                     vehicleId = declaration.vehicleId
                 )
                 movingDetailDao.insert(movingDetail)

--- a/app/src/main/java/com/ioannapergamali/mysmartroute/viewmodel/VehicleRequestViewModel.kt
+++ b/app/src/main/java/com/ioannapergamali/mysmartroute/viewmodel/VehicleRequestViewModel.kt
@@ -546,6 +546,7 @@ class VehicleRequestViewModel(
                         startPoiId = current.startPoiId,
                         endPoiId = current.endPoiId,
                         cost = declaration?.cost ?: 0.0,
+                        durationMinutes = declaration?.durationMinutes ?: 0,
                         startTime = declaration?.startTime ?: 0L
                     )
                     resDao.insert(reservation)


### PR DESCRIPTION
## Περίληψη
- Προστέθηκε πεδίο `durationMinutes` στις οντότητες `SeatReservationDetailEntity` και `MovingDetailEntity` και ενημερώθηκαν οι χαρτογραφήσεις Firestore.
- Προσαρμόστηκε το `BookingViewModel` και τα σχετικά UI για μεταφορά της διάρκειας σε κρατήσεις και μετακινήσεις.
- Αναβαθμίστηκε η βάση δεδομένων σε έκδοση 76 με νέα migration για τις επιπλέον στήλες.

## Έλεγχοι
- `./gradlew test` *(αποτυχία: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_68c787b809b883289208b1b33d2d66bd