### PR TITLE
Fix missing auth view model in PrintCompletedScreen

### DIFF
--- a/app/src/main/java/com/ioannapergamali/mysmartroute/view/ui/screens/PrintCompletedScreen.kt
+++ b/app/src/main/java/com/ioannapergamali/mysmartroute/view/ui/screens/PrintCompletedScreen.kt
@@ -20,12 +20,12 @@ import androidx.navigation.NavController
 import com.ioannapergamali.mysmartroute.R
 
 import com.ioannapergamali.mysmartroute.data.local.MySmartRouteDatabase
-
+import com.ioannapergamali.mysmartroute.model.enumerations.UserRole
 import com.ioannapergamali.mysmartroute.view.ui.components.ScreenContainer
 import com.ioannapergamali.mysmartroute.view.ui.components.TopBar
+import com.ioannapergamali.mysmartroute.viewmodel.AuthenticationViewModel
 import com.ioannapergamali.mysmartroute.viewmodel.RouteViewModel
 import com.ioannapergamali.mysmartroute.viewmodel.TransportDeclarationViewModel
-
 import com.ioannapergamali.mysmartroute.viewmodel.UserViewModel
 
 import java.text.SimpleDateFormat
@@ -41,10 +41,11 @@ fun PrintCompletedScreen(navController: NavController, openDrawer: () -> Unit) {
     val routeViewModel: RouteViewModel = viewModel()
 
     val userViewModel: UserViewModel = viewModel()
+    val authViewModel: AuthenticationViewModel = viewModel()
     val declarations by declarationViewModel.completedDeclarations.collectAsState()
     val routes by routeViewModel.routes.collectAsState()
+    val role by authViewModel.currentUserRole.collectAsState()
     val passengerNames = remember { mutableStateMapOf<String, List<String>>() }
-
 
     LaunchedEffect(Unit) {
         authViewModel.loadCurrentUserRole(context)


### PR DESCRIPTION
## Summary
- add the AuthenticationViewModel and role state to PrintCompletedScreen so the authViewModel reference resolves

## Testing
- ⚠️ `./gradlew :app:compileDebugKotlin --console=plain --no-daemon` *(fails: Android SDK not available in the CI container)*

------
https://chatgpt.com/codex/tasks/task_e_68cc2b06299c83289f4edb85b06ca7c0