### PR TITLE
Προβολή τοπικών διαδρομών πριν τον συγχρονισμό

### DIFF
--- a/app/src/main/java/com/ioannapergamali/mysmartroute/viewmodel/RouteViewModel.kt
+++ b/app/src/main/java/com/ioannapergamali/mysmartroute/viewmodel/RouteViewModel.kt
@@ -121,6 +121,8 @@ class RouteViewModel : ViewModel() {
                 }
             }.getOrDefault(emptyList())
 
+            _routes.value = localRoutes
+
             val snapshot = runCatching { query.get().await() }.getOrNull()
             if (snapshot != null) {
                 var list = snapshot.documents.mapNotNull { it.toRouteWithStations() }.toMutableList()
@@ -155,15 +157,13 @@ class RouteViewModel : ViewModel() {
                     points.forEach { pointDao.insert(it) }
                     busStations.forEach { busDao.insert(it) }
                 }
-                val localRoutes = when {
+                val updatedLocalRoutes = when {
                     includeAll -> routeDao.getAll().first()
                     userId != null -> routeDao.getRoutesForUser(userId).first()
                     else -> emptyList()
                 }
-                val combined = (list.map { it.first } + localRoutes).distinctBy { it.id }
+                val combined = (list.map { it.first } + updatedLocalRoutes).distinctBy { it.id }
                 _routes.value = combined
-            } else {
-                _routes.value = localRoutes
             }
         }
     }


### PR DESCRIPTION
## Περίληψη
- ενημέρωση του `RouteViewModel.loadRoutes` ώστε να εμφανίζει άμεσα τις διαδρομές από τη Room
- επαναχρησιμοποίηση των δεδομένων της Room μετά τον συγχρονισμό για να προστεθούν νέες διαδρομές από το Firebase

## Έλεγχοι
- ⚠️ `./gradlew :app:assembleDebug --console=plain` (αποτυχία λόγω έλλειψης Android SDK στο περιβάλλον ελέγχου)


------
https://chatgpt.com/codex/tasks/task_e_68c850fb948c8328b080f6822ec4de5e