### PR TITLE
Προσθήκη περιγραφής δυνατοτήτων ρόλων

### DIFF
--- a/app/src/main/java/com/ioannapergamali/mysmartroute/model/enumerations/UserRole.kt
+++ b/app/src/main/java/com/ioannapergamali/mysmartroute/model/enumerations/UserRole.kt
@@ -34,3 +34,72 @@ fun UserRole.parent(): UserRole? = when (this) {
     UserRole.ADMIN -> UserRole.DRIVER
 }
 
+/**
+ * Ελληνικά: Μια δυνατότητα ρόλου με τίτλο και περιγραφή.
+ * English: A role capability with a title and description resource.
+ */
+data class RoleCapability(
+    @StringRes val titleRes: Int,
+    @StringRes val descriptionRes: Int
+)
+
+/** Επιστρέφει τις διαθέσιμες δυνατότητες του ρόλου. / Returns the capabilities for the given role. */
+fun UserRole.capabilities(): List<RoleCapability> = when (this) {
+    UserRole.PASSENGER -> passengerCapabilities()
+    UserRole.DRIVER -> passengerCapabilities() + driverCapabilities()
+    UserRole.ADMIN -> passengerCapabilities() + driverCapabilities() + adminCapabilities()
+}
+
+/** Επιστρέφει τοπικοποιημένο τίτλο δυνατότητας. / Returns a localized capability title. */
+@Composable
+fun RoleCapability.localizedTitle(): String = stringResource(id = titleRes)
+
+/** Επιστρέφει τοπικοποιημένη περιγραφή δυνατότητας. / Returns a localized capability description. */
+@Composable
+fun RoleCapability.localizedDescription(): String = stringResource(id = descriptionRes)
+
+private fun passengerCapabilities(): List<RoleCapability> = listOf(
+    RoleCapability(
+        titleRes = R.string.role_passenger_capability_search_title,
+        descriptionRes = R.string.role_passenger_capability_search_desc
+    ),
+    RoleCapability(
+        titleRes = R.string.role_passenger_capability_booking_title,
+        descriptionRes = R.string.role_passenger_capability_booking_desc
+    ),
+    RoleCapability(
+        titleRes = R.string.role_passenger_capability_profile_title,
+        descriptionRes = R.string.role_passenger_capability_profile_desc
+    )
+)
+
+private fun driverCapabilities(): List<RoleCapability> = listOf(
+    RoleCapability(
+        titleRes = R.string.role_driver_capability_fleet_title,
+        descriptionRes = R.string.role_driver_capability_fleet_desc
+    ),
+    RoleCapability(
+        titleRes = R.string.role_driver_capability_passengers_title,
+        descriptionRes = R.string.role_driver_capability_passengers_desc
+    ),
+    RoleCapability(
+        titleRes = R.string.role_driver_capability_routes_title,
+        descriptionRes = R.string.role_driver_capability_routes_desc
+    )
+)
+
+private fun adminCapabilities(): List<RoleCapability> = listOf(
+    RoleCapability(
+        titleRes = R.string.role_admin_capability_users_title,
+        descriptionRes = R.string.role_admin_capability_users_desc
+    ),
+    RoleCapability(
+        titleRes = R.string.role_admin_capability_content_title,
+        descriptionRes = R.string.role_admin_capability_content_desc
+    ),
+    RoleCapability(
+        titleRes = R.string.role_admin_capability_system_title,
+        descriptionRes = R.string.role_admin_capability_system_desc
+    )
+)
+

--- a/app/src/main/java/com/ioannapergamali/mysmartroute/view/ui/screens/RolesScreen.kt
+++ b/app/src/main/java/com/ioannapergamali/mysmartroute/view/ui/screens/RolesScreen.kt
@@ -1,11 +1,19 @@
 package com.ioannapergamali.mysmartroute.view.ui.screens
 
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.items
+import androidx.compose.material3.Card
+import androidx.compose.material3.Divider
 import androidx.compose.material3.Scaffold
 import androidx.compose.material3.Text
