### PR TITLE
Περιορισμός δημιουργίας εγγραφών transfer_requests

### DIFF
--- a/app/src/main/java/com/ioannapergamali/mysmartroute/viewmodel/DatabaseViewModel.kt
+++ b/app/src/main/java/com/ioannapergamali/mysmartroute/viewmodel/DatabaseViewModel.kt
@@ -1007,7 +1007,18 @@ class DatabaseViewModel : ViewModel() {
                     updateSyncTable(context, "seat_reservation_details")
                     seatResDetails.forEach { db.seatReservationDetailDao().insert(it) }
                     updateSyncTable(context, "transfer_requests")
-                    transferRequests.forEach { db.transferRequestDao().insert(it) }
+                    if (transferRequests.isNotEmpty()) {
+                        val existingRequestNumbers = db.transferRequestDao()
+                            .getAll()
+                            .first()
+                            .map { it.requestNumber }
+                            .toSet()
+                        transferRequests.forEach { request ->
+                            if (request.requestNumber in existingRequestNumbers) {
+                                db.transferRequestDao().insert(request)
+                            }
+                        }
+                    }
                     updateSyncTable(context, "trip_ratings")
                     tripRatings.forEach { db.tripRatingDao().upsert(it) }
                     Log.d(TAG, "Inserted remote data to local DB")


### PR DESCRIPTION
## Summary
- Προστέθηκε έλεγχος στον συγχρονισμό βάσης ώστε τα transfer_requests να ενημερώνονται μόνο όταν υπάρχουν ήδη τοπικά

## Testing
- ./gradlew test --console=plain (αποτυχία: λείπει Android SDK στο περιβάλλον)

------
https://chatgpt.com/codex/tasks/task_e_68cad2c450c8832885e4010d28b0333a