### PR TITLE
Use car icon for duplicate route selection

### DIFF
--- a/app/src/main/java/com/ioannapergamali/mysmartroute/view/ui/screens/ReviewRouteScreen.kt
+++ b/app/src/main/java/com/ioannapergamali/mysmartroute/view/ui/screens/ReviewRouteScreen.kt
@@ -8,6 +8,7 @@ import androidx.compose.material3.*
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.Check
 import androidx.compose.material.icons.filled.DoneAll
+import androidx.compose.material.icons.filled.DirectionsCar
 import androidx.compose.runtime.*
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.Alignment
@@ -101,7 +102,10 @@ fun ReviewRouteScreen(navController: NavController, openDrawer: () -> Unit) {
                                     contentPadding = PaddingValues(0.dp),
                                     modifier = Modifier.size(48.dp)
                                 ) {
-                                    Text(route.name.take(2))
+                                    Icon(
+                                        imageVector = Icons.Filled.DirectionsCar,
+                                        contentDescription = stringResource(R.string.route)
+                                    )
                                 }
                                 Text(route.name)
                             }


### PR DESCRIPTION
## Summary
- replace text with a car icon on the duplicate route selection button

## Testing
- `./gradlew test` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_68c8286f05a4832899151c887f4f79af