### PR TITLE
Implement progressive system initialization cleanup

### DIFF
--- a/app/src/main/java/com/ioannapergamali/mysmartroute/view/ui/screens/DatabaseMenuScreen.kt
+++ b/app/src/main/java/com/ioannapergamali/mysmartroute/view/ui/screens/DatabaseMenuScreen.kt
@@ -101,6 +101,16 @@ fun DatabaseMenuScreen(navController: NavController, openDrawer: () -> Unit) {
             Spacer(modifier = Modifier.height(16.dp))
 
             when (val state = clearState) {
+                is ClearState.Running -> {
+                    state.message?.takeIf { it.isNotBlank() }?.let { message ->
+                        Text(
+                            text = message,
+                            style = MaterialTheme.typography.bodyMedium,
+                            color = MaterialTheme.colorScheme.secondary
+                        )
+                    }
+                }
+
                 is ClearState.Success -> {
                     Text(
                         text = state.message,
@@ -162,7 +172,7 @@ private fun TableSelectionRow(
             text = table.title,
             style = MaterialTheme.typography.bodyLarge,
             modifier = Modifier.weight(1f),
-            maxLines = 1
+            maxLines = 2
         )
         Switch(
             checked = table.selected,

--- a/app/src/main/res/values-el/strings.xml
+++ b/app/src/main/res/values-el/strings.xml
@@ -68,6 +68,7 @@
     <string name="clear_success">Ο καθαρισμός ολοκληρώθηκε</string>
     <string name="clear_error_no_selection">Επιλέξτε τουλάχιστον έναν πίνακα</string>
     <string name="clear_error_generic">Αποτυχία καθαρισμού δεδομένων: %1$s</string>
+    <string name="clear_progress_message">Διαγράφεται: %1$s\nDeleting: %2$s</string>
     <string name="initialize_button">Αρχικοποίηση</string>
     <string name="initialize_success">Η αρχικοποίηση ολοκληρώθηκε</string>
     <string name="local_db">Τοπική ΒΔ</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -66,6 +66,7 @@
     <string name="clear_success">Data cleared successfully</string>
     <string name="clear_error_no_selection">Select at least one table</string>
     <string name="clear_error_generic">Failed to clear data: %1$s</string>
+    <string name="clear_progress_message">Διαγράφεται: %1$s\nDeleting: %2$s</string>
     <string name="initialize_button">Initialize</string>
     <string name="initialize_success">Initialization completed</string>
     <string name="local_db">Local DB</string>


### PR DESCRIPTION
## Summary
- keep the signed-in administrator when clearing Room and Firebase data and emit bilingual progress updates for every table
- surface Greek/English labels for all database tables in the menu UI and progress state
- add a reusable bilingual progress string shared by both locale resource sets

## Testing
- `./gradlew lint --console=plain` *(fails: Android SDK not installed in container)*

------
https://chatgpt.com/codex/tasks/task_e_68c855d7f48c8328a0c047aeaebbadf8