### PR TITLE
Prefill availability declaration when launching from transfer requests

### DIFF
--- a/app/src/main/java/com/ioannapergamali/mysmartroute/model/navigation/NavigationHost.kt
+++ b/app/src/main/java/com/ioannapergamali/mysmartroute/model/navigation/NavigationHost.kt
@@ -1,7 +1,9 @@
 package com.ioannapergamali.mysmartroute.model.navigation
 
+import android.net.Uri
 import androidx.compose.runtime.Composable
 import androidx.navigation.NavHostController
+import androidx.navigation.NavType
 import androidx.navigation.compose.NavHost
 import androidx.navigation.compose.composable
 import androidx.navigation.navArgument
@@ -115,14 +117,25 @@ fun NavigationHost(
         }
 
         composable(
-            route = "announceAvailability?routeId={routeId}",
-            arguments = listOf(navArgument("routeId") { defaultValue = "" })
+            route = "announceAvailability?routeId={routeId}&dateMillis={dateMillis}&routeName={routeName}",
+            arguments = listOf(
+                navArgument("routeId") { defaultValue = "" },
+                navArgument("dateMillis") {
+                    type = NavType.LongType
+                    defaultValue = -1L
+                },
+                navArgument("routeName") { defaultValue = "" }
+            )
         ) { backStackEntry ->
             val routeId = backStackEntry.arguments?.getString("routeId").orEmpty()
+            val dateMillis = backStackEntry.arguments?.getLong("dateMillis") ?: -1L
+            val rawRouteName = backStackEntry.arguments?.getString("routeName").orEmpty()
             AnnounceTransportScreen(
                 navController = navController,
                 openDrawer = openDrawer,
-                initialRouteId = routeId.ifBlank { null }
+                initialRouteId = routeId.ifBlank { null },
+                initialRouteName = Uri.decode(rawRouteName).ifBlank { null },
+                initialDateTimeMillis = dateMillis.takeIf { it > 0L }
             )
         }
 

--- a/app/src/main/java/com/ioannapergamali/mysmartroute/view/ui/screens/ViewTransportRequestsScreen.kt
+++ b/app/src/main/java/com/ioannapergamali/mysmartroute/view/ui/screens/ViewTransportRequestsScreen.kt
@@ -245,8 +245,12 @@ fun ViewTransportRequestsScreen(
                                 TextButton(
                                     onClick = {
                                         if (req.routeId.isNotBlank()) {
-                                            val encoded = Uri.encode(req.routeId)
-                                            navController.navigate("announceAvailability?routeId=$encoded")
+                                            val encodedRouteId = Uri.encode(req.routeId)
+                                            val encodedRouteName = Uri.encode(routeName)
+                                            val dateParam = req.date.takeIf { it > 0L }?.toString().orEmpty()
+                                            val targetRoute =
+                                                "announceAvailability?routeId=$encodedRouteId&dateMillis=$dateParam&routeName=$encodedRouteName"
+                                            navController.navigate(targetRoute)
                                         }
                                     },
                                     modifier = Modifier.width(columnWidth),


### PR DESCRIPTION
## Summary
- pass transfer request data when navigating to the availability declaration screen
- allow the declaration screen to prefill route name and scheduled date/time when available
- keep auto-time updates only when no explicit schedule has been provided

## Testing
- ./gradlew test --console=plain *(fails: SDK location not configured in the environment)*

------
https://chatgpt.com/codex/tasks/task_e_68cb3eca2d948328a713d7ed277b30e6