### PR TITLE
Ensure new routes are only created after POI membership changes

### DIFF
--- a/app/src/main/java/com/ioannapergamali/mysmartroute/utils/PoiChangeUtils.kt
+++ b/app/src/main/java/com/ioannapergamali/mysmartroute/utils/PoiChangeUtils.kt
@@ -1,0 +1,17 @@
+package com.ioannapergamali.mysmartroute.utils
+
+/**
+ * Επιστρέφει true μόνο όταν η λίστα των POI έχει αλλάξει από προσθήκη ή αφαίρεση.
+ * Η σειρά των στοιχείων αγνοείται, έτσι ώστε απλές αναδιατάξεις να μην θεωρούνται αλλαγές.
+ */
+fun havePoiMembershipChanged(
+    originalPoiIds: List<String>,
+    currentPoiIds: List<String>
+): Boolean {
+    if (originalPoiIds.size != currentPoiIds.size) return true
+
+    val originalCounts = originalPoiIds.groupingBy { it }.eachCount()
+    val currentCounts = currentPoiIds.groupingBy { it }.eachCount()
+
+    return originalCounts != currentCounts
+}

--- a/app/src/main/java/com/ioannapergamali/mysmartroute/view/ui/screens/BookSeatScreen.kt
+++ b/app/src/main/java/com/ioannapergamali/mysmartroute/view/ui/screens/BookSeatScreen.kt
@@ -63,6 +63,7 @@ import com.ioannapergamali.mysmartroute.utils.ATHENS_ZONE_ID
 import com.ioannapergamali.mysmartroute.utils.MapsUtils
 import com.ioannapergamali.mysmartroute.utils.offsetPois
 import com.ioannapergamali.mysmartroute.utils.combineDateAndTimeAsAthensInstant
+import com.ioannapergamali.mysmartroute.utils.havePoiMembershipChanged
 import com.ioannapergamali.mysmartroute.view.ui.components.ScreenContainer
 import com.ioannapergamali.mysmartroute.view.ui.components.TopBar
 import com.ioannapergamali.mysmartroute.view.ui.components.BookingStepsIndicator
@@ -201,9 +202,7 @@ fun BookSeatScreen(
 
     suspend fun resolveRouteForRequest(): Pair<String, Boolean> {
         val currentRouteId = selectedRouteId ?: return "" to false
-        val currentCounts = poiIds.groupingBy { it }.eachCount()
-        val originalCounts = originalPoiIds.groupingBy { it }.eachCount()
-        if (currentCounts == originalCounts) return currentRouteId to false
+        if (!havePoiMembershipChanged(originalPoiIds, poiIds)) return currentRouteId to false
 
         val uid = SessionManager.currentUserId() ?: return "" to false
         val username = FirebaseFirestore.getInstance()

--- a/app/src/main/java/com/ioannapergamali/mysmartroute/view/ui/screens/FindVehicleScreen.kt
+++ b/app/src/main/java/com/ioannapergamali/mysmartroute/view/ui/screens/FindVehicleScreen.kt
@@ -30,6 +30,7 @@ import com.ioannapergamali.mysmartroute.model.enumerations.VehicleType
 import com.ioannapergamali.mysmartroute.utils.MapsUtils
 import com.ioannapergamali.mysmartroute.utils.SessionManager
 import com.ioannapergamali.mysmartroute.utils.offsetPois
+import com.ioannapergamali.mysmartroute.utils.havePoiMembershipChanged
 import com.ioannapergamali.mysmartroute.view.ui.components.ScreenContainer
 import com.ioannapergamali.mysmartroute.view.ui.components.TopBar
 import com.ioannapergamali.mysmartroute.viewmodel.PoIViewModel
@@ -96,9 +97,7 @@ fun FindVehicleScreen(navController: NavController, openDrawer: () -> Unit) {
 
     suspend fun resolveRouteForVehicleSearch(): String {
         val currentRouteId = selectedRouteId ?: return ""
-        val currentCounts = routePoiIds.groupingBy { it }.eachCount()
-        val originalCounts = originalPoiIds.groupingBy { it }.eachCount()
-        if (currentCounts == originalCounts) return currentRouteId
+        if (!havePoiMembershipChanged(originalPoiIds, routePoiIds)) return currentRouteId
 
         val uid = SessionManager.currentUserId() ?: return ""
         val username = FirebaseFirestore.getInstance()

--- a/app/src/main/java/com/ioannapergamali/mysmartroute/view/ui/screens/RouteModeScreen.kt
+++ b/app/src/main/java/com/ioannapergamali/mysmartroute/view/ui/screens/RouteModeScreen.kt
@@ -58,6 +58,7 @@ import kotlin.math.abs
 import com.google.firebase.firestore.FirebaseFirestore
 import kotlinx.coroutines.tasks.await
 import com.ioannapergamali.mysmartroute.utils.SessionManager
+import com.ioannapergamali.mysmartroute.utils.havePoiMembershipChanged
 
 
 @OptIn(ExperimentalMaterial3Api::class)
@@ -163,9 +164,7 @@ fun RouteModeScreen(
     }
     suspend fun resolveRouteForRequest(): Pair<String, Boolean> {
         val currentRouteId = selectedRouteId ?: return "" to false
-        val currentCounts = routePoiIds.groupingBy { it }.eachCount()
-        val originalCounts = originalPoiIds.groupingBy { it }.eachCount()
-        if (currentCounts == originalCounts) return currentRouteId to false
+        if (!havePoiMembershipChanged(originalPoiIds, routePoiIds)) return currentRouteId to false
 
         val uid = SessionManager.currentUserId() ?: return "" to false
         val username = FirebaseFirestore.getInstance()


### PR DESCRIPTION
## Summary
- add `havePoiMembershipChanged` helper to centralize POI addition/removal checks
- reuse the helper when resolving routes on the find vehicle, route mode, and book seat screens so new routes are only created after POI membership changes

## Testing
- `./gradlew test --console=plain` *(fails: Android SDK not available in CI environment)*

------
https://chatgpt.com/codex/tasks/task_e_68cb4af1d8b083289d7ccced549177a0