### PR TITLE
Fix syncDatabases block braces

### DIFF
--- a/app/src/main/java/com/ioannapergamali/mysmartroute/viewmodel/DatabaseViewModel.kt
+++ b/app/src/main/java/com/ioannapergamali/mysmartroute/viewmodel/DatabaseViewModel.kt
@@ -1116,7 +1116,6 @@ class DatabaseViewModel : ViewModel() {
                     prefs.edit().putLong("last_sync", newTs).apply()
                     _lastSyncTime.value = newTs
                 }
-                }
                 _syncState.value = SyncState.Success
             } catch (e: TimeoutCancellationException) {
                 Log.e(TAG, "Sync timeout", e)


### PR DESCRIPTION
## Summary
- remove an extra closing brace left in the syncDatabases suspend function so the Kotlin file parses correctly

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68c85f62aac083288f6d955f6c748583