### PR TITLE
Add passenger notification when driver offers route

### DIFF
--- a/app/src/main/res/values-el/strings.xml
+++ b/app/src/main/res/values-el/strings.xml
@@ -350,6 +350,8 @@
     <string name="cancel_request">Ακύρωση αιτήματος</string>
     <string name="notify_route">Ειδοποίηση διαδρομής</string>
     <string name="notify_selected">Ειδοποίηση επιλεγμένων</string>
+    <string name="request_expired">Το αίτημα έχει λήξει</string>
+    <string name="request_already_pending">Το αίτημα βρίσκεται ήδη σε εκκρεμότητα</string>
     <string name="accept_offer">Αποδοχή</string>
     <string name="reject_offer">Απόρριψη</string>
     <string name="no_notifications">Καμία ειδοποίηση</string>
@@ -361,6 +363,7 @@
     <string name="transport_request_declaration_link">Δήλωση</string>
     <!-- Notification text -->
     <string name="app_started_notification">Η εφαρμογή ξεκίνησε</string>
+    <string name="request_pending_notification">Ο οδηγός %1$s ενδιαφέρεται να εξυπηρετήσει το αίτημά σας. Αίτημα αριθμός %2$d</string>
     <string name="request_accepted">Το αίτημα έγινε αποδεκτό</string>
 
     <string name="request_rejected_notification">Το αίτημά σας με αριθμό %1$d δεν έγινε αποδεκτό</string>
@@ -368,7 +371,7 @@
     <string name="request_accepted_notification">Το αίτημά σας με αριθμό %1$d έγινε αποδεκτό</string>
 
     <string name="passenger_request_notification">Ο επιβάτης %1$s ζήτησε μεταφορά. Αίτημα αριθμός %2$d</string>
-    <string name="driver_offer_notification">Ο οδηγός %1$s προσφέρθηκε να σας μεταφέρει. Αίτημα αριθμός %2$d</string>
+    <string name="driver_offer_notification">Ο οδηγός %1$s ενδιαφέρεται να εξυπηρετήσει το αίτημά σας. Αίτημα αριθμός %2$d</string>
     <string name="available_transports">Διαθέσιμες μεταφορές</string>
     <string name="no_transports_found">Δεν βρέθηκαν μεταφορές</string>
     <string name="rating_label">Βαθμολογία: %1$d</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -371,6 +371,7 @@
     <string name="notify_route">Notify route</string>
     <string name="notify_selected">Notify selected</string>
     <string name="request_expired">Request expired</string>
+    <string name="request_already_pending">Request is already pending</string>
     <string name="request_unsuccessful">Ανεπιτυχής</string>
     <string name="accept_offer">Accept</string>
     <string name="reject_offer">Reject</string>
@@ -390,9 +391,9 @@
 
     <!-- Notification text -->
     <string name="app_started_notification">App started successfully</string>
-    <string name="driver_offer_notification">Ο οδηγός %1$s προσφέρθηκε να σας μεταφέρει. Αίτημα αριθμός %2$d</string>
+    <string name="driver_offer_notification">Driver %1$s is interested in serving your request. Request number %2$d</string>
     <string name="passenger_request_notification">Ο επιβάτης %1$s ζήτησε μεταφορά. Αίτημα αριθμός %2$d</string>
-    <string name="request_pending_notification">Driver %1$s responded to your request. Request number %2$d</string>
+    <string name="request_pending_notification">Driver %1$s is interested in serving your request. Request number %2$d</string>
     <string name="request_accepted">Request accepted</string>
     <string name="request_accept_failed">Αποτυχία αποδοχής αιτήματος</string>
 


### PR DESCRIPTION
## Summary
- persist passenger notifications when a driver expresses interest and trigger in-app navigation when possible
- avoid duplicate driver offers and reuse request status messaging for the new alerts
- refresh notification strings with driver interest wording and provide Greek translations, including a toast for already pending requests

## Testing
- `./gradlew test --console=plain` *(fails: SDK location not found in environment)*

------
https://chatgpt.com/codex/tasks/task_e_68cac79560f08328b3e3f1e6c845edc1