### PR TITLE
Fix unresolved collectAsState import in navigation drawer

### DIFF
--- a/app/src/main/java/com/ioannapergamali/mysmartroute/view/ui/components/NavigationDrawer.kt
+++ b/app/src/main/java/com/ioannapergamali/mysmartroute/view/ui/components/NavigationDrawer.kt
@@ -24,6 +24,8 @@ import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.DisposableEffect
 import androidx.compose.runtime.rememberCoroutineScope
+import androidx.compose.runtime.collectAsState
+import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.unit.dp


### PR DESCRIPTION
## Summary
- add the missing Compose runtime imports needed by the navigation drawer

## Testing
- ./gradlew :app:compileDebugKotlin *(fails: Android SDK not present in container)*

------
https://chatgpt.com/codex/tasks/task_e_68c85855fd308328a5218dc05ea296ec