### PR TITLE
Store transport request time in Athens timezone

### DIFF
--- a/app/src/main/java/com/ioannapergamali/mysmartroute/utils/DateTimeUtils.kt
+++ b/app/src/main/java/com/ioannapergamali/mysmartroute/utils/DateTimeUtils.kt
@@ -1,0 +1,14 @@
+package com.ioannapergamali.mysmartroute.utils
+
+import java.time.Instant
+import java.time.LocalTime
+import java.time.ZoneId
+import java.time.ZonedDateTime
+
+private val ATHENS_ZONE_ID: ZoneId = ZoneId.of("Europe/Athens")
+
+fun combineDateAndTimeAsAthensInstant(dateMillis: Long, timeMillis: Long): Long {
+    val localDate = Instant.ofEpochMilli(dateMillis).atZone(ATHENS_ZONE_ID).toLocalDate()
+    val localTime = LocalTime.ofNanoOfDay(timeMillis * 1_000_000L)
+    return ZonedDateTime.of(localDate, localTime, ATHENS_ZONE_ID).toInstant().toEpochMilli()
+}

--- a/app/src/main/java/com/ioannapergamali/mysmartroute/view/ui/screens/BookSeatScreen.kt
+++ b/app/src/main/java/com/ioannapergamali/mysmartroute/view/ui/screens/BookSeatScreen.kt
@@ -61,6 +61,7 @@ import com.ioannapergamali.mysmartroute.data.local.PoIEntity
 import com.ioannapergamali.mysmartroute.model.enumerations.VehicleType
 import com.ioannapergamali.mysmartroute.utils.MapsUtils
 import com.ioannapergamali.mysmartroute.utils.offsetPois
+import com.ioannapergamali.mysmartroute.utils.combineDateAndTimeAsAthensInstant
 import com.ioannapergamali.mysmartroute.view.ui.components.ScreenContainer
 import com.ioannapergamali.mysmartroute.view.ui.components.TopBar
 import com.ioannapergamali.mysmartroute.view.ui.components.BookingStepsIndicator
@@ -640,12 +641,13 @@ fun BookSeatScreen(
                                 return@launch
                             }
 
+                            val requestDateTime = combineDateAndTimeAsAthensInstant(dateMillis, timeMillis)
                             transferRequestViewModel.submitRequest(
                                 context,
                                 routeId,
                                 startId,
                                 endId,
-                                dateMillis + timeMillis,
+                                requestDateTime,
                                 null,
                                 poiChanged
                             )

--- a/app/src/main/java/com/ioannapergamali/mysmartroute/view/ui/screens/RouteModeScreen.kt
+++ b/app/src/main/java/com/ioannapergamali/mysmartroute/view/ui/screens/RouteModeScreen.kt
@@ -44,6 +44,7 @@ import com.ioannapergamali.mysmartroute.viewmodel.TransferRequestViewModel
 import com.ioannapergamali.mysmartroute.model.enumerations.VehicleType
 import com.ioannapergamali.mysmartroute.utils.MapsUtils
 import com.ioannapergamali.mysmartroute.utils.offsetPois
+import com.ioannapergamali.mysmartroute.utils.combineDateAndTimeAsAthensInstant
 import androidx.lifecycle.compose.LocalLifecycleOwner
 import androidx.lifecycle.Lifecycle
 import androidx.lifecycle.LifecycleEventObserver
@@ -539,12 +540,13 @@ fun RouteModeScreen(
                                 return@launch
                             }
 
+                            val requestDateTime = combineDateAndTimeAsAthensInstant(date, time)
                             transferRequestViewModel.submitRequest(
                                 context,
                                 routeId,
                                 fromId,
                                 toId,
-                                date + time,
+                                requestDateTime,
                                 cost,
                                 poiChanged
                             )


### PR DESCRIPTION
## Summary
- Δημιουργήθηκε βοηθητικό `combineDateAndTimeAsAthensInstant` που συνδυάζει ημερομηνία/ώρα σύμφωνα με τη ζώνη `Europe/Athens`.
- Ενημερώθηκαν οι οθόνες εύρεσης μεταφοράς (`RouteModeScreen`, `BookSeatScreen`) ώστε τα αιτήματα να αποθηκεύουν την ώρα με βάση την ώρα Ελλάδος.

## Testing
- ./gradlew lint --console=plain *(αποτυχία: λείπει Android SDK / μη έγκυρο sdk.dir)*

------
https://chatgpt.com/codex/tasks/task_e_68caff840de0832891ce5baa20a3372f