### PR TITLE
Διαγραφή αιτημάτων μεταφοράς και από transfer_requests

### DIFF
--- a/app/src/main/java/com/ioannapergamali/mysmartroute/data/local/TransferRequestDao.kt
+++ b/app/src/main/java/com/ioannapergamali/mysmartroute/data/local/TransferRequestDao.kt
@@ -29,6 +29,9 @@ interface TransferRequestDao {
     @Query("SELECT * FROM transfer_requests WHERE requestNumber = :requestNumber")
     suspend fun getRequestByNumber(requestNumber: Int): TransferRequestEntity?
 
+    @Query("DELETE FROM transfer_requests WHERE requestNumber IN (:requestNumbers)")
+    suspend fun deleteByRequestNumbers(requestNumbers: List<Int>)
+
     @Query("SELECT * FROM transfer_requests WHERE passengerId = :passengerId")
     fun getRequestsForPassenger(passengerId: String): Flow<List<TransferRequestEntity>>
 


### PR DESCRIPTION
## Summary
- προστέθηκε μέθοδος DAO για διαγραφή αιτημάτων μεταφοράς βάσει requestNumber
- ενημερώθηκε η deleteRequests ώστε να αφαιρεί πρώτα τις εγγραφές από movings και στη συνέχεια από transfer_requests σε Room και Firestore
- προστέθηκε χειρισμός σφαλμάτων και αναμονή για τις διαγραφές στο Firebase

## Testing
- ./gradlew lint --console=plain *(αποτυχία: λείπει Android SDK στον CI χώρο)*

------
https://chatgpt.com/codex/tasks/task_e_68cac906d4e48328ae8bffb8a3c2a3f3