### PR TITLE
Εναρμόνιση ώρας εφαρμογής με ζώνη Αθήνας

### DIFF
--- a/app/src/main/java/com/ioannapergamali/mysmartroute/data/local/AppDateTimeExtensions.kt
+++ b/app/src/main/java/com/ioannapergamali/mysmartroute/data/local/AppDateTimeExtensions.kt
@@ -1,13 +1,13 @@
 package com.ioannapergamali.mysmartroute.data.local
 
+import com.ioannapergamali.mysmartroute.utils.ATHENS_ZONE_ID
 import java.time.Instant
 import java.time.LocalDateTime
-import java.time.ZoneId
 
 /** Επιστρέφει την αποθηκευμένη ημερομηνία/ώρα της εφαρμογής ως [LocalDateTime]. */
 suspend fun MySmartRouteDatabase.currentAppDateTime(): LocalDateTime {
     val storedMillis = appDateTimeDao().getDateTime()?.timestamp ?: System.currentTimeMillis()
     return Instant.ofEpochMilli(storedMillis)
-        .atZone(ZoneId.systemDefault())
+        .atZone(ATHENS_ZONE_ID)
         .toLocalDateTime()
 }

--- a/app/src/main/java/com/ioannapergamali/mysmartroute/utils/AthensTime.kt
+++ b/app/src/main/java/com/ioannapergamali/mysmartroute/utils/AthensTime.kt
@@ -1,0 +1,10 @@
+package com.ioannapergamali.mysmartroute.utils
+
+import java.time.ZoneId
+import java.util.TimeZone
+
+/** Ζώνη ώρας και χρονική ζώνη που αντιστοιχούν στην Ελλάδα (Αθήνα). */
+val ATHENS_ZONE_ID: ZoneId = ZoneId.of("Europe/Athens")
+
+/** [TimeZone] για χρήση με APIs που δεν υποστηρίζουν [ZoneId]. */
+val ATHENS_TIME_ZONE: TimeZone = TimeZone.getTimeZone("Europe/Athens")

--- a/app/src/main/java/com/ioannapergamali/mysmartroute/utils/DateTimeUtils.kt
+++ b/app/src/main/java/com/ioannapergamali/mysmartroute/utils/DateTimeUtils.kt
@@ -2,10 +2,7 @@ package com.ioannapergamali.mysmartroute.utils
 
 import java.time.Instant
 import java.time.LocalTime
-import java.time.ZoneId
 import java.time.ZonedDateTime
