### PR TITLE
Fix TimePickerDialog reference in BookSeatScreen

### DIFF
--- a/app/src/main/java/com/ioannapergamali/mysmartroute/view/ui/screens/BookSeatScreen.kt
+++ b/app/src/main/java/com/ioannapergamali/mysmartroute/view/ui/screens/BookSeatScreen.kt
@@ -24,7 +24,7 @@ import androidx.compose.material3.SelectableDates
 import androidx.compose.material3.TextButton
 import androidx.compose.material3.rememberDatePickerState
 import androidx.compose.material3.TimePicker
-import androidx.compose.material3.TimePickerDialog
+import androidx.compose.material3.AlertDialog
 import androidx.compose.material3.rememberTimePickerState
 import androidx.compose.material3.OutlinedTextField
 import androidx.compose.material3.OutlinedTextFieldDefaults
@@ -665,4 +665,19 @@ fun BookSeatScreen(
             }
         }
     }
+}
+
+@Composable
+private fun TimePickerDialog(
+    onDismissRequest: () -> Unit,
+    confirmButton: @Composable () -> Unit,
+    dismissButton: @Composable (() -> Unit)? = null,
+    content: @Composable () -> Unit
+) {
+    AlertDialog(
+        onDismissRequest = onDismissRequest,
+        confirmButton = confirmButton,
+        dismissButton = dismissButton,
+        text = content
+    )
 }


### PR DESCRIPTION
## Summary
- replace the Material3 TimePickerDialog import with AlertDialog and provide a local wrapper that hosts the compose TimePicker

## Testing
- `./gradlew :app:compileDebugKotlin` *(fails: Android SDK is not available in the container)*

------
https://chatgpt.com/codex/tasks/task_e_68cad8b9151c8328be7086c4b078d14b