### PR TITLE
Προσθήκη ώρας στην επισήμανση συγχρονισμού

### DIFF
--- a/app/src/main/java/com/ioannapergamali/mysmartroute/view/ui/screens/DatabaseSyncScreen.kt
+++ b/app/src/main/java/com/ioannapergamali/mysmartroute/view/ui/screens/DatabaseSyncScreen.kt
@@ -234,7 +234,7 @@ private fun SyncActions(
     currentMessage: String?,
     onSync: () -> Unit
 ) {
-    val lastSyncText = remember(lastSync) { formatTimestamp(lastSync) }
+    val lastSyncText = remember(lastSync) { formatTimestamp(lastSync, includeTime = true) }
 
     Text(
         text = stringResource(R.string.sync_last_sync, lastSyncText),


### PR DESCRIPTION
## Summary
- Εμφανίζει και την ώρα στον δείκτη "Τελευταίος συγχρονισμός" στην οθόνη συγχρονισμού βάσης δεδομένων

## Testing
- ./gradlew test --console=plain --no-daemon *(αποτυχία: λείπει Android SDK στο περιβάλλον του agent)*

------
https://chatgpt.com/codex/tasks/task_e_68c86cf976608328867377bad3a74054