### PR TITLE
Load roles before syncing databases on RolesScreen

### DIFF
--- a/app/src/main/java/com/ioannapergamali/mysmartroute/view/ui/screens/RolesScreen.kt
+++ b/app/src/main/java/com/ioannapergamali/mysmartroute/view/ui/screens/RolesScreen.kt
@@ -58,8 +58,8 @@ fun RolesScreen(navController: NavController, openDrawer: () -> Unit) {
     }
 
     LaunchedEffect(Unit) {
-        dbViewModel.syncDatabasesSuspend(context)
         viewModel.loadRoles(context)
+        dbViewModel.syncDatabasesSuspend(context)
     }
 
     Scaffold(


### PR DESCRIPTION
## Summary
- start collecting roles before triggering the heavy database sync in RolesScreen
- allow the UI to show locally cached roles while synchronization is still running

## Testing
- `./gradlew :app:compileDebugKotlin --console=plain --no-daemon` *(fails: Android SDK not available in CI image)*

------
https://chatgpt.com/codex/tasks/task_e_68c89b1e6d2883288198b10dbb2a6cc4