### PR TITLE
Avoid creating duplicate routes when POIs unchanged

### DIFF
--- a/app/src/main/java/com/ioannapergamali/mysmartroute/view/ui/screens/BookSeatScreen.kt
+++ b/app/src/main/java/com/ioannapergamali/mysmartroute/view/ui/screens/BookSeatScreen.kt
@@ -201,9 +201,9 @@ fun BookSeatScreen(
 
     suspend fun resolveRouteForRequest(): Pair<String, Boolean> {
         val currentRouteId = selectedRouteId ?: return "" to false
-        val current = poiIds.toSet()
-        val original = originalPoiIds.toSet()
-        if (current == original) return currentRouteId to false
+        val currentCounts = poiIds.groupingBy { it }.eachCount()
+        val originalCounts = originalPoiIds.groupingBy { it }.eachCount()
+        if (currentCounts == originalCounts) return currentRouteId to false
 
         val uid = SessionManager.currentUserId() ?: return "" to false
         val username = FirebaseFirestore.getInstance()

--- a/app/src/main/java/com/ioannapergamali/mysmartroute/view/ui/screens/RouteModeScreen.kt
+++ b/app/src/main/java/com/ioannapergamali/mysmartroute/view/ui/screens/RouteModeScreen.kt
@@ -163,9 +163,9 @@ fun RouteModeScreen(
     }
     suspend fun resolveRouteForRequest(): Pair<String, Boolean> {
         val currentRouteId = selectedRouteId ?: return "" to false
-        val current = routePoiIds.toSet()
-        val original = originalPoiIds.toSet()
-        if (current == original) return currentRouteId to false
+        val currentCounts = routePoiIds.groupingBy { it }.eachCount()
+        val originalCounts = originalPoiIds.groupingBy { it }.eachCount()
+        if (currentCounts == originalCounts) return currentRouteId to false
 
         val uid = SessionManager.currentUserId() ?: return "" to false
         val username = FirebaseFirestore.getInstance()


### PR DESCRIPTION
## Summary
- ensure the vehicle request flow only creates a new route when POI additions or removals are detected in RouteModeScreen
- apply the same POI change detection to BookSeatScreen so unchanged routes are reused

## Testing
- ./gradlew test --console=plain *(fails: Android SDK not available in CI environment)*

------
https://chatgpt.com/codex/tasks/task_e_68cb3a06ecec8328bdffc27d4d350e0c