### PR TITLE
Ensure consistent request numbering

### DIFF
--- a/app/src/main/java/com/ioannapergamali/mysmartroute/utils/RequestNumberProvider.kt
+++ b/app/src/main/java/com/ioannapergamali/mysmartroute/utils/RequestNumberProvider.kt
@@ -1,0 +1,44 @@
+package com.ioannapergamali.mysmartroute.utils
+
+import android.util.Log
+import com.google.firebase.firestore.FirebaseFirestore
+import com.google.firebase.firestore.Query
+import com.ioannapergamali.mysmartroute.data.local.TransferRequestDao
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.tasks.await
+import kotlinx.coroutines.withContext
+import kotlin.math.max
+
+object RequestNumberProvider {
+    private const val TAG = "RequestNumberProvider"
+
+    suspend fun nextRequestNumber(
+        transferDao: TransferRequestDao,
+        firestore: FirebaseFirestore
+    ): Int = withContext(Dispatchers.IO) {
+        val localLast = try {
+            transferDao.getMaxRequestNumber() ?: 0
+        } catch (error: Exception) {
+            Log.w(TAG, "Αποτυχία ανάκτησης τοπικού request number", error)
+            0
+        }
+
+        val remoteLast = try {
+            firestore.collection("transfer_requests")
+                .orderBy("requestNumber", Query.Direction.DESCENDING)
+                .limit(1)
+                .get()
+                .await()
+                .documents
+                .firstOrNull()
+                ?.getLong("requestNumber")
+                ?.toInt()
+                ?: 0
+        } catch (error: Exception) {
+            Log.w(TAG, "Αποτυχία ανάκτησης απομακρυσμένου request number", error)
+            0
+        }
+
+        max(localLast, remoteLast) + 1
+    }
+}

--- a/app/src/main/java/com/ioannapergamali/mysmartroute/viewmodel/VehicleRequestViewModel.kt
+++ b/app/src/main/java/com/ioannapergamali/mysmartroute/viewmodel/VehicleRequestViewModel.kt
@@ -42,6 +42,7 @@ import java.util.UUID
 import com.google.android.gms.maps.model.LatLng
 import com.ioannapergamali.mysmartroute.model.enumerations.VehicleType
 import com.ioannapergamali.mysmartroute.utils.MapsUtils
+import com.ioannapergamali.mysmartroute.utils.RequestNumberProvider
 import com.ioannapergamali.mysmartroute.utils.SessionManager
 
 data class PassengerRequest(
@@ -77,13 +78,6 @@ class VehicleRequestViewModel(
     companion object {
         private const val TAG = "VehicleRequestVM"
         const val WALKING_ID = "WALK"
-    }
-
-    private fun getNextRequestNumber(context: Context): Int {
-        val prefs = context.getSharedPreferences("vehicle_requests", Context.MODE_PRIVATE)
-        val next = prefs.getInt("next_request_number", 1)
-        prefs.edit().putInt("next_request_number", next + 1).apply()
-        return next
     }
 
     /**
@@ -462,6 +456,7 @@ class VehicleRequestViewModel(
         viewModelScope.launch {
             val dbInstance = MySmartRouteDatabase.getInstance(context)
             val dao = dbInstance.movingDao()
+            val transferDao = dbInstance.transferRequestDao()
             val routeName = dbInstance.routeDao().findById(routeId)?.name ?: ""
             val creator = FirebaseAuth.getInstance().currentUser
             val creatorId = creator?.uid ?: ""
@@ -473,7 +468,7 @@ class VehicleRequestViewModel(
                 return@launch
             }
             val id = UUID.randomUUID().toString()
-            val requestNumber = getNextRequestNumber(context)
+            val requestNumber = RequestNumberProvider.nextRequestNumber(transferDao, db)
 
             val routePoints = dbInstance.routePointDao().getPointsForRoute(routeId).first()
             val poiDao = dbInstance.poIDao()


### PR DESCRIPTION
## Summary
- add a RequestNumberProvider utility that fetches the next transfer request number from Room and Firestore
- use the shared provider inside TransferRequestViewModel when creating new transfer requests
- update VehicleRequestViewModel to obtain request numbers from the same provider instead of SharedPreferences

## Testing
- ./gradlew --console=plain app:compileDebugKotlin *(fails: SDK location not found in container)*

------
https://chatgpt.com/codex/tasks/task_e_68caf810f7108328b036cfe297ca3708