### PR TITLE
Fix announce availability navigation route check

### DIFF
--- a/app/src/main/java/com/ioannapergamali/mysmartroute/view/ui/screens/MenuScreen.kt
+++ b/app/src/main/java/com/ioannapergamali/mysmartroute/view/ui/screens/MenuScreen.kt
@@ -74,12 +74,19 @@ fun MenuScreen(navController: NavController, openDrawer: () -> Unit) {
                         else -> route
                     }
 
+                    val normalizedTargetRoute = targetRoute.substringBefore("?")
                     val destinationExists = if (targetRoute.startsWith("definePoi")) {
                         navController.graph.any {
                             it.route == "definePoi?lat={lat}&lng={lng}&source={source}&view={view}&routeId={routeId}"
                         }
                     } else {
-                        navController.graph.any { it.route == targetRoute }
+                        navController.graph.any { destination ->
+                            val destinationRoute = destination.route ?: return@any false
+                            destinationRoute == targetRoute || (
+                                destinationRoute.contains("?") &&
+                                    destinationRoute.substringBefore("?") == normalizedTargetRoute
+                            )
+                        }
                     }
 
                     if (


### PR DESCRIPTION
## Summary
- ensure menu navigation detects destinations with optional query arguments such as announce availability

## Testing
- ./gradlew :app:lintDebug --console=plain *(fails: SDK location not found in container)*

------
https://chatgpt.com/codex/tasks/task_e_68c8a73294ac83288933892f01585609