### PR TITLE
Sync moving details from declarations on acceptance

### DIFF
--- a/app/src/main/java/com/ioannapergamali/mysmartroute/data/local/MovingDao.kt
+++ b/app/src/main/java/com/ioannapergamali/mysmartroute/data/local/MovingDao.kt
@@ -15,6 +15,9 @@ interface MovingDao {
     @Query("SELECT * FROM movings WHERE userId = :userId")
     fun getMovingsForUser(userId: String): kotlinx.coroutines.flow.Flow<List<MovingEntity>>
 
+    @Query("SELECT * FROM movings WHERE routeId = :routeId AND userId = :userId")
+    suspend fun getForRouteAndUser(routeId: String, userId: String): List<MovingEntity>
+
     @Query("SELECT * FROM movings")
     fun getAll(): kotlinx.coroutines.flow.Flow<List<MovingEntity>>
 

--- a/app/src/main/java/com/ioannapergamali/mysmartroute/data/local/MovingDetailDao.kt
+++ b/app/src/main/java/com/ioannapergamali/mysmartroute/data/local/MovingDetailDao.kt
@@ -17,6 +17,9 @@ interface MovingDetailDao {
     @Query("SELECT * FROM moving_details WHERE movingId = :movingId")
     fun getForMoving(movingId: String): Flow<List<MovingDetailEntity>>
 
+    @Query("SELECT EXISTS(SELECT 1 FROM moving_details WHERE movingId = :movingId LIMIT 1)")
+    suspend fun hasDetailsForMoving(movingId: String): Boolean
+
     @Query("DELETE FROM moving_details WHERE movingId = :movingId")
     suspend fun deleteForMoving(movingId: String)
 }

--- a/app/src/main/java/com/ioannapergamali/mysmartroute/data/local/TransportDeclarationDao.kt
+++ b/app/src/main/java/com/ioannapergamali/mysmartroute/data/local/TransportDeclarationDao.kt
@@ -22,6 +22,15 @@ interface TransportDeclarationDao {
     @Query("SELECT * FROM transport_declarations WHERE id = :id LIMIT 1")
     suspend fun getById(id: String): TransportDeclarationEntity?
 
+    @Query(
+        "SELECT * FROM transport_declarations WHERE routeId = :routeId AND driverId = :driverId AND date = :date LIMIT 1"
+    )
+    suspend fun findByRouteDriverAndDate(
+        routeId: String,
+        driverId: String,
+        date: Long
+    ): TransportDeclarationEntity?
+
     @Query("DELETE FROM transport_declarations WHERE driverId = :driverId")
     suspend fun deleteForDriver(driverId: String)
 


### PR DESCRIPTION
## Summary
- add DAO helpers to locate movings without stored detail records and fetch matching transport declarations
- update passenger acceptance flow so declaration details are copied to every related moving and uploaded to Firestore when missing

## Testing
- ./gradlew --console=plain :app:lint *(attempted, stopped after prolonged execution without feedback)*

------
https://chatgpt.com/codex/tasks/task_e_68cb01981a3083289ac3e9694f2a3c85