### PR TITLE
Show only date in transport request list

### DIFF
--- a/app/src/main/java/com/ioannapergamali/mysmartroute/view/ui/screens/ViewTransportRequestsScreen.kt
+++ b/app/src/main/java/com/ioannapergamali/mysmartroute/view/ui/screens/ViewTransportRequestsScreen.kt
@@ -189,9 +189,7 @@ fun ViewTransportRequestsScreen(
                             val isChecked = selectedRequests[req.id] ?: false
                             val dateTimeText = if (req.date > 0L) {
                                 val date = Date(req.date)
-                                val dateStr = DateFormat.getDateFormat(context).format(date)
-                                val timeStr = DateFormat.format("HH:mm", date).toString()
-                                "$dateStr $timeStr"
+                                DateFormat.getDateFormat(context).format(date)
                             } else ""
                             Row(
                                 modifier = Modifier.padding(vertical = 8.dp),


### PR DESCRIPTION
## Summary
- display μόνο την τοπική ημερομηνία χωρίς ώρα στη στήλη "Ημερομηνία" της προβολής αιτημάτων μεταφοράς

## Testing
- ./gradlew test *(αποτυγχάνει: δεν υπάρχει ρυθμισμένο Android SDK στο περιβάλλον CI)*

------
https://chatgpt.com/codex/tasks/task_e_68cac5abeeb0832897fe055179ea21ff