### PR TITLE
Αύξηση χρονικού ορίου συγχρονισμού της βάσης

### DIFF
--- a/app/src/main/java/com/ioannapergamali/mysmartroute/viewmodel/DatabaseViewModel.kt
+++ b/app/src/main/java/com/ioannapergamali/mysmartroute/viewmodel/DatabaseViewModel.kt
@@ -92,6 +92,7 @@ class DatabaseViewModel : ViewModel() {
 
     companion object {
         private const val TAG = "DatabaseViewModel"
+        private const val SYNC_TIMEOUT_MS = 120_000L
     }
 
     private val auth = FirebaseAuth.getInstance()
@@ -763,7 +764,7 @@ class DatabaseViewModel : ViewModel() {
         val db = MySmartRouteDatabase.getInstance(context)
 
         try {
-            withTimeout(30000L) {
+            withTimeout(SYNC_TIMEOUT_MS) {
                 if (remoteTs > localTs) {
                     logStep("Το Firestore είναι νεότερο - λήψη δεδομένων")
                     Log.d(TAG, "Fetching users from Firestore")


### PR DESCRIPTION
## Summary
- αυξήθηκε το χρονικό όριο του συγχρονισμού ώστε οι μεταφορές δεδομένων Firestore να μην ακυρώνονται πρόωρα

## Testing
- `./gradlew :app:lint --console=plain` *(αποτυχία λόγω έλλειψης Android SDK στο περιβάλλον CI)*

------
https://chatgpt.com/codex/tasks/task_e_68c88356f9088328867d60685277fad4