### PR TITLE
Διόρθωση ελέγχου αποθήκευσης διαδρομής

### DIFF
--- a/app/src/main/java/com/ioannapergamali/mysmartroute/view/ui/screens/DeclareRouteScreen.kt
+++ b/app/src/main/java/com/ioannapergamali/mysmartroute/view/ui/screens/DeclareRouteScreen.kt
@@ -661,7 +661,7 @@ fun DeclareRouteScreen(navController: NavController, openDrawer: () -> Unit) {
                                 navController.previousBackStackEntry?.savedStateHandle?.set("newRouteId", newId)
                                 navController.popBackStack()
                             } else {
-                                Toast.makeText(context, context.getString(R.string.route_exists), Toast.LENGTH_SHORT).show()
+                                Toast.makeText(context, context.getString(R.string.route_save_failed), Toast.LENGTH_SHORT).show()
                             }
                         } else {
                             Toast.makeText(context, context.getString(R.string.fill_all_fields), Toast.LENGTH_SHORT).show()

--- a/app/src/main/java/com/ioannapergamali/mysmartroute/viewmodel/RouteViewModel.kt
+++ b/app/src/main/java/com/ioannapergamali/mysmartroute/viewmodel/RouteViewModel.kt
@@ -284,7 +284,7 @@ class RouteViewModel : ViewModel() {
         }
         val busStations = busIds.mapIndexed { index, p -> RouteBusStationEntity(id, index, p) }
 
-        runCatching {
+        val firestoreSuccess = runCatching {
             val routeRef = firestore.collection("routes").document(id)
             routeRef.set(entity.toFirestoreMap(points)).await()
             if (busStations.isNotEmpty()) {
@@ -302,7 +302,9 @@ class RouteViewModel : ViewModel() {
             }
         }.onFailure { e ->
             Log.e("RouteViewModel", "Αποτυχία αποθήκευσης στο Firestore", e)
-        }
+        }.isSuccess
+
+        if (!firestoreSuccess) return null
 
         routeDao.insert(entity)
         points.forEach { pointDao.insert(it) }


### PR DESCRIPTION
## Περίληψη
- Προσθήκη ελέγχου επιτυχίας Firestore πριν την οριστικοποίηση αποθήκευσης διαδρομής
- Ενημέρωση UI ώστε να εμφανίζει μήνυμα αποτυχίας όταν η αποθήκευση δεν ολοκληρώνεται

## Δοκιμές
- `./gradlew test` (αποτυχία: SDK location not found)

------
https://chatgpt.com/codex/tasks/task_e_68c819fdb20c83289f67b42aff803e6e