### PR TITLE
Ενοποίηση διαδρομών Room και Firebase στην εύρεση οχήματος

### DIFF
--- a/app/src/main/java/com/ioannapergamali/mysmartroute/viewmodel/RouteViewModel.kt
+++ b/app/src/main/java/com/ioannapergamali/mysmartroute/viewmodel/RouteViewModel.kt
@@ -140,12 +140,18 @@ class RouteViewModel : ViewModel() {
                         }
                     }
                 }
-                _routes.value = list.map { it.first }
                 list.forEach { (route, points, busStations) ->
                     routeDao.insert(route)
                     points.forEach { pointDao.insert(it) }
                     busStations.forEach { busDao.insert(it) }
                 }
+                val localRoutes = when {
+                    includeAll -> routeDao.getAll().first()
+                    userId != null -> routeDao.getRoutesForUser(userId).first()
+                    else -> emptyList()
+                }
+                val combined = (list.map { it.first } + localRoutes).distinctBy { it.id }
+                _routes.value = combined
             } else {
                 _routes.value = if (includeAll) {
                     routeDao.getAll().first()


### PR DESCRIPTION
## Summary
- Συνδύασα τα routes του Firestore με όσα υπάρχουν στη Room ώστε ο πίνακας routes να έχει το ενοποιημένο σύνολο.

## Testing
- `./gradlew :app:testDebugUnitTest --console=plain --no-daemon` *(αποτυχία: λείπει Android SDK στο περιβάλλον δοκιμών)*

------
https://chatgpt.com/codex/tasks/task_e_68c8479bc5b483289ff9ea7d50238406