+import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.CircularProgressIndicator
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
@@ -22,9 +30,14 @@ import com.ioannapergamali.mysmartroute.viewmodel.DatabaseViewModel
 import com.ioannapergamali.mysmartroute.viewmodel.SyncState
 import androidx.compose.ui.res.stringResource
 import com.ioannapergamali.mysmartroute.R
+import com.ioannapergamali.mysmartroute.model.enumerations.RoleCapability
 import com.ioannapergamali.mysmartroute.model.enumerations.UserRole
+import com.ioannapergamali.mysmartroute.model.enumerations.capabilities
+import com.ioannapergamali.mysmartroute.model.enumerations.localizedDescription
 import com.ioannapergamali.mysmartroute.model.enumerations.localizedName
+import com.ioannapergamali.mysmartroute.model.enumerations.localizedTitle
 import android.widget.Toast
+import androidx.compose.ui.unit.dp
 
 @Composable
 fun RolesScreen(navController: NavController, openDrawer: () -> Unit) {
@@ -72,7 +85,10 @@ fun RolesScreen(navController: NavController, openDrawer: () -> Unit) {
                     Text(stringResource(R.string.roles_empty))
                 }
                 else -> {
-                    LazyColumn(modifier = Modifier.fillMaxSize()) {
+                    LazyColumn(
+                        modifier = Modifier.fillMaxSize(),
+                        verticalArrangement = Arrangement.spacedBy(12.dp)
+                    ) {
                         items(roles) { role ->
                             val roleEnum = try {
                                 UserRole.valueOf(role.name)
@@ -80,11 +96,74 @@ fun RolesScreen(navController: NavController, openDrawer: () -> Unit) {
                                 null
                             }
                             val displayName = roleEnum?.localizedName() ?: role.name
-                            Text("${role.id} - $displayName")
+                            RoleCard(
+                                roleId = role.id,
+                                displayName = displayName,
+                                capabilities = roleEnum?.capabilities(),
+                                fallbackMessage = stringResource(R.string.role_capabilities_unavailable)
+                            )
                         }
                     }
                 }
             }
         }
+    }
+}
+
+@Composable
+private fun RoleCard(
+    roleId: String,
+    displayName: String,
+    capabilities: List<RoleCapability>?,
+    fallbackMessage: String
+) {
+    Card(modifier = Modifier.fillMaxWidth()) {
+        Column(modifier = Modifier.padding(16.dp)) {
+            Text(
+                text = stringResource(R.string.role_card_header, roleId, displayName),
+                style = MaterialTheme.typography.titleMedium,
+                color = MaterialTheme.colorScheme.onSurface
+            )
+            Spacer(modifier = Modifier.height(12.dp))
+            Text(
+                text = stringResource(R.string.role_capabilities_section_title),
+                style = MaterialTheme.typography.titleSmall,
+                color = MaterialTheme.colorScheme.primary
+            )
+            Spacer(modifier = Modifier.height(8.dp))
+            if (capabilities.isNullOrEmpty()) {
+                Text(
+                    text = fallbackMessage,
+                    style = MaterialTheme.typography.bodyMedium,
+                    color = MaterialTheme.colorScheme.onSurfaceVariant
+                )
+            } else {
+                capabilities.forEachIndexed { index, capability ->
+                    RoleCapabilityItem(capability)
+                    if (index < capabilities.lastIndex) {
+                        Spacer(modifier = Modifier.height(8.dp))
+                        Divider()
+                        Spacer(modifier = Modifier.height(8.dp))
+                    }
+                }
+            }
+        }
+    }
+}
+
+@Composable
+private fun RoleCapabilityItem(capability: RoleCapability) {
+    Column(modifier = Modifier.fillMaxWidth()) {
+        Text(
+            text = capability.localizedTitle(),
+            style = MaterialTheme.typography.bodyLarge,
+            color = MaterialTheme.colorScheme.onSurface
+        )
+        Spacer(modifier = Modifier.height(4.dp))
+        Text(
+            text = capability.localizedDescription(),
+            style = MaterialTheme.typography.bodyMedium,
+            color = MaterialTheme.colorScheme.onSurfaceVariant
+        )
     }
 }

