### PR TITLE
Load passenger favorites before filtering transports

### DIFF
--- a/app/src/main/java/com/ioannapergamali/mysmartroute/view/ui/screens/AvailableTransportsScreen.kt
+++ b/app/src/main/java/com/ioannapergamali/mysmartroute/view/ui/screens/AvailableTransportsScreen.kt
@@ -145,6 +145,7 @@ fun AvailableTransportsScreen(
         userViewModel.loadDrivers(context)
         poiViewModel.loadPois(context)
         routeViewModel.loadRoutes(context, includeAll = true)
+        favoritesViewModel.loadFavorites(context)
     }
 
     val driverNames = drivers.associate { it.id to "${it.name} ${it.surname}" }


### PR DESCRIPTION
## Summary
- ensure the available transports view fetches the latest passenger vehicle preferences before filtering results

## Testing
- ./gradlew lint *(fails: missing Android SDK in container environment)*

------
https://chatgpt.com/codex/tasks/task_e_68cc142cf98c83288a7e7f55ee19c409