### PR TITLE
Handle clearing the walking routes table

### DIFF
--- a/app/src/main/java/com/ioannapergamali/mysmartroute/viewmodel/DatabaseViewModel.kt
+++ b/app/src/main/java/com/ioannapergamali/mysmartroute/viewmodel/DatabaseViewModel.kt
@@ -13,6 +13,7 @@ import com.google.firebase.firestore.FirebaseFirestoreException
 import com.ioannapergamali.mysmartroute.utils.toFirestoreMap
 import com.ioannapergamali.mysmartroute.utils.toUserEntity
 import com.ioannapergamali.mysmartroute.data.local.MySmartRouteDatabase
+import com.ioannapergamali.mysmartroute.data.local.WalkingRouteDatabase
 import com.ioannapergamali.mysmartroute.data.local.PoIEntity
 import com.ioannapergamali.mysmartroute.data.local.PoiTypeEntity
 import com.ioannapergamali.mysmartroute.data.local.SettingsEntity
@@ -378,6 +379,10 @@ class DatabaseViewModel : ViewModel() {
         tableName: String,
         preserveUserId: String?
     ) {
+        if (tableName == "walking_routes") {
+            clearWalkingRoutes(context)
+            return
+        }
         withContext(Dispatchers.IO) {
             db.withTransaction {
                 val sqliteDb = db.openHelper.writableDatabase
@@ -416,6 +421,20 @@ class DatabaseViewModel : ViewModel() {
                 }
                 val after = sqliteDb.countRows(tableName)
                 Log.d(TAG, "Cleared local table $tableName (rowsAfter=$after)")
+            }
+        }
+    }
+
+    private suspend fun clearWalkingRoutes(context: Context) {
+        withContext(Dispatchers.IO) {
+            val walkingDb = WalkingRouteDatabase.getDatabase(context)
+            walkingDb.withTransaction {
+                val sqliteDb = walkingDb.openHelper.writableDatabase
+                val before = sqliteDb.countRows("walking_routes")
+                Log.d(TAG, "Clearing local table walking_routes (rowsBefore=$before)")
+                sqliteDb.execSQL("DELETE FROM `walking_routes`")
+                val after = sqliteDb.countRows("walking_routes")
+                Log.d(TAG, "Cleared local table walking_routes (rowsAfter=$after)")
             }
         }
     }


### PR DESCRIPTION
## Summary
- avoid querying the walking_routes table on the main Room database
- clear walking routes through its dedicated Room database when requested

## Testing
- ./gradlew --console=plain :app:compileDebugKotlin *(fails: SDK location not found in container)*

------
https://chatgpt.com/codex/tasks/task_e_68c893109a208328a5e910fd6cbea1a0