### PR TITLE
Add offline authentication with encrypted credentials

### DIFF
--- a/app/src/main/java/com/ioannapergamali/mysmartroute/data/local/AuthenticationDao.kt
+++ b/app/src/main/java/com/ioannapergamali/mysmartroute/data/local/AuthenticationDao.kt
@@ -1,0 +1,22 @@
+package com.ioannapergamali.mysmartroute.data.local
+
+import androidx.room.Dao
+import androidx.room.Insert
+import androidx.room.OnConflictStrategy
+import androidx.room.Query
+
+/**
+ * DAO για αποθήκευση και ανάκτηση κρυπτογραφημένων διαπιστευτηρίων.
+ * DAO used to persist and retrieve encrypted credentials.
+ */
+@Dao
+interface AuthenticationDao {
+    @Insert(onConflict = OnConflictStrategy.REPLACE)
+    suspend fun upsert(entity: AuthenticationEntity)
+
+    @Query("SELECT * FROM auth_credentials WHERE email = :email LIMIT 1")
+    suspend fun findByEmail(email: String): AuthenticationEntity?
+
+    @Query("DELETE FROM auth_credentials WHERE userId = :userId")
+    suspend fun deleteByUserId(userId: String)
+}

--- a/app/src/main/java/com/ioannapergamali/mysmartroute/data/local/AuthenticationEntity.kt
+++ b/app/src/main/java/com/ioannapergamali/mysmartroute/data/local/AuthenticationEntity.kt
@@ -1,0 +1,28 @@
+package com.ioannapergamali.mysmartroute.data.local
+
+import androidx.room.Entity
+import androidx.room.ForeignKey
+import androidx.room.Index
+import androidx.room.PrimaryKey
+
+/**
+ * Οντότητα που αποθηκεύει τα διαπιστευτήρια σύνδεσης ενός χρήστη.
+ * Room entity storing encrypted credentials for offline authentication.
+ */
+@Entity(
+    tableName = "auth_credentials",
+    foreignKeys = [
+        ForeignKey(
+            entity = UserEntity::class,
+            parentColumns = ["id"],
+            childColumns = ["userId"],
+            onDelete = ForeignKey.CASCADE
+        )
+    ],
+    indices = [Index(value = ["email"], unique = true)]
+)
+data class AuthenticationEntity(
+    @PrimaryKey val userId: String,
+    val email: String,
+    val encryptedPassword: String
+)

--- a/app/src/main/java/com/ioannapergamali/mysmartroute/repository/FavoritesRepository.kt
+++ b/app/src/main/java/com/ioannapergamali/mysmartroute/repository/FavoritesRepository.kt
@@ -1,9 +1,9 @@
 package com.ioannapergamali.mysmartroute.repository
 
-import com.google.firebase.auth.FirebaseAuth
 import com.ioannapergamali.mysmartroute.data.local.MySmartRouteDatabase
 import com.ioannapergamali.mysmartroute.data.local.UserPoiEntity
 import com.ioannapergamali.mysmartroute.data.local.insertUserPoiSafely
+import com.ioannapergamali.mysmartroute.utils.SessionManager
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.flowOf
 
