### PR TITLE
Handle Firestore routeId references when loading routes

### DIFF
--- a/app/src/main/java/com/ioannapergamali/mysmartroute/viewmodel/RouteViewModel.kt
+++ b/app/src/main/java/com/ioannapergamali/mysmartroute/viewmodel/RouteViewModel.kt
@@ -4,6 +4,7 @@ import android.content.Context
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import com.google.firebase.auth.FirebaseAuth
+import com.google.firebase.firestore.DocumentReference
 import com.google.firebase.firestore.FirebaseFirestore
 import android.util.Log
 import com.ioannapergamali.mysmartroute.data.local.MySmartRouteDatabase
@@ -118,7 +119,13 @@ class RouteViewModel : ViewModel() {
                         firestore.collection("transport_declarations").get().await()
                     }.getOrNull()
                     val declaredIds = declSnap?.documents
-                        ?.mapNotNull { it.getString("routeId") }
+                        ?.mapNotNull { doc ->
+                            when (val routeRef = doc.get("routeId")) {
+                                is DocumentReference -> routeRef.id
+                                is String -> routeRef
+                                else -> doc.getString("routeId")
+                            }
+                        }
                         ?.toSet() ?: emptySet()
                     val existingIds = list.map { it.first.id }.toMutableSet()
                     for (routeId in declaredIds) {


### PR DESCRIPTION
## Summary
- handle Firestore transport declaration routeId fields that are stored as DocumentReferences or strings
- keep using the resolved IDs when merging declared routes into the local list

## Testing
- ./gradlew :app:compileDebugKotlin --console=plain --no-daemon *(fails: SDK location not found in CI environment)*

------
https://chatgpt.com/codex/tasks/task_e_68c83ecbfbf883289119afe7e41ffccb