### PR TITLE
Allow duplicate PoI declarations

### DIFF
--- a/app/src/main/java/com/ioannapergamali/mysmartroute/view/ui/screens/DefinePoiScreen.kt
+++ b/app/src/main/java/com/ioannapergamali/mysmartroute/view/ui/screens/DefinePoiScreen.kt
@@ -135,10 +135,6 @@ fun DefinePoiScreen(
                 viewModel.resetAddState()
                 navController.popBackStack()
             }
-            PoIViewModel.AddPoiState.Exists -> {
-                Toast.makeText(context, context.getString(R.string.poi_exists), Toast.LENGTH_SHORT).show()
-                viewModel.resetAddState()
-            }
             else -> {}
         }
     }

--- a/app/src/main/java/com/ioannapergamali/mysmartroute/viewmodel/PoIViewModel.kt
+++ b/app/src/main/java/com/ioannapergamali/mysmartroute/viewmodel/PoIViewModel.kt
@@ -51,8 +51,8 @@ class PoIViewModel : ViewModel() {
     }
 
     /**
-     * Προσθέτει νέο σημείο ενδιαφέροντος αν δεν υπάρχει με το ίδιο όνομα.
-     * Adds a new point of interest if no point with the same name exists.
+     * Προσθέτει νέο σημείο ενδιαφέροντος χωρίς περιορισμό ονόματος ή συντεταγμένων.
+     * Adds a new point of interest without enforcing unique name or coordinates.
      */
     fun addPoi(
         context: Context,
@@ -64,13 +64,6 @@ class PoIViewModel : ViewModel() {
     ) {
         viewModelScope.launch {
             val dao = MySmartRouteDatabase.getInstance(context).poIDao()
-            // Επιτρέπουμε αποθήκευση ίδιου σημείου αν έχει διαφορετικό όνομα.
-            // Allow saving the same location if it has a different name.
-            val exists = dao.findByName(name) != null
-            if (exists) {
-                _addState.value = AddPoiState.Exists
-                return@launch
-            }
 
             val id = UUID.randomUUID().toString()
             val poi = PoIEntity(
@@ -100,7 +93,6 @@ class PoIViewModel : ViewModel() {
     sealed class AddPoiState {
         object Idle : AddPoiState()
         data class Success(val id: String) : AddPoiState()
-        object Exists : AddPoiState()
         data class Error(val message: String) : AddPoiState()
     }
 


### PR DESCRIPTION
## Summary
- remove the duplicate-name check when creating a new PoI so identical names and coordinates are allowed
- drop the unused duplicate-exists branch from the PoI definition screen state handler

## Testing
- ./gradlew :app:testDebugUnitTest --console=plain --no-daemon *(fails: Android SDK not installed in container)*

------
https://chatgpt.com/codex/tasks/task_e_68cb290d85c08328b26bcc6abc20e6c3