### PR TITLE
Δημιουργία μετακίνησης μαζί με αίτημα

### DIFF
--- a/app/src/main/java/com/ioannapergamali/mysmartroute/view/ui/screens/BookSeatScreen.kt
+++ b/app/src/main/java/com/ioannapergamali/mysmartroute/view/ui/screens/BookSeatScreen.kt
@@ -65,7 +65,6 @@ import com.ioannapergamali.mysmartroute.viewmodel.BookingViewModel
 import com.ioannapergamali.mysmartroute.viewmodel.RouteViewModel
 import com.ioannapergamali.mysmartroute.viewmodel.PoIViewModel
 import com.ioannapergamali.mysmartroute.viewmodel.TransportDeclarationViewModel
-import com.ioannapergamali.mysmartroute.viewmodel.VehicleRequestViewModel
 import com.ioannapergamali.mysmartroute.viewmodel.TransferRequestViewModel
 import kotlinx.coroutines.launch
 import java.time.Instant
@@ -93,7 +92,6 @@ fun BookSeatScreen(
     val routeViewModel: RouteViewModel = viewModel()
     val poiViewModel: PoIViewModel = viewModel()
     val declarationViewModel: TransportDeclarationViewModel = viewModel()
-    val requestViewModel: VehicleRequestViewModel = viewModel()
     val transferRequestViewModel: TransferRequestViewModel = viewModel()
     val routes by viewModel.availableRoutes.collectAsState()
     val allPois by poiViewModel.pois.collectAsState()
@@ -576,19 +574,15 @@ fun BookSeatScreen(
                             val startId = startIndex?.let { pois[it].id } ?: return@launch
                             val endId = endIndex?.let { pois[it].id } ?: return@launch
                             val routeId = saveEditedRouteIfChanged()
-                            requestViewModel.requestTransport(
+                            val poiChanged = poiIds.toSet() != originalPoiIds.toSet()
+                            transferRequestViewModel.submitRequest(
                                 context,
                                 routeId,
                                 startId,
                                 endId,
-                                null,
-                                dateMillis
-                            )
-                            transferRequestViewModel.submitRequest(
-                                context,
-                                routeId,
                                 dateMillis,
-                                null
+                                null,
+                                poiChanged
                             )
                             message = context.getString(R.string.request_sent)
                         }

--- a/app/src/main/java/com/ioannapergamali/mysmartroute/view/ui/screens/RouteModeScreen.kt
+++ b/app/src/main/java/com/ioannapergamali/mysmartroute/view/ui/screens/RouteModeScreen.kt
@@ -38,7 +38,6 @@ import com.ioannapergamali.mysmartroute.view.ui.components.ScreenContainer
 import com.ioannapergamali.mysmartroute.view.ui.components.TopBar
 import com.ioannapergamali.mysmartroute.viewmodel.PoIViewModel
 import com.ioannapergamali.mysmartroute.viewmodel.RouteViewModel
-import com.ioannapergamali.mysmartroute.viewmodel.VehicleRequestViewModel
 import com.ioannapergamali.mysmartroute.viewmodel.TransferRequestViewModel
 import com.ioannapergamali.mysmartroute.model.enumerations.VehicleType
 import com.ioannapergamali.mysmartroute.utils.MapsUtils
@@ -69,7 +68,6 @@ fun RouteModeScreen(
     val context = LocalContext.current
     val routeViewModel: RouteViewModel = viewModel()
     val poiViewModel: PoIViewModel = viewModel()
-    val requestViewModel: VehicleRequestViewModel = viewModel()
     val transferRequestViewModel: TransferRequestViewModel = viewModel()
     val routes by routeViewModel.routes.collectAsState()
     val allPois by poiViewModel.pois.collectAsState()
@@ -479,9 +477,16 @@ fun RouteModeScreen(
                             val cost = maxCostText.toDoubleOrNull()
                             val date = datePickerState.selectedDateMillis ?: 0L
                             val routeId = saveEditedRouteAsNewRoute()
-
-                            requestViewModel.requestTransport(context, routeId, fromId, toId, cost, date)
-                            transferRequestViewModel.submitRequest(context, routeId, date, cost)
+                            val poiChanged = routePoiIds.toSet() != originalPoiIds.toSet()
+                            transferRequestViewModel.submitRequest(
+                                context,
+                                routeId,
+                                fromId,
+                                toId,
+                                date,
+                                cost,
+                                poiChanged
+                            )
                             message = context.getString(R.string.request_sent)
                         }
                     },

--- a/app/src/main/java/com/ioannapergamali/mysmartroute/viewmodel/TransferRequestViewModel.kt
+++ b/app/src/main/java/com/ioannapergamali/mysmartroute/viewmodel/TransferRequestViewModel.kt
@@ -6,6 +6,8 @@ import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import com.google.firebase.auth.FirebaseAuth
 import com.google.firebase.firestore.FirebaseFirestore
+import com.ioannapergamali.mysmartroute.data.local.MovingDetailEntity
+import com.ioannapergamali.mysmartroute.data.local.MovingEntity
 import com.ioannapergamali.mysmartroute.data.local.MySmartRouteDatabase
 import com.ioannapergamali.mysmartroute.data.local.TransferRequestEntity
 import com.ioannapergamali.mysmartroute.model.enumerations.RequestStatus
@@ -13,6 +15,8 @@ import com.ioannapergamali.mysmartroute.utils.toFirestoreMap
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.tasks.await
+import java.util.ArrayDeque
+import java.util.UUID
 
 /**
  * ViewModel για υποβολή και διαχείριση αιτημάτων μεταφοράς.
@@ -33,34 +37,114 @@ class TransferRequestViewModel : ViewModel() {
     fun submitRequest(
         context: Context,
         routeId: String,
+        startPoiId: String,
+        endPoiId: String,
         date: Long,
-            cost: Double?,
+        cost: Double?,
+        poiChanged: Boolean = false,
     ) {
         val passengerId = auth.currentUser?.uid ?: return
-        val entity = TransferRequestEntity(
-            routeId = routeId,
-            passengerId = passengerId,
-            driverId = "",
-            date = date,
-            cost = cost,
-            status = RequestStatus.OPEN
-        )
         viewModelScope.launch(Dispatchers.IO) {
-            val dao = MySmartRouteDatabase.getInstance(context).transferRequestDao()
+            val dbInstance = MySmartRouteDatabase.getInstance(context)
+            val transferDao = dbInstance.transferRequestDao()
+            val movingDao = dbInstance.movingDao()
+            val detailDao = dbInstance.movingDetailDao()
+
+            val requestEntity = TransferRequestEntity(
+                routeId = routeId,
+                passengerId = passengerId,
+                driverId = "",
+                date = date,
+                cost = cost,
+                status = RequestStatus.OPEN
+            )
+
             try {
-                Log.d(TAG, "Εισαγωγή αιτήματος: $entity")
-                val id = dao.insert(entity).toInt()
-                Log.d(TAG, "Το αίτημα αποθηκεύτηκε τοπικά με id=$id")
-                val saved = entity.copy(requestNumber = id)
-                val docRef = db.collection("transfer_requests")
-                    .add(saved.toFirestoreMap())
+                val requestNumber = transferDao.insert(requestEntity).toInt()
+                val savedRequest = requestEntity.copy(requestNumber = requestNumber)
+
+                val baseSegments = if (poiChanged) emptyList() else fetchSegments(routeId, startPoiId, endPoiId)
+                val duration = baseSegments.sumOf { it.durationMinutes }
+                val movingId = UUID.randomUUID().toString()
+                val segments = baseSegments.map { it.copy(movingId = movingId) }
+                val moving = MovingEntity(
+                    id = movingId,
+                    routeId = routeId,
+                    userId = passengerId,
+                    date = date,
+                    cost = cost,
+                    durationMinutes = duration,
+                    startPoiId = startPoiId,
+                    endPoiId = endPoiId,
+                    driverId = "",
+                    status = "open",
+                    requestNumber = requestNumber
+                )
+
+                movingDao.insert(moving)
+                segments.forEach { detailDao.insert(it) }
+
+                val reqRef = db.collection("transfer_requests")
+                    .add(savedRequest.toFirestoreMap())
                     .await()
-                dao.setFirebaseId(id, docRef.id)
-                Log.d(TAG, "Το αίτημα αποθηκεύτηκε στο Firestore με id=${docRef.id}")
+                transferDao.setFirebaseId(requestNumber, reqRef.id)
+
+                val movingRef = db.collection("movings").document(movingId)
+                movingRef.set(moving.toFirestoreMap()).await()
+                segments.forEach { seg ->
+                    movingRef.collection("details")
+                        .document(seg.id)
+                        .set(seg.toFirestoreMap())
+                        .await()
+                }
             } catch (e: Exception) {
                 Log.e(TAG, "Αποτυχία υποβολής αιτήματος", e)
             }
         }
+    }
+
+    private suspend fun fetchSegments(
+        routeId: String,
+        startPoiId: String,
+        endPoiId: String,
+    ): List<MovingDetailEntity> {
+        val routeRef = db.collection("routes").document(routeId)
+        val declSnap = db.collection("transport_declarations")
+            .whereEqualTo("routeId", routeRef)
+            .get()
+            .await()
+        val rawSegments = mutableListOf<MovingDetailEntity>()
+        declSnap.documents.forEach { decl ->
+            val dets = decl.reference.collection("details").get().await()
+            dets.documents.forEach { doc ->
+                val start = doc.getString("startPoiId") ?: return@forEach
+                val end = doc.getString("endPoiId") ?: return@forEach
+                val duration = (doc.getLong("durationMinutes") ?: 0L).toInt()
+                val vehicle = doc.getString("vehicleId") ?: ""
+                rawSegments += MovingDetailEntity(
+                    id = UUID.randomUUID().toString(),
+                    movingId = "",
+                    startPoiId = start,
+                    endPoiId = end,
+                    durationMinutes = duration,
+                    vehicleId = vehicle,
+                )
+            }
+        }
+        val graph = rawSegments.groupBy { it.startPoiId }
+        val queue: ArrayDeque<List<MovingDetailEntity>> = ArrayDeque()
+        queue.add(emptyList())
+        val visited = mutableSetOf<String>()
+        while (queue.isNotEmpty()) {
+            val path = queue.removeFirst()
+            val current = path.lastOrNull()?.endPoiId ?: startPoiId
+            if (current == endPoiId) return path
+            if (!visited.add(current)) continue
+            graph[current].orEmpty().forEach { seg ->
+                queue.add(path + seg)
+            }
+        }
+        return emptyList()
     }
 
     /**


### PR DESCRIPTION
## Περίληψη
- Δημιουργία `MovingEntity` και λεπτομερειών κατά την υποβολή αιτήματος.
- Ενημέρωση οθονών BookSeat και RouteMode ώστε να καλούν την νέα υποβολή με έλεγχο αλλαγής στάσεων.

## Έλεγχοι
- `./gradlew test` *(αποτυχία: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_68c834412f9c8328a39e4ebe7bf04fe0