### PR TITLE
Display route names and stops in transfer request screens

### DIFF
--- a/app/src/main/java/com/ioannapergamali/mysmartroute/view/ui/screens/ViewRequestsScreen.kt
+++ b/app/src/main/java/com/ioannapergamali/mysmartroute/view/ui/screens/ViewRequestsScreen.kt
@@ -148,6 +148,10 @@ fun ViewRequestsScreen(
                                     modifier = Modifier.width(columnWidth)
                                 )
                                 Text(
+                                    stringResource(R.string.stops_header),
+                                    modifier = Modifier.width(columnWidth)
+                                )
+                                Text(
                                     stringResource(R.string.cost),
                                     modifier = Modifier.width(columnWidth)
                                 )
@@ -169,8 +173,9 @@ fun ViewRequestsScreen(
                         items(sortedRequests) { req ->
                             val fromName = poiNames[req.startPoiId] ?: ""
                             val toName = poiNames[req.endPoiId] ?: ""
-                            val routeName = if (fromName.isNotBlank() && toName.isNotBlank())
+                            val stationsText = if (fromName.isNotBlank() && toName.isNotBlank())
                                 "$fromName → $toName" else ""
+                            val routeName = req.routeName.ifBlank { stationsText }
                             val dateTimeText = if (req.date > 0L) {
                                 val date = Date(req.date)
                                 val dateStr = DateFormat.getDateFormat(context).format(date)
@@ -187,6 +192,7 @@ fun ViewRequestsScreen(
                             ) {
                                 Text(req.requestNumber.toString(), modifier = Modifier.width(columnWidth))
                                 Text(routeName, modifier = Modifier.width(columnWidth))
+                                Text(stationsText, modifier = Modifier.width(columnWidth))
                                 Text(costText, modifier = Modifier.width(columnWidth))
                                 Text(dateTimeText, modifier = Modifier.width(columnWidth))
                                 Text(driverName, modifier = Modifier.width(columnWidth))

--- a/app/src/main/java/com/ioannapergamali/mysmartroute/view/ui/screens/ViewTransportRequestsScreen.kt
+++ b/app/src/main/java/com/ioannapergamali/mysmartroute/view/ui/screens/ViewTransportRequestsScreen.kt
@@ -154,6 +154,11 @@ fun ViewTransportRequestsScreen(
                                     style = MaterialTheme.typography.labelMedium
                                 )
                                 Text(
+                                    stringResource(R.string.stops_header),
+                                    modifier = Modifier.width(columnWidth),
+                                    style = MaterialTheme.typography.labelMedium
+                                )
+                                Text(
                                     stringResource(R.string.cost),
                                     modifier = Modifier.width(columnWidth),
                                     style = MaterialTheme.typography.labelMedium
@@ -184,7 +189,8 @@ fun ViewTransportRequestsScreen(
                         items(requests) { req ->
                             val fromName = poiNames[req.startPoiId] ?: ""
                             val toName = poiNames[req.endPoiId] ?: ""
-                            val routeName = if (fromName.isNotBlank() && toName.isNotBlank()) "$fromName - $toName" else ""
+                            val stationsText = if (fromName.isNotBlank() && toName.isNotBlank()) "$fromName - $toName" else ""
+                            val routeName = req.routeName.ifBlank { stationsText }
                             val userName = userNames[req.userId] ?: ""
                             val isChecked = selectedRequests[req.id] ?: false
                             val dateTimeText = if (req.date > 0L) {
@@ -208,6 +214,7 @@ fun ViewTransportRequestsScreen(
                                 )
                                 Text(userName, modifier = Modifier.width(columnWidth))
                                 Text(routeName, modifier = Modifier.width(columnWidth))
+                                Text(stationsText, modifier = Modifier.width(columnWidth))
                                 val costText = req.cost?.toString() ?: "∞"
                                 Text(costText, modifier = Modifier.width(columnWidth))
                                 Text(dateTimeText, modifier = Modifier.width(columnWidth))


### PR DESCRIPTION
## Summary
- show the saved route name instead of stop labels in both passenger and driver transfer request lists
- add a dedicated "Stops" column that continues to show the start and end stop names for each request

## Testing
- ./gradlew :app:lintDebug --console=plain *(fails: Android SDK missing in container)*

------
https://chatgpt.com/codex/tasks/task_e_68cad3fc7a0c83289f23f08071beec81