### PR TITLE
Add passenger satisfaction ranking screen

### DIFF
--- a/app/src/main/java/com/ioannapergamali/mysmartroute/data/local/TripRatingDao.kt
+++ b/app/src/main/java/com/ioannapergamali/mysmartroute/data/local/TripRatingDao.kt
@@ -8,6 +8,7 @@ import androidx.room.OnConflictStrategy
 import androidx.room.Query
 import kotlinx.coroutines.flow.Flow
 import com.ioannapergamali.mysmartroute.model.classes.users.DriverRating
+import com.ioannapergamali.mysmartroute.model.classes.users.PassengerSatisfaction
 
 @Dao
 interface TripRatingDao {
@@ -47,4 +48,30 @@ interface TripRatingDao {
         """
     )
     fun getWorstDrivers(): Flow<List<DriverRating>>
+
+    @Query(
+        """
+            SELECT u.id AS passengerId, u.name AS name, u.surname AS surname, AVG(r.rating) AS averageRating
+            FROM trip_ratings r
+            INNER JOIN users u ON u.id = r.userId
+            WHERE r.userId <> ''
+            GROUP BY u.id
+            ORDER BY averageRating DESC, COUNT(r.rating) DESC
+            LIMIT 10
+        """
+    )
+    fun getMostSatisfiedPassengers(): Flow<List<PassengerSatisfaction>>
+
+    @Query(
+        """
+            SELECT u.id AS passengerId, u.name AS name, u.surname AS surname, AVG(r.rating) AS averageRating
+            FROM trip_ratings r
+            INNER JOIN users u ON u.id = r.userId
+            WHERE r.userId <> ''
+            GROUP BY u.id
+            ORDER BY averageRating ASC, COUNT(r.rating) DESC
+            LIMIT 10
+        """
+    )
+    fun getLeastSatisfiedPassengers(): Flow<List<PassengerSatisfaction>>
 }

--- a/app/src/main/java/com/ioannapergamali/mysmartroute/model/classes/users/PassengerSatisfaction.kt
+++ b/app/src/main/java/com/ioannapergamali/mysmartroute/model/classes/users/PassengerSatisfaction.kt
@@ -1,0 +1,8 @@
+package com.ioannapergamali.mysmartroute.model.classes.users
+
+data class PassengerSatisfaction(
+    val passengerId: String,
+    val name: String,
+    val surname: String,
+    val averageRating: Double,
+)

--- a/app/src/main/java/com/ioannapergamali/mysmartroute/model/navigation/NavigationHost.kt
+++ b/app/src/main/java/com/ioannapergamali/mysmartroute/model/navigation/NavigationHost.kt
@@ -64,6 +64,7 @@ import com.ioannapergamali.mysmartroute.view.ui.screens.NotificationsScreen
 import com.ioannapergamali.mysmartroute.view.ui.screens.ReservationDetailsScreen
 import com.ioannapergamali.mysmartroute.view.ui.screens.RankTransportsScreen
 import com.ioannapergamali.mysmartroute.view.ui.screens.RankDriversScreen
+import com.ioannapergamali.mysmartroute.view.ui.screens.RankPassengersScreen
 import com.ioannapergamali.mysmartroute.view.ui.screens.ReviewRouteScreen
 import com.ioannapergamali.mysmartroute.view.ui.screens.PassengerRoutesScreen
 import com.ioannapergamali.mysmartroute.R
@@ -343,6 +344,10 @@ fun NavigationHost(
 
         composable("rankDrivers") {
             RankDriversScreen(navController = navController, openDrawer = openDrawer)
+        }
+
+        composable("rankPassengers") {
+            RankPassengersScreen(navController = navController, openDrawer = openDrawer)
         }
 
         composable("printTicket") {

--- a/app/src/main/java/com/ioannapergamali/mysmartroute/view/ui/screens/RankPassengersScreen.kt
+++ b/app/src/main/java/com/ioannapergamali/mysmartroute/view/ui/screens/RankPassengersScreen.kt
@@ -1,0 +1,75 @@
+package com.ioannapergamali.mysmartroute.view.ui.screens
+
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Scaffold
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.collectAsState
+import androidx.compose.runtime.getValue
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.unit.dp
+import androidx.lifecycle.viewmodel.compose.viewModel
+import androidx.navigation.NavController
+import com.ioannapergamali.mysmartroute.R
+import com.ioannapergamali.mysmartroute.view.ui.components.ScreenContainer
+import com.ioannapergamali.mysmartroute.view.ui.components.TopBar
+import com.ioannapergamali.mysmartroute.viewmodel.PassengerSatisfactionViewModel
+
+@Composable
+fun RankPassengersScreen(navController: NavController, openDrawer: () -> Unit) {
+    val context = LocalContext.current
+    val viewModel: PassengerSatisfactionViewModel = viewModel()
+    val mostSatisfied by viewModel.mostSatisfied.collectAsState()
+    val leastSatisfied by viewModel.leastSatisfied.collectAsState()
+
+    LaunchedEffect(Unit) { viewModel.loadRatings(context) }
+
+    Scaffold(
+        topBar = {
+            TopBar(
+                title = stringResource(R.string.rank_passengers),
+                navController = navController,
+                showMenu = true,
+                onMenuClick = openDrawer
+            )
+        }
+    ) { padding ->
+        ScreenContainer(modifier = Modifier.padding(padding)) {
+            Text(
+                stringResource(R.string.most_satisfied_passengers),
+                style = MaterialTheme.typography.titleMedium
+            )
+            if (mostSatisfied.isEmpty()) {
+                Text(stringResource(R.string.no_passenger_ratings))
+            } else {
+                mostSatisfied.forEachIndexed { index, passenger ->
+                    Text(
+                        "${index + 1}. ${passenger.name} ${passenger.surname} - " +
+                            stringResource(R.string.average_rating_label, passenger.averageRating)
+                    )
+                }
+            }
+            Spacer(modifier = Modifier.height(16.dp))
+            Text(
+                stringResource(R.string.least_satisfied_passengers),
+                style = MaterialTheme.typography.titleMedium
+            )
+            if (leastSatisfied.isEmpty()) {
+                Text(stringResource(R.string.no_passenger_ratings))
+            } else {
+                leastSatisfied.forEachIndexed { index, passenger ->
+                    Text(
+                        "${index + 1}. ${passenger.name} ${passenger.surname} - " +
+                            stringResource(R.string.average_rating_label, passenger.averageRating)
+                    )
+                }
+            }
+        }
+    }
+}

--- a/app/src/main/java/com/ioannapergamali/mysmartroute/viewmodel/PassengerSatisfactionViewModel.kt
+++ b/app/src/main/java/com/ioannapergamali/mysmartroute/viewmodel/PassengerSatisfactionViewModel.kt
@@ -1,0 +1,33 @@
+package com.ioannapergamali.mysmartroute.viewmodel
+
+import android.content.Context
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.viewModelScope
+import com.ioannapergamali.mysmartroute.data.local.MySmartRouteDatabase
+import com.ioannapergamali.mysmartroute.model.classes.users.PassengerSatisfaction
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.combine
+import kotlinx.coroutines.launch
+
+class PassengerSatisfactionViewModel : ViewModel() {
+    private val _mostSatisfied = MutableStateFlow<List<PassengerSatisfaction>>(emptyList())
+    val mostSatisfied: StateFlow<List<PassengerSatisfaction>> = _mostSatisfied
+
+    private val _leastSatisfied = MutableStateFlow<List<PassengerSatisfaction>>(emptyList())
+    val leastSatisfied: StateFlow<List<PassengerSatisfaction>> = _leastSatisfied
+
+    fun loadRatings(context: Context) {
+        val db = MySmartRouteDatabase.getInstance(context)
+        viewModelScope.launch {
+            combine(
+                db.tripRatingDao().getMostSatisfiedPassengers(),
+                db.tripRatingDao().getLeastSatisfiedPassengers()
+            ) { top, bottom ->
+                val topIds = top.map { it.passengerId }.toSet()
+                _mostSatisfied.value = top
+                _leastSatisfied.value = bottom.filterNot { it.passengerId in topIds }
+            }.collect { }
+        }
+    }
+}

--- a/app/src/main/res/values-el/strings.xml
+++ b/app/src/main/res/values-el/strings.xml
@@ -237,6 +237,9 @@
     <string name="no_driver_ratings">Δεν υπάρχουν βαθμολογίες οδηγών</string>
     <string name="average_rating_label">Μέση βαθμολογία: %1$.1f/5</string>
     <string name="rank_passengers">Προβολή 10 πιο και λιγότερο ικανοποιημένων επιβατών</string>
+    <string name="most_satisfied_passengers">Οι 10 πιο ικανοποιημένοι επιβάτες</string>
+    <string name="least_satisfied_passengers">Οι 10 λιγότερο ικανοποιημένοι επιβάτες</string>
+    <string name="no_passenger_ratings">Δεν υπάρχουν διαθέσιμες αξιολογήσεις επιβατών</string>
     <string name="view_vehicles">Προβολή διαθέσιμων οχημάτων</string>
     <string name="vehicles_empty">Δεν βρέθηκαν οχήματα</string>
     <string name="view_pois">Προβολή σημείων ενδιαφέροντος</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -237,6 +237,9 @@
     <string name="no_driver_ratings">No driver ratings found</string>
     <string name="average_rating_label">Avg rating: %1$.1f/5</string>
     <string name="rank_passengers">View 10 Happiest/Least Happy Passengers</string>
+    <string name="most_satisfied_passengers">Top 10 most satisfied passengers</string>
+    <string name="least_satisfied_passengers">Bottom 10 least satisfied passengers</string>
+    <string name="no_passenger_ratings">No passenger ratings available</string>
     <string name="view_vehicles">View Available Vehicles</string>
     <string name="vehicles_empty">No vehicles found</string>
     <string name="view_pois">View PoIs</string>


### PR DESCRIPTION
## Summary
- add Room queries and data class to retrieve passenger satisfaction averages
- implement PassengerSatisfactionViewModel and Compose screen to show top and bottom 10 passengers
- expose the new screen via navigation and localised strings

## Testing
- ./gradlew test --console=plain --no-daemon *(fails: missing Android SDK in CI environment)*

------
https://chatgpt.com/codex/tasks/task_e_68cc1ef94d58832892d10bedeb8cb11e