### PR TITLE
Fix Compose State delegate import

### DIFF
--- a/app/src/main/java/com/ioannapergamali/mysmartroute/view/ui/components/NavigationDrawer.kt
+++ b/app/src/main/java/com/ioannapergamali/mysmartroute/view/ui/components/NavigationDrawer.kt
@@ -26,6 +26,7 @@ import androidx.compose.runtime.DisposableEffect
 import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.getValue
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.unit.dp


### PR DESCRIPTION
## Summary
- import the Compose `getValue` extension to allow using `State` as a property delegate in `NavigationDrawer`

## Testing
- `./gradlew :app:compileDebugKotlin` *(fails: SDK location not found in this environment)*

------
https://chatgpt.com/codex/tasks/task_e_68c85b135774832887ee95fccfc98949