### PR TITLE
Βελτίωση οθόνης ειδοποιήσεων

### DIFF
--- a/app/src/main/java/com/ioannapergamali/mysmartroute/data/local/NotificationDao.kt
+++ b/app/src/main/java/com/ioannapergamali/mysmartroute/data/local/NotificationDao.kt
@@ -13,7 +13,7 @@ interface NotificationDao {
     @Insert(onConflict = OnConflictStrategy.REPLACE)
     suspend fun insert(notification: NotificationEntity)
 
-    @Query("SELECT * FROM notifications WHERE receiverId = :userId")
+    @Query("SELECT * FROM notifications WHERE receiverId = :userId ORDER BY sentDate DESC, sentTime DESC")
     fun getForUser(userId: String): Flow<List<NotificationEntity>>
 
     @Query("SELECT * FROM notifications")

--- a/app/src/main/java/com/ioannapergamali/mysmartroute/viewmodel/UserViewModel.kt
+++ b/app/src/main/java/com/ioannapergamali/mysmartroute/viewmodel/UserViewModel.kt
@@ -136,6 +136,20 @@ class UserViewModel : ViewModel() {
     }
 
     /**
+     * Διαγράφει μια συγκεκριμένη ειδοποίηση.
+     * Deletes a single notification.
+     */
+    fun deleteNotification(context: Context, notificationId: String) {
+        viewModelScope.launch {
+            val dao = MySmartRouteDatabase.getInstance(context).notificationDao()
+            dao.deleteById(notificationId)
+            runCatching {
+                db.collection("notifications").document(notificationId).delete().await()
+            }
+        }
+    }
+
+    /**
      * Αλλάζει τον ρόλο ενός χρήστη και ενημερώνει τα σχετικά δεδομένα.
      * Changes a user's role and updates related data.
      */

--- a/app/src/main/res/values-el/strings.xml
+++ b/app/src/main/res/values-el/strings.xml
@@ -357,6 +357,7 @@
     <string name="accept_offer">Αποδοχή</string>
     <string name="reject_offer">Απόρριψη</string>
     <string name="no_notifications">Καμία ειδοποίηση</string>
+    <string name="delete_notification">Διαγραφή ειδοποίησης</string>
     <string name="no_scheduled_transports">Δεν βρέθηκαν προγραμματισμένες μεταφορές</string>
     <string name="request_number">Αριθμός αιτήματος</string>
     <string name="transport_request_new_column">ΝΕΑ</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -379,6 +379,7 @@
     <string name="accept_offer">Accept</string>
     <string name="reject_offer">Reject</string>
     <string name="no_notifications">No notifications</string>
+    <string name="delete_notification">Delete notification</string>
     <string name="no_scheduled_transports">No scheduled transports</string>
 
     <string name="walking">Walking</string>


### PR DESCRIPTION
## Περίληψη
- Προστέθηκε λίστα αντικειμένων ειδοποίησης με εικονίδιο, ημερομηνία/ώρα και κουμπί διαγραφής στην NotificationsScreen.
- Προστέθηκε νέα συνάρτηση στο UserViewModel για διαγραφή μεμονωμένης ειδοποίησης και ταξινόμηση των εγγραφών από το NotificationDao.
- Εμπλουτίστηκαν τα string resources με κείμενο διαγραφής στα ελληνικά και αγγλικά.

## Έλεγχοι
- `./gradlew lint --console=plain` *(αποτυγχάνει επειδή δεν υπάρχει Android SDK στον φάκελο που ορίζεται στο local.properties)*

------
https://chatgpt.com/codex/tasks/task_e_68caf50ed64c8328800d5fc8dc36599c