### PR TITLE
Αφαίρεση πεδίου διαθέσιμες θέσεις από την προετοιμασία ολοκλήρωσης διαδρομής

### DIFF
--- a/app/src/main/java/com/ioannapergamali/mysmartroute/view/ui/screens/PrepareCompleteRouteScreen.kt
+++ b/app/src/main/java/com/ioannapergamali/mysmartroute/view/ui/screens/PrepareCompleteRouteScreen.kt
@@ -265,8 +265,6 @@ fun PrepareCompleteRouteScreen(navController: NavController, openDrawer: () -> U
                 Spacer(Modifier.height(16.dp))
             }
 
-            val seats = selectedDeclaration?.seats ?: 0
-
             if (selectedRoute != null && pathPoints.isNotEmpty() && !isKeyMissing) {
                 GoogleMap(
                     modifier = Modifier
@@ -282,11 +280,6 @@ fun PrepareCompleteRouteScreen(navController: NavController, openDrawer: () -> U
                 Spacer(Modifier.height(16.dp))
             } else if (isKeyMissing) {
                 Text(stringResource(R.string.map_api_key_missing))
-                Spacer(Modifier.height(16.dp))
-            }
-
-            if (seats > 0) {
-                Text(stringResource(R.string.available_seats, seats - reservations.size))
                 Spacer(Modifier.height(16.dp))
             }
 

--- a/app/src/main/res/values-el/strings.xml
+++ b/app/src/main/res/values-el/strings.xml
@@ -207,7 +207,6 @@
     <string name="seat_unavailable">Δεν υπάρχουν διαθέσιμες θέσεις.</string>
     <string name="reserve_seat">Κλείσε Θέση</string>
     <string name="reserve_seat_title">Κράτηση θέσης</string>
-    <string name="available_seats">Διαθέσιμες θέσεις: %1$d</string>
     <string name="select_route">Επιλογή διαδρομής</string>
     <string name="add_poi_option">Προσθήκη POI</string>
     <string name="select_date">Επιλογή ημερομηνίας</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -211,7 +211,6 @@
     <string name="seat_unavailable">No available seats.</string>
     <string name="reserve_seat">Reserve Seat</string>
     <string name="reserve_seat_title">Seat reservation</string>
-    <string name="available_seats">Available seats: %1$d</string>
     <string name="select_route">Select route</string>
     <string name="add_poi_option">Add POI</string>
     <string name="select_date">Select date</string>


### PR DESCRIPTION
## Περίληψη
- Κατάργηση υπολογισμού/εμφάνισης διαθέσιμων θέσεων στην οθόνη `PrepareCompleteRouteScreen`
- Αφαίρεση των εγγραφών `available_seats` από τα `strings.xml`

## Έλεγχοι
- `./gradlew test` *(αποτυχία: λείπει το Android SDK)*

------
https://chatgpt.com/codex/tasks/task_e_68c78c835c3c8328aff17c05c07fb9eb