### PR TITLE
Add database cleanup toggles for system initialization

### DIFF
--- a/app/src/main/java/com/ioannapergamali/mysmartroute/view/ui/screens/DatabaseMenuScreen.kt
+++ b/app/src/main/java/com/ioannapergamali/mysmartroute/view/ui/screens/DatabaseMenuScreen.kt
@@ -1,21 +1,48 @@
 package com.ioannapergamali.mysmartroute.view.ui.screens
 
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
 import androidx.compose.material3.Button
+import androidx.compose.material3.Card
+import androidx.compose.material3.Divider
+import androidx.compose.material3.LinearProgressIndicator
+import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Scaffold
+import androidx.compose.material3.Switch
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.collectAsState
+import androidx.compose.runtime.getValue
+import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.unit.dp
+import androidx.lifecycle.viewmodel.compose.viewModel
 import androidx.navigation.NavController
+import com.ioannapergamali.mysmartroute.R
 import com.ioannapergamali.mysmartroute.view.ui.components.ScreenContainer
 import com.ioannapergamali.mysmartroute.view.ui.components.TopBar
-import androidx.compose.ui.res.stringResource
-import com.ioannapergamali.mysmartroute.R
+import com.ioannapergamali.mysmartroute.viewmodel.ClearState
+import com.ioannapergamali.mysmartroute.viewmodel.DatabaseViewModel
+import com.ioannapergamali.mysmartroute.viewmodel.TableToggleState
 
 @Composable
 fun DatabaseMenuScreen(navController: NavController, openDrawer: () -> Unit) {
+    val viewModel: DatabaseViewModel = viewModel()
+    val localTables by viewModel.localTables.collectAsState()
+    val firebaseTables by viewModel.firebaseTables.collectAsState()
+    val clearState by viewModel.clearState.collectAsState()
+    val context = LocalContext.current
+
+    val isClearing = clearState is ClearState.Running
+    val hasSelection = localTables.any { it.selected } || firebaseTables.any { it.selected }
+
     Scaffold(
         topBar = {
             TopBar(
@@ -27,17 +54,111 @@ fun DatabaseMenuScreen(navController: NavController, openDrawer: () -> Unit) {
         }
     ) { padding ->
         ScreenContainer(modifier = Modifier.padding(padding)) {
-            Button(onClick = { navController.navigate("localDb") }) {
-                Text(stringResource(R.string.local_db))
+            Text(
+                text = stringResource(R.string.room_tables),
+                style = MaterialTheme.typography.titleMedium
+            )
+            Spacer(modifier = Modifier.height(8.dp))
+            TableSelectionCard(
+                tables = localTables,
+                enabled = !isClearing,
+                onToggle = { id, checked -> viewModel.setLocalTableSelected(id, checked) }
+            )
+            Spacer(modifier = Modifier.height(16.dp))
+            Text(
+                text = stringResource(R.string.firebase_tables),
+                style = MaterialTheme.typography.titleMedium
+            )
+            Spacer(modifier = Modifier.height(8.dp))
+            TableSelectionCard(
+                tables = firebaseTables,
+                enabled = !isClearing,
+                onToggle = { id, checked -> viewModel.setFirebaseTableSelected(id, checked) }
+            )
+            Spacer(modifier = Modifier.height(24.dp))
+
+            if (isClearing) {
+                LinearProgressIndicator(modifier = Modifier.fillMaxWidth())
+                Spacer(modifier = Modifier.height(16.dp))
             }
-            Spacer(modifier = Modifier.padding(8.dp))
-            Button(onClick = { navController.navigate("firebaseDb") }) {
-                Text(stringResource(R.string.firebase_db))
+
+            Button(
+                onClick = { viewModel.clearSelectedTables(context) },
+                enabled = hasSelection && !isClearing
+            ) {
+                Text(stringResource(R.string.clear_data))
             }
-            Spacer(modifier = Modifier.padding(8.dp))
-            Button(onClick = { navController.navigate("syncDb") }) {
-                Text(stringResource(R.string.sync_db))
+
+            Spacer(modifier = Modifier.height(16.dp))
+
+            when (val state = clearState) {
+                is ClearState.Success -> {
+                    Text(
+                        text = state.message,
+                        style = MaterialTheme.typography.bodyMedium,
+                        color = MaterialTheme.colorScheme.primary
+                    )
+                }
+
+                is ClearState.Error -> {
+                    Text(
+                        text = state.message,
+                        style = MaterialTheme.typography.bodyMedium,
+                        color = MaterialTheme.colorScheme.error
+                    )
+                }
+
+                else -> Unit
             }
         }
+    }
+}
+
+@Composable
+private fun TableSelectionCard(
+    tables: List<TableToggleState>,
+    enabled: Boolean,
+    onToggle: (String, Boolean) -> Unit
+) {
+    Card(modifier = Modifier.fillMaxWidth()) {
+        Column {
+            tables.forEachIndexed { index, table ->
+                TableSelectionRow(
+                    table = table,
+                    enabled = enabled,
+                    onToggle = { checked -> onToggle(table.id, checked) }
+                )
+                if (index < tables.lastIndex) {
+                    Divider()
+                }
+            }
+        }
+    }
+}
+
+@Composable
+private fun TableSelectionRow(
+    table: TableToggleState,
+    enabled: Boolean,
+    onToggle: (Boolean) -> Unit
+) {
+    Row(
+        modifier = Modifier
+            .fillMaxWidth()
+            .padding(horizontal = 16.dp, vertical = 12.dp),
+        horizontalArrangement = Arrangement.SpaceBetween,
+        verticalAlignment = Alignment.CenterVertically
+    ) {
+        Text(
+            text = table.title,
+            style = MaterialTheme.typography.bodyLarge,
+            modifier = Modifier.weight(1f),
+            maxLines = 1
+        )
+        Switch(
+            checked = table.selected,
+            onCheckedChange = onToggle,
+            enabled = enabled
+        )
     }
 }

--- a/app/src/main/res/values-el/strings.xml
+++ b/app/src/main/res/values-el/strings.xml
@@ -62,6 +62,12 @@
     <string name="about_title">Σχετικά</string>
     <string name="support_title">Υποστήριξη</string>
     <string name="databases_title">Βάσεις Δεδομένων</string>
+    <string name="room_tables">Πίνακες Room</string>
+    <string name="firebase_tables">Συλλογές Firebase</string>
+    <string name="clear_data">Καθάρισε</string>
+    <string name="clear_success">Ο καθαρισμός ολοκληρώθηκε</string>
+    <string name="clear_error_no_selection">Επιλέξτε τουλάχιστον έναν πίνακα</string>
+    <string name="clear_error_generic">Αποτυχία καθαρισμού δεδομένων: %1$s</string>
     <string name="local_db">Τοπική ΒΔ</string>
     <string name="firebase_db">Firestore ΒΔ</string>
     <string name="sync_db">Συγχρονισμός</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -60,6 +60,12 @@
     <string name="about_title">About</string>
     <string name="support_title">Support</string>
     <string name="databases_title">Databases</string>
+    <string name="room_tables">Room tables</string>
+    <string name="firebase_tables">Firebase collections</string>
+    <string name="clear_data">Clear</string>
+    <string name="clear_success">Data cleared successfully</string>
+    <string name="clear_error_no_selection">Select at least one table</string>
+    <string name="clear_error_generic">Failed to clear data: %1$s</string>
     <string name="local_db">Local DB</string>
     <string name="firebase_db">Firestore DB</string>
     <string name="sync_db">Synchronization</string>


### PR DESCRIPTION
## Summary
- replace the database menu with Room and Firebase tables that can be toggled on or off
- manage the toggle state inside DatabaseViewModel and clear the selected Room tables or Firebase collections
- add localized strings for the new labels and feedback messages

## Testing
- ./gradlew lintDebug --console=plain *(fails: SDK location not found in container)*

------
https://chatgpt.com/codex/tasks/task_e_68c84897f0608328bca4c983f3ee6159