### PR TITLE
Προσθήκη ένδειξης ΝΕΑ και συντόμευσης δήλωσης

### DIFF
--- a/app/src/main/java/com/ioannapergamali/mysmartroute/model/navigation/NavigationHost.kt
+++ b/app/src/main/java/com/ioannapergamali/mysmartroute/model/navigation/NavigationHost.kt
@@ -114,8 +114,16 @@ fun NavigationHost(
             DeclareRouteScreen(navController = navController, openDrawer = openDrawer)
         }
 
-        composable("announceAvailability") {
-            AnnounceTransportScreen(navController = navController, openDrawer = openDrawer)
+        composable(
+            route = "announceAvailability?routeId={routeId}",
+            arguments = listOf(navArgument("routeId") { defaultValue = "" })
+        ) { backStackEntry ->
+            val routeId = backStackEntry.arguments?.getString("routeId").orEmpty()
+            AnnounceTransportScreen(
+                navController = navController,
+                openDrawer = openDrawer,
+                initialRouteId = routeId.ifBlank { null }
+            )
         }
 
         composable("viewPois") {

--- a/app/src/main/java/com/ioannapergamali/mysmartroute/view/ui/screens/AnnounceTransportScreen.kt
+++ b/app/src/main/java/com/ioannapergamali/mysmartroute/view/ui/screens/AnnounceTransportScreen.kt
@@ -116,7 +116,11 @@ private fun canSend(
 
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable
-fun AnnounceTransportScreen(navController: NavController, openDrawer: () -> Unit) {
+fun AnnounceTransportScreen(
+    navController: NavController,
+    openDrawer: () -> Unit,
+    initialRouteId: String? = null
+) {
     val context = LocalContext.current
     val scope = rememberCoroutineScope()
     val routeViewModel: RouteViewModel = viewModel()
@@ -136,7 +140,9 @@ fun AnnounceTransportScreen(navController: NavController, openDrawer: () -> Unit
     var selectedDriverId by remember { mutableStateOf<String?>(null) }
     var selectedDriverName by remember { mutableStateOf("") }
     var expandedRoute by remember { mutableStateOf(false) }
-    var selectedRouteId by remember { mutableStateOf<String?>(null) }
+    var selectedRouteId by remember(initialRouteId) {
+        mutableStateOf(initialRouteId?.takeIf { it.isNotBlank() })
+    }
     var expandedVehicle by remember { mutableStateOf(false) }
     var selectedVehicle by remember { mutableStateOf<VehicleType?>(null) }
     var selectedVehicleId by remember { mutableStateOf("") }

--- a/app/src/main/res/values-el/strings.xml
+++ b/app/src/main/res/values-el/strings.xml
@@ -332,6 +332,10 @@
     <string name="no_notifications">Καμία ειδοποίηση</string>
     <string name="no_scheduled_transports">Δεν βρέθηκαν προγραμματισμένες μεταφορές</string>
     <string name="request_number">Αριθμός αιτήματος</string>
+    <string name="transport_request_new_column">ΝΕΑ</string>
+    <string name="transport_request_new_yes">ναι</string>
+    <string name="transport_request_new_no">όχι</string>
+    <string name="transport_request_declaration_link">Δήλωση</string>
     <!-- Notification text -->
     <string name="app_started_notification">Η εφαρμογή ξεκίνησε</string>
     <string name="request_accepted">Το αίτημα έγινε αποδεκτό</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -340,6 +340,10 @@
     <string name="sort_by_date">Sort by date</string>
     <string name="cancel_request">Cancel request</string>
     <string name="request_number">Request number</string>
+    <string name="transport_request_new_column">New</string>
+    <string name="transport_request_new_yes">yes</string>
+    <string name="transport_request_new_no">no</string>
+    <string name="transport_request_declaration_link">Declaration</string>
     <string name="notify_route">Notify route</string>
     <string name="notify_selected">Notify selected</string>
     <string name="request_expired">Request expired</string>


### PR DESCRIPTION
## Περίληψη
- προστέθηκε στήλη «ΝΕΑ» στα αιτήματα μεταφοράς με έλεγχο δηλώσεων μεταφοράς ανά οδηγό
- προστέθηκε σύνδεσμος «Δήλωση» που ανοίγει την οθόνη διαθεσιμότητας με προσυμπληρωμένη διαδρομή
- ενημερώθηκε η πλοήγηση και η οθόνη δήλωσης για να δέχονται προαιρετικό routeId

## Έλεγχοι
- ./gradlew --console=plain lint *(αποτυχία λόγω ελλιπούς Android SDK στο περιβάλλον δοκιμών)*

------
https://chatgpt.com/codex/tasks/task_e_68c88dc1ce6083288fa94e909d411256