### PR TITLE
Add initialize button to wipe all database tables

### DIFF
--- a/app/src/main/java/com/ioannapergamali/mysmartroute/view/ui/screens/DatabaseMenuScreen.kt
+++ b/app/src/main/java/com/ioannapergamali/mysmartroute/view/ui/screens/DatabaseMenuScreen.kt
@@ -89,6 +89,15 @@ fun DatabaseMenuScreen(navController: NavController, openDrawer: () -> Unit) {
                 Text(stringResource(R.string.clear_data))
             }
 
+            Spacer(modifier = Modifier.height(8.dp))
+
+            Button(
+                onClick = { viewModel.clearAllTables(context) },
+                enabled = !isClearing
+            ) {
+                Text(stringResource(R.string.initialize_button))
+            }
+
             Spacer(modifier = Modifier.height(16.dp))
 
             when (val state = clearState) {

--- a/app/src/main/java/com/ioannapergamali/mysmartroute/viewmodel/DatabaseViewModel.kt
+++ b/app/src/main/java/com/ioannapergamali/mysmartroute/viewmodel/DatabaseViewModel.kt
@@ -234,6 +234,29 @@ class DatabaseViewModel : ViewModel() {
             return
         }
 
+        clearTables(
+            context = context,
+            localToClear = localToClear,
+            firebaseToClear = firebaseToClear,
+            successMessage = context.getString(R.string.clear_success)
+        )
+    }
+
+    fun clearAllTables(context: Context) {
+        clearTables(
+            context = context,
+            localToClear = localTableDefinitions,
+            firebaseToClear = firebaseTableDefinitions.map { it.collection },
+            successMessage = context.getString(R.string.initialize_success)
+        )
+    }
+
+    private fun clearTables(
+        context: Context,
+        localToClear: List<String>,
+        firebaseToClear: List<String>,
+        successMessage: String
+    ) {
         viewModelScope.launch {
             _clearState.value = ClearState.Running
             try {
@@ -241,7 +264,7 @@ class DatabaseViewModel : ViewModel() {
                 clearFirebaseCollections(firebaseToClear)
                 _localTables.update { tables -> tables.map { it.copy(selected = false) } }
                 _firebaseTables.update { tables -> tables.map { it.copy(selected = false) } }
-                _clearState.value = ClearState.Success(context.getString(R.string.clear_success))
+                _clearState.value = ClearState.Success(successMessage)
             } catch (e: Exception) {
                 Log.e(TAG, "Error clearing tables", e)
                 val reason = e.localizedMessage ?: e.message ?: ""

--- a/app/src/main/res/values-el/strings.xml
+++ b/app/src/main/res/values-el/strings.xml
@@ -68,6 +68,8 @@
     <string name="clear_success">Ο καθαρισμός ολοκληρώθηκε</string>
     <string name="clear_error_no_selection">Επιλέξτε τουλάχιστον έναν πίνακα</string>
     <string name="clear_error_generic">Αποτυχία καθαρισμού δεδομένων: %1$s</string>
+    <string name="initialize_button">Αρχικοποίηση</string>
+    <string name="initialize_success">Η αρχικοποίηση ολοκληρώθηκε</string>
     <string name="local_db">Τοπική ΒΔ</string>
     <string name="firebase_db">Firestore ΒΔ</string>
     <string name="sync_db">Συγχρονισμός</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -66,6 +66,8 @@
     <string name="clear_success">Data cleared successfully</string>
     <string name="clear_error_no_selection">Select at least one table</string>
     <string name="clear_error_generic">Failed to clear data: %1$s</string>
+    <string name="initialize_button">Initialize</string>
+    <string name="initialize_success">Initialization completed</string>
     <string name="local_db">Local DB</string>
     <string name="firebase_db">Firestore DB</string>
     <string name="sync_db">Synchronization</string>


### PR DESCRIPTION
## Summary
- add an "Initialize" action in the database menu to clear all tables in a single step
- refactor the database clearing logic into a shared helper that also drives the new initialize flow
- provide button label and success message resources in both English and Greek locales

## Testing
- ./gradlew test --console=plain --no-daemon *(fails: Android SDK is unavailable in the container)*

------
https://chatgpt.com/codex/tasks/task_e_68c84f559b1c8328abd132d0af4ee88f