-
-private val ATHENS_ZONE_ID: ZoneId = ZoneId.of("Europe/Athens")
 
 fun combineDateAndTimeAsAthensInstant(dateMillis: Long, timeMillis: Long): Long {
     val localDate = Instant.ofEpochMilli(dateMillis).atZone(ATHENS_ZONE_ID).toLocalDate()

--- a/app/src/main/java/com/ioannapergamali/mysmartroute/utils/NotificationUtils.kt
+++ b/app/src/main/java/com/ioannapergamali/mysmartroute/utils/NotificationUtils.kt
@@ -72,7 +72,7 @@ object NotificationUtils {
                     runCatching {
                         val database = MySmartRouteDatabase.getInstance(context)
                         val now = runCatching { database.currentAppDateTime() }
-                            .getOrElse { LocalDateTime.now() }
+                            .getOrElse { LocalDateTime.now(ATHENS_ZONE_ID) }
                         val entity = NotificationEntity(
                             id = roomNotificationId ?: UUID.randomUUID().toString(),
                             senderId = senderId,

--- a/app/src/main/java/com/ioannapergamali/mysmartroute/utils/ReservationPrinter.kt
+++ b/app/src/main/java/com/ioannapergamali/mysmartroute/utils/ReservationPrinter.kt
@@ -21,7 +21,9 @@ class ReservationPrinter(
 ) {
     suspend fun buildPrintText(): String = withContext(Dispatchers.IO) {
         val reservations = dao.getAllList()
-        val formatter = SimpleDateFormat("HH:mm", Locale.getDefault())
+        val formatter = SimpleDateFormat("HH:mm", Locale.getDefault()).apply {
+            timeZone = ATHENS_TIME_ZONE
+        }
         if (reservations.isEmpty()) {
             "Δεν βρέθηκαν κρατήσεις."
         } else {

--- a/app/src/main/java/com/ioannapergamali/mysmartroute/view/ui/components/TopBar.kt
+++ b/app/src/main/java/com/ioannapergamali/mysmartroute/view/ui/components/TopBar.kt
@@ -37,6 +37,7 @@ import com.ioannapergamali.mysmartroute.viewmodel.AppDateTimeViewModel
 import java.text.SimpleDateFormat
 import java.util.Date
 import java.util.Locale
+import com.ioannapergamali.mysmartroute.utils.ATHENS_TIME_ZONE
 import androidx.lifecycle.viewmodel.compose.viewModel
 import com.ioannapergamali.mysmartroute.viewmodel.SettingsViewModel
 import com.ioannapergamali.mysmartroute.viewmodel.AuthenticationViewModel
@@ -77,7 +78,12 @@ fun TopBar(
     LaunchedEffect(Unit) {
         dateTimeViewModel.load(context)
     }
-    val formattedDate = storedMillis?.let { SimpleDateFormat("dd/MM/yyyy HH:mm", Locale.getDefault()).format(Date(it)) } ?: ""
+    val formatter = remember {
+        SimpleDateFormat("dd/MM/yyyy HH:mm", Locale.getDefault()).apply {
+            timeZone = ATHENS_TIME_ZONE
+        }
+    }
+    val formattedDate = storedMillis?.let { formatter.format(Date(it)) } ?: ""
 
     LaunchedEffect(Unit) {
         authViewModel.loadCurrentUserRole(context)

--- a/app/src/main/java/com/ioannapergamali/mysmartroute/view/ui/screens/AdvanceDateScreen.kt
+++ b/app/src/main/java/com/ioannapergamali/mysmartroute/view/ui/screens/AdvanceDateScreen.kt
@@ -21,13 +21,18 @@ import com.ioannapergamali.mysmartroute.view.ui.components.TopBar
 import com.ioannapergamali.mysmartroute.viewmodel.AppDateTimeViewModel
 import java.text.SimpleDateFormat
 import java.util.*
+import com.ioannapergamali.mysmartroute.utils.ATHENS_TIME_ZONE
 
 @Composable
 fun AdvanceDateScreen(navController: NavController, openDrawer: () -> Unit) {
     val context = LocalContext.current
     val dateViewModel: AppDateTimeViewModel = viewModel()
     val storedMillis by dateViewModel.dateTime.collectAsState()
-    val format = remember { SimpleDateFormat("dd/MM/yyyy HH:mm", Locale.getDefault()) }
+    val format = remember {
+        SimpleDateFormat("dd/MM/yyyy HH:mm", Locale.getDefault()).apply {
+            timeZone = ATHENS_TIME_ZONE
+        }
+    }
 
     LaunchedEffect(Unit) { dateViewModel.load(context) }
 
@@ -49,10 +54,10 @@ fun AdvanceDateScreen(navController: NavController, openDrawer: () -> Unit) {
             Text(stringResource(R.string.stored_datetime) + ": " + storedText)
             Spacer(Modifier.height(16.dp))
             Button(onClick = {
-                val cal = Calendar.getInstance()
+                val cal = Calendar.getInstance(ATHENS_TIME_ZONE)
                 DatePickerDialog(context, { _, y, m, d ->
                     TimePickerDialog(context, { _, h, min ->
-                        val newCal = Calendar.getInstance().apply { set(y, m, d, h, min) }
+                        val newCal = Calendar.getInstance(ATHENS_TIME_ZONE).apply { set(y, m, d, h, min) }
                         dateViewModel.save(context, newCal.timeInMillis)
                     }, cal.get(Calendar.HOUR_OF_DAY), cal.get(Calendar.MINUTE), true).show()
                 }, cal.get(Calendar.YEAR), cal.get(Calendar.MONTH), cal.get(Calendar.DAY_OF_MONTH)).show()

--- a/app/src/main/java/com/ioannapergamali/mysmartroute/view/ui/screens/AnnounceTransportScreen.kt
+++ b/app/src/main/java/com/ioannapergamali/mysmartroute/view/ui/screens/AnnounceTransportScreen.kt
@@ -47,10 +47,10 @@ import com.ioannapergamali.mysmartroute.data.local.PoIEntity
 import com.ioannapergamali.mysmartroute.data.local.TransportDeclarationDetailEntity
 import kotlinx.coroutines.launch
 import com.ioannapergamali.mysmartroute.model.classes.poi.PoiAddress
+import com.ioannapergamali.mysmartroute.utils.ATHENS_ZONE_ID
 import com.ioannapergamali.mysmartroute.utils.MapsUtils
 import com.ioannapergamali.mysmartroute.utils.offsetPois
 import java.time.Instant
-import java.time.ZoneId
 import java.time.format.DateTimeFormatter
 import java.time.LocalDate
 import java.time.LocalDateTime
@@ -161,9 +161,9 @@ fun AnnounceTransportScreen(
         }
     }
     var calculating by remember { mutableStateOf(false) }
-    val now = LocalDateTime.now()
+    val now = LocalDateTime.now(ATHENS_ZONE_ID)
     val todayMillis = remember {
-        LocalDate.now().atStartOfDay(ZoneId.systemDefault()).toInstant().toEpochMilli()
+        LocalDate.now(ATHENS_ZONE_ID).atStartOfDay(ATHENS_ZONE_ID).toInstant().toEpochMilli()
     }
     val datePickerState = rememberDatePickerState(
         initialSelectedDateMillis = todayMillis,
@@ -175,7 +175,7 @@ fun AnnounceTransportScreen(
     var showDatePicker by remember { mutableStateOf(false) }
     val dateFormatter = remember { DateTimeFormatter.ofPattern("dd/MM/yyyy") }
     val selectedDateText = datePickerState.selectedDateMillis?.let { millis ->
-        Instant.ofEpochMilli(millis).atZone(ZoneId.systemDefault()).toLocalDate().format(dateFormatter)
+        Instant.ofEpochMilli(millis).atZone(ATHENS_ZONE_ID).toLocalDate().format(dateFormatter)
     } ?: stringResource(R.string.select_date)
     val timePickerState = rememberTimePickerState(
         initialHour = now.hour,
@@ -185,7 +185,7 @@ fun AnnounceTransportScreen(
     val selectedTimeText = String.format("%02d:%02d", timePickerState.hour, timePickerState.minute)
     LaunchedEffect(datePickerState.selectedDateMillis) {
         if (datePickerState.selectedDateMillis == todayMillis) {
-            val currentTime = LocalTime.now()
+            val currentTime = LocalTime.now(ATHENS_ZONE_ID)
             timePickerState.hour = currentTime.hour
             timePickerState.minute = currentTime.minute
         }
@@ -691,10 +691,10 @@ fun AnnounceTransportScreen(
                         TextButton(onClick = {
                             val selectedDateMillis = datePickerState.selectedDateMillis ?: todayMillis
                             val selectedDate = Instant.ofEpochMilli(selectedDateMillis)
-                                .atZone(ZoneId.systemDefault()).toLocalDate()
+                                .atZone(ATHENS_ZONE_ID).toLocalDate()
                             val selectedTime = LocalTime.of(timePickerState.hour, timePickerState.minute)
                             val chosenDateTime = LocalDateTime.of(selectedDate, selectedTime)
-                            if (chosenDateTime.isBefore(LocalDateTime.now())) {
+                            if (chosenDateTime.isBefore(LocalDateTime.now(ATHENS_ZONE_ID))) {
                                 Toast.makeText(
                                     context,
                                     R.string.invalid_datetime,
@@ -758,12 +758,12 @@ fun AnnounceTransportScreen(
                 onClick = {
                     val routeId = selectedRouteId
                     val date = datePickerState.selectedDateMillis ?: 0L
-                    val selectedDate = Instant.ofEpochMilli(date).atZone(ZoneId.systemDefault()).toLocalDate()
+                    val selectedDate = Instant.ofEpochMilli(date).atZone(ATHENS_ZONE_ID).toLocalDate()
                     val selectedTime = LocalTime.of(timePickerState.hour, timePickerState.minute)
                     val chosenDateTime = LocalDateTime.of(selectedDate, selectedTime)
                     val driverId = selectedDriverId ?: ""
                     if (routeId != null) {
-                        if (chosenDateTime.isBefore(LocalDateTime.now())) {
+                        if (chosenDateTime.isBefore(LocalDateTime.now(ATHENS_ZONE_ID))) {
                             Toast.makeText(
                                 context,
                                 R.string.invalid_datetime,

--- a/app/src/main/java/com/ioannapergamali/mysmartroute/view/ui/screens/AvailableTransportsScreen.kt
+++ b/app/src/main/java/com/ioannapergamali/mysmartroute/view/ui/screens/AvailableTransportsScreen.kt
@@ -31,6 +31,7 @@ import com.ioannapergamali.mysmartroute.viewmodel.UserViewModel
 import com.ioannapergamali.mysmartroute.viewmodel.PoIViewModel
 import com.ioannapergamali.mysmartroute.viewmodel.RouteViewModel
 import com.ioannapergamali.mysmartroute.viewmodel.AppDateTimeViewModel
+import com.ioannapergamali.mysmartroute.utils.ATHENS_ZONE_ID
 import com.ioannapergamali.mysmartroute.utils.matchesFavorites
 import com.ioannapergamali.mysmartroute.utils.isUpcoming
 import com.ioannapergamali.mysmartroute.data.local.TransportDeclarationDetailEntity
@@ -38,7 +39,6 @@ import com.ioannapergamali.mysmartroute.data.local.TransportDeclarationEntity
 import kotlinx.coroutines.launch
 import kotlin.math.max
 import java.time.Instant
-import java.time.ZoneId
 import java.time.LocalTime
 import java.time.format.DateTimeFormatter
 import java.time.LocalDate
@@ -178,8 +178,8 @@ fun AvailableTransportsScreen(
     }
 
     val today = remember(appTime) {
-        val currentDate = Instant.ofEpochMilli(now).atZone(ZoneId.systemDefault()).toLocalDate()
-        currentDate.atStartOfDay(ZoneId.systemDefault()).toInstant().toEpochMilli()
+        val currentDate = Instant.ofEpochMilli(now).atZone(ATHENS_ZONE_ID).toLocalDate()
+        currentDate.atStartOfDay(ATHENS_ZONE_ID).toInstant().toEpochMilli()
     }
     val sortedDecls = declarations.filter { decl ->
         if (routeId != null && decl.routeId != routeId) return@filter false
@@ -231,7 +231,7 @@ fun AvailableTransportsScreen(
                         val routeName = routeNames[decl.routeId] ?: ""
 
                         val dateText = Instant.ofEpochMilli(decl.date)
-                            .atZone(ZoneId.systemDefault())
+                            .atZone(ATHENS_ZONE_ID)
                             .toLocalDate()
                             .format(formatter)
                         val timeText = LocalTime.ofSecondOfDay(decl.startTime / 1000)

--- a/app/src/main/java/com/ioannapergamali/mysmartroute/view/ui/screens/BookSeatScreen.kt
+++ b/app/src/main/java/com/ioannapergamali/mysmartroute/view/ui/screens/BookSeatScreen.kt
@@ -59,6 +59,7 @@ import com.google.maps.android.compose.rememberCameraPositionState
 import com.ioannapergamali.mysmartroute.R
 import com.ioannapergamali.mysmartroute.data.local.PoIEntity
 import com.ioannapergamali.mysmartroute.model.enumerations.VehicleType
+import com.ioannapergamali.mysmartroute.utils.ATHENS_ZONE_ID
 import com.ioannapergamali.mysmartroute.utils.MapsUtils
 import com.ioannapergamali.mysmartroute.utils.offsetPois
 import com.ioannapergamali.mysmartroute.utils.combineDateAndTimeAsAthensInstant
@@ -72,7 +73,6 @@ import com.ioannapergamali.mysmartroute.viewmodel.TransportDeclarationViewModel
 import com.ioannapergamali.mysmartroute.viewmodel.TransferRequestViewModel
 import kotlinx.coroutines.launch
 import java.time.Instant
-import java.time.ZoneId
 import java.time.LocalTime
 import java.time.format.DateTimeFormatter
 import kotlin.math.abs
@@ -129,7 +129,7 @@ fun BookSeatScreen(
         remember(declarations, selectedRouteId) {
             declarations.filter { it.routeId == selectedRouteId }
                 .map {
-                    Instant.ofEpochMilli(it.date).atZone(ZoneId.systemDefault()).toLocalDate()
+                    Instant.ofEpochMilli(it.date).atZone(ATHENS_ZONE_ID).toLocalDate()
                 }
                 .toSet()
         }
@@ -139,7 +139,7 @@ fun BookSeatScreen(
         rememberDatePickerState(
             selectableDates = object : SelectableDates {
                 override fun isSelectableDate(dateMillis: Long): Boolean {
-                    val date = Instant.ofEpochMilli(dateMillis).atZone(ZoneId.systemDefault()).toLocalDate()
+                    val date = Instant.ofEpochMilli(dateMillis).atZone(ATHENS_ZONE_ID).toLocalDate()
                     return availableDates.contains(date)
                 }
             }
@@ -161,7 +161,7 @@ fun BookSeatScreen(
     val dateFormatter = remember { DateTimeFormatter.ofPattern("dd/MM/yyyy") }
     val timeFormatter = remember { DateTimeFormatter.ofPattern("HH:mm") }
     val selectedDateText = datePickerState.selectedDateMillis?.let { millis ->
-        Instant.ofEpochMilli(millis).atZone(ZoneId.systemDefault()).toLocalDate().format(dateFormatter)
+        Instant.ofEpochMilli(millis).atZone(ATHENS_ZONE_ID).toLocalDate().format(dateFormatter)
     } ?: stringResource(R.string.select_date)
     val selectedTimeText = selectedTimeMillis?.let { millis ->
         LocalTime.ofSecondOfDay(millis / 1000).format(timeFormatter)

--- a/app/src/main/java/com/ioannapergamali/mysmartroute/view/ui/screens/DatabaseSyncScreen.kt
+++ b/app/src/main/java/com/ioannapergamali/mysmartroute/view/ui/screens/DatabaseSyncScreen.kt
@@ -65,6 +65,7 @@ import com.ioannapergamali.mysmartroute.viewmodel.SyncState
 import java.text.SimpleDateFormat
 import java.util.Date
 import java.util.Locale
+import com.ioannapergamali.mysmartroute.utils.ATHENS_TIME_ZONE
 
 @Composable
 fun DatabaseSyncScreen(navController: NavController, openDrawer: () -> Unit) {
@@ -601,7 +602,10 @@ private fun DatabaseData.toTableDisplays(context: Context): List<TableDisplay> {
 private fun formatTimestamp(timestamp: Long, includeTime: Boolean = false): String {
     if (timestamp == 0L) return "-"
     val pattern = if (includeTime) "dd/MM/yyyy HH:mm" else "dd/MM/yyyy"
-    return SimpleDateFormat(pattern, Locale.getDefault()).format(Date(timestamp))
+    val formatter = SimpleDateFormat(pattern, Locale.getDefault()).apply {
+        timeZone = ATHENS_TIME_ZONE
+    }
+    return formatter.format(Date(timestamp))
 }
 
 private fun formatDate(timestamp: Long): String = formatTimestamp(timestamp, includeTime = false)

--- a/app/src/main/java/com/ioannapergamali/mysmartroute/view/ui/screens/FindPassengersScreen.kt
+++ b/app/src/main/java/com/ioannapergamali/mysmartroute/view/ui/screens/FindPassengersScreen.kt
@@ -28,6 +28,7 @@ import com.ioannapergamali.mysmartroute.view.ui.components.TopBar
 import com.ioannapergamali.mysmartroute.viewmodel.*
 import java.util.Date
 import android.text.format.DateFormat
+import com.ioannapergamali.mysmartroute.utils.ATHENS_TIME_ZONE
 
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable
@@ -70,7 +71,9 @@ fun FindPassengersScreen(
     val datePickerState = rememberDatePickerState()
     var showDatePicker by remember { mutableStateOf(false) }
     val selectedDateMillis = datePickerState.selectedDateMillis
-    val dateFormatter = remember { DateFormat.getDateFormat(context) }
+    val dateFormatter = remember(context) {
+        DateFormat.getDateFormat(context).apply { timeZone = ATHENS_TIME_ZONE }
+    }
     val selectedDateText = selectedDateMillis?.let { dateFormatter.format(Date(it)) }
         ?: stringResource(R.string.select_date)
 

--- a/app/src/main/java/com/ioannapergamali/mysmartroute/view/ui/screens/MovingListScreen.kt
+++ b/app/src/main/java/com/ioannapergamali/mysmartroute/view/ui/screens/MovingListScreen.kt
@@ -7,8 +7,8 @@ import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import com.ioannapergamali.mysmartroute.data.local.MovingEntity
 import com.ioannapergamali.mysmartroute.data.local.categorizeMovings
+import com.ioannapergamali.mysmartroute.utils.ATHENS_ZONE_ID
 import java.time.Instant
-import java.time.ZoneId
 import java.time.format.DateTimeFormatter
 import java.util.Locale
 
@@ -42,13 +42,13 @@ fun MovingListScreen(movings: List<MovingEntity>, now: Long = System.currentTime
 
 private fun formatDate(epochMillis: Long): String =
     Instant.ofEpochMilli(epochMillis)
-        .atZone(ZoneId.systemDefault())
+        .atZone(ATHENS_ZONE_ID)
         .toLocalDate()
         .format(DateTimeFormatter.ofPattern("yyyy-MM-dd"))
 
 private fun formatTime(epochMillis: Long): String =
     Instant.ofEpochMilli(epochMillis)
-        .atZone(ZoneId.systemDefault())
+        .atZone(ATHENS_ZONE_ID)
         .toLocalTime()
         .format(DateTimeFormatter.ofPattern("HH:mm"))
 

--- a/app/src/main/java/com/ioannapergamali/mysmartroute/view/ui/screens/MovingScreen.kt
+++ b/app/src/main/java/com/ioannapergamali/mysmartroute/view/ui/screens/MovingScreen.kt
@@ -12,10 +12,10 @@ import androidx.compose.runtime.getValue
 import androidx.compose.ui.platform.LocalContext
 import androidx.hilt.navigation.compose.hiltViewModel
 import androidx.lifecycle.viewmodel.compose.viewModel
+import com.ioannapergamali.mysmartroute.utils.ATHENS_ZONE_ID
 import com.ioannapergamali.mysmartroute.viewmodel.MovingViewModel
 import com.ioannapergamali.mysmartroute.viewmodel.AppDateTimeViewModel
 import java.time.Instant
-import java.time.ZoneId
 import java.time.format.DateTimeFormatter
 
 private const val TAG = "MovingScreen"
@@ -57,5 +57,5 @@ fun MovingScreen(viewModel: MovingViewModel = hiltViewModel()) {
 
 private fun formatDate(epochMillis: Long): String =
     Instant.ofEpochMilli(epochMillis)
-        .atZone(ZoneId.systemDefault())
+        .atZone(ATHENS_ZONE_ID)
         .format(DateTimeFormatter.ofPattern("yyyy-MM-dd HH:mm"))

--- a/app/src/main/java/com/ioannapergamali/mysmartroute/view/ui/screens/PassengerMovingsScreen.kt
+++ b/app/src/main/java/com/ioannapergamali/mysmartroute/view/ui/screens/PassengerMovingsScreen.kt
@@ -26,6 +26,7 @@ import androidx.compose.ui.unit.dp
 import androidx.lifecycle.viewmodel.compose.viewModel
 import androidx.navigation.NavController
 import com.ioannapergamali.mysmartroute.R
+import com.ioannapergamali.mysmartroute.utils.ATHENS_ZONE_ID
 import com.ioannapergamali.mysmartroute.data.local.MovingEntity
 import com.ioannapergamali.mysmartroute.data.local.MovingStatus
 import com.ioannapergamali.mysmartroute.data.local.categorizeMovings
@@ -36,7 +37,6 @@ import com.ioannapergamali.mysmartroute.viewmodel.VehicleRequestViewModel
 import com.ioannapergamali.mysmartroute.viewmodel.AuthenticationViewModel
 import com.ioannapergamali.mysmartroute.model.enumerations.UserRole
 import java.time.Instant
-import java.time.ZoneId
 import java.time.format.DateTimeFormatter
 import java.util.Locale
 
@@ -149,7 +149,7 @@ private fun MovingTable(list: List<MovingEntity>) {
 
 private fun formatDate(epochMillis: Long): String =
     Instant.ofEpochMilli(epochMillis)
-        .atZone(ZoneId.systemDefault())
+        .atZone(ATHENS_ZONE_ID)
         .toLocalDate()
         .format(DateTimeFormatter.ofPattern("yyyy-MM-dd"))
 

--- a/app/src/main/java/com/ioannapergamali/mysmartroute/view/ui/screens/PrepareCompleteRouteScreen.kt
+++ b/app/src/main/java/com/ioannapergamali/mysmartroute/view/ui/screens/PrepareCompleteRouteScreen.kt
@@ -27,6 +27,7 @@ import com.ioannapergamali.mysmartroute.data.local.PoIEntity
 import com.ioannapergamali.mysmartroute.data.local.RouteEntity
 import com.ioannapergamali.mysmartroute.data.local.TransportDeclarationEntity
 import com.ioannapergamali.mysmartroute.model.enumerations.VehicleType
+import com.ioannapergamali.mysmartroute.utils.ATHENS_ZONE_ID
 import com.ioannapergamali.mysmartroute.utils.MapsUtils
 import com.ioannapergamali.mysmartroute.utils.offsetPois
 import com.ioannapergamali.mysmartroute.view.ui.components.ScreenContainer
@@ -219,7 +220,7 @@ fun PrepareCompleteRouteScreen(navController: NavController, openDrawer: () -> U
             var showDatePicker by remember { mutableStateOf(false) }
             val dateFormatter = remember { java.time.format.DateTimeFormatter.ofPattern("dd/MM/yyyy") }
             val selectedDateText = selectedDate?.let { millis ->
-                java.time.Instant.ofEpochMilli(millis).atZone(java.time.ZoneId.systemDefault()).toLocalDate().format(dateFormatter)
+                java.time.Instant.ofEpochMilli(millis).atZone(ATHENS_ZONE_ID).toLocalDate().format(dateFormatter)
             } ?: stringResource(R.string.select_date)
 
             if (selectedRoute != null) {

--- a/app/src/main/java/com/ioannapergamali/mysmartroute/view/ui/screens/PrintCompletedScreen.kt
+++ b/app/src/main/java/com/ioannapergamali/mysmartroute/view/ui/screens/PrintCompletedScreen.kt
@@ -24,6 +24,7 @@ import com.ioannapergamali.mysmartroute.viewmodel.TransportDeclarationViewModel
 import java.text.SimpleDateFormat
 import java.util.Date
 import java.util.Locale
+import com.ioannapergamali.mysmartroute.utils.ATHENS_TIME_ZONE
 import com.ioannapergamali.mysmartroute.utils.SessionManager
 
 @Composable
@@ -58,7 +59,11 @@ fun PrintCompletedScreen(navController: NavController, openDrawer: () -> Unit) {
             if (declarations.isEmpty()) {
                 Text(text = stringResource(R.string.no_completed_transports))
             } else {
-                val formatter = remember { SimpleDateFormat("dd/MM/yyyy", Locale.getDefault()) }
+                val formatter = remember {
+                    SimpleDateFormat("dd/MM/yyyy", Locale.getDefault()).apply {
+                        timeZone = ATHENS_TIME_ZONE
+                    }
+                }
                 LazyColumn {
                     items(declarations) { decl ->
                         val routeName = routeNames[decl.routeId] ?: ""

--- a/app/src/main/java/com/ioannapergamali/mysmartroute/view/ui/screens/PrintDeclarationsScreen.kt
+++ b/app/src/main/java/com/ioannapergamali/mysmartroute/view/ui/screens/PrintDeclarationsScreen.kt
@@ -43,6 +43,7 @@ import com.ioannapergamali.mysmartroute.utils.SessionManager
 import java.text.SimpleDateFormat
 import java.util.Date
 import java.util.Locale
+import com.ioannapergamali.mysmartroute.utils.ATHENS_TIME_ZONE
 
 @Composable
 fun PrintDeclarationsScreen(navController: NavController, openDrawer: () -> Unit) {
@@ -149,7 +150,11 @@ private fun DeclarationItem(
         else -> Icons.Filled.DirectionsCar
     }
 
-    val formatter = SimpleDateFormat("dd/MM/yyyy", Locale.getDefault())
+    val formatter = remember {
+        SimpleDateFormat("dd/MM/yyyy", Locale.getDefault()).apply {
+            timeZone = ATHENS_TIME_ZONE
+        }
+    }
     val dateText = formatter.format(Date(declaration.date))
 
     Card(

--- a/app/src/main/java/com/ioannapergamali/mysmartroute/view/ui/screens/PrintScheduledScreen.kt
+++ b/app/src/main/java/com/ioannapergamali/mysmartroute/view/ui/screens/PrintScheduledScreen.kt
@@ -29,6 +29,7 @@ import kotlinx.coroutines.flow.first
 import java.text.SimpleDateFormat
 import java.util.Date
 import java.util.Locale
+import com.ioannapergamali.mysmartroute.utils.ATHENS_TIME_ZONE
 import com.ioannapergamali.mysmartroute.utils.SessionManager
 
 @Composable
@@ -83,7 +84,11 @@ fun PrintScheduledScreen(navController: NavController, openDrawer: () -> Unit) {
             if (scheduled.isEmpty()) {
                 Text(text = stringResource(R.string.no_scheduled_transports))
             } else {
-                val formatter = remember { SimpleDateFormat("dd/MM/yyyy", Locale.getDefault()) }
+                val formatter = remember {
+                    SimpleDateFormat("dd/MM/yyyy", Locale.getDefault()).apply {
+                        timeZone = ATHENS_TIME_ZONE
+                    }
+                }
                 LazyColumn {
                     items(scheduled) { decl ->
                         val routeName = routeNames[decl.routeId] ?: ""

--- a/app/src/main/java/com/ioannapergamali/mysmartroute/view/ui/screens/PrintTicketScreen.kt
+++ b/app/src/main/java/com/ioannapergamali/mysmartroute/view/ui/screens/PrintTicketScreen.kt
@@ -35,6 +35,7 @@ import com.ioannapergamali.mysmartroute.viewmodel.UserReservationsViewModel
 import java.text.SimpleDateFormat
 import java.util.Date
 import java.util.Locale
+import com.ioannapergamali.mysmartroute.utils.ATHENS_TIME_ZONE
 
 @Composable
 fun PrintTicketScreen(navController: NavController, openDrawer: () -> Unit) {
@@ -82,7 +83,11 @@ fun ReservationItem(
     navController: NavController,
     onDelete: (SeatReservationEntity) -> Unit
 ) {
-    val formatter = SimpleDateFormat("dd/MM/yyyy", Locale.getDefault())
+    val formatter = remember {
+        SimpleDateFormat("dd/MM/yyyy", Locale.getDefault()).apply {
+            timeZone = ATHENS_TIME_ZONE
+        }
+    }
     val dateText = formatter.format(Date(reservation.date))
     var checked by remember { mutableStateOf(false) }
     Card(

--- a/app/src/main/java/com/ioannapergamali/mysmartroute/view/ui/screens/RankTransportsScreen.kt
+++ b/app/src/main/java/com/ioannapergamali/mysmartroute/view/ui/screens/RankTransportsScreen.kt
@@ -44,6 +44,7 @@ import androidx.compose.material.icons.filled.Star
 import androidx.compose.material.icons.outlined.Star
 import android.text.format.DateFormat
 import java.util.Date
+import com.ioannapergamali.mysmartroute.utils.ATHENS_TIME_ZONE
 import androidx.compose.ui.graphics.Color
 import android.widget.Toast
 
@@ -108,8 +109,11 @@ private fun TripRatingItem(
 
 
     val context = LocalContext.current
+    val dateFormatter = remember(context) {
+        DateFormat.getDateFormat(context).apply { timeZone = ATHENS_TIME_ZONE }
+    }
     val dateText = if (trip.moving.date > 0L) {
-        DateFormat.getDateFormat(context).format(Date(trip.moving.date))
+        dateFormatter.format(Date(trip.moving.date))
     } else ""
     val headerText = listOf(dateText, trip.moving.routeName)
         .filter { it.isNotBlank() }

--- a/app/src/main/java/com/ioannapergamali/mysmartroute/view/ui/screens/ReservationDetailsScreen.kt
+++ b/app/src/main/java/com/ioannapergamali/mysmartroute/view/ui/screens/ReservationDetailsScreen.kt
@@ -30,6 +30,7 @@ import kotlinx.coroutines.tasks.await
 import java.text.SimpleDateFormat
 import java.util.Date
 import java.util.Locale
+import com.ioannapergamali.mysmartroute.utils.ATHENS_TIME_ZONE
 
 @Composable
 fun ReservationDetailsScreen(
@@ -47,6 +48,16 @@ fun ReservationDetailsScreen(
     var driverName by remember { mutableStateOf("") }
     var passengerName by remember { mutableStateOf("") }
     var detailInfos by remember { mutableStateOf<List<DetailInfo>>(emptyList()) }
+    val dateFormatter = remember {
+        SimpleDateFormat("dd/MM/yyyy", Locale.getDefault()).apply {
+            timeZone = ATHENS_TIME_ZONE
+        }
+    }
+    val timeFormatter = remember {
+        SimpleDateFormat("HH:mm", Locale.getDefault()).apply {
+            timeZone = ATHENS_TIME_ZONE
+        }
+    }
 
     LaunchedEffect(reservation) {
         reservation?.let { res ->
@@ -123,8 +134,6 @@ fun ReservationDetailsScreen(
         }
     ) { paddingValues ->
         reservation?.let { res ->
-            val formatter = SimpleDateFormat("dd/MM/yyyy", Locale.getDefault())
-            val timeFormatter = SimpleDateFormat("HH:mm", Locale.getDefault())
             Card(
                 modifier = Modifier
                     .padding(paddingValues)
@@ -142,7 +151,7 @@ fun ReservationDetailsScreen(
                         Text(stringResource(R.string.ticket))
                     }
                     Spacer(modifier = Modifier.height(8.dp))
-                    Text("${stringResource(R.string.date)}: ${formatter.format(Date(res.date))}")
+                    Text("${stringResource(R.string.date)}: ${dateFormatter.format(Date(res.date))}")
                     Text("${stringResource(R.string.route)}: $routeName")
                     Text("${stringResource(R.string.driver)}: $driverName")
                     Text("${stringResource(R.string.passenger)}: $passengerName")

--- a/app/src/main/java/com/ioannapergamali/mysmartroute/view/ui/screens/RouteModeScreen.kt
+++ b/app/src/main/java/com/ioannapergamali/mysmartroute/view/ui/screens/RouteModeScreen.kt
@@ -42,6 +42,7 @@ import com.ioannapergamali.mysmartroute.viewmodel.PoIViewModel
 import com.ioannapergamali.mysmartroute.viewmodel.RouteViewModel
 import com.ioannapergamali.mysmartroute.viewmodel.TransferRequestViewModel
 import com.ioannapergamali.mysmartroute.model.enumerations.VehicleType
+import com.ioannapergamali.mysmartroute.utils.ATHENS_ZONE_ID
 import com.ioannapergamali.mysmartroute.utils.MapsUtils
 import com.ioannapergamali.mysmartroute.utils.offsetPois
 import com.ioannapergamali.mysmartroute.utils.combineDateAndTimeAsAthensInstant
@@ -51,7 +52,6 @@ import androidx.lifecycle.LifecycleEventObserver
 import androidx.lifecycle.LifecycleOwner
 import kotlinx.coroutines.launch
 import java.time.Instant
-import java.time.ZoneId
 import java.time.format.DateTimeFormatter
 import java.time.LocalTime
 import kotlin.math.abs
@@ -102,7 +102,7 @@ fun RouteModeScreen(
     val dateFormatter = remember { DateTimeFormatter.ofPattern("dd/MM/yyyy") }
     val timeFormatter = remember { DateTimeFormatter.ofPattern("HH:mm") }
     val selectedDateText = datePickerState.selectedDateMillis?.let { millis ->
-        Instant.ofEpochMilli(millis).atZone(ZoneId.systemDefault()).toLocalDate().format(dateFormatter)
+        Instant.ofEpochMilli(millis).atZone(ATHENS_ZONE_ID).toLocalDate().format(dateFormatter)
     } ?: stringResource(R.string.select_date)
     val selectedTimeText = selectedTimeMillis?.let { millis ->
         LocalTime.ofSecondOfDay(millis / 1000).format(timeFormatter)

--- a/app/src/main/java/com/ioannapergamali/mysmartroute/view/ui/screens/ViewRequestsScreen.kt
+++ b/app/src/main/java/com/ioannapergamali/mysmartroute/view/ui/screens/ViewRequestsScreen.kt
@@ -43,6 +43,7 @@ import com.ioannapergamali.mysmartroute.viewmodel.AuthenticationViewModel
 import com.ioannapergamali.mysmartroute.model.enumerations.UserRole
 import android.text.format.DateFormat
 import java.util.Date
+import com.ioannapergamali.mysmartroute.utils.ATHENS_TIME_ZONE
 
 private enum class SortOption { COST, DATE }
 
@@ -64,6 +65,12 @@ fun ViewRequestsScreen(
     val pois by poiViewModel.pois.collectAsState()
     val role by authViewModel.currentUserRole.collectAsState()
     val driverNames = remember { mutableStateMapOf<String, String>() }
+    val dateFormatter = remember(context) {
+        DateFormat.getDateFormat(context).apply { timeZone = ATHENS_TIME_ZONE }
+    }
+    val timeFormatter = remember(context) {
+        DateFormat.getTimeFormat(context).apply { timeZone = ATHENS_TIME_ZONE }
+    }
     val scrollState = rememberScrollState()
     val listState = rememberLazyListState()
     val columnWidth = 150.dp
@@ -181,8 +188,8 @@ fun ViewRequestsScreen(
                                 "$fromName → $toName" else ""
                             val routeName = req.routeName.ifBlank { stationsText }
                             val dateValue = req.date.takeIf { it > 0L }?.let { Date(it) }
-                            val dateText = dateValue?.let { DateFormat.getDateFormat(context).format(it) } ?: ""
-                            val timeText = dateValue?.let { DateFormat.getTimeFormat(context).format(it) } ?: ""
+                            val dateText = dateValue?.let { dateFormatter.format(it) } ?: ""
+                            val timeText = dateValue?.let { timeFormatter.format(it) } ?: ""
                             val costText = req.cost?.toString() ?: "-"
                             val isExpired = req.date > 0L && now > req.date && req.status != "completed"
                             val statusText = if (isExpired) stringResource(R.string.request_unsuccessful) else req.status

--- a/app/src/main/java/com/ioannapergamali/mysmartroute/view/ui/screens/ViewTransportRequestsScreen.kt
+++ b/app/src/main/java/com/ioannapergamali/mysmartroute/view/ui/screens/ViewTransportRequestsScreen.kt
@@ -40,6 +40,7 @@ import com.ioannapergamali.mysmartroute.utils.SessionManager
 import android.text.format.DateFormat
 import android.net.Uri
 import java.util.Date
+import com.ioannapergamali.mysmartroute.utils.ATHENS_TIME_ZONE
 
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable
@@ -58,6 +59,12 @@ fun ViewTransportRequestsScreen(
     val pois by poiViewModel.pois.collectAsState()
     val userNames = remember { mutableStateMapOf<String, String>() }
     val selectedRequests = remember { mutableStateMapOf<String, Boolean>() }
+    val dateFormatter = remember(context) {
+        DateFormat.getDateFormat(context).apply { timeZone = ATHENS_TIME_ZONE }
+    }
+    val timeFormatter = remember(context) {
+        DateFormat.getTimeFormat(context).apply { timeZone = ATHENS_TIME_ZONE }
+    }
     val scrollState = rememberScrollState()
     val listState = rememberLazyListState()
     val columnWidth = 150.dp
@@ -199,8 +206,8 @@ fun ViewTransportRequestsScreen(
                             val userName = userNames[req.userId] ?: ""
                             val isChecked = selectedRequests[req.id] ?: false
                             val dateValue = req.date.takeIf { it > 0L }?.let { Date(it) }
-                            val dateText = dateValue?.let { DateFormat.getDateFormat(context).format(it) } ?: ""
-                            val timeText = dateValue?.let { DateFormat.getTimeFormat(context).format(it) } ?: ""
+                            val dateText = dateValue?.let { dateFormatter.format(it) } ?: ""
+                            val timeText = dateValue?.let { timeFormatter.format(it) } ?: ""
                             Row(
                                 modifier = Modifier.padding(vertical = 8.dp),
                                 verticalAlignment = Alignment.CenterVertically

--- a/app/src/main/java/com/ioannapergamali/mysmartroute/view/ui/screens/WalkingScreen.kt
+++ b/app/src/main/java/com/ioannapergamali/mysmartroute/view/ui/screens/WalkingScreen.kt
@@ -38,6 +38,7 @@ import androidx.lifecycle.LifecycleOwner
 import kotlin.math.abs
 
 import com.ioannapergamali.mysmartroute.R
+import com.ioannapergamali.mysmartroute.utils.ATHENS_TIME_ZONE
 import com.ioannapergamali.mysmartroute.view.ui.components.ScreenContainer
 import com.ioannapergamali.mysmartroute.view.ui.components.TopBar
 import com.ioannapergamali.mysmartroute.viewmodel.RouteViewModel
@@ -75,7 +76,7 @@ fun WalkingScreen(navController: NavController, openDrawer: () -> Unit) {
     var timeText by rememberSaveable { mutableStateOf("") }
     var showDatePicker by remember { mutableStateOf(false) }
     var showTimePicker by remember { mutableStateOf(false) }
-    val calendar = remember { Calendar.getInstance() }
+    val calendar = remember { Calendar.getInstance(ATHENS_TIME_ZONE) }
     var pathPoints by remember { mutableStateOf<List<LatLng>>(emptyList()) }
     var calculating by remember { mutableStateOf(false) }
     var pendingPoi by remember { mutableStateOf<Triple<String, Double, Double>?>(null) }


### PR DESCRIPTION
## Summary
- πρόσθεσα κοινόχρηστες σταθερές ζώνης ώρας/χρονικής ζώνης για την Αθήνα και ενοποίησα την ερμηνεία χρόνων στα utilities της βάσης δεδομένων και των ειδοποιήσεων
- αντικατέστησα κάθε χρήση του system default time zone σε οθόνες κράτησης/ανακοινώσεων/κινητικότητας με τον χρόνο Ελλάδας
- ρύθμισα όλες τις μορφοποιήσεις SimpleDateFormat/DateFormat να χρησιμοποιούν την ζώνη Europe/Athens σε συνιστώσες UI και helper κλάσεις

## Testing
- `./gradlew lint --console=plain --no-daemon` *(αποτυχία: λείπει το Android SDK στον τρέχοντα φάκελο local.properties)*

------
https://chatgpt.com/codex/tasks/task_e_68cb0bd7ce908328afc2feb14f1af7d9