### PR TITLE
Αποθήκευση ειδοποιήσεων στην Room

### DIFF
--- a/app/src/main/java/com/ioannapergamali/mysmartroute/utils/NotificationUtils.kt
+++ b/app/src/main/java/com/ioannapergamali/mysmartroute/utils/NotificationUtils.kt
@@ -5,9 +5,19 @@ import android.app.NotificationManager
 import android.app.PendingIntent
 import android.content.Context
 import android.os.Build
+import android.util.Log
 import androidx.core.app.NotificationCompat
 import androidx.core.app.NotificationManagerCompat
 import com.ioannapergamali.mysmartroute.R
+import com.ioannapergamali.mysmartroute.data.local.MySmartRouteDatabase
+import com.ioannapergamali.mysmartroute.data.local.NotificationEntity
+import com.ioannapergamali.mysmartroute.data.local.currentAppDateTime
+import com.ioannapergamali.mysmartroute.utils.SessionManager
+import java.time.LocalDateTime
+import java.util.UUID
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.launch
 
 /**
  * Απλοποιεί τη δημιουργία ειδοποιήσεων.
@@ -15,13 +25,18 @@ import com.ioannapergamali.mysmartroute.R
  */
 object NotificationUtils {
     private const val CHANNEL_ID = "default_channel"
+    private const val TAG = "NotificationUtils"
 
     fun showNotification(
         context: Context,
         title: String,
         text: String,
         id: Int = 0,
-        pendingIntent: PendingIntent? = null
+        pendingIntent: PendingIntent? = null,
+        storeInRoom: Boolean = false,
+        receiverId: String? = SessionManager.currentUserId(),
+        senderId: String = SessionManager.currentUserId().orEmpty(),
+        roomNotificationId: String? = null
     ) {
         // Δημιουργία καναλιού ειδοποίησης για Android 8+
         // Create notification channel for Android 8+
@@ -49,5 +64,29 @@ object NotificationUtils {
         val notification = builder.build()
 
         NotificationManagerCompat.from(context).notify(id, notification)
+
+        if (storeInRoom) {
+            val targetReceiver = receiverId ?: SessionManager.currentUserId()
+            if (!targetReceiver.isNullOrBlank()) {
+                CoroutineScope(Dispatchers.IO).launch {
+                    runCatching {
+                        val database = MySmartRouteDatabase.getInstance(context)
+                        val now = runCatching { database.currentAppDateTime() }
+                            .getOrElse { LocalDateTime.now() }
+                        val entity = NotificationEntity(
+                            id = roomNotificationId ?: UUID.randomUUID().toString(),
+                            senderId = senderId,
+                            receiverId = targetReceiver,
+                            message = text,
+                            sentDate = now.toLocalDate().toString(),
+                            sentTime = now.toLocalTime().withSecond(0).withNano(0).toString()
+                        )
+                        database.notificationDao().insert(entity)
+                    }.onFailure { error ->
+                        Log.e(TAG, "Failed to store notification", error)
+                    }
+                }
+            }
+        }
     }
 }

--- a/app/src/main/java/com/ioannapergamali/mysmartroute/viewmodel/VehicleRequestViewModel.kt
+++ b/app/src/main/java/com/ioannapergamali/mysmartroute/viewmodel/VehicleRequestViewModel.kt
@@ -752,7 +752,11 @@ class VehicleRequestViewModel(
                         req.requestNumber
                     ),
                     req.id.hashCode(),
-                    pending
+                    pending,
+                    storeInRoom = true,
+                    receiverId = SessionManager.currentUserId(),
+                    senderId = req.userId,
+                    roomNotificationId = "${req.id}_awaiting_driver"
                 )
                 notifiedRequests.add(req.id)
             }
@@ -786,7 +790,11 @@ class VehicleRequestViewModel(
                     req.requestNumber
                 ),
                 req.id.hashCode(),
-                pending
+                pending,
+                storeInRoom = true,
+                receiverId = SessionManager.currentUserId(),
+                senderId = req.driverId,
+                roomNotificationId = "${req.id}_pending"
             )
             notifiedRequests.add(req.id)
         }
@@ -811,7 +819,11 @@ class VehicleRequestViewModel(
                     context.getString(R.string.notifications),
                     context.getString(R.string.request_accepted_notification, req.requestNumber),
                     req.id.hashCode(),
-                    pending
+                    pending,
+                    storeInRoom = true,
+                    receiverId = userId,
+                    senderId = req.userId,
+                    roomNotificationId = "${req.id}_accepted"
                 )
                 notifiedRequests.add(req.id)
             }
@@ -839,7 +851,11 @@ class VehicleRequestViewModel(
                         req.requestNumber
                     ),
                     req.id.hashCode(),
-                    pending
+                    pending,
+                    storeInRoom = true,
+                    receiverId = userId,
+                    senderId = req.userId,
+                    roomNotificationId = "${req.id}_rejected"
                 )
                 notifiedRequests.add(req.id)
             }


### PR DESCRIPTION
## Summary
- επέκταση του NotificationUtils ώστε να μπορεί να αποθηκεύει τις ειδοποιήσεις στη Room όταν ζητηθεί
- αποθήκευση των ειδοποιήσεων που εμφανίζονται από το VehicleRequestViewModel με σταθερά αναγνωριστικά

## Testing
- `./gradlew lint --console=plain` *(αποτυγχάνει: λείπει Android SDK στον χώρο εργασίας)*

------
https://chatgpt.com/codex/tasks/task_e_68caf435ec5883289e565f6c2be7c18a