### PR TITLE
Fix moving status classification for accepted routes

### DIFF
--- a/app/src/test/java/com/ioannapergamali/mysmartroute/data/local/MovingStatusTest.kt
+++ b/app/src/test/java/com/ioannapergamali/mysmartroute/data/local/MovingStatusTest.kt
@@ -1,0 +1,43 @@
+package com.ioannapergamali.mysmartroute.data.local
+
+import kotlin.test.Test
+import kotlin.test.assertEquals
+
+class MovingStatusTest {
+    private val now = 1_000_000L
+    private val past = now - 10_000L
+    private val future = now + 10_000L
+
+    @Test
+    fun completedStatus_returnsCompleted() {
+        val moving = moving(status = "completed", date = future)
+        assertEquals(MovingStatus.COMPLETED, moving.movingStatus(now))
+    }
+
+    @Test
+    fun acceptedFuture_returnsPending() {
+        val moving = moving(status = "accepted", date = future)
+        assertEquals(MovingStatus.PENDING, moving.movingStatus(now))
+    }
+
+    @Test
+    fun acceptedPast_returnsUnsuccessful() {
+        val moving = moving(status = "accepted", date = past)
+        assertEquals(MovingStatus.UNSUCCESSFUL, moving.movingStatus(now))
+    }
+
+    @Test
+    fun rejectedFuture_returnsUnsuccessful() {
+        val moving = moving(status = "rejected", date = future)
+        assertEquals(MovingStatus.UNSUCCESSFUL, moving.movingStatus(now))
+    }
+
+    @Test
+    fun unknownFuture_returnsPending() {
+        val moving = moving(status = "in_progress", date = future)
+        assertEquals(MovingStatus.PENDING, moving.movingStatus(now))
+    }
+
+    private fun moving(status: String, date: Long): MovingEntity =
+        MovingEntity(id = "id_$status", status = status, date = date)
+}


### PR DESCRIPTION
## Summary
- treat accepted moving requests as pending before their scheduled time and classify cancelled states explicitly
- keep future unknown statuses pending while logging consistent results
- add unit tests covering the moving status classification rules

## Testing
- `./gradlew test` *(fails: Android SDK not available in container)*

------
https://chatgpt.com/codex/tasks/task_e_68cb21b743a48328a5db74bd12314763