### PR TITLE
Συγχρονισμός λεπτομερειών μετακινήσεων κατά την αποδοχή αιτήματος

### DIFF
--- a/app/src/main/java/com/ioannapergamali/mysmartroute/data/local/MovingDetailDao.kt
+++ b/app/src/main/java/com/ioannapergamali/mysmartroute/data/local/MovingDetailDao.kt
@@ -22,4 +22,22 @@ interface MovingDetailDao {
 
     @Query("DELETE FROM moving_details WHERE movingId = :movingId")
     suspend fun deleteForMoving(movingId: String)
+
+    @Query(
+        "SELECT EXISTS(" +
+            "SELECT 1 FROM moving_details md " +
+            "INNER JOIN movings m ON m.id = md.movingId " +
+            "WHERE m.routeId = :routeId AND m.userId = :userId " +
+            "LIMIT 1" +
+            ")"
+    )
+    suspend fun hasDetailsForRoute(routeId: String, userId: String): Boolean
+
+    @Query(
+        "SELECT md.vehicleId FROM moving_details md " +
+            "INNER JOIN movings m ON m.id = md.movingId " +
+            "WHERE m.routeId = :routeId AND m.userId = :userId " +
+            "AND md.vehicleId <> '' LIMIT 1"
+    )
+    suspend fun findVehicleIdForRoute(routeId: String, userId: String): String?
 }

--- a/app/src/main/java/com/ioannapergamali/mysmartroute/viewmodel/VehicleRequestViewModel.kt
+++ b/app/src/main/java/com/ioannapergamali/mysmartroute/viewmodel/VehicleRequestViewModel.kt
@@ -660,14 +660,22 @@ class VehicleRequestViewModel(
                         dao.getForRouteAndUser(current.routeId, current.userId)
                     }.getOrElse { emptyList() }
                     val uniqueMovings = (relatedMovings + current).distinctBy { it.id }
-                    val movingsWithoutDetails = uniqueMovings.filter { moving ->
-                        runCatching { detailDao.hasDetailsForMoving(moving.id) }
-                            .getOrDefault(false)
-                            .not()
-                    }
+                    val needsRouteDetails = runCatching {
+                        detailDao.hasDetailsForRoute(current.routeId, current.userId)
+                    }.getOrDefault(false).not()
+                    val movingsWithoutDetails =
+                        if (needsRouteDetails) {
+                            uniqueMovings.filter { moving ->
+                                runCatching { detailDao.hasDetailsForMoving(moving.id) }
+                                    .getOrDefault(false)
+                                    .not()
+                            }
+                        } else {
+                            emptyList()
+                        }
 
                     val shouldUploadRemoteDetails =
-                        if (movingsWithoutDetails.any { it.id == requestId }) {
+                        if (needsRouteDetails && movingsWithoutDetails.any { it.id == requestId }) {
                             runCatching {
                                 movingRef.collection("details").limit(1).get().await().isEmpty()
                             }.getOrDefault(false)
@@ -711,29 +719,34 @@ class VehicleRequestViewModel(
                         }
                     }
 
-                    var declarationDetails = if (declaration != null) {
-                        runCatching { declarationDetailDao.getForDeclaration(declaration.id) }
-                            .getOrElse { emptyList() }
-                    } else {
-                        emptyList()
-                    }
+                    var declarationDetails: List<TransportDeclarationDetailEntity> = emptyList()
+                    if (needsRouteDetails && declaration != null) {
+                        declarationDetails = runCatching {
+                            declarationDetailDao.getForDeclaration(declaration.id)
+                        }.getOrElse { emptyList() }
 
-                    if (declarationDetails.isEmpty() && declaration != null) {
-                        declarationDetails = try {
-                            db.collection("transport_declarations")
-                                .document(declaration.id)
-                                .collection("details")
-                                .get()
-                                .await()
-                                .documents
-                                .mapNotNull { it.toTransportDeclarationDetailEntity(declaration.id) }
-                        } catch (e: Exception) {
-                            Log.e(TAG, "Failed to load declaration details", e)
-                            emptyList()
+                        if (declarationDetails.isEmpty()) {
+                            declarationDetails = try {
+                                db.collection("transport_declarations")
+                                    .document(declaration.id)
+                                    .collection("details")
+                                    .get()
+                                    .await()
+                                    .documents
+                                    .mapNotNull {
+                                        it.toTransportDeclarationDetailEntity(declaration.id)
+                                    }
+                            } catch (e: Exception) {
+                                Log.e(TAG, "Failed to load declaration details", e)
+                                emptyList()
+                            }
                         }
                     }
 
-                    if (declarationDetails.isNotEmpty() && movingsWithoutDetails.isNotEmpty()) {
+                    if (needsRouteDetails &&
+                        declarationDetails.isNotEmpty() &&
+                        movingsWithoutDetails.isNotEmpty()
+                    ) {
                         val detailsByMoving = movingsWithoutDetails.associate { moving ->
                             val generated = declarationDetails.map { detail ->
                                 val resolvedVehicleId =
@@ -775,6 +788,12 @@ class VehicleRequestViewModel(
                             vehicleIdFromDetails =
                                 currentDetails.firstOrNull { it.vehicleId.isNotBlank() }?.vehicleId
                         }
+                    }
+
+                    if (vehicleIdFromDetails.isNullOrBlank()) {
+                        vehicleIdFromDetails = runCatching {
+                            detailDao.findVehicleIdForRoute(current.routeId, current.userId)
+                        }.getOrNull()
                     }
 
                     if (vehicleIdFromDetails.isNullOrBlank()) {


### PR DESCRIPTION
## Summary
- προστέθηκαν βοηθητικές μέθοδοι στο `MovingDetailDao` για έλεγχο ύπαρξης λεπτομερειών ανά διαδρομή και εύρεση οχήματος
- ενημερώθηκε η `respondToOffer` ώστε να αντιγράφει λεπτομέρειες δηλώσεων μόνο όταν λείπουν για τη διαδρομή και να ενημερώνει το όχημα από τις υπάρχουσες εγγραφές

## Testing
- ./gradlew test --console=plain --no-daemon *(αποτυχία: το περιβάλλον δεν διαθέτει εγκατεστημένο Android SDK)*

------
https://chatgpt.com/codex/tasks/task_e_68cb0b9fcf7083289d46e676e948fbd4