### PR TITLE
Prevent auto inserting transfer requests on view

### DIFF
--- a/app/src/main/java/com/ioannapergamali/mysmartroute/viewmodel/VehicleRequestViewModel.kt
+++ b/app/src/main/java/com/ioannapergamali/mysmartroute/viewmodel/VehicleRequestViewModel.kt
@@ -151,7 +151,12 @@ class VehicleRequestViewModel(
             _requests.value = movings
 
             if (remote.isNotEmpty()) {
-                remote.forEach { dao.insert(it) }
+                val existingNumbers = local.map { it.requestNumber }.toSet()
+                remote.forEach { request ->
+                    if (request.requestNumber in existingNumbers) {
+                        dao.insert(request)
+                    }
+                }
             }
 
             passengerRequests.clear()


### PR DESCRIPTION
## Summary
- avoid writing transfer requests from Firestore into Room when simply loading the requests screen
- resolve transfer request documents directly in Firestore so driver notifications and status updates succeed without local records

## Testing
- ./gradlew test --console=plain *(fails: Android SDK not available in container)*

------
https://chatgpt.com/codex/tasks/task_e_68cac980ccb88328b38dc13f10e4857c