### PR TITLE
Allow naming edited routes in vehicle search screen

### DIFF
--- a/app/src/main/res/values-el/strings.xml
+++ b/app/src/main/res/values-el/strings.xml
@@ -316,6 +316,7 @@
     <string name="select_pois_screen_title">Αποθήκευση ενδιαφερόντων σημείων ενδιαφέροντος</string>
     <string name="choose_pois">Επιλογή σημείων ενδιαφέροντος</string>
     <string name="route_saved">Η διαδρομή αποθηκεύτηκε</string>
+    <string name="route_name_required">Παρακαλώ δώστε όνομα διαδρομής</string>
     <string name="route_saved_success">Η διαδρομή αποθηκεύτηκε με επιτυχία</string>
     <string name="route_save_failed">Η αποθήκευση διαδρομής απέτυχε</string>
     <string name="route_exists">Υπάρχει ήδη διαδρομή με αυτό το όνομα</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -325,6 +325,7 @@
     <string name="select_pois_screen_title">Save interesting points of interest</string>
     <string name="choose_pois">Choose points of interest</string>
     <string name="route_saved">Route saved</string>
+    <string name="route_name_required">Please provide a route name</string>
     <string name="route_save_failed">Unable to save route</string>
     <string name="recalculate_route">Recalculate route</string>
     <string name="departure_date">Departure date</string>


### PR DESCRIPTION
## Summary
- track when POI membership changes on the vehicle search screen and remember a user-provided route name
- require a non-empty route name before saving a modified route copy and refresh the route list after updates
- surface a dedicated "route name" text field and add localized validation messaging

## Testing
- ./gradlew lint --console=plain *(fails: Android SDK location not configured in container)*

------
https://chatgpt.com/codex/tasks/task_e_68cc0a4216fc8328a141e9f03830a7a5