### PR TITLE
Allow admins to view driver transfer requests

### DIFF
--- a/app/src/main/java/com/ioannapergamali/mysmartroute/view/ui/components/TopBar.kt
+++ b/app/src/main/java/com/ioannapergamali/mysmartroute/view/ui/components/TopBar.kt
@@ -90,7 +90,8 @@ fun TopBar(
     }
     LaunchedEffect(role) {
         role?.let {
-            requestViewModel.loadRequests(context, allUsers = it == UserRole.DRIVER)
+            val shouldLoadAll = it == UserRole.DRIVER || it == UserRole.ADMIN
+            requestViewModel.loadRequests(context, allUsers = shouldLoadAll)
         }
     }
 


### PR DESCRIPTION
## Summary
- ensure the shared top bar loads all transfer requests for administrators so the driver view is populated

## Testing
- ./gradlew test --no-daemon --console=plain *(fails: Android SDK not installed in container)*

------
https://chatgpt.com/codex/tasks/task_e_68cb33ce37f48328b18cee9590b514e9