### PR TITLE
Disable route notification for new transport requests

### DIFF
--- a/app/src/main/java/com/ioannapergamali/mysmartroute/view/ui/screens/ViewTransportRequestsScreen.kt
+++ b/app/src/main/java/com/ioannapergamali/mysmartroute/view/ui/screens/ViewTransportRequestsScreen.kt
@@ -239,12 +239,16 @@ fun ViewTransportRequestsScreen(
                                 }
                                 val isExpired = req.date > 0L && now > req.date && req.status != "completed"
                                 if (req.status == "open" && !isExpired) {
+                                    val canNotifyRoute = !isNewRequest && req.routeId.isNotBlank()
                                     Button(
                                         onClick = {
-                                            viewModel.notifyRoute(context, req.id)
-                                            transferViewModel.notifyDriver(context, req.requestNumber)
+                                            if (canNotifyRoute) {
+                                                viewModel.notifyRoute(context, req.id)
+                                                transferViewModel.notifyDriver(context, req.requestNumber)
+                                            }
                                         },
-                                        modifier = Modifier.width(columnWidth)
+                                        modifier = Modifier.width(columnWidth),
+                                        enabled = canNotifyRoute
                                     ) {
                                         Text(stringResource(R.string.notify_route))
                                     }


### PR DESCRIPTION
## Summary
- disable route notifications for transport requests marked as new until the route is declared
- guard the notification logic to avoid firing when the button is disabled

## Testing
- ./gradlew :app:lint --console plain --no-daemon *(fails: SDK location not found in CI environment)*

------
https://chatgpt.com/codex/tasks/task_e_68cac57c8938832897a2e44dfc94530c