### PR TITLE
Διόρθωση κλεισίματος του withTimeout στο DatabaseViewModel

### DIFF
--- a/app/src/main/java/com/ioannapergamali/mysmartroute/viewmodel/DatabaseViewModel.kt
+++ b/app/src/main/java/com/ioannapergamali/mysmartroute/viewmodel/DatabaseViewModel.kt
@@ -1116,16 +1116,16 @@ class DatabaseViewModel : ViewModel() {
                     prefs.edit().putLong("last_sync", newTs).apply()
                     _lastSyncTime.value = newTs
                 }
-                _syncState.value = SyncState.Success
-            } catch (e: TimeoutCancellationException) {
-                Log.e(TAG, "Sync timeout", e)
-                _syncState.value = SyncState.Error("Sync timeout")
-            } catch (e: Exception) {
-                Log.e(TAG, "Sync error", e)
-                _syncState.value = SyncState.Error(
-                    e.localizedMessage ?: "Sync failed"
-                )
             }
+            _syncState.value = SyncState.Success
+        } catch (e: TimeoutCancellationException) {
+            Log.e(TAG, "Sync timeout", e)
+            _syncState.value = SyncState.Error("Sync timeout")
+        } catch (e: Exception) {
+            Log.e(TAG, "Sync error", e)
+            _syncState.value = SyncState.Error(
+                e.localizedMessage ?: "Sync failed"
+            )
         } finally {
             if (_syncState.value !is SyncState.Loading) {
                 updateSyncMessage(null)


### PR DESCRIPTION
## Summary
- έκλεισα σωστά το μπλοκ `withTimeout` πριν από την ενημέρωση της κατάστασης συγχρονισμού στο `DatabaseViewModel`
- ευθυγράμμισα τα τμήματα `catch`/`finally` ώστε να εκτελούνται εκτός του `withTimeout`

## Testing
- ⚠️ `./gradlew :app:compileDebugKotlin --no-daemon --console=plain` (αποτυχία γιατί δεν υπάρχει εγκατεστημένο Android SDK στο περιβάλλον)


------
https://chatgpt.com/codex/tasks/task_e_68c86121cc2c8328bba0004c24ef2bb6