### PR TITLE
Επέκταση ελέγχου διπλών διαδρομών

### DIFF
--- a/app/src/main/java/com/ioannapergamali/mysmartroute/view/ui/screens/ReviewRouteScreen.kt
+++ b/app/src/main/java/com/ioannapergamali/mysmartroute/view/ui/screens/ReviewRouteScreen.kt
@@ -86,7 +86,7 @@ fun ReviewRouteScreen(navController: NavController, openDrawer: () -> Unit) {
                 )
             } else {
                 duplicateGroups.forEach { group ->
-                    Text(group.firstOrNull()?.name.orEmpty())
+                    Text(group.map { it.name }.distinct().joinToString(" / "))
                     LazyRow(horizontalArrangement = Arrangement.spacedBy(8.dp)) {
                         items(group) { route ->
                             Column(horizontalAlignment = Alignment.CenterHorizontally) {
@@ -104,6 +104,7 @@ fun ReviewRouteScreen(navController: NavController, openDrawer: () -> Unit) {
                                     Text(route.name.take(2))
                                 }
                                 Text(route.name)
+                                Text(stringResource(R.string.registered_by, route.userId))
                             }
                         }
                     }

--- a/app/src/main/java/com/ioannapergamali/mysmartroute/viewmodel/AdminRouteViewModel.kt
+++ b/app/src/main/java/com/ioannapergamali/mysmartroute/viewmodel/AdminRouteViewModel.kt
@@ -14,7 +14,7 @@ import kotlinx.coroutines.launch
 
 class AdminRouteViewModel(private val repo: AdminRouteRepository) : ViewModel() {
     val duplicateRoutes: StateFlow<List<List<RouteEntity>>> =
-        repo.getRoutesWithSameName().stateIn(
+        repo.getDuplicateRoutes().stateIn(
             scope = viewModelScope,
             started = SharingStarted.Eagerly,
             initialValue = emptyList()

--- a/app/src/main/res/values-el/strings.xml
+++ b/app/src/main/res/values-el/strings.xml
@@ -238,6 +238,7 @@
     <string name="max_cost">Μέγιστο κόστος</string>
     <string name="request_sent">Το αίτημα καταχωρήθηκε</string>
     <string name="view_requests">Προβολή αιτημάτων</string>
+    <string name="registered_by">Καταχωρήθηκε από: %1$s</string>
     <string name="view_movings">Προβολή μετακινήσεων</string>
     <string name="no_movings">Δεν βρέθηκαν μετακινήσεις</string>
     <string name="active_movings">Ενεργές μετακινήσεις</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -250,6 +250,7 @@
     <string name="max_cost">Maximum cost</string>
     <string name="request_sent">Request saved</string>
     <string name="view_requests">View Requests</string>
+    <string name="registered_by">Registered by: %1$s</string>
     <string name="no_requests">No requests found</string>
     <string name="no_routes_available">No routes available</string>
     <string name="view_movings">View Movings</string>


### PR DESCRIPTION
## Περίληψη
- Έλεγχος διαδρομών και για ίδια POIs εκτός από όνομα
- Προβολή χρήστη που καταχώρησε κάθε διαδρομή στην οθόνη ελέγχου
- Προσθήκη αντίστοιχων πόρων κειμένου

## Έλεγχοι
- `./gradlew test` *(αποτυχία: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_68c829ae17048328b88a961c2e45c73c