### PR TITLE
Expand notification record schema

### DIFF
--- a/app/src/main/java/com/ioannapergamali/mysmartroute/data/local/MySmartRouteDatabase.kt
+++ b/app/src/main/java/com/ioannapergamali/mysmartroute/data/local/MySmartRouteDatabase.kt
@@ -82,7 +82,7 @@ import com.ioannapergamali.mysmartroute.data.local.AuthenticationDao
         AppDateTimeEntity::class
     ],
 
-    version = 77
+    version = 78
 
 )
 @TypeConverters(Converters::class)
@@ -1057,6 +1057,28 @@ abstract class MySmartRouteDatabase : RoomDatabase() {
             }
         }
 
+        private val MIGRATION_77_78 = object : Migration(77, 78) {
+            override fun migrate(database: SupportSQLiteDatabase) {
+                database.execSQL(
+                    "CREATE TABLE IF NOT EXISTS `notifications_new` (" +
+                        "`id` TEXT NOT NULL, " +
+                        "`senderId` TEXT NOT NULL, " +
+                        "`receiverId` TEXT NOT NULL, " +
+                        "`message` TEXT NOT NULL, " +
+                        "`sentDate` TEXT NOT NULL, " +
+                        "`sentTime` TEXT NOT NULL, " +
+                        "PRIMARY KEY(`id`)" +
+                        ")"
+                )
+                database.execSQL(
+                    "INSERT INTO `notifications_new` (`id`, `senderId`, `receiverId`, `message`, `sentDate`, `sentTime`) " +
+                        "SELECT `id`, '' AS senderId, `userId` AS receiverId, `message`, '' AS sentDate, '' AS sentTime FROM `notifications`"
+                )
+                database.execSQL("DROP TABLE `notifications`")
+                database.execSQL("ALTER TABLE `notifications_new` RENAME TO `notifications`")
+            }
+        }
+
         private fun prepopulate(db: SupportSQLiteDatabase) {
             Log.d(TAG, "Prepopulating database")
             db.execSQL(
@@ -1212,7 +1234,8 @@ abstract class MySmartRouteDatabase : RoomDatabase() {
                     MIGRATION_73_74,
                     MIGRATION_74_75,
                     MIGRATION_75_76,
-                    MIGRATION_76_77
+                    MIGRATION_76_77,
+                    MIGRATION_77_78
 
                 )
                     .addCallback(object : RoomDatabase.Callback() {

--- a/app/src/main/java/com/ioannapergamali/mysmartroute/data/local/NotificationDao.kt
+++ b/app/src/main/java/com/ioannapergamali/mysmartroute/data/local/NotificationDao.kt
@@ -13,7 +13,7 @@ interface NotificationDao {
     @Insert(onConflict = OnConflictStrategy.REPLACE)
     suspend fun insert(notification: NotificationEntity)
 
-    @Query("SELECT * FROM notifications WHERE userId = :userId")
+    @Query("SELECT * FROM notifications WHERE receiverId = :userId")
     fun getForUser(userId: String): Flow<List<NotificationEntity>>
 
     @Query("SELECT * FROM notifications")

--- a/app/src/main/java/com/ioannapergamali/mysmartroute/data/local/NotificationEntity.kt
+++ b/app/src/main/java/com/ioannapergamali/mysmartroute/data/local/NotificationEntity.kt
@@ -9,6 +9,9 @@ import androidx.room.PrimaryKey
 @Entity(tableName = "notifications")
 data class NotificationEntity(
     @PrimaryKey val id: String = "",
-    val userId: String = "",
-    val message: String = ""
+    val senderId: String = "",
+    val receiverId: String = "",
+    val message: String = "",
+    val sentDate: String = "",
+    val sentTime: String = ""
 )

--- a/app/src/main/java/com/ioannapergamali/mysmartroute/view/ui/screens/DatabaseSyncScreen.kt
+++ b/app/src/main/java/com/ioannapergamali/mysmartroute/view/ui/screens/DatabaseSyncScreen.kt
@@ -586,7 +586,10 @@ private fun DatabaseData.toTableDisplays(context: Context): List<TableDisplay> {
             context.getString(
                 R.string.table_notifications_row,
                 notification.id.ifBlankDash(),
-                notification.userId.ifBlankDash(),
+                notification.senderId.ifBlankDash(),
+                notification.receiverId.ifBlankDash(),
+                notification.sentDate.ifBlankDash(),
+                notification.sentTime.ifBlankDash(),
                 notification.message.ifBlankDash()
             )
         }

--- a/app/src/main/java/com/ioannapergamali/mysmartroute/view/ui/screens/FirebaseDatabaseScreen.kt
+++ b/app/src/main/java/com/ioannapergamali/mysmartroute/view/ui/screens/FirebaseDatabaseScreen.kt
@@ -158,7 +158,7 @@ fun FirebaseDatabaseScreen(navController: NavController, openDrawer: () -> Unit)
                 item { Spacer(modifier = Modifier.padding(8.dp)) }
                 item { Text("Notifications", style = MaterialTheme.typography.titleMedium) }
                 items(data!!.notifications) { n ->
-                    Text("${n.userId} -> ${n.message}")
+                    Text("${n.senderId} -> ${n.receiverId} (${n.sentDate} ${n.sentTime}): ${n.message}")
                 }
                 item { Spacer(modifier = Modifier.padding(8.dp)) }
                 item { Text("Authentication table δεν είναι διαθέσιμη από το client", color = MaterialTheme.colorScheme.error) }

--- a/app/src/main/java/com/ioannapergamali/mysmartroute/view/ui/screens/LocalDatabaseScreen.kt
+++ b/app/src/main/java/com/ioannapergamali/mysmartroute/view/ui/screens/LocalDatabaseScreen.kt
@@ -250,7 +250,7 @@ fun LocalDatabaseScreen(navController: NavController, openDrawer: () -> Unit) {
                     item { Text("Ο πίνακας είναι άδειος") }
                 } else {
                     items(data!!.notifications) { n ->
-                        Text("${n.userId} -> ${n.message}")
+                        Text("${n.senderId} -> ${n.receiverId} (${n.sentDate} ${n.sentTime}): ${n.message}")
                     }
                 }
                 }

--- a/app/src/main/java/com/ioannapergamali/mysmartroute/viewmodel/UserViewModel.kt
+++ b/app/src/main/java/com/ioannapergamali/mysmartroute/viewmodel/UserViewModel.kt
@@ -205,10 +205,14 @@ class UserViewModel : ViewModel() {
 
                 // ενημερώνουμε τον επιβάτη με ειδοποίηση
                 // notify the passenger with a notification
+                val now = java.time.LocalDateTime.now()
                 val notification = NotificationEntity(
                     id = java.util.UUID.randomUUID().toString(),
-                    userId = reservation.userId,
+                    senderId = driverId,
+                    receiverId = reservation.userId,
                     message = "Η κράτησή σας ακυρώθηκε λόγω αλλαγής οδηγού.",
+                    sentDate = now.toLocalDate().toString(),
+                    sentTime = now.toLocalTime().withSecond(0).withNano(0).toString(),
                 )
                 notifDao.insert(notification)
                 runCatching {

--- a/app/src/main/java/com/ioannapergamali/mysmartroute/viewmodel/VehicleRequestViewModel.kt
+++ b/app/src/main/java/com/ioannapergamali/mysmartroute/viewmodel/VehicleRequestViewModel.kt
@@ -561,10 +561,14 @@ class VehicleRequestViewModel(
                     driverName,
                     updated.requestNumber
                 )
+                val now = java.time.LocalDateTime.now()
                 val notification = NotificationEntity(
                     id = UUID.randomUUID().toString(),
-                    userId = updated.userId,
-                    message = message
+                    senderId = driver.uid,
+                    receiverId = updated.userId,
+                    message = message,
+                    sentDate = now.toLocalDate().toString(),
+                    sentTime = now.toLocalTime().withSecond(0).withNano(0).toString()
                 )
                 try {
                     dbInstance.notificationDao().insert(notification)

--- a/app/src/main/res/values-el/strings.xml
+++ b/app/src/main/res/values-el/strings.xml
@@ -139,7 +139,7 @@
     <string name="table_seat_reservations_row">[%1$s] διαδρομή %2$s, χρήστης %3$s, ημερομηνία %4$s, ώρα %5$s</string>
     <string name="table_transfer_requests_row">Αίτημα #%1$d, διαδρομή %2$s, επιβάτης %3$s, οδηγός %4$s, κατάσταση %5$s</string>
     <string name="table_trip_ratings_row">Μετακίνηση %1$s, χρήστης %2$s, βαθμολογία %3$d, σχόλιο: %4$s</string>
-    <string name="table_notifications_row">[%1$s] χρήστης %2$s, μήνυμα: %3$s</string>
+    <string name="table_notifications_row">[%1$s] %2$s → %3$s (%4$s %5$s): %6$s</string>
     <string name="user_points">Σημεία χρηστών</string>
     <string name="admin_option">Επιλογή Διαχειριστή</string>
     <string name="profile">Προφίλ</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -139,7 +139,7 @@
     <string name="table_seat_reservations_row">[%1$s] διαδρομή %2$s, χρήστης %3$s, ημερομηνία %4$s, ώρα %5$s</string>
     <string name="table_transfer_requests_row">Αίτημα #%1$d, διαδρομή %2$s, επιβάτης %3$s, οδηγός %4$s, κατάσταση %5$s</string>
     <string name="table_trip_ratings_row">Μετακίνηση %1$s, χρήστης %2$s, βαθμολογία %3$d, σχόλιο: %4$s</string>
-    <string name="table_notifications_row">[%1$s] χρήστης %2$s, μήνυμα: %3$s</string>
+    <string name="table_notifications_row">[%1$s] %2$s → %3$s (%4$s %5$s): %6$s</string>
     <string name="user_points">User Points</string>
     <string name="admin_option">Admin Option</string>
     <string name="profile">Profile</string>


### PR DESCRIPTION
## Summary
- add sender, receiver and timestamp columns to the notifications entity and DAO
- bump the Room schema to v78 with a migration and sync the Firestore mappers
- populate the new fields when creating notifications and expose them in the database overview UI

## Testing
- ./gradlew test --console=plain *(fails: Android SDK not installed in CI sandbox)*

------
https://chatgpt.com/codex/tasks/task_e_68cadeb3c7c883289191a61aefa5c33d