### PR TITLE
Fix Firebase data loading dependencies

### DIFF
--- a/app/src/main/java/com/ioannapergamali/mysmartroute/view/ui/screens/DatabaseSyncScreen.kt
+++ b/app/src/main/java/com/ioannapergamali/mysmartroute/view/ui/screens/DatabaseSyncScreen.kt
@@ -39,7 +39,7 @@ import androidx.compose.ui.unit.dp
 import androidx.lifecycle.viewmodel.compose.viewModel
 import androidx.navigation.NavController
 import com.ioannapergamali.mysmartroute.R
-import com.ioannapergamali.mysmartroute.data.local.DatabaseData
+import com.ioannapergamali.mysmartroute.viewmodel.DatabaseData
 import com.ioannapergamali.mysmartroute.data.local.FavoriteEntity
 import com.ioannapergamali.mysmartroute.data.local.FavoriteRouteEntity
 import com.ioannapergamali.mysmartroute.data.local.LanguageSettingEntity
@@ -86,7 +86,7 @@ fun DatabaseSyncScreen(navController: NavController, openDrawer: () -> Unit) {
     LaunchedEffect(selectedTab) {
         when (selectedTab) {
             SyncTab.LOCAL -> viewModel.loadLocalData(context)
-            SyncTab.FIRESTORE -> viewModel.loadFirebaseData()
+            SyncTab.FIRESTORE -> viewModel.loadFirebaseData(context)
             SyncTab.SYNC -> Unit
         }
     }
@@ -123,7 +123,7 @@ fun DatabaseSyncScreen(navController: NavController, openDrawer: () -> Unit) {
                         data = firebaseData,
                         emptyMessage = stringResource(R.string.sync_empty_table),
                         refreshLabel = stringResource(R.string.sync_reload_firestore),
-                        onRefresh = { viewModel.loadFirebaseData() }
+                        onRefresh = { viewModel.loadFirebaseData(context) }
                     )
                 }
 

--- a/app/src/main/java/com/ioannapergamali/mysmartroute/view/ui/screens/FirebaseDatabaseScreen.kt
+++ b/app/src/main/java/com/ioannapergamali/mysmartroute/view/ui/screens/FirebaseDatabaseScreen.kt
@@ -18,6 +18,7 @@ import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.unit.dp
+import androidx.compose.ui.platform.LocalContext
 import androidx.lifecycle.viewmodel.compose.viewModel
 import androidx.navigation.NavController
 import com.ioannapergamali.mysmartroute.view.ui.components.TopBar
@@ -31,9 +32,10 @@ import com.ioannapergamali.mysmartroute.model.enumerations.localizedName
 @Composable
 fun FirebaseDatabaseScreen(navController: NavController, openDrawer: () -> Unit) {
     val viewModel: DatabaseViewModel = viewModel()
+    val context = LocalContext.current
     val data by viewModel.firebaseData.collectAsState()
 
-    LaunchedEffect(Unit) { viewModel.loadFirebaseData() }
+    LaunchedEffect(Unit) { viewModel.loadFirebaseData(context) }
 
     Scaffold(
         topBar = {

--- a/app/src/main/java/com/ioannapergamali/mysmartroute/viewmodel/DatabaseViewModel.kt
+++ b/app/src/main/java/com/ioannapergamali/mysmartroute/viewmodel/DatabaseViewModel.kt
@@ -501,7 +501,7 @@ class DatabaseViewModel : ViewModel() {
      * Αντλεί δεδομένα από το Firebase Firestore για πλήρη εικόνα του συστήματος.
      * Retrieves data from Firebase Firestore for a complete system view.
      */
-    fun loadFirebaseData() {
+    fun loadFirebaseData(context: Context) {
         viewModelScope.launch {
             try {
                 Log.d(TAG, "Loading Firebase data")

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -78,6 +78,7 @@
     <string name="sync_success">Ο συγχρονισμός ολοκληρώθηκε</string>
     <string name="sync_error_prefix">Σφάλμα συγχρονισμού: %1$s</string>
     <string name="sync_empty_table">Ο πίνακας είναι άδειος</string>
+    <string name="syncing_table">Συγχρονίζεται ο πίνακας %1$s</string>
     <string name="sync_table_title">Πίνακας %1$s (%2$d εγγραφές)</string>
     <string name="sync_local_title">Τοπική βάση δεδομένων</string>
     <string name="sync_firestore_title">Firestore</string>


### PR DESCRIPTION
## Summary
- update the sync screen to use the shared DatabaseData model and pass a Context when requesting Firestore data
- require a Context when loading Firebase data inside the DatabaseViewModel and keep progress updates working
- add the missing syncing_table string resource used by the sync progress messages

## Testing
- ./gradlew :app:compileDebugKotlin --console=plain *(fails: Android SDK not installed in container)*

------
https://chatgpt.com/codex/tasks/task_e_68c86a0d7f808328b052bcf796106c4d