### PR TITLE
Διόρθωση κλεισίματος DatabaseViewModel

### DIFF
--- a/app/src/main/java/com/ioannapergamali/mysmartroute/viewmodel/DatabaseViewModel.kt
+++ b/app/src/main/java/com/ioannapergamali/mysmartroute/viewmodel/DatabaseViewModel.kt
@@ -1173,6 +1173,8 @@ class DatabaseViewModel : ViewModel() {
         else -> tableId.replace('_', ' ').replaceFirstChar { if (it.isLowerCase()) it.titlecase(Locale.getDefault()) else it.toString() }
     }
 
+}
+
 data class TableToggleState(
     val id: String,
     val title: String,


### PR DESCRIPTION
## Summary
- προστέθηκε το κλείσιμο της κλάσης `DatabaseViewModel` πριν από τις δηλώσεις των καθολικών data/ sealed classes

## Testing
- ./gradlew :app:compileDebugKotlin --console=plain --no-daemon *(απέτυχε: λείπει Android SDK στο περιβάλλον του CI)*

------
https://chatgpt.com/codex/tasks/task_e_68c8661cd2908328822f78aa522db716