### PR TITLE
Ensure unique transfer request numbering

### DIFF
--- a/app/src/main/java/com/ioannapergamali/mysmartroute/data/local/TransferRequestDao.kt
+++ b/app/src/main/java/com/ioannapergamali/mysmartroute/data/local/TransferRequestDao.kt
@@ -35,6 +35,9 @@ interface TransferRequestDao {
     @Query("SELECT * FROM transfer_requests WHERE driverId = :driverId")
     fun getRequestsForDriver(driverId: String): Flow<List<TransferRequestEntity>>
 
+    @Query("SELECT MAX(requestNumber) FROM transfer_requests")
+    suspend fun getMaxRequestNumber(): Int?
+
     @Query("DELETE FROM transfer_requests WHERE driverId = :driverId")
     suspend fun deleteForDriver(driverId: String)
 


### PR DESCRIPTION
## Summary
- add a DAO helper to retrieve the μέγιστο requestNumber από τη Room βάση
- πριν την αποθήκευση ενός νέου αιτήματος, αντλούμε τον τελευταίο αριθμό τόσο από τοπική Room όσο και από το Firestore και ορίζουμε ρητά τον επόμενο μοναδικό αριθμό

## Testing
- ./gradlew test --console=plain *(αποτυχία: λείπει Android SDK στο περιβάλλον CI)*

------
https://chatgpt.com/codex/tasks/task_e_68cac66103bc83289ad9569fe33a2816