### PR TITLE
Handle dependencies when clearing poi types

### DIFF
--- a/app/src/main/res/values-el/strings.xml
+++ b/app/src/main/res/values-el/strings.xml
@@ -68,6 +68,7 @@
     <string name="clear_success">Ο καθαρισμός ολοκληρώθηκε</string>
     <string name="clear_error_no_selection">Επιλέξτε τουλάχιστον έναν πίνακα</string>
     <string name="clear_error_generic">Αποτυχία καθαρισμού δεδομένων: %1$s</string>
+    <string name="clear_error_dependency">Ο πίνακας %1$s / %2$s έχει ακόμη %5$d σχετικές εγγραφές με τον πίνακα %3$s / %4$s. Καθαρίστε πρώτα τον %3$s / %4$s.</string>
     <string name="clear_progress_message">Διαγράφεται: %1$s\nDeleting: %2$s</string>
     <string name="initialize_button">Αρχικοποίηση</string>
     <string name="initialize_success">Η αρχικοποίηση ολοκληρώθηκε</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -66,6 +66,7 @@
     <string name="clear_success">Data cleared successfully</string>
     <string name="clear_error_no_selection">Select at least one table</string>
     <string name="clear_error_generic">Failed to clear data: %1$s</string>
+    <string name="clear_error_dependency">Table %1$s / %2$s still has %5$d related rows with table %3$s / %4$s. Clear %3$s / %4$s first.</string>
     <string name="clear_progress_message">Διαγράφεται: %1$s\nDeleting: %2$s</string>
     <string name="initialize_button">Initialize</string>
     <string name="initialize_success">Initialization completed</string>


### PR DESCRIPTION
## Summary
- reorder the local clearing order so POIs are removed before POI types
- guard the POI type purge with a localized error message when POIs still exist

## Testing
- ./gradlew :app:lintDebug --console=plain *(fails: Android SDK not installed in CI container)*

------
https://chatgpt.com/codex/tasks/task_e_68c88f2f1238832880aa91ecfe61d8c7