@@ -16,7 +16,7 @@ class FavoritesRepository(private val db: MySmartRouteDatabase) {
     private val userDao = db.userDao()
     private val poiDao = db.poIDao()
 
-    private fun userId() = FirebaseAuth.getInstance().currentUser?.uid ?: ""
+    private fun userId() = SessionManager.currentUserId() ?: ""
 
     /**
      * Αποθηκεύει ένα POI ως αγαπημένο για τον τρέχοντα χρήστη.

--- a/app/src/main/java/com/ioannapergamali/mysmartroute/repository/WalkRepository.kt
+++ b/app/src/main/java/com/ioannapergamali/mysmartroute/repository/WalkRepository.kt
@@ -4,6 +4,7 @@ import com.google.firebase.Timestamp
 import com.google.firebase.auth.FirebaseAuth
 import com.google.firebase.firestore.FieldValue
 import com.google.firebase.firestore.FirebaseFirestore
+import com.ioannapergamali.mysmartroute.utils.SessionManager
 import kotlinx.coroutines.tasks.await
 import java.util.Date
 
@@ -57,7 +58,7 @@ class WalkRepository(
      * Starts a walking session recording the time chosen by the user.
      */
     suspend fun startWalk(startTimeMillis: Long) {
-        val uid = auth.currentUser?.uid ?: return
+        val uid = SessionManager.currentUserId(auth) ?: return
 
         cleanupUserWalks(uid, startTimeMillis)
 

--- a/app/src/main/java/com/ioannapergamali/mysmartroute/utils/EncryptionManager.kt
+++ b/app/src/main/java/com/ioannapergamali/mysmartroute/utils/EncryptionManager.kt
@@ -1,0 +1,65 @@
+package com.ioannapergamali.mysmartroute.utils
+
+import android.security.keystore.KeyGenParameterSpec
+import android.security.keystore.KeyProperties
+import android.util.Base64
+import java.security.KeyStore
+import javax.crypto.Cipher
+import javax.crypto.KeyGenerator
+import javax.crypto.SecretKey
+import javax.crypto.spec.GCMParameterSpec
+
+/**
+ * Απλός διαχειριστής συμμετρικής κρυπτογράφησης με χρήση του Android Keystore.
+ * Simple AES/GCM helper backed by the Android Keystore.
+ */
+object EncryptionManager {
+    private const val ANDROID_KEY_STORE = "AndroidKeyStore"
+    private const val KEY_ALIAS = "mysmartroute_auth_key"
+    private const val TRANSFORMATION = "AES/GCM/NoPadding"
+    private const val GCM_IV_LENGTH = 12
+    private const val GCM_TAG_LENGTH = 128
+
+    private fun getOrCreateSecretKey(): SecretKey {
+        val keyStore = KeyStore.getInstance(ANDROID_KEY_STORE).apply { load(null) }
+        val existing = keyStore.getEntry(KEY_ALIAS, null) as? KeyStore.SecretKeyEntry
+        if (existing != null) return existing.secretKey
+
+        val generator = KeyGenerator.getInstance(KeyProperties.KEY_ALGORITHM_AES, ANDROID_KEY_STORE)
+        val spec = KeyGenParameterSpec.Builder(
+            KEY_ALIAS,
+            KeyProperties.PURPOSE_ENCRYPT or KeyProperties.PURPOSE_DECRYPT
+        )
+            .setBlockModes(KeyProperties.BLOCK_MODE_GCM)
+            .setEncryptionPaddings(KeyProperties.ENCRYPTION_PADDING_NONE)
+            .setRandomizedEncryptionRequired(true)
+            .build()
+        generator.init(spec)
+        return generator.generateKey()
+    }
+
+    fun encrypt(plainText: String): String {
+        if (plainText.isEmpty()) return plainText
+        val cipher = Cipher.getInstance(TRANSFORMATION)
+        cipher.init(Cipher.ENCRYPT_MODE, getOrCreateSecretKey())
+        val iv = cipher.iv
+        val cipherBytes = cipher.doFinal(plainText.toByteArray(Charsets.UTF_8))
+        val combined = ByteArray(iv.size + cipherBytes.size)
+        System.arraycopy(iv, 0, combined, 0, iv.size)
+        System.arraycopy(cipherBytes, 0, combined, iv.size, cipherBytes.size)
+        return Base64.encodeToString(combined, Base64.NO_WRAP)
+    }
+
+    fun decrypt(cipherText: String): String {
+        if (cipherText.isEmpty()) return cipherText
+        val data = Base64.decode(cipherText, Base64.NO_WRAP)
+        require(data.size > GCM_IV_LENGTH) { "Κρυπτογραφημένα δεδομένα μη έγκυρα" }
+        val iv = data.copyOfRange(0, GCM_IV_LENGTH)
+        val encrypted = data.copyOfRange(GCM_IV_LENGTH, data.size)
+        val cipher = Cipher.getInstance(TRANSFORMATION)
+        val spec = GCMParameterSpec(GCM_TAG_LENGTH, iv)
+        cipher.init(Cipher.DECRYPT_MODE, getOrCreateSecretKey(), spec)
+        val decoded = cipher.doFinal(encrypted)
+        return String(decoded, Charsets.UTF_8)
+    }
+}

--- a/app/src/main/java/com/ioannapergamali/mysmartroute/utils/SessionManager.kt
+++ b/app/src/main/java/com/ioannapergamali/mysmartroute/utils/SessionManager.kt
@@ -1,0 +1,27 @@
+package com.ioannapergamali.mysmartroute.utils
+
+import com.google.firebase.auth.FirebaseAuth
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+
+/**
+ * Απλός διαχειριστής που κρατά τοπικά το αναγνωριστικό χρήστη όταν δεν υπάρχει σύνδεση.
+ * Keeps track of the authenticated user id when FirebaseAuth is unavailable offline.
+ */
+object SessionManager {
+    private val offlineUserId = MutableStateFlow<String?>(null)
+
+    val userIdFlow: StateFlow<String?> = offlineUserId
+
+    fun currentUserId(auth: FirebaseAuth): String? = auth.currentUser?.uid ?: offlineUserId.value
+
+    fun currentUserId(): String? = currentUserId(FirebaseAuth.getInstance())
+
+    fun setOfflineUser(userId: String?) {
+        offlineUserId.value = userId
+    }
+
+    fun clear() {
+        offlineUserId.value = null
+    }
+}

--- a/app/src/main/java/com/ioannapergamali/mysmartroute/view/ui/components/TopBar.kt
+++ b/app/src/main/java/com/ioannapergamali/mysmartroute/view/ui/components/TopBar.kt
@@ -33,7 +33,6 @@ import com.ioannapergamali.mysmartroute.utils.LanguagePreferenceManager
 import com.ioannapergamali.mysmartroute.utils.LocaleUtils
 import com.ioannapergamali.mysmartroute.model.AppLanguage
 import kotlinx.coroutines.launch
-import com.google.firebase.auth.FirebaseAuth
 import com.ioannapergamali.mysmartroute.viewmodel.AppDateTimeViewModel
 import java.text.SimpleDateFormat
 import java.util.Date
@@ -43,6 +42,7 @@ import com.ioannapergamali.mysmartroute.viewmodel.SettingsViewModel
 import com.ioannapergamali.mysmartroute.viewmodel.AuthenticationViewModel
 import com.ioannapergamali.mysmartroute.viewmodel.VehicleRequestViewModel
 import com.ioannapergamali.mysmartroute.model.enumerations.UserRole
+import com.ioannapergamali.mysmartroute.utils.SessionManager
 
 private const val TAG = "TopBar"
 
@@ -88,7 +88,7 @@ fun TopBar(
         }
     }
 
-    val userId = FirebaseAuth.getInstance().currentUser?.uid
+    val userId = SessionManager.currentUserId()
     val isLoggedIn = userId != null
 
     val logoutAction = {

--- a/app/src/main/java/com/ioannapergamali/mysmartroute/view/ui/screens/AnnounceTransportScreen.kt
+++ b/app/src/main/java/com/ioannapergamali/mysmartroute/view/ui/screens/AnnounceTransportScreen.kt
@@ -46,7 +46,6 @@ import com.ioannapergamali.mysmartroute.data.local.VehicleEntity
 import com.ioannapergamali.mysmartroute.data.local.PoIEntity
 import com.ioannapergamali.mysmartroute.data.local.TransportDeclarationDetailEntity
 import kotlinx.coroutines.launch
-import com.google.firebase.auth.FirebaseAuth
 import com.ioannapergamali.mysmartroute.model.classes.poi.PoiAddress
 import com.ioannapergamali.mysmartroute.utils.MapsUtils
 import com.ioannapergamali.mysmartroute.utils.offsetPois
@@ -64,6 +63,7 @@ import androidx.compose.material3.TimePicker
 import androidx.compose.material3.rememberTimePickerState
 import androidx.compose.material3.FilledIconButton
 import com.google.android.libraries.places.api.model.Place
+import com.ioannapergamali.mysmartroute.utils.SessionManager
 
 private fun iconForVehicle(type: VehicleType): ImageVector = when (type) {
     VehicleType.CAR, VehicleType.TAXI -> Icons.Default.DirectionsCar
@@ -255,7 +255,7 @@ fun AnnounceTransportScreen(navController: NavController, openDrawer: () -> Unit
             selectedDriverId = null
             selectedDriverName = ""
         } else {
-            val uid = FirebaseAuth.getInstance().currentUser?.uid
+            val uid = SessionManager.currentUserId()
             if (uid != null) {
                 selectedDriverId = uid
                 selectedDriverName = userViewModel.getUserName(context, uid)
@@ -271,7 +271,7 @@ fun AnnounceTransportScreen(navController: NavController, openDrawer: () -> Unit
 
     LaunchedEffect(role, drivers) {
         if (role != UserRole.ADMIN && selectedDriverName.isBlank()) {
-            val uid = FirebaseAuth.getInstance().currentUser?.uid
+            val uid = SessionManager.currentUserId()
             if (uid != null) {
                 selectedDriverId = uid
                 selectedDriverName = userViewModel.getUserName(context, uid)

--- a/app/src/main/java/com/ioannapergamali/mysmartroute/view/ui/screens/BookSeatScreen.kt
+++ b/app/src/main/java/com/ioannapergamali/mysmartroute/view/ui/screens/BookSeatScreen.kt
@@ -73,8 +73,8 @@ import java.time.format.DateTimeFormatter
 import kotlin.math.abs
 import androidx.compose.ui.graphics.Color
 import androidx.annotation.StringRes
-import com.google.firebase.auth.FirebaseAuth
 import com.google.firebase.firestore.FirebaseFirestore
+import com.ioannapergamali.mysmartroute.utils.SessionManager
 import kotlinx.coroutines.tasks.await
 
 private const val MARKER_ORANGE = BitmapDescriptorFactory.HUE_ORANGE
@@ -186,7 +186,7 @@ fun BookSeatScreen(
         val original = originalPoiIds.toSet()
         if (current == original) return currentRouteId to false
 
-        val uid = FirebaseAuth.getInstance().currentUser?.uid ?: return "" to false
+        val uid = SessionManager.currentUserId() ?: return "" to false
         val username = FirebaseFirestore.getInstance()
             .collection("users")
             .document(uid)

--- a/app/src/main/java/com/ioannapergamali/mysmartroute/view/ui/screens/NotificationsScreen.kt
+++ b/app/src/main/java/com/ioannapergamali/mysmartroute/view/ui/screens/NotificationsScreen.kt
@@ -18,7 +18,6 @@ import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.res.stringResource
 import androidx.lifecycle.viewmodel.compose.viewModel
 import androidx.navigation.NavController
-import com.google.firebase.auth.FirebaseAuth
 import com.ioannapergamali.mysmartroute.R
 import com.ioannapergamali.mysmartroute.model.enumerations.UserRole
 import com.ioannapergamali.mysmartroute.view.ui.components.ScreenContainer
@@ -26,6 +25,7 @@ import com.ioannapergamali.mysmartroute.view.ui.components.TopBar
 import com.ioannapergamali.mysmartroute.viewmodel.AuthenticationViewModel
 import com.ioannapergamali.mysmartroute.viewmodel.VehicleRequestViewModel
 import com.ioannapergamali.mysmartroute.viewmodel.UserViewModel
+import com.ioannapergamali.mysmartroute.utils.SessionManager
 
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable
@@ -36,7 +36,7 @@ fun NotificationsScreen(navController: NavController, openDrawer: () -> Unit) {
     val userViewModel: UserViewModel = viewModel()
     val role by authViewModel.currentUserRole.collectAsState()
     val requests by requestViewModel.requests.collectAsState()
-    val userId = FirebaseAuth.getInstance().currentUser?.uid ?: ""
+    val userId = SessionManager.currentUserId() ?: ""
     val systemNotifications by userViewModel.getNotifications(context, userId).collectAsState(emptyList())
 
     LaunchedEffect(Unit) {

--- a/app/src/main/java/com/ioannapergamali/mysmartroute/view/ui/screens/PrepareCompleteRouteScreen.kt
+++ b/app/src/main/java/com/ioannapergamali/mysmartroute/view/ui/screens/PrepareCompleteRouteScreen.kt
@@ -40,8 +40,7 @@ import kotlinx.coroutines.flow.firstOrNull
 import com.ioannapergamali.mysmartroute.viewmodel.PoIViewModel
 import com.ioannapergamali.mysmartroute.viewmodel.AuthenticationViewModel
 import com.ioannapergamali.mysmartroute.model.enumerations.UserRole
-import com.google.firebase.auth.FirebaseAuth
-
+import com.ioannapergamali.mysmartroute.utils.SessionManager
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable
 fun PrepareCompleteRouteScreen(navController: NavController, openDrawer: () -> Unit) {
@@ -86,7 +85,7 @@ fun PrepareCompleteRouteScreen(navController: NavController, openDrawer: () -> U
             selectedDriverId = null
             selectedDriverName = ""
         } else {
-            val uid = FirebaseAuth.getInstance().currentUser?.uid
+            val uid = SessionManager.currentUserId()
             if (uid != null) {
                 selectedDriverId = uid
                 selectedDriverName = userViewModel.getUserName(context, uid)
@@ -96,7 +95,7 @@ fun PrepareCompleteRouteScreen(navController: NavController, openDrawer: () -> U
 
     LaunchedEffect(role, drivers) {
         if (role != UserRole.ADMIN && selectedDriverName.isBlank()) {
-            val uid = FirebaseAuth.getInstance().currentUser?.uid
+            val uid = SessionManager.currentUserId()
             if (uid != null) {
                 selectedDriverId = uid
                 selectedDriverName = userViewModel.getUserName(context, uid)

--- a/app/src/main/java/com/ioannapergamali/mysmartroute/view/ui/screens/PrintCompletedScreen.kt
+++ b/app/src/main/java/com/ioannapergamali/mysmartroute/view/ui/screens/PrintCompletedScreen.kt
@@ -16,7 +16,6 @@ import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.res.stringResource
 import androidx.lifecycle.viewmodel.compose.viewModel
 import androidx.navigation.NavController
-import com.google.firebase.auth.FirebaseAuth
 import com.ioannapergamali.mysmartroute.R
 import com.ioannapergamali.mysmartroute.view.ui.components.ScreenContainer
 import com.ioannapergamali.mysmartroute.view.ui.components.TopBar
@@ -25,6 +24,7 @@ import com.ioannapergamali.mysmartroute.viewmodel.TransportDeclarationViewModel
 import java.text.SimpleDateFormat
 import java.util.Date
 import java.util.Locale
+import com.ioannapergamali.mysmartroute.utils.SessionManager
 
 @Composable
 fun PrintCompletedScreen(navController: NavController, openDrawer: () -> Unit) {
@@ -35,7 +35,7 @@ fun PrintCompletedScreen(navController: NavController, openDrawer: () -> Unit) {
     val routes by routeViewModel.routes.collectAsState()
 
     LaunchedEffect(Unit) {
-        val driverId = FirebaseAuth.getInstance().currentUser?.uid
+        val driverId = SessionManager.currentUserId()
         if (driverId != null) {
             declarationViewModel.loadDeclarations(context, driverId)
             routeViewModel.loadRoutes(context)

--- a/app/src/main/java/com/ioannapergamali/mysmartroute/view/ui/screens/PrintDeclarationsScreen.kt
+++ b/app/src/main/java/com/ioannapergamali/mysmartroute/view/ui/screens/PrintDeclarationsScreen.kt
@@ -39,7 +39,7 @@ import com.ioannapergamali.mysmartroute.view.ui.components.TopBar
 import com.ioannapergamali.mysmartroute.viewmodel.TransportDeclarationViewModel
 import com.ioannapergamali.mysmartroute.viewmodel.AuthenticationViewModel
 import com.ioannapergamali.mysmartroute.model.enumerations.UserRole
-import com.google.firebase.auth.FirebaseAuth
+import com.ioannapergamali.mysmartroute.utils.SessionManager
 import java.text.SimpleDateFormat
 import java.util.Date
 import java.util.Locale
@@ -58,7 +58,7 @@ fun PrintDeclarationsScreen(navController: NavController, openDrawer: () -> Unit
     }
 
     LaunchedEffect(role) {
-        val uid = FirebaseAuth.getInstance().currentUser?.uid
+        val uid = SessionManager.currentUserId()
         if (role == UserRole.ADMIN) {
             viewModel.loadDeclarations(context)
         } else if (role != null && uid != null) {

--- a/app/src/main/java/com/ioannapergamali/mysmartroute/view/ui/screens/PrintScheduledScreen.kt
+++ b/app/src/main/java/com/ioannapergamali/mysmartroute/view/ui/screens/PrintScheduledScreen.kt
@@ -17,7 +17,6 @@ import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.res.stringResource
 import androidx.navigation.NavController
 import androidx.lifecycle.viewmodel.compose.viewModel
-import com.google.firebase.auth.FirebaseAuth
 import com.ioannapergamali.mysmartroute.R
 import com.ioannapergamali.mysmartroute.data.local.MySmartRouteDatabase
 import com.ioannapergamali.mysmartroute.view.ui.components.ScreenContainer
@@ -30,6 +29,7 @@ import kotlinx.coroutines.flow.first
 import java.text.SimpleDateFormat
 import java.util.Date
 import java.util.Locale
+import com.ioannapergamali.mysmartroute.utils.SessionManager
 
 @Composable
 fun PrintScheduledScreen(navController: NavController, openDrawer: () -> Unit) {
@@ -43,7 +43,7 @@ fun PrintScheduledScreen(navController: NavController, openDrawer: () -> Unit) {
     val passengerNames = remember { mutableStateMapOf<String, List<String>>() }
 
     LaunchedEffect(Unit) {
-        val driverId = FirebaseAuth.getInstance().currentUser?.uid
+        val driverId = SessionManager.currentUserId()
         if (driverId != null) {
             declarationViewModel.loadDeclarations(context, driverId)
             routeViewModel.loadRoutes(context)

--- a/app/src/main/java/com/ioannapergamali/mysmartroute/view/ui/screens/RouteModeScreen.kt
+++ b/app/src/main/java/com/ioannapergamali/mysmartroute/view/ui/screens/RouteModeScreen.kt
@@ -52,9 +52,9 @@ import java.time.ZoneId
 import java.time.format.DateTimeFormatter
 import kotlin.math.abs
 import android.widget.Toast
-import com.google.firebase.auth.FirebaseAuth
 import com.google.firebase.firestore.FirebaseFirestore
 import kotlinx.coroutines.tasks.await
+import com.ioannapergamali.mysmartroute.utils.SessionManager
 
 
 @OptIn(ExperimentalMaterial3Api::class)
@@ -150,7 +150,7 @@ fun RouteModeScreen(
         val original = originalPoiIds.toSet()
         if (current == original) return currentRouteId to false
 
-        val uid = FirebaseAuth.getInstance().currentUser?.uid ?: return "" to false
+        val uid = SessionManager.currentUserId() ?: return "" to false
         val username = FirebaseFirestore.getInstance()
             .collection("users")
             .document(uid)

--- a/app/src/main/java/com/ioannapergamali/mysmartroute/viewmodel/AvailabilityViewModel.kt
+++ b/app/src/main/java/com/ioannapergamali/mysmartroute/viewmodel/AvailabilityViewModel.kt
@@ -7,6 +7,7 @@ import com.ioannapergamali.mysmartroute.data.local.AvailabilityEntity
 import com.ioannapergamali.mysmartroute.data.local.MySmartRouteDatabase
 import com.google.firebase.firestore.FirebaseFirestore
 import com.ioannapergamali.mysmartroute.utils.toFirestoreMap
+import com.ioannapergamali.mysmartroute.utils.SessionManager
 import kotlinx.coroutines.tasks.await
 import kotlinx.coroutines.launch
 import java.util.UUID
@@ -29,7 +30,7 @@ class AvailabilityViewModel : ViewModel() {
         viewModelScope.launch {
             val dao = MySmartRouteDatabase.getInstance(context).availabilityDao()
             val id = UUID.randomUUID().toString()
-            val userId = com.google.firebase.auth.FirebaseAuth.getInstance().currentUser?.uid ?: ""
+            val userId = SessionManager.currentUserId() ?: ""
             val entity = AvailabilityEntity(id, userId, date, fromTime, toTime)
             dao.insert(entity)
             try {

--- a/app/src/main/java/com/ioannapergamali/mysmartroute/viewmodel/BookingViewModel.kt
+++ b/app/src/main/java/com/ioannapergamali/mysmartroute/viewmodel/BookingViewModel.kt
@@ -12,6 +12,7 @@ import com.ioannapergamali.mysmartroute.data.local.SeatReservationDetailEntity
 import com.ioannapergamali.mysmartroute.data.local.MovingEntity
 import com.ioannapergamali.mysmartroute.data.local.MovingDetailEntity
 import com.ioannapergamali.mysmartroute.utils.toFirestoreMap
+import com.ioannapergamali.mysmartroute.utils.SessionManager
 import kotlinx.coroutines.tasks.await
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.withContext
@@ -74,7 +75,7 @@ class BookingViewModel : ViewModel() {
         declarationId: String = "",
         driverId: String = ""
     ): Result<Unit> = withContext(Dispatchers.IO) {
-        val userId = auth.currentUser?.uid
+        val userId = SessionManager.currentUserId(auth)
             ?: return@withContext Result.failure(Exception("Απαιτείται σύνδεση"))
 
         if (segments.isEmpty()) {

--- a/app/src/main/java/com/ioannapergamali/mysmartroute/viewmodel/FavoriteRoutePoisViewModel.kt
+++ b/app/src/main/java/com/ioannapergamali/mysmartroute/viewmodel/FavoriteRoutePoisViewModel.kt
@@ -3,13 +3,13 @@ package com.ioannapergamali.mysmartroute.viewmodel
 import android.content.Context
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
-import com.google.firebase.auth.FirebaseAuth
 import com.google.firebase.firestore.FirebaseFirestore
 import com.ioannapergamali.mysmartroute.data.local.MySmartRouteDatabase
 
 import com.ioannapergamali.mysmartroute.data.local.PoIEntity
 import com.ioannapergamali.mysmartroute.data.local.UserEntity
 import com.ioannapergamali.mysmartroute.data.local.UserPoiEntity
+import com.ioannapergamali.mysmartroute.utils.SessionManager
 
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.tasks.await
@@ -21,7 +21,7 @@ import kotlinx.coroutines.tasks.await
 class FavoriteRoutePoisViewModel : ViewModel() {
     private val firestore = FirebaseFirestore.getInstance()
 
-    private fun userId(): String = FirebaseAuth.getInstance().currentUser?.uid ?: ""
+    private fun userId(): String = SessionManager.currentUserId() ?: ""
 
     private fun userDoc(uid: String) = firestore.collection("users").document(uid)
 

--- a/app/src/main/java/com/ioannapergamali/mysmartroute/viewmodel/FavoriteRoutesViewModel.kt
+++ b/app/src/main/java/com/ioannapergamali/mysmartroute/viewmodel/FavoriteRoutesViewModel.kt
@@ -3,10 +3,10 @@ package com.ioannapergamali.mysmartroute.viewmodel
 import android.content.Context
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
-import com.google.firebase.auth.FirebaseAuth
 import com.google.firebase.firestore.FirebaseFirestore
 import com.ioannapergamali.mysmartroute.data.local.FavoriteRouteEntity
 import com.ioannapergamali.mysmartroute.data.local.MySmartRouteDatabase
+import com.ioannapergamali.mysmartroute.utils.SessionManager
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.first
@@ -28,7 +28,7 @@ class FavoriteRoutesViewModel : ViewModel() {
 
     private fun userDoc(uid: String) = firestore.collection("users").document(uid)
 
-    private fun userId() = FirebaseAuth.getInstance().currentUser?.uid ?: ""
+    private fun userId() = SessionManager.currentUserId() ?: ""
 
     private fun routesCollection(uid: String) =
         userDoc(uid).collection("favorites").document("data").collection("routes")

--- a/app/src/main/java/com/ioannapergamali/mysmartroute/viewmodel/FavoritesViewModel.kt
+++ b/app/src/main/java/com/ioannapergamali/mysmartroute/viewmodel/FavoritesViewModel.kt
@@ -7,8 +7,8 @@ import com.ioannapergamali.mysmartroute.model.enumerations.VehicleType
 import com.ioannapergamali.mysmartroute.data.local.MySmartRouteDatabase
 import com.ioannapergamali.mysmartroute.data.local.insertFavoriteSafely
 import com.ioannapergamali.mysmartroute.utils.toFirestoreMap
-import com.google.firebase.auth.FirebaseAuth
 import com.google.firebase.firestore.FirebaseFirestore
+import com.ioannapergamali.mysmartroute.utils.SessionManager
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.map
 import kotlinx.coroutines.launch
@@ -28,7 +28,7 @@ class FavoritesViewModel : ViewModel() {
         .document("vehicles")
         .collection("items")
 
-    private fun userId() = FirebaseAuth.getInstance().currentUser?.uid ?: ""
+    private fun userId() = SessionManager.currentUserId() ?: ""
 
     /**
      * Φορτώνει τα αγαπημένα οχήματα από το Firestore και τα συγχρονίζει με την τοπική βάση.

--- a/app/src/main/java/com/ioannapergamali/mysmartroute/viewmodel/RouteViewModel.kt
+++ b/app/src/main/java/com/ioannapergamali/mysmartroute/viewmodel/RouteViewModel.kt
@@ -3,7 +3,6 @@ package com.ioannapergamali.mysmartroute.viewmodel
 import android.content.Context
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
-import com.google.firebase.auth.FirebaseAuth
 import com.google.firebase.firestore.DocumentReference
 import com.google.firebase.firestore.FirebaseFirestore
 import android.util.Log
@@ -26,9 +25,10 @@ import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.launch
-import kotlinx.coroutines.tasks.await
 import java.util.UUID
 import kotlin.math.abs
+import kotlinx.coroutines.tasks.await
+import com.ioannapergamali.mysmartroute.utils.SessionManager
 
 /**
  * ViewModel για διαχείριση διαδρομών στο Firestore και στη Room DB.
@@ -103,7 +103,7 @@ class RouteViewModel : ViewModel() {
             val routeDao = db.routeDao()
             val pointDao = db.routePointDao()
             val busDao = db.routeBusStationDao()
-            val userId = FirebaseAuth.getInstance().currentUser?.uid
+            val userId = SessionManager.currentUserId()
 
             val query = if (includeAll) {
                 firestore.collection("routes")
@@ -222,7 +222,7 @@ class RouteViewModel : ViewModel() {
      */
     fun loadUserWalkingRoutes() {
         viewModelScope.launch {
-            val userId = FirebaseAuth.getInstance().currentUser?.uid ?: return@launch
+            val userId = SessionManager.currentUserId() ?: return@launch
             val snapshot = runCatching {
                 firestore.collection("users")
                     .document(userId)
@@ -302,7 +302,7 @@ class RouteViewModel : ViewModel() {
 
         val pointDao = db.routePointDao()
         val busDao = db.routeBusStationDao()
-        val userId = FirebaseAuth.getInstance().currentUser?.uid ?: return null
+        val userId = SessionManager.currentUserId() ?: return null
         val id = UUID.randomUUID().toString()
         val entity = RouteEntity(id, userId, name, poiIds.first(), poiIds.last())
         val points = poiIds.mapIndexed { index, p -> RoutePointEntity(id, index, p) }

--- a/app/src/main/java/com/ioannapergamali/mysmartroute/viewmodel/SettingsViewModel.kt
+++ b/app/src/main/java/com/ioannapergamali/mysmartroute/viewmodel/SettingsViewModel.kt
@@ -21,6 +21,7 @@ import com.ioannapergamali.mysmartroute.model.interfaces.ThemeOption
 import com.ioannapergamali.mysmartroute.utils.SoundPreferenceManager
 import com.ioannapergamali.mysmartroute.utils.LanguagePreferenceManager
 import com.ioannapergamali.mysmartroute.utils.LocaleUtils
+import com.ioannapergamali.mysmartroute.utils.SessionManager
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.withContext
@@ -42,7 +43,7 @@ class SettingsViewModel : ViewModel() {
         context: Context,
         transform: (SettingsEntity) -> SettingsEntity
     ) {
-        val userId = auth.currentUser?.uid
+        val userId = SessionManager.currentUserId(auth)
         if (userId == null) {
             val message = "Δεν βρέθηκε χρήστης"
             Log.w("SettingsViewModel", message)
@@ -205,7 +206,7 @@ class SettingsViewModel : ViewModel() {
      */
     fun syncSettings(context: Context) {
         viewModelScope.launch {
-            val userId = auth.currentUser?.uid ?: return@launch
+            val userId = SessionManager.currentUserId(auth) ?: return@launch
             val dbLocal = MySmartRouteDatabase.getInstance(context)
             val userDao = dbLocal.userDao()
             if (userDao.getUser(userId) == null) {
@@ -268,7 +269,7 @@ class SettingsViewModel : ViewModel() {
 
             // Αν δεν υπάρχει συνδεδεμένος χρήστης, αποθηκεύουμε μόνο τοπικά
             // If no user is logged in, save only locally
-            if (auth.currentUser?.uid == null) {
+            if (SessionManager.currentUserId(auth) == null) {
                 ThemePreferenceManager.setTheme(context, theme)
                 ThemePreferenceManager.setDarkTheme(context, dark)
                 FontPreferenceManager.setFont(context, font)

--- a/app/src/main/java/com/ioannapergamali/mysmartroute/viewmodel/TransferRequestViewModel.kt
+++ b/app/src/main/java/com/ioannapergamali/mysmartroute/viewmodel/TransferRequestViewModel.kt
@@ -13,6 +13,7 @@ import com.ioannapergamali.mysmartroute.data.local.MySmartRouteDatabase
 import com.ioannapergamali.mysmartroute.data.local.TransferRequestEntity
 import com.ioannapergamali.mysmartroute.model.enumerations.RequestStatus
 import com.ioannapergamali.mysmartroute.utils.toFirestoreMap
+import com.ioannapergamali.mysmartroute.utils.SessionManager
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.tasks.await
@@ -44,7 +45,7 @@ class TransferRequestViewModel : ViewModel() {
         cost: Double?,
         poiChanged: Boolean = false,
     ) {
-        val passengerId = auth.currentUser?.uid ?: return
+        val passengerId = SessionManager.currentUserId(auth) ?: return
         viewModelScope.launch(Dispatchers.IO) {
             val dbInstance = MySmartRouteDatabase.getInstance(context)
             val transferDao = dbInstance.transferRequestDao()
@@ -167,7 +168,7 @@ class TransferRequestViewModel : ViewModel() {
      * Notifies the driver that they have taken a transfer request.
      */
     fun notifyDriver(context: Context, requestNumber: Int) {
-        val driverId = auth.currentUser?.uid ?: return
+        val driverId = SessionManager.currentUserId(auth) ?: return
         viewModelScope.launch(Dispatchers.IO) {
             val dbInstance = MySmartRouteDatabase.getInstance(context)
             val dao = dbInstance.transferRequestDao()

--- a/app/src/main/java/com/ioannapergamali/mysmartroute/viewmodel/TripRatingViewModel.kt
+++ b/app/src/main/java/com/ioannapergamali/mysmartroute/viewmodel/TripRatingViewModel.kt
@@ -10,6 +10,7 @@ import com.ioannapergamali.mysmartroute.data.local.MySmartRouteDatabase
 import com.ioannapergamali.mysmartroute.data.local.TripRatingEntity
 import com.ioannapergamali.mysmartroute.model.classes.transports.TripWithRating
 import com.ioannapergamali.mysmartroute.repository.TripRatingRepository
+import com.ioannapergamali.mysmartroute.utils.SessionManager
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.combine
@@ -29,7 +30,7 @@ class TripRatingViewModel : ViewModel() {
 
     fun loadTrips(context: Context) {
         viewModelScope.launch {
-            val userId = auth.currentUser?.uid ?: run {
+            val userId = SessionManager.currentUserId(auth) ?: run {
                 _trips.value = emptyList()
                 return@launch
             }

--- a/app/src/main/java/com/ioannapergamali/mysmartroute/viewmodel/UserReservationsViewModel.kt
+++ b/app/src/main/java/com/ioannapergamali/mysmartroute/viewmodel/UserReservationsViewModel.kt
@@ -8,6 +8,7 @@ import com.google.firebase.firestore.FirebaseFirestore
 import com.ioannapergamali.mysmartroute.data.local.MySmartRouteDatabase
 import com.ioannapergamali.mysmartroute.data.local.SeatReservationEntity
 import com.ioannapergamali.mysmartroute.utils.NetworkUtils
+import com.ioannapergamali.mysmartroute.utils.SessionManager
 import com.ioannapergamali.mysmartroute.utils.toSeatReservationEntity
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
@@ -32,7 +33,7 @@ class UserReservationsViewModel : ViewModel() {
      */
     fun load(context: Context) {
         viewModelScope.launch {
-            val userId = auth.currentUser?.uid ?: return@launch
+            val userId = SessionManager.currentUserId(auth) ?: return@launch
             val dao = MySmartRouteDatabase.getInstance(context).seatReservationDao()
             _reservations.value = dao.getReservationsForUser(userId).first()
 

--- a/app/src/main/java/com/ioannapergamali/mysmartroute/viewmodel/UserViewModel.kt
+++ b/app/src/main/java/com/ioannapergamali/mysmartroute/viewmodel/UserViewModel.kt
@@ -3,7 +3,6 @@ package com.ioannapergamali.mysmartroute.viewmodel
 import android.content.Context
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
-import com.google.firebase.auth.FirebaseAuth
 import com.google.firebase.firestore.DocumentReference
 import com.google.firebase.firestore.FirebaseFirestore
 import com.ioannapergamali.mysmartroute.data.local.MySmartRouteDatabase
@@ -16,6 +15,7 @@ import com.ioannapergamali.mysmartroute.utils.toFirestoreMap
 import com.ioannapergamali.mysmartroute.model.enumerations.UserRole
 import com.ioannapergamali.mysmartroute.utils.NetworkUtils
 import com.ioannapergamali.mysmartroute.utils.toUserEntity
+import com.ioannapergamali.mysmartroute.utils.SessionManager
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.first
@@ -169,7 +169,7 @@ class UserViewModel : ViewModel() {
             if (oldRole == UserRole.PASSENGER && newRole == UserRole.DRIVER) {
                 handlePassengerPromotion(dbInstance, userId)
             }
-            if (FirebaseAuth.getInstance().currentUser?.uid == userId) {
+            if (SessionManager.currentUserId() == userId) {
                 authViewModel?.loadCurrentUserRole(context, loadMenus = true)
             }
         }

--- a/app/src/main/java/com/ioannapergamali/mysmartroute/viewmodel/VehicleRequestViewModel.kt
+++ b/app/src/main/java/com/ioannapergamali/mysmartroute/viewmodel/VehicleRequestViewModel.kt
@@ -7,7 +7,6 @@ import android.util.Log
 import android.widget.Toast
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
-import com.google.firebase.auth.FirebaseAuth
 import com.google.firebase.firestore.FirebaseFirestore
 import com.google.firebase.Timestamp
 import com.ioannapergamali.mysmartroute.data.local.MovingEntity
@@ -39,6 +38,7 @@ import java.util.UUID
 import com.google.android.gms.maps.model.LatLng
 import com.ioannapergamali.mysmartroute.model.enumerations.VehicleType
 import com.ioannapergamali.mysmartroute.utils.MapsUtils
+import com.ioannapergamali.mysmartroute.utils.SessionManager
 
 data class PassengerRequest(
     val passengerId: String,
@@ -93,7 +93,7 @@ class VehicleRequestViewModel(
             val routeDao = dbInstance.routeDao()
             val userDao = dbInstance.userDao()
             val vehicleDao = dbInstance.vehicleDao()
-            val userId = FirebaseAuth.getInstance().currentUser?.uid
+            val userId = SessionManager.currentUserId()
 
             val local: List<TransferRequestEntity> = if (allUsers) {
                 dao.getAll().first()
@@ -192,7 +192,7 @@ class VehicleRequestViewModel(
      */
     fun loadPassengerMovings(context: Context, allUsers: Boolean = false) {
         viewModelScope.launch {
-            val uid = FirebaseAuth.getInstance().currentUser?.uid
+            val uid = SessionManager.currentUserId()
                 ?: return@launch
             val dbInstance = MySmartRouteDatabase.getInstance(context)
             val dao = dbInstance.movingDao()
@@ -277,7 +277,7 @@ class VehicleRequestViewModel(
         viewModelScope.launch {
             val dbInstance = MySmartRouteDatabase.getInstance(context)
             val dao = dbInstance.movingDao()
-            val userId = FirebaseAuth.getInstance().currentUser?.uid ?: return@launch
+            val userId = SessionManager.currentUserId() ?: return@launch
             val id = UUID.randomUUID().toString()
             val entity = MovingEntity(
                 id = id,
@@ -318,7 +318,7 @@ class VehicleRequestViewModel(
         walkDurationMinutes: Int
     ) {
         viewModelScope.launch {
-            val userId = FirebaseAuth.getInstance().currentUser?.uid ?: return@launch
+            val userId = SessionManager.currentUserId() ?: return@launch
             val id = UUID.randomUUID().toString()
             val routeRef = db.collection("routes").document(routeId)
             val data = mapOf(
@@ -342,7 +342,7 @@ class VehicleRequestViewModel(
      * Marks notifications as read.
      */
     fun markNotificationsRead(allUsers: Boolean) {
-        val userId = FirebaseAuth.getInstance().currentUser?.uid
+        val userId = SessionManager.currentUserId()
         val notifications = if (allUsers) {
             _requests.value.filter {
                 (it.driverId.isBlank() && it.status.isBlank()) ||
@@ -680,7 +680,7 @@ class VehicleRequestViewModel(
     }
 
     private suspend fun showAcceptedNotifications(context: Context) {
-        val userId = FirebaseAuth.getInstance().currentUser?.uid ?: return
+        val userId = SessionManager.currentUserId() ?: return
         _requests.value.filter { it.status == "accepted" && it.driverId == userId && it.id !in notifiedRequests }
             .forEach { req ->
                 val intent = Intent(context, MainActivity::class.java).apply {
@@ -705,7 +705,7 @@ class VehicleRequestViewModel(
     }
 
     private suspend fun showRejectedNotifications(context: Context) {
-        val userId = FirebaseAuth.getInstance().currentUser?.uid ?: return
+        val userId = SessionManager.currentUserId() ?: return
         _requests.value.filter { it.status == "rejected" && it.driverId == userId && it.id !in notifiedRequests }
             .forEach { req ->
                 val intent = Intent(context, MainActivity::class.java).apply {

--- a/app/src/main/java/com/ioannapergamali/mysmartroute/viewmodel/VehicleViewModel.kt
+++ b/app/src/main/java/com/ioannapergamali/mysmartroute/viewmodel/VehicleViewModel.kt
@@ -17,6 +17,7 @@ import com.ioannapergamali.mysmartroute.model.classes.vehicles.RemoteVehicle
 import com.ioannapergamali.mysmartroute.utils.toVehicleEntity
 import com.ioannapergamali.mysmartroute.R
 import com.ioannapergamali.mysmartroute.repository.VehicleRepository
+import com.ioannapergamali.mysmartroute.utils.SessionManager
 import kotlinx.coroutines.tasks.await
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
@@ -66,7 +67,7 @@ class VehicleViewModel : ViewModel() {
             Log.d(TAG, "Έναρξη καταχώρησης οχήματος $name τύπος=$type")
             _registerState.value = RegisterState.Loading
 
-            val userId = auth.currentUser?.uid
+            val userId = SessionManager.currentUserId(auth)
             if (userId == null) {
                 _registerState.value = RegisterState.Error(
                     context.getString(R.string.user_not_logged_in)
@@ -148,7 +149,7 @@ class VehicleViewModel : ViewModel() {
         userId: String? = null
     ) {
         val repo = getRepository(context)
-        val uid = userId ?: auth.currentUser?.uid
+        val uid = userId ?: SessionManager.currentUserId(auth)
         vehiclesJob?.cancel()
         vehiclesJob = viewModelScope.launch {
             when {


### PR DESCRIPTION
## Summary
- add a Room authentication table and migration to store encrypted user credentials
- introduce an EncryptionManager and SessionManager to manage encrypted credentials and offline sessions
- update authentication logic, repositories, viewmodels, and key UI components to rely on the encrypted credentials when offline

## Testing
- ./gradlew lint --console=plain *(fails: SDK location not found in container)*

------
https://chatgpt.com/codex/tasks/task_e_68c84e811aa48328ada5df1c5500287c