### PR TITLE
Add time column to transport request listings

### DIFF
--- a/app/src/main/java/com/ioannapergamali/mysmartroute/view/ui/screens/ViewRequestsScreen.kt
+++ b/app/src/main/java/com/ioannapergamali/mysmartroute/view/ui/screens/ViewRequestsScreen.kt
@@ -160,6 +160,10 @@ fun ViewRequestsScreen(
                                     modifier = Modifier.width(columnWidth)
                                 )
                                 Text(
+                                    stringResource(R.string.time),
+                                    modifier = Modifier.width(columnWidth)
+                                )
+                                Text(
                                     stringResource(R.string.driver),
                                     modifier = Modifier.width(columnWidth)
                                 )
@@ -176,12 +180,9 @@ fun ViewRequestsScreen(
                             val stationsText = if (fromName.isNotBlank() && toName.isNotBlank())
                                 "$fromName → $toName" else ""
                             val routeName = req.routeName.ifBlank { stationsText }
-                            val dateTimeText = if (req.date > 0L) {
-                                val date = Date(req.date)
-                                val dateStr = DateFormat.getDateFormat(context).format(date)
-                                val timeStr = DateFormat.format("HH:mm", date).toString()
-                                "$dateStr $timeStr"
-                            } else ""
+                            val dateValue = req.date.takeIf { it > 0L }?.let { Date(it) }
+                            val dateText = dateValue?.let { DateFormat.getDateFormat(context).format(it) } ?: ""
+                            val timeText = dateValue?.let { DateFormat.getTimeFormat(context).format(it) } ?: ""
                             val costText = req.cost?.toString() ?: "-"
                             val isExpired = req.date > 0L && now > req.date && req.status != "completed"
                             val statusText = if (isExpired) stringResource(R.string.request_unsuccessful) else req.status
@@ -194,7 +195,8 @@ fun ViewRequestsScreen(
                                 Text(routeName, modifier = Modifier.width(columnWidth))
                                 Text(stationsText, modifier = Modifier.width(columnWidth))
                                 Text(costText, modifier = Modifier.width(columnWidth))
-                                Text(dateTimeText, modifier = Modifier.width(columnWidth))
+                                Text(dateText, modifier = Modifier.width(columnWidth))
+                                Text(timeText, modifier = Modifier.width(columnWidth))
                                 Text(driverName, modifier = Modifier.width(columnWidth))
                                 if (req.status == "pending" && req.driverId.isNotBlank() && !isExpired) {
                                     Button(onClick = {

--- a/app/src/main/java/com/ioannapergamali/mysmartroute/view/ui/screens/ViewTransportRequestsScreen.kt
+++ b/app/src/main/java/com/ioannapergamali/mysmartroute/view/ui/screens/ViewTransportRequestsScreen.kt
@@ -169,6 +169,11 @@ fun ViewTransportRequestsScreen(
                                     style = MaterialTheme.typography.labelMedium
                                 )
                                 Text(
+                                    stringResource(R.string.time),
+                                    modifier = Modifier.width(columnWidth),
+                                    style = MaterialTheme.typography.labelMedium
+                                )
+                                Text(
                                     stringResource(R.string.request_number),
                                     modifier = Modifier.width(columnWidth),
                                     style = MaterialTheme.typography.labelMedium
@@ -193,10 +198,9 @@ fun ViewTransportRequestsScreen(
                             val routeName = req.routeName.ifBlank { stationsText }
                             val userName = userNames[req.userId] ?: ""
                             val isChecked = selectedRequests[req.id] ?: false
-                            val dateTimeText = if (req.date > 0L) {
-                                val date = Date(req.date)
-                                DateFormat.getDateFormat(context).format(date)
-                            } else ""
+                            val dateValue = req.date.takeIf { it > 0L }?.let { Date(it) }
+                            val dateText = dateValue?.let { DateFormat.getDateFormat(context).format(it) } ?: ""
+                            val timeText = dateValue?.let { DateFormat.getTimeFormat(context).format(it) } ?: ""
                             Row(
                                 modifier = Modifier.padding(vertical = 8.dp),
                                 verticalAlignment = Alignment.CenterVertically
@@ -217,7 +221,8 @@ fun ViewTransportRequestsScreen(
                                 Text(stationsText, modifier = Modifier.width(columnWidth))
                                 val costText = req.cost?.toString() ?: "∞"
                                 Text(costText, modifier = Modifier.width(columnWidth))
-                                Text(dateTimeText, modifier = Modifier.width(columnWidth))
+                                Text(dateText, modifier = Modifier.width(columnWidth))
+                                Text(timeText, modifier = Modifier.width(columnWidth))
                                 Text(req.requestNumber.toString(), modifier = Modifier.width(columnWidth))
                                 val isNewRequest = req.routeId.isBlank() || req.routeId !in declaredRouteIds
                                 Text(


### PR DESCRIPTION
## Summary
- add a localized time column to the driver transport request table so the departure time is visible at a glance
- split the passenger transport request date display into separate date and time columns to match the new requirement

## Testing
- ./gradlew lint --console=plain *(fails: Android SDK is not available in the container)*

------
https://chatgpt.com/codex/tasks/task_e_68cadd19cf90832897248531ae9cb8c0