### PR TITLE
Ensure admin movings screen shows all results

### DIFF
--- a/app/src/main/java/com/ioannapergamali/mysmartroute/viewmodel/VehicleRequestViewModel.kt
+++ b/app/src/main/java/com/ioannapergamali/mysmartroute/viewmodel/VehicleRequestViewModel.kt
@@ -120,33 +120,33 @@ class VehicleRequestViewModel(
             }.getOrNull()
 
             val remoteRaw = snapshot?.documents?.mapNotNull { it.toTransferRequestEntity() }.orEmpty()
-            val remote: List<TransferRequestEntity> =
-                if (remoteRaw.isEmpty()) {
-                    emptyList()
-                } else {
-                    val deduped = mutableMapOf<Int, TransferRequestEntity>()
-                    for (request in remoteRaw) {
-                        val existing = deduped[request.requestNumber]
-                        val localMatch = localByNumber[request.requestNumber]
-                        val shouldReplace = when {
-                            existing == null -> true
-                            localMatch?.firebaseId?.isNotBlank() == true &&
-                                request.firebaseId == localMatch.firebaseId -> true
-                            existing.firebaseId.isBlank() && request.firebaseId.isNotBlank() -> true
-                            else -> false
-                        }
-                        if (shouldReplace) {
-                            deduped[request.requestNumber] = request
-                        }
+            val remoteMerged = linkedMapOf<Int, TransferRequestEntity>()
+            if (remoteRaw.isNotEmpty()) {
+                for (request in remoteRaw) {
+                    val localMatch = localByNumber[request.requestNumber]
+                    val candidate = localMatch?.let { request.withLocalFallback(it) } ?: request
+                    val existing = remoteMerged[request.requestNumber]
+                    val shouldReplace = when {
+                        existing == null -> true
+                        localMatch?.firebaseId?.isNotBlank() == true &&
+                            candidate.firebaseId == localMatch.firebaseId -> true
+                        existing.firebaseId.isBlank() && candidate.firebaseId.isNotBlank() -> true
+                        existing.movingId.isBlank() && candidate.movingId.isNotBlank() -> true
+                        else -> false
                     }
-                    deduped.values.toList()
+                    if (shouldReplace) {
+                        remoteMerged[request.requestNumber] = candidate
+                    }
                 }
-
-            val target = when {
-                remote.isNotEmpty() -> remote
-                local.isNotEmpty() -> local
-                else -> emptyList()
             }
+
+            val combinedByRequestNumber = linkedMapOf<Int, TransferRequestEntity>()
+            combinedByRequestNumber.putAll(remoteMerged)
+            for (localRequest in local) {
+                combinedByRequestNumber.putIfAbsent(localRequest.requestNumber, localRequest)
+            }
+
+            val target = combinedByRequestNumber.values.toList()
 
             val movings = mutableListOf<MovingEntity>()
             val declarations = runCatching { declarationDao.getAll().first() }.getOrElse { emptyList() }
@@ -208,9 +208,9 @@ class VehicleRequestViewModel(
 
             _requests.value = movings
 
-            if (remote.isNotEmpty()) {
+            if (remoteMerged.isNotEmpty()) {
                 val existingNumbers = local.map { it.requestNumber }.toSet()
-                remote.forEach { request ->
+                remoteMerged.values.forEach { request ->
                     if (request.requestNumber in existingNumbers) {
                         dao.insert(request)
                     }
@@ -248,6 +248,18 @@ class VehicleRequestViewModel(
                 showRejectedNotifications(context)
             }
         }
+    }
+
+    private fun TransferRequestEntity.withLocalFallback(local: TransferRequestEntity): TransferRequestEntity {
+        return copy(
+            routeId = routeId.ifBlank { local.routeId },
+            passengerId = passengerId.ifBlank { local.passengerId },
+            driverId = driverId.ifBlank { local.driverId },
+            driverName = driverName.ifBlank { local.driverName },
+            firebaseId = firebaseId.ifBlank { local.firebaseId },
+            movingId = movingId.ifBlank { local.movingId },
+            cost = cost ?: local.cost
+        )
     }
 
     /**
@@ -291,19 +303,36 @@ class VehicleRequestViewModel(
                     .mapNotNull { it.toMovingEntity() }
             }
 
-            val target = if (remote.isNotEmpty()) remote else localMovings
+            val mergedMovings = mergeMovings(localMovings, remote)
 
-            target.forEach { m ->
+            mergedMovings.forEach { m ->
                 enrichMoving(m, routeDao, userDao, vehicleDao)
             }
 
-            _requests.value = target
+            _requests.value = mergedMovings
 
             if (remote.isNotEmpty()) {
                 remote.forEach { dao.insert(it) }
             }
         }
     }
+
+    private fun mergeMovings(
+        localMovings: List<MovingEntity>,
+        remoteMovings: List<MovingEntity>
+    ): List<MovingEntity> {
+        if (localMovings.isEmpty()) return remoteMovings
+        if (remoteMovings.isEmpty()) return localMovings
+        return (localMovings + remoteMovings)
+            .associateBy { it.deduplicationKey() }
+            .values
+            .toList()
+    }
+
+    private fun MovingEntity.deduplicationKey(): String =
+        id.takeIf { it.isNotBlank() }
+            ?: listOf(routeId, userId, driverId, date.toString(), requestNumber.toString())
+                .joinToString(separator = "|")
 
     private suspend fun enrichMoving(
         m: MovingEntity,


### PR DESCRIPTION
## Summary
- merge remote transfer requests with local fallbacks before updating the passenger movings state so administrators can see every entry
- enrich remote requests with missing local fields while still letting remote data win on duplicates

## Testing
- `./gradlew test --console=plain` *(fails: SDK location not found in container)*

------
https://chatgpt.com/codex/tasks/task_e_68cb2c89764483288e93ae9e9b8172d2