### PR TITLE
Prevent duplicate notification storage

### DIFF
--- a/app/src/main/java/com/ioannapergamali/mysmartroute/data/local/NotificationDao.kt
+++ b/app/src/main/java/com/ioannapergamali/mysmartroute/data/local/NotificationDao.kt
@@ -13,6 +13,24 @@ interface NotificationDao {
     @Insert(onConflict = OnConflictStrategy.REPLACE)
     suspend fun insert(notification: NotificationEntity)
 
+    @Query(
+        """
+            SELECT id
+            FROM notifications
+            WHERE receiverId = :receiverId
+              AND message = :message
+              AND sentDate = :sentDate
+              AND sentTime = :sentTime
+            LIMIT 1
+        """
+    )
+    suspend fun findIdForMessage(
+        receiverId: String,
+        message: String,
+        sentDate: String,
+        sentTime: String
+    ): String?
+
     @Query("SELECT * FROM notifications WHERE receiverId = :userId ORDER BY sentDate DESC, sentTime DESC")
     fun getForUser(userId: String): Flow<List<NotificationEntity>>
 


### PR DESCRIPTION
## Summary
- avoid storing duplicate notifications by reusing the existing entry id for the same receiver, message and timestamp
- add a Room DAO query that looks up a notification id for identical content so we can collapse duplicates

## Testing
- `./gradlew :app:compileDebugKotlin --console=plain --quiet` *(fails: Android SDK is not available in the container environment)*

------
https://chatgpt.com/codex/tasks/task_e_68cb170aede88328b00c8b96c52e049c