### PR TITLE
Ενημέρωση ειδοποιήσεων οδηγών για ανοιχτά αιτήματα

### DIFF
--- a/app/src/main/java/com/ioannapergamali/mysmartroute/data/local/MovingEntity.kt
+++ b/app/src/main/java/com/ioannapergamali/mysmartroute/data/local/MovingEntity.kt
@@ -94,3 +94,13 @@ data class MovingEntity(
         this.vehicleName = vehicleName
     }
 }
+
+/**
+ * Επιστρέφει true όταν το αίτημα είναι ανοιχτό και δεν έχει ακόμη οδηγό.
+ * Returns true when the request is open and no driver has expressed interest yet.
+ */
+fun MovingEntity.isAwaitingDriver(): Boolean =
+    driverId.isBlank() && status.isOpenStatus()
+
+private fun String.isOpenStatus(): Boolean =
+    isBlank() || equals("open", ignoreCase = true)

--- a/app/src/main/java/com/ioannapergamali/mysmartroute/view/ui/screens/NotificationsScreen.kt
+++ b/app/src/main/java/com/ioannapergamali/mysmartroute/view/ui/screens/NotificationsScreen.kt
@@ -25,6 +25,7 @@ import com.ioannapergamali.mysmartroute.view.ui.components.TopBar
 import com.ioannapergamali.mysmartroute.viewmodel.AuthenticationViewModel
 import com.ioannapergamali.mysmartroute.viewmodel.VehicleRequestViewModel
 import com.ioannapergamali.mysmartroute.viewmodel.UserViewModel
+import com.ioannapergamali.mysmartroute.data.local.isAwaitingDriver
 import com.ioannapergamali.mysmartroute.utils.SessionManager
 
 @OptIn(ExperimentalMaterial3Api::class)
@@ -63,11 +64,11 @@ fun NotificationsScreen(navController: NavController, openDrawer: () -> Unit) {
 
     val requestMessages = when (role) {
         UserRole.DRIVER -> requests.filter {
-            (it.driverId.isBlank() && it.status.isBlank()) ||
+            it.isAwaitingDriver() ||
                 (it.driverId == userId && (it.status == "accepted" || it.status == "rejected"))
         }.map { req ->
             when {
-                req.driverId.isBlank() -> stringResource(
+                req.isAwaitingDriver() -> stringResource(
                     R.string.passenger_request_notification,
                     req.createdByName,
                     req.requestNumber

--- a/app/src/main/java/com/ioannapergamali/mysmartroute/viewmodel/VehicleRequestViewModel.kt
+++ b/app/src/main/java/com/ioannapergamali/mysmartroute/viewmodel/VehicleRequestViewModel.kt
@@ -18,6 +18,7 @@ import com.ioannapergamali.mysmartroute.data.local.UserDao
 import com.ioannapergamali.mysmartroute.data.local.VehicleDao
 import com.ioannapergamali.mysmartroute.data.local.TransferRequestEntity
 import com.ioannapergamali.mysmartroute.data.local.currentAppDateTime
+import com.ioannapergamali.mysmartroute.data.local.isAwaitingDriver
 import kotlinx.coroutines.Dispatchers
 import com.ioannapergamali.mysmartroute.utils.toFirestoreMap
 import com.ioannapergamali.mysmartroute.utils.toMovingEntity
@@ -176,7 +177,7 @@ class VehicleRequestViewModel(
 
             val notifications = if (allUsers) {
                 _requests.value.filter {
-                    (it.driverId.isBlank() && it.status.isBlank()) ||
+                    it.isAwaitingDriver() ||
                         (it.driverId == userId && it.status == "accepted")
                 }
             } else {
@@ -353,7 +354,7 @@ class VehicleRequestViewModel(
         val userId = SessionManager.currentUserId()
         val notifications = if (allUsers) {
             _requests.value.filter {
-                (it.driverId.isBlank() && it.status.isBlank()) ||
+                it.isAwaitingDriver() ||
                     (it.driverId == userId && it.status == "accepted")
             }
         } else {
@@ -729,7 +730,7 @@ class VehicleRequestViewModel(
     }
 
     private suspend fun showPassengerRequestNotifications(context: Context) {
-        _requests.value.filter { it.driverId.isBlank() && it.status.isBlank() && it.id !in notifiedRequests }
+        _requests.value.filter { it.isAwaitingDriver() && it.id !in notifiedRequests }
             .forEach { req ->
                 val passengerName = UserViewModel().getUserName(context, req.userId)
                 val intent = Intent(context, MainActivity::class.java).apply {


### PR DESCRIPTION
## Περίληψη
- προστέθηκε συνάρτηση `isAwaitingDriver` στο `MovingEntity` για να αναγνωρίζονται αιτήματα που δεν έχουν οδηγό
- προσαρμόστηκαν τα φίλτρα του `VehicleRequestViewModel` ώστε να ειδοποιούν τους οδηγούς για αιτήματα με κατάσταση open
- ενημερώθηκε η οθόνη ειδοποιήσεων ώστε να εμφανίζει τα νέα αιτήματα οδηγών και να οδηγεί στη σωστή οθόνη

## Δοκιμές
- `./gradlew :app:compileDebugKotlin --console=plain --info` *(αποτυχημένο λόγω έλλειψης Android SDK στον τρέχοντα χώρο εργασίας)*

------
https://chatgpt.com/codex/tasks/task_e_68cae95919988328a8446d18e3fe6c48