### PR TITLE
Enable scroll and label duplicate route groups

### DIFF
--- a/app/src/main/java/com/ioannapergamali/mysmartroute/viewmodel/AdminRouteViewModel.kt
+++ b/app/src/main/java/com/ioannapergamali/mysmartroute/viewmodel/AdminRouteViewModel.kt
@@ -7,17 +7,18 @@ import androidx.lifecycle.viewModelScope
 import com.ioannapergamali.mysmartroute.data.local.MySmartRouteDatabase
 import com.ioannapergamali.mysmartroute.data.local.RouteEntity
 import com.ioannapergamali.mysmartroute.repository.AdminRouteRepository
+import com.ioannapergamali.mysmartroute.repository.RouteDuplicateGroups
 import kotlinx.coroutines.flow.SharingStarted
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.stateIn
 import kotlinx.coroutines.launch
 
 class AdminRouteViewModel(private val repo: AdminRouteRepository) : ViewModel() {
-    val duplicateRoutes: StateFlow<List<List<RouteEntity>>> =
+    val duplicateRoutes: StateFlow<RouteDuplicateGroups> =
         repo.getDuplicateRoutes().stateIn(
             scope = viewModelScope,
             started = SharingStarted.Eagerly,
-            initialValue = emptyList()
+            initialValue = RouteDuplicateGroups(emptyList(), emptyList())
         )
 
     fun updateRoute(route: RouteEntity) {

--- a/app/src/main/res/values-el/strings.xml
+++ b/app/src/main/res/values-el/strings.xml
@@ -132,6 +132,8 @@
     <string name="review_poi">Έλεγχος ονομάτων σημείων ενδιαφέροντος</string>
     <string name="review_route">Έλεγχος ονομάτων διαδρομών</string>
     <string name="no_duplicate_routes">Δεν βρέθηκαν διπλές διαδρομές</string>
+    <string name="duplicate_routes_same_name">Διαδρομές με ίδιο όνομα</string>
+    <string name="duplicate_routes_same_pois">Διαδρομές με ίδια σημεία</string>
     <string name="rank_drivers">Προβολή 10 καλύτερων και χειρότερων οδηγών</string>
     <string name="top_drivers">Κορυφαίοι 10 οδηγοί</string>
     <string name="worst_drivers">Χειρότεροι 10 οδηγοί</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -130,6 +130,8 @@
     <string name="review_poi">Review Point of Interest Names</string>
     <string name="review_route">Review Route Names</string>
     <string name="no_duplicate_routes">No duplicate routes found</string>
+    <string name="duplicate_routes_same_name">Routes with same name</string>
+    <string name="duplicate_routes_same_pois">Routes with same points</string>
     <string name="rank_drivers">Show 10 Best and Worst Drivers</string>
     <string name="top_drivers">Top 10 drivers</string>
     <string name="worst_drivers">Bottom 10 drivers</string>


### PR DESCRIPTION
## Summary
- allow vertical scrolling and show headers in review route screen
- expose duplicate route groups by name and POIs
- add string resources for new headers

## Testing
- `./gradlew test` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_68c837e9c0508328be4601a1ef66f49c