### PR TITLE
Εμφάνιση ονόματος πίνακα κατά την αρχικοποίηση

### DIFF
--- a/app/src/main/java/com/ioannapergamali/mysmartroute/view/ui/screens/DatabaseMenuScreen.kt
+++ b/app/src/main/java/com/ioannapergamali/mysmartroute/view/ui/screens/DatabaseMenuScreen.kt
@@ -78,6 +78,18 @@ fun DatabaseMenuScreen(navController: NavController, openDrawer: () -> Unit) {
             Spacer(modifier = Modifier.height(24.dp))
 
             if (isClearing) {
+                (clearState as? ClearState.Running)
+                    ?.message
+                    ?.takeIf { it.isNotBlank() }
+                    ?.let { message ->
+                        Text(
+                            text = message,
+                            style = MaterialTheme.typography.bodyMedium,
+                            color = MaterialTheme.colorScheme.secondary
+                        )
+                        Spacer(modifier = Modifier.height(8.dp))
+                    }
+
                 LinearProgressIndicator(modifier = Modifier.fillMaxWidth())
                 Spacer(modifier = Modifier.height(16.dp))
             }
@@ -101,16 +113,6 @@ fun DatabaseMenuScreen(navController: NavController, openDrawer: () -> Unit) {
             Spacer(modifier = Modifier.height(16.dp))
 
             when (val state = clearState) {
-                is ClearState.Running -> {
-                    state.message?.takeIf { it.isNotBlank() }?.let { message ->
-                        Text(
-                            text = message,
-                            style = MaterialTheme.typography.bodyMedium,
-                            color = MaterialTheme.colorScheme.secondary
-                        )
-                    }
-                }
-
                 is ClearState.Success -> {
                     Text(
                         text = state.message,


### PR DESCRIPTION
## Summary
- εμφάνιση του τρέχοντος μηνύματος εκκαθάρισης πάνω από τη μπάρα προόδου στην οθόνη διαχείρισης βάσης
- αποφυγή διπλής εμφάνισης μηνυμάτων κατά την εκκαθάριση πινάκων

## Testing
- ./gradlew :app:compileDebugKotlin *(αποτυχία λόγω απουσίας Android SDK στο περιβάλλον CI)*

------
https://chatgpt.com/codex/tasks/task_e_68c88f8d8fb083289777e1427e3837c1