### PR TITLE
Προσθήκη επιλογής Ρόλοι στο συρτάρι πλοήγησης

### DIFF
--- a/app/src/main/java/com/ioannapergamali/mysmartroute/view/ui/components/NavigationDrawer.kt
+++ b/app/src/main/java/com/ioannapergamali/mysmartroute/view/ui/components/NavigationDrawer.kt
@@ -7,6 +7,7 @@ import androidx.compose.material.icons.filled.ExitToApp
 import androidx.compose.material.icons.filled.Logout
 import androidx.compose.material.icons.filled.AdminPanelSettings
 import androidx.compose.material.icons.filled.Person
+import androidx.compose.material.icons.filled.People
 import androidx.compose.material.icons.filled.Login
 import androidx.compose.material.icons.filled.Settings
 import androidx.compose.material.icons.filled.Menu
@@ -144,6 +145,15 @@ fun DrawerMenu(navController: NavController, closeDrawer: () -> Unit) {
                 closeDrawer()
             },
             icon = { Icon(Icons.Filled.AdminPanelSettings, contentDescription = null, tint = MaterialTheme.colorScheme.primary) }
+        )
+        NavigationDrawerItem(
+            label = { Text(stringResource(R.string.drawer_roles)) },
+            selected = false,
+            onClick = {
+                navController.navigate("roles")
+                closeDrawer()
+            },
+            icon = { Icon(Icons.Filled.People, contentDescription = null, tint = MaterialTheme.colorScheme.primary) }
         )
         if (isLoggedIn) {
             NavigationDrawerItem(

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -57,6 +57,7 @@
     <string name="roles_title">Roles</string>
     <string name="roles_load_error">Failed to load roles: %1$s</string>
     <string name="roles_empty">No roles found</string>
+    <string name="drawer_roles">Ρόλοι</string>
     <string name="about_title">About</string>
     <string name="support_title">Support</string>
     <string name="databases_title">Databases</string>


### PR DESCRIPTION
## Summary
- προστέθηκε νέο στοιχείο «Ρόλοι» στο αριστερό συρτάρι πλοήγησης για άμεσο άνοιγμα της οθόνης RolesScreen
- δημιουργήθηκε νέο string πόρου για την ελληνική ετικέτα του μενού

## Testing
- ./gradlew :app:lintDebug --console=plain *(αποτυχία: δεν υπάρχει εγκατεστημένο Android SDK στο περιβάλλον)*

------
https://chatgpt.com/codex/tasks/task_e_68c898c41b0883288d426a7ae6b41eeb