### PR TITLE
Use stored app clock for notification timestamps

### DIFF
--- a/app/src/main/java/com/ioannapergamali/mysmartroute/data/local/AppDateTimeExtensions.kt
+++ b/app/src/main/java/com/ioannapergamali/mysmartroute/data/local/AppDateTimeExtensions.kt
@@ -1,0 +1,13 @@
+package com.ioannapergamali.mysmartroute.data.local
+
+import java.time.Instant
+import java.time.LocalDateTime
+import java.time.ZoneId
+
+/** Επιστρέφει την αποθηκευμένη ημερομηνία/ώρα της εφαρμογής ως [LocalDateTime]. */
+suspend fun MySmartRouteDatabase.currentAppDateTime(): LocalDateTime {
+    val storedMillis = appDateTimeDao().getDateTime()?.timestamp ?: System.currentTimeMillis()
+    return Instant.ofEpochMilli(storedMillis)
+        .atZone(ZoneId.systemDefault())
+        .toLocalDateTime()
+}

--- a/app/src/main/java/com/ioannapergamali/mysmartroute/viewmodel/TransferRequestViewModel.kt
+++ b/app/src/main/java/com/ioannapergamali/mysmartroute/viewmodel/TransferRequestViewModel.kt
@@ -15,6 +15,7 @@ import com.ioannapergamali.mysmartroute.data.local.MySmartRouteDatabase
 import com.ioannapergamali.mysmartroute.data.local.NotificationEntity
 import com.ioannapergamali.mysmartroute.data.local.TransferRequestDao
 import com.ioannapergamali.mysmartroute.data.local.TransferRequestEntity
+import com.ioannapergamali.mysmartroute.data.local.currentAppDateTime
 import com.ioannapergamali.mysmartroute.model.enumerations.RequestStatus
 import com.ioannapergamali.mysmartroute.model.enumerations.UserRole
 import com.ioannapergamali.mysmartroute.utils.SessionManager
@@ -351,7 +352,7 @@ class TransferRequestViewModel : ViewModel() {
         targetDrivers
             .filter { it != passengerId }
             .forEach { driverId ->
-                val now = java.time.LocalDateTime.now()
+                val now = database.currentAppDateTime()
                 val notification = NotificationEntity(
                     id = UUID.randomUUID().toString(),
                     senderId = passengerId,

--- a/app/src/main/java/com/ioannapergamali/mysmartroute/viewmodel/UserViewModel.kt
+++ b/app/src/main/java/com/ioannapergamali/mysmartroute/viewmodel/UserViewModel.kt
@@ -8,6 +8,7 @@ import com.google.firebase.firestore.FirebaseFirestore
 import com.ioannapergamali.mysmartroute.data.local.MySmartRouteDatabase
 import com.ioannapergamali.mysmartroute.data.local.UserEntity
 import com.ioannapergamali.mysmartroute.data.local.NotificationEntity
+import com.ioannapergamali.mysmartroute.data.local.currentAppDateTime
 import com.ioannapergamali.mysmartroute.data.local.demoteDriverToPassenger
 import com.ioannapergamali.mysmartroute.data.local.promotePassengerToDriver
 import com.ioannapergamali.mysmartroute.data.local.insertUserSafely
@@ -205,7 +206,7 @@ class UserViewModel : ViewModel() {
 
                 // ενημερώνουμε τον επιβάτη με ειδοποίηση
                 // notify the passenger with a notification
-                val now = java.time.LocalDateTime.now()
+                val now = dbInstance.currentAppDateTime()
                 val notification = NotificationEntity(
                     id = java.util.UUID.randomUUID().toString(),
                     senderId = driverId,

--- a/app/src/main/java/com/ioannapergamali/mysmartroute/viewmodel/VehicleRequestViewModel.kt
+++ b/app/src/main/java/com/ioannapergamali/mysmartroute/viewmodel/VehicleRequestViewModel.kt
@@ -17,6 +17,7 @@ import com.ioannapergamali.mysmartroute.data.local.RouteDao
 import com.ioannapergamali.mysmartroute.data.local.UserDao
 import com.ioannapergamali.mysmartroute.data.local.VehicleDao
 import com.ioannapergamali.mysmartroute.data.local.TransferRequestEntity
+import com.ioannapergamali.mysmartroute.data.local.currentAppDateTime
 import kotlinx.coroutines.Dispatchers
 import com.ioannapergamali.mysmartroute.utils.toFirestoreMap
 import com.ioannapergamali.mysmartroute.utils.toMovingEntity
@@ -561,7 +562,7 @@ class VehicleRequestViewModel(
                     driverName,
                     updated.requestNumber
                 )
-                val now = java.time.LocalDateTime.now()
+                val now = dbInstance.currentAppDateTime()
                 val notification = NotificationEntity(
                     id = UUID.randomUUID().toString(),
                     senderId = driver.uid,


### PR DESCRIPTION
## Summary
- προστέθηκε επέκταση Room για ανάγνωση της αποθηκευμένης ημερομηνίας και ώρας της εφαρμογής
- ενημερώθηκαν οι ViewModel αποστολής ειδοποιήσεων ώστε να χρησιμοποιούν την αποθηκευμένη ημερομηνία/ώρα στις εγγραφές Room και Firestore

## Testing
- ./gradlew :app:compileDebugKotlin --no-daemon --console=plain --info *(αποτυχία: το περιβάλλον δεν διαθέτει εγκατεστημένο Android SDK)*

------
https://chatgpt.com/codex/tasks/task_e_68cae5cadbb48328bbf39510c3f16714