### PR TITLE
Update duration field on find vehicle route edits

### DIFF
--- a/app/src/main/res/values-el/strings.xml
+++ b/app/src/main/res/values-el/strings.xml
@@ -261,6 +261,8 @@
     <string name="vehicle">Όχημα</string>
     <string name="cost">Κόστος</string>
     <string name="duration">Διάρκεια</string>
+    <string name="duration_not_available">Μη διαθέσιμο</string>
+    <string name="minutes_suffix">λεπτά</string>
     <string name="date">Ημερομηνία</string>
     <string name="status">Κατάσταση</string>
     <string name="time">Ώρα</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -262,6 +262,8 @@
     <string name="vehicle">Vehicle</string>
     <string name="cost">Cost</string>
     <string name="duration">Duration</string>
+    <string name="duration_not_available">Not available</string>
+    <string name="minutes_suffix">min</string>
     <string name="date">Date</string>
     <string name="status">Status</string>
     <string name="time">Time</string>


### PR DESCRIPTION
## Summary
- store the calculated duration when recomputing routes on the Find Vehicle screen
- present a read-only duration field with appropriate placeholders while recomputing
- add localized strings for the duration placeholder and units

## Testing
- ./gradlew :app:lint --console=plain --no-daemon *(fails: requires local Android SDK path)*

------
https://chatgpt.com/codex/tasks/task_e_68cacdc33a6883289f63c2cfcbdb8b44