### PR TITLE
Remove databases option from navigation drawer

### DIFF
--- a/app/src/main/java/com/ioannapergamali/mysmartroute/view/ui/components/NavigationDrawer.kt
+++ b/app/src/main/java/com/ioannapergamali/mysmartroute/view/ui/components/NavigationDrawer.kt
@@ -5,7 +5,6 @@ import androidx.compose.material.icons.filled.Info
 import androidx.compose.material.icons.filled.Email
 import androidx.compose.material.icons.filled.ExitToApp
 import androidx.compose.material.icons.filled.Logout
-import androidx.compose.material.icons.filled.Storage
 import androidx.compose.material.icons.filled.AdminPanelSettings
 import androidx.compose.material.icons.filled.Person
 import androidx.compose.material.icons.filled.Login
@@ -111,15 +110,6 @@ fun DrawerMenu(navController: NavController, closeDrawer: () -> Unit) {
                 closeDrawer()
             },
             icon = { Icon(Icons.Filled.Email, contentDescription = null, tint = MaterialTheme.colorScheme.primary) }
-        )
-        NavigationDrawerItem(
-            label = { Text(stringResource(R.string.databases_title)) },
-            selected = false,
-            onClick = {
-                navController.navigate("databaseMenu")
-                closeDrawer()
-            },
-            icon = { Icon(Icons.Filled.Storage, contentDescription = null, tint = MaterialTheme.colorScheme.primary) }
         )
         NavigationDrawerItem(
             label = { Text(stringResource(R.string.admin_option)) },


### PR DESCRIPTION
## Summary
- Κατάργησα την επιλογή "Βάσεις Δεδομένων" από το πλαϊνό μενού
- Αφαίρεσα την αχρησιμοποίητη εισαγωγή του εικονιδίου αποθήκευσης

## Testing
- ./gradlew lint --console=plain *(αποτυχία: λείπει Android SDK στο περιβάλλον build)*

------
https://chatgpt.com/codex/tasks/task_e_68c856126c2c832890bc8348f4256181