### PR TITLE
Απενεργοποίηση διπλού κατακόρυφου scroll στο ReviewRouteScreen

### DIFF
--- a/app/src/main/java/com/ioannapergamali/mysmartroute/view/ui/screens/ReviewRouteScreen.kt
+++ b/app/src/main/java/com/ioannapergamali/mysmartroute/view/ui/screens/ReviewRouteScreen.kt
@@ -76,7 +76,7 @@ fun ReviewRouteScreen(navController: NavController, openDrawer: () -> Unit) {
             onMenuClick = openDrawer
         )
     }) { padding ->
-        ScreenContainer(modifier = Modifier.padding(padding)) {
+        ScreenContainer(modifier = Modifier.padding(padding), scrollable = false) {
             if (duplicateGroups.isEmpty()) {
                 Text(
                     text = stringResource(R.string.no_duplicate_routes),


### PR DESCRIPTION
## Summary
- σταμάτησα το κάθετο scroll στο ReviewRouteScreen όταν χρησιμοποιείται LazyColumn

## Testing
- `./gradlew test` *(απέτυχε: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_68c8351f07ec8328a1b89fc30279c881