--- a/app/src/main/res/values-el/strings.xml
+++ b/app/src/main/res/values-el/strings.xml
@@ -154,6 +154,28 @@
     <string name="role_driver">Οδηγός</string>
     <string name="role_admin">Διαχειριστής</string>
     <string name="select_role">Επιλογή ρόλου</string>
+    <string name="role_card_header">[%1$s] %2$s</string>
+    <string name="role_capabilities_section_title">Τι μπορείς να κάνεις</string>
+    <string name="role_capabilities_unavailable">Δεν υπάρχουν διαθέσιμες δυνατότητες για αυτόν τον ρόλο.</string>
+    <!-- Δυνατότητες ρόλων -->
+    <string name="role_passenger_capability_search_title">Αναζήτηση διαδρομών και μετακινήσεων</string>
+    <string name="role_passenger_capability_search_desc">Περιηγήσου σε διαθέσιμες διαδρομές, μέσα μεταφοράς, σημεία ενδιαφέροντος και προτάσεις πεζοπορίας που ταιριάζουν στα σχέδιά σου.</string>
+    <string name="role_passenger_capability_booking_title">Κράτηση και διαχείριση θέσεων</string>
+    <string name="role_passenger_capability_booking_desc">Κάνε κράτηση θέσεων ή εισιτηρίων, εκτύπωσε αποδείξεις και ακύρωσε κρατήσεις όταν αλλάζουν τα πλάνα σου.</string>
+    <string name="role_passenger_capability_profile_title">Προσωποποίηση εμπειρίας</string>
+    <string name="role_passenger_capability_profile_desc">Διαχειρίσου αγαπημένα, παρακολούθησε αιτήματα μεταφοράς, βαθμολόγησε ολοκληρωμένες διαδρομές και κλείσε τη συνεδρία σου.</string>
+    <string name="role_driver_capability_fleet_title">Διαχείριση στόλου και διαθεσιμότητας</string>
+    <string name="role_driver_capability_fleet_desc">Καταχώρησε οχήματα, δήλωσε διαδρομές μεταφοράς, ανακοίνωσε διαθεσιμότητες και εκτύπωσε τις απαιτούμενες δηλώσεις.</string>
+    <string name="role_driver_capability_passengers_title">Συντονισμός επιβατών</string>
+    <string name="role_driver_capability_passengers_desc">Εντόπισε επιβάτες, διαχειρίσου αιτήματα μεταφοράς και εκτύπωσε λίστες επιβατών για προγραμματισμένα ή ολοκληρωμένα δρομολόγια.</string>
+    <string name="role_driver_capability_routes_title">Ολοκλήρωση δρομολογίων</string>
+    <string name="role_driver_capability_routes_desc">Προετοίμασε τη διαδικασία ολοκλήρωσης και φρόντισε κάθε διαδρομή να ενημερώνει σωστά τις κρατήσεις.</string>
+    <string name="role_admin_capability_users_title">Διαχείριση χρηστών και ρόλων</string>
+    <string name="role_admin_capability_users_desc">Δημιούργησε λογαριασμούς, τροποποίησε προνόμια, αξιολόγησε την απόδοση χρηστών και κράτησε οργανωμένο το μητρώο.</string>
+    <string name="role_admin_capability_content_title">Επιμέλεια διαδρομών και σημείων</string>
+    <string name="role_admin_capability_content_desc">Όρισε ή έλεγξε σημεία ενδιαφέροντος, επεξεργάσου διαδρομές, ανάθεσε εκκρεμότητες και παρακολούθησε τα διαθέσιμα οχήματα.</string>
+    <string name="role_admin_capability_system_title">Συντήρηση πλατφόρμας</string>
+    <string name="role_admin_capability_system_desc">Αρχικοποίησε και συγχρόνισε δεδομένα, ρύθμισε την ημερομηνία συστήματος και οργάνωσε εργασίες συντήρησης ή τερματισμού.</string>
     <!-- Titles μενού δυναμικών επιλογών -->
     <string name="passenger_menu_title">Μενού Επιβάτη</string>
     <string name="driver_menu_title">Μενού Οδηγού</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -153,6 +153,28 @@
     <string name="role_driver">Driver</string>
     <string name="role_admin">Administrator</string>
     <string name="select_role">Select Role</string>
