### PR TITLE
Persist trip rating feedback to Room database

### DIFF
--- a/app/src/main/java/com/ioannapergamali/mysmartroute/viewmodel/TripRatingViewModel.kt
+++ b/app/src/main/java/com/ioannapergamali/mysmartroute/viewmodel/TripRatingViewModel.kt
@@ -1,6 +1,7 @@
 package com.ioannapergamali.mysmartroute.viewmodel
 
 import android.content.Context
+import android.util.Log
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import com.google.firebase.auth.FirebaseAuth
@@ -10,11 +11,13 @@ import com.ioannapergamali.mysmartroute.data.local.MySmartRouteDatabase
 import com.ioannapergamali.mysmartroute.data.local.TripRatingEntity
 import com.ioannapergamali.mysmartroute.model.classes.transports.TripWithRating
 import com.ioannapergamali.mysmartroute.repository.TripRatingRepository
+import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.combine
 import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.launch
+import kotlinx.coroutines.withContext
 
 class TripRatingViewModel : ViewModel() {
 
@@ -76,29 +79,43 @@ class TripRatingViewModel : ViewModel() {
     fun saveTripRating(context: Context, moving: MovingEntity, rating: Int, comment: String) {
         viewModelScope.launch {
             val db = MySmartRouteDatabase.getInstance(context)
-            try {
-                db.tripRatingDao().upsert(
-                    TripRatingEntity(moving.id, moving.userId, rating, comment)
-                )
-                val success = repository.saveTripRating(
+            val entity = TripRatingEntity(moving.id, moving.userId, rating, comment)
+
+            val localResult = runCatching {
+                withContext(Dispatchers.IO) {
+                    db.tripRatingDao().upsert(entity)
+                }
+            }
+            localResult.exceptionOrNull()?.let {
+                Log.e(TAG, "Αποτυχία αποθήκευσης βαθμολογίας στη Room", it)
+            }
+
+            val remoteSuccess = try {
+                repository.saveTripRating(
                     moving.id,
                     moving.userId,
                     rating,
                     comment,
                 )
-                _message.value = if (success) {
-                    context.getString(R.string.rating_saved_success)
-                } else {
-                    context.getString(R.string.rating_save_failed)
-                }
-            } catch (_: Exception) {
-                _message.value = context.getString(R.string.rating_save_failed)
+            } catch (e: Exception) {
+                Log.e(TAG, "Αποτυχία αποθήκευσης βαθμολογίας στο Firestore", e)
+                false
+            }
+
+            _message.value = when {
+                remoteSuccess -> context.getString(R.string.rating_saved_success)
+                localResult.isSuccess -> context.getString(R.string.rating_saved_offline)
+                else -> context.getString(R.string.rating_save_failed)
             }
         }
     }
 
     fun clearMessage() {
         _message.value = null
+    }
+
+    companion object {
+        private const val TAG = "TripRatingViewModel"
     }
 }
 

--- a/app/src/main/res/values-el/strings.xml
+++ b/app/src/main/res/values-el/strings.xml
@@ -300,6 +300,7 @@
     <string name="declare_success">Η δήλωση στάλθηκε επιτυχώς</string>
     <string name="declare_failure">Αποτυχία αποστολής δήλωσης</string>
     <string name="rating_saved_success">Η βαθμολογία αποθηκεύτηκε</string>
+    <string name="rating_saved_offline">Αποθηκεύτηκε τοπικά. Θα συγχρονιστεί μόλις υπάρξει σύνδεση</string>
     <string name="rating_save_failed">Αποτυχία αποθήκευσης βαθμολογίας</string>
     <string name="new_route_name">Νέο όνομα διαδρομής</string>
     <string name="save_as_new_route">Αποθήκευση ως νέα διαδρομή</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -324,6 +324,7 @@
     <string name="declare_success">Transport declared successfully</string>
     <string name="declare_failure">Failed to declare transport</string>
     <string name="rating_saved_success">Rating saved</string>
+    <string name="rating_saved_offline">Saved locally. Will sync when online</string>
     <string name="rating_save_failed">Unable to save rating</string>
     <string name="new_route_name">New route name</string>
     <string name="save_as_new_route">Save as new route</string>


### PR DESCRIPTION
## Summary
- ensure the trip rating screen always persists ratings/comments into Room and logs failures
- add a user-facing message when only a local save succeeds so feedback is not lost offline

## Testing
- ./gradlew test --console=plain --no-daemon *(fails: SDK location not found in container)*

------
https://chatgpt.com/codex/tasks/task_e_68c84d3d23c0832898a4d8f84d5ff81a