### PR TITLE
Ensure route cloning only when POIs change

### DIFF
--- a/app/src/main/java/com/ioannapergamali/mysmartroute/view/ui/screens/BookSeatScreen.kt
+++ b/app/src/main/java/com/ioannapergamali/mysmartroute/view/ui/screens/BookSeatScreen.kt
@@ -605,19 +605,27 @@ fun BookSeatScreen(
                     enabled = selectedRoute != null && startIndex != null && endIndex != null &&
                             datePickerState.selectedDateMillis != null && selectedTimeMillis != null,
                     onClick = {
-                        val r = selectedRoute ?: return@Button
-                        val dateMillis = datePickerState.selectedDateMillis ?: return@Button
-                        val startId = startIndex?.let { pois[it].id } ?: return@Button
-                        val endId = endIndex?.let { pois[it].id } ?: return@Button
-                        val timeMillis = selectedTimeMillis ?: return@Button
-                        navController.navigate(
-                            "availableTransports?routeId=" +
-                                    r.id +
-                                    "&startId=" + startId +
-                                    "&endId=" + endId +
-                                    "&maxCost=&date=" + dateMillis +
-                                    "&time=" + timeMillis
-                        )
+                        scope.launch {
+                            val dateMillis = datePickerState.selectedDateMillis ?: return@launch
+                            val startId = startIndex?.let { pois[it].id } ?: return@launch
+                            val endId = endIndex?.let { pois[it].id } ?: return@launch
+                            val timeMillis = selectedTimeMillis ?: return@launch
+
+                            val (resolvedRouteId, _) = resolveRouteForRequest()
+                            if (resolvedRouteId.isBlank()) {
+                                message = context.getString(R.string.request_unsuccessful)
+                                return@launch
+                            }
+
+                            navController.navigate(
+                                "availableTransports?routeId=" +
+                                        resolvedRouteId +
+                                        "&startId=" + startId +
+                                        "&endId=" + endId +
+                                        "&maxCost=&date=" + dateMillis +
+                                        "&time=" + timeMillis
+                            )
+                        }
                     }
                 ) {
                     Icon(Icons.Default.Search, contentDescription = null)

--- a/app/src/main/java/com/ioannapergamali/mysmartroute/view/ui/screens/RouteModeScreen.kt
+++ b/app/src/main/java/com/ioannapergamali/mysmartroute/view/ui/screens/RouteModeScreen.kt
@@ -490,28 +490,35 @@ fun RouteModeScreen(
             Column(verticalArrangement = Arrangement.spacedBy(8.dp)) {
                 Button(
                     onClick = {
-                        val fromIdx = startIndex ?: return@Button
-                        val toIdx = endIndex ?: return@Button
-                        if (fromIdx >= toIdx) {
-                            message = context.getString(R.string.invalid_stop_order)
-                            return@Button
-                        }
-                        val fromId = routePois[fromIdx].id
-                        val toId = routePois[toIdx].id
-                        val cost = maxCostText.toDoubleOrNull()
-                        val routeId = selectedRouteId ?: return@Button
-                        val date = datePickerState.selectedDateMillis ?: 0L
-                        val time = selectedTimeMillis
+                        coroutineScope.launch {
+                            val fromIdx = startIndex ?: return@launch
+                            val toIdx = endIndex ?: return@launch
+                            if (fromIdx >= toIdx) {
+                                message = context.getString(R.string.invalid_stop_order)
+                                return@launch
+                            }
+                            val fromId = routePois[fromIdx].id
+                            val toId = routePois[toIdx].id
+                            val cost = maxCostText.toDoubleOrNull()
+                            val date = datePickerState.selectedDateMillis ?: 0L
+                            val time = selectedTimeMillis
 
-                        navController.navigate(
-                            "availableTransports?routeId=" +
-                                routeId +
-                                "&startId=" + fromId +
-                                "&endId=" + toId +
-                                "&maxCost=" + (cost?.toString() ?: "") +
-                                "&date=" + date +
-                                "&time=" + (time?.toString() ?: "")
-                        )
+                            val (resolvedRouteId, _) = resolveRouteForRequest()
+                            if (resolvedRouteId.isBlank()) {
+                                message = context.getString(R.string.request_unsuccessful)
+                                return@launch
+                            }
+
+                            navController.navigate(
+                                "availableTransports?routeId=" +
+                                    resolvedRouteId +
+                                    "&startId=" + fromId +
+                                    "&endId=" + toId +
+                                    "&maxCost=" + (cost?.toString() ?: "") +
+                                    "&date=" + date +
+                                    "&time=" + (time?.toString() ?: "")
+                            )
+                        }
                     },
                     enabled = selectedRouteId != null && startIndex != null && endIndex != null,
                 ) {


### PR DESCRIPTION
## Summary
- resolve the route before navigating from the "Find now" action so cloning happens only when POIs were modified
- reuse the same route resolution in the booking flow and surface failures to the user

## Testing
- ./gradlew :app:compileDebugKotlin --console=plain --quiet *(fails: Android SDK is not available in the container environment)*

------
https://chatgpt.com/codex/tasks/task_e_68cb439bf17c8328bbf206a86e8cf8c7