### PR TITLE
Sync trip ratings from Firestore at startup

### DIFF
--- a/app/src/main/java/com/ioannapergamali/mysmartroute/MySmartRouteApplication.kt
+++ b/app/src/main/java/com/ioannapergamali/mysmartroute/MySmartRouteApplication.kt
@@ -6,10 +6,15 @@ import com.ioannapergamali.mysmartroute.BuildConfig
 import com.ioannapergamali.mysmartroute.utils.LanguagePreferenceManager
 import com.ioannapergamali.mysmartroute.utils.LocaleUtils
 import com.ioannapergamali.mysmartroute.utils.ShortcutUtils
+import com.ioannapergamali.mysmartroute.utils.TripRatingSyncManager
 import com.ioannapergamali.mysmartroute.utils.populatePoiTypes
 import com.ioannapergamali.mysmartroute.viewmodel.AuthenticationViewModel
 import com.ioannapergamali.mysmartroute.work.SyncWorker
 import dagger.hilt.android.HiltAndroidApp
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.SupervisorJob
+import kotlinx.coroutines.launch
 import kotlinx.coroutines.runBlocking
 import org.acra.config.mailSender
 import org.acra.data.StringFormat
@@ -26,6 +31,8 @@ import androidx.work.WorkManager
  */
 @HiltAndroidApp
 class MySmartRouteApplication : Application() {
+
+    private val applicationScope = CoroutineScope(SupervisorJob() + Dispatchers.IO)
 
     override fun onCreate() {
         super.onCreate()
@@ -70,5 +77,10 @@ class MySmartRouteApplication : Application() {
             )
             .build()
         WorkManager.getInstance(this).enqueue(syncRequest)
+
+        // 7. Άμεσος συγχρονισμός αξιολογήσεων μετακινήσεων
+        applicationScope.launch {
+            TripRatingSyncManager.sync(this@MySmartRouteApplication)
+        }
     }
 }

--- a/app/src/main/java/com/ioannapergamali/mysmartroute/utils/TripRatingSyncManager.kt
+++ b/app/src/main/java/com/ioannapergamali/mysmartroute/utils/TripRatingSyncManager.kt
@@ -1,0 +1,43 @@
+package com.ioannapergamali.mysmartroute.utils
+
+import android.content.Context
+import android.util.Log
+import androidx.room.withTransaction
+import com.google.firebase.firestore.FirebaseFirestore
+import com.ioannapergamali.mysmartroute.data.local.MySmartRouteDatabase
+import com.ioannapergamali.mysmartroute.utils.toTripRatingEntity
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.tasks.await
+import kotlinx.coroutines.withContext
+
+/**
+ * Υπεύθυνο αντικείμενο για συγχρονισμό των αξιολογήσεων διαδρομών από το Firestore στη Room.
+ * Provides a lightweight one-shot synchronisation for the trip ratings table.
+ */
+object TripRatingSyncManager {
+
+    private const val TAG = "TripRatingSync"
+    private val firestore: FirebaseFirestore by lazy { FirebaseFirestore.getInstance() }
+
+    suspend fun sync(context: Context) {
+        withContext(Dispatchers.IO) {
+            val db = MySmartRouteDatabase.getInstance(context)
+            try {
+                val snapshot = firestore.collection("trip_ratings").get().await()
+                val tripRatings = snapshot.documents.mapNotNull { it.toTripRatingEntity() }
+                if (tripRatings.isEmpty()) {
+                    Log.d(TAG, "Δεν βρέθηκαν απομακρυσμένες αξιολογήσεις προς συγχρονισμό")
+                    return@withContext
+                }
+
+                db.withTransaction {
+                    val dao = db.tripRatingDao()
+                    tripRatings.forEach { dao.upsert(it) }
+                }
+                Log.d(TAG, "Συγχρονίστηκαν ${tripRatings.size} αξιολογήσεις διαδρομών από το Firestore")
+            } catch (error: Exception) {
+                Log.e(TAG, "Αποτυχία συγχρονισμού αξιολογήσεων", error)
+            }
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- add a TripRatingSyncManager that pulls Firestore trip ratings into the local Room table
- launch a startup coroutine from MySmartRouteApplication to immediately sync ratings alongside the background worker

## Testing
- ./gradlew :app:lint *(fails: SDK location not found in container)*

------
https://chatgpt.com/codex/tasks/task_e_68cc3048d738832883881cfad54f89b4