### PR TITLE
Handle admin printing for scheduled and completed routes

### DIFF
--- a/app/src/main/java/com/ioannapergamali/mysmartroute/view/ui/screens/PrintCompletedScreen.kt
+++ b/app/src/main/java/com/ioannapergamali/mysmartroute/view/ui/screens/PrintCompletedScreen.kt
@@ -17,10 +17,12 @@ import androidx.compose.ui.res.stringResource
 import androidx.lifecycle.viewmodel.compose.viewModel
 import androidx.navigation.NavController
 import com.ioannapergamali.mysmartroute.R
+import com.ioannapergamali.mysmartroute.model.enumerations.UserRole
 import com.ioannapergamali.mysmartroute.view.ui.components.ScreenContainer
 import com.ioannapergamali.mysmartroute.view.ui.components.TopBar
 import com.ioannapergamali.mysmartroute.viewmodel.RouteViewModel
 import com.ioannapergamali.mysmartroute.viewmodel.TransportDeclarationViewModel
+import com.ioannapergamali.mysmartroute.viewmodel.AuthenticationViewModel
 import java.text.SimpleDateFormat
 import java.util.Date
 import java.util.Locale
@@ -32,14 +34,26 @@ fun PrintCompletedScreen(navController: NavController, openDrawer: () -> Unit) {
     val context = LocalContext.current
     val declarationViewModel: TransportDeclarationViewModel = viewModel()
     val routeViewModel: RouteViewModel = viewModel()
+    val authViewModel: AuthenticationViewModel = viewModel()
     val declarations by declarationViewModel.completedDeclarations.collectAsState()
     val routes by routeViewModel.routes.collectAsState()
+    val role by authViewModel.currentUserRole.collectAsState()
 
     LaunchedEffect(Unit) {
-        val driverId = SessionManager.currentUserId()
-        if (driverId != null) {
-            declarationViewModel.loadDeclarations(context, driverId)
-            routeViewModel.loadRoutes(context)
+        authViewModel.loadCurrentUserRole(context)
+    }
+
+    LaunchedEffect(role) {
+        val admin = role == UserRole.ADMIN
+        if (admin) {
+            declarationViewModel.loadDeclarations(context)
+            routeViewModel.loadRoutes(context, includeAll = true)
+        } else {
+            val driverId = SessionManager.currentUserId()
+            if (role != null && driverId != null) {
+                declarationViewModel.loadDeclarations(context, driverId)
+                routeViewModel.loadRoutes(context)
+            }
         }
     }
 


### PR DESCRIPTION
## Summary
- load the authenticated role in the scheduled and completed print screens
- fetch all declarations and routes when the current user is an administrator so every transport appears
- reset cached passenger names when switching between admin and driver views

## Testing
- ./gradlew :app:lint --console=plain *(fails: SDK location not found in container)*

------
https://chatgpt.com/codex/tasks/task_e_68cc25b24f4c8328b504cc96b325ac8c