+    <string name="role_card_header">[%1$s] %2$s</string>
+    <string name="role_capabilities_section_title">What you can do</string>
+    <string name="role_capabilities_unavailable">Capabilities are not available for this role.</string>
+    <!-- Role capabilities -->
+    <string name="role_passenger_capability_search_title">Discover routes and transport options</string>
+    <string name="role_passenger_capability_search_desc">Browse routes, transport modes, points of interest, and walking suggestions that match your plans.</string>
+    <string name="role_passenger_capability_booking_title">Book and manage seats</string>
+    <string name="role_passenger_capability_booking_desc">Reserve seats or tickets, print confirmations, and cancel reservations whenever your schedule changes.</string>
+    <string name="role_passenger_capability_profile_title">Personalize your experience</string>
+    <string name="role_passenger_capability_profile_desc">Manage favourites, review transport requests, rate completed trips, sign out, or shut down the app when you finish.</string>
+    <string name="role_driver_capability_fleet_title">Manage fleet and availability</string>
+    <string name="role_driver_capability_fleet_desc">Register vehicles, declare transport routes, publish availability, and print the necessary declarations.</string>
+    <string name="role_driver_capability_passengers_title">Coordinate passengers</string>
+    <string name="role_driver_capability_passengers_desc">Find passengers, handle transport requests, and print passenger lists for upcoming or completed rides.</string>
+    <string name="role_driver_capability_routes_title">Complete planned routes</string>
+    <string name="role_driver_capability_routes_desc">Prepare route completion workflows so every journey is finalised with accurate booking updates.</string>
+    <string name="role_admin_capability_users_title">Administer users and roles</string>
+    <string name="role_admin_capability_users_desc">Create accounts, adjust privileges, inspect user performance, and keep the user registry organised.</string>
+    <string name="role_admin_capability_content_title">Curate routes and points of interest</string>
+    <string name="role_admin_capability_content_desc">Define or review points of interest, edit transport routes, assign pending tasks, and monitor available vehicles.</string>
+    <string name="role_admin_capability_system_title">Maintain platform operations</string>
+    <string name="role_admin_capability_system_desc">Initialise and synchronise system data, adjust the current date, and orchestrate maintenance or shutdown actions.</string>
     <!-- Dynamic menu titles -->
     <string name="passenger_menu_title">Passenger Menu</string>
     <string name="driver_menu_title">Driver Menu</string>


### PR DESCRIPTION
## Summary
- προστέθηκε η κλάση `RoleCapability` και συναρτήσεις επικόλλησης για να περιγραφούν οι δυνατότητες κάθε ρόλου
- προστέθηκαν αγγλικές και ελληνικές συμβολοσειρές με τους τίτλους και τις περιγραφές των δυνατοτήτων
- η οθόνη `RolesScreen` παρουσιάζει πλέον για κάθε ρόλο τις σχετικές δυνατότητες με τίτλο και περιγραφή

## Testing
- `./gradlew lint --console=plain` *(αποτυχία: δεν υπάρχει εγκατεστημένο Android SDK στο περιβάλλον)*

------
https://chatgpt.com/codex/tasks/task_e_68c89127aa6483289c131547c0733eff