### PR TITLE
Fix moving acceptance to update existing record

### DIFF
--- a/app/src/main/java/com/ioannapergamali/mysmartroute/data/local/TransferRequestDao.kt
+++ b/app/src/main/java/com/ioannapergamali/mysmartroute/data/local/TransferRequestDao.kt
@@ -26,6 +26,9 @@ interface TransferRequestDao {
     @Query("UPDATE transfer_requests SET firebaseId = :firebaseId WHERE requestNumber = :requestNumber")
     suspend fun setFirebaseId(requestNumber: Int, firebaseId: String)
 
+    @Query("UPDATE transfer_requests SET movingId = :movingId WHERE requestNumber = :requestNumber")
+    suspend fun setMovingId(requestNumber: Int, movingId: String)
+
     @Query("SELECT * FROM transfer_requests WHERE requestNumber = :requestNumber")
     suspend fun getRequestByNumber(requestNumber: Int): TransferRequestEntity?
 

--- a/app/src/main/java/com/ioannapergamali/mysmartroute/data/local/TransferRequestEntity.kt
+++ b/app/src/main/java/com/ioannapergamali/mysmartroute/data/local/TransferRequestEntity.kt
@@ -15,6 +15,7 @@ data class TransferRequestEntity(
     val driverId: String = "",
     val driverName: String = "",
     val firebaseId: String = "",
+    val movingId: String = "",
 
     /** Ημερομηνία σε millis */
     val date: Long = 0L,

--- a/app/src/main/java/com/ioannapergamali/mysmartroute/utils/FirestoreMappers.kt
+++ b/app/src/main/java/com/ioannapergamali/mysmartroute/utils/FirestoreMappers.kt
@@ -609,6 +609,9 @@ fun TransferRequestEntity.toFirestoreMap(): Map<String, Any> {
         "status" to status.name
     )
     cost?.let { map["cost"] = it }
+    if (movingId.isNotBlank()) {
+        map["movingId"] = db.collection("movings").document(movingId)
+    }
 
     if (driverId.isNotBlank()) {
         map["driverId"] = db.collection("users").document(driverId)
@@ -642,7 +645,23 @@ fun DocumentSnapshot.toTransferRequestEntity(): TransferRequestEntity? {
     val dateVal = getLong("date") ?: 0L
     val costVal = getDouble("cost")
     val statusStr = getString("status") ?: RequestStatus.OPEN.name
-    return TransferRequestEntity(number, routeId, passengerId, driverId, driverName, id, dateVal, costVal, enumValueOf(statusStr))
+    val movingId = when (val raw = get("movingId")) {
+        is DocumentReference -> raw.id
+        is String -> raw
+        else -> getString("movingId")
+    } ?: ""
+    return TransferRequestEntity(
+        requestNumber = number,
+        routeId = routeId,
+        passengerId = passengerId,
+        driverId = driverId,
+        driverName = driverName,
+        firebaseId = id,
+        movingId = movingId,
+        date = dateVal,
+        cost = costVal,
+        status = enumValueOf(statusStr)
+    )
 }
 
 fun NotificationEntity.toFirestoreMap(): Map<String, Any> {

--- a/app/src/main/java/com/ioannapergamali/mysmartroute/viewmodel/TransferRequestViewModel.kt
+++ b/app/src/main/java/com/ioannapergamali/mysmartroute/viewmodel/TransferRequestViewModel.kt
@@ -73,11 +73,15 @@ class TransferRequestViewModel : ViewModel() {
             try {
                 requestNumber = RequestNumberProvider.nextRequestNumber(transferDao, db)
 
+                val generatedMovingId = UUID.randomUUID().toString()
+                movingId = generatedMovingId
+
                 val requestEntity = TransferRequestEntity(
                     requestNumber = requestNumber,
                     routeId = routeId,
                     passengerId = passengerId,
                     driverId = "",
+                    movingId = generatedMovingId,
                     date = date,
                     cost = cost,
                     status = RequestStatus.OPEN
@@ -85,8 +89,7 @@ class TransferRequestViewModel : ViewModel() {
 
                 val baseSegments = if (poiChanged) emptyList() else fetchSegments(routeId, startPoiId, endPoiId)
                 val duration = baseSegments.sumOf { it.durationMinutes }
-                movingId = UUID.randomUUID().toString()
-                val currentMovingId = movingId!!
+                val currentMovingId = generatedMovingId
                 segments = baseSegments.map { it.copy(movingId = currentMovingId) }
                 val moving = MovingEntity(
                     id = currentMovingId,


### PR DESCRIPTION
## Summary
- add persistent movingId information to transfer requests and propagate it through Room, Firestore mapping and request submission
- update vehicle request flows to resolve the correct moving document id when notifying, accepting or deleting so we update existing entries instead of creating new ones
- add a Room migration to backfill moving ids and clean up duplicate rows while registering the new column

## Testing
- `./gradlew -q testDebugUnitTest --console=plain` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_68cb0d028edc8328be7bfbe70f6d119b