### PR TITLE
Update passenger search and list to use MOVINGS data

### DIFF
--- a/app/src/main/java/com/ioannapergamali/mysmartroute/view/ui/screens/FindPassengersScreen.kt
+++ b/app/src/main/java/com/ioannapergamali/mysmartroute/view/ui/screens/FindPassengersScreen.kt
@@ -29,7 +29,6 @@ import com.ioannapergamali.mysmartroute.viewmodel.*
 import java.util.Date
 import android.text.format.DateFormat
 import com.ioannapergamali.mysmartroute.utils.ATHENS_TIME_ZONE
-import java.util.Locale
 
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable
@@ -88,11 +87,9 @@ fun FindPassengersScreen(
     val filteredMovings = movings.filter { req ->
         val reqDate = req.date - (req.date % dayMillis)
         val reqTime = req.date % dayMillis
-        val status = req.status.lowercase(Locale.ROOT)
         (selectedRouteId == null || req.routeId == selectedRouteId) &&
             (selectedDateMillis == null || reqDate == selectedDateMillis) &&
-            (selectedTimeMillis == null || reqTime == selectedTimeMillis) &&
-            (status == "pending" || status == "accepted")
+            (selectedTimeMillis == null || reqTime == selectedTimeMillis)
     }
 
     LaunchedEffect(selectedDateMillis, selectedTimeMillis, selectedRouteId) {

--- a/app/src/main/java/com/ioannapergamali/mysmartroute/view/ui/screens/PrintListScreen.kt
+++ b/app/src/main/java/com/ioannapergamali/mysmartroute/view/ui/screens/PrintListScreen.kt
@@ -18,37 +18,38 @@ import androidx.compose.ui.res.stringResource
 import androidx.lifecycle.viewmodel.compose.viewModel
 import androidx.navigation.NavController
 import com.ioannapergamali.mysmartroute.R
-import com.ioannapergamali.mysmartroute.data.local.MySmartRouteDatabase
 import com.ioannapergamali.mysmartroute.view.ui.components.ScreenContainer
 import com.ioannapergamali.mysmartroute.view.ui.components.TopBar
-import com.ioannapergamali.mysmartroute.viewmodel.RouteViewModel
 import com.ioannapergamali.mysmartroute.viewmodel.UserViewModel
-import kotlinx.coroutines.flow.first
+import com.ioannapergamali.mysmartroute.viewmodel.VehicleRequestViewModel
 
 @Composable
 fun PrintListScreen(navController: NavController, openDrawer: () -> Unit) {
     val context = LocalContext.current
-    val routeViewModel: RouteViewModel = viewModel()
+    val requestViewModel: VehicleRequestViewModel = viewModel()
     val userViewModel: UserViewModel = viewModel()
-    val routes by routeViewModel.routes.collectAsState()
-    val passengerNames = remember { mutableStateMapOf<String, List<String>>() }
+    val movings by requestViewModel.movings.collectAsState()
+    val passengerNames = remember { mutableStateMapOf<String, String>() }
 
     LaunchedEffect(Unit) {
-        routeViewModel.loadRoutes(context)
+        requestViewModel.loadPassengerMovings(context, allUsers = true)
     }
 
-    LaunchedEffect(routes) {
-        val db = MySmartRouteDatabase.getInstance(context)
-        routes.forEach { route ->
-            if (passengerNames[route.id] == null) {
-                val reservations = db.seatReservationDao().getReservationsForRoute(route.id).first()
-                val names = reservations.map { res ->
-                    userViewModel.getUserName(context, res.userId)
-                }.filter { it.isNotBlank() }.distinct()
-                passengerNames[route.id] = names
+    LaunchedEffect(movings) {
+        movings.forEach { moving ->
+            val passengerId = moving.userId
+            if (passengerId.isNotBlank() && passengerNames[passengerId].isNullOrBlank()) {
+                val cachedName = moving.createdByName.takeIf { it.isNotBlank() }
+                    ?: userViewModel.getUserName(context, passengerId)
+                if (cachedName.isNotBlank()) {
+                    passengerNames[passengerId] = cachedName
+                }
             }
         }
     }
+
+    val groupedRoutes = remember(movings) { movings.groupBy { it.routeId } }
+    val routeEntries = remember(groupedRoutes) { groupedRoutes.entries.toList() }
 
     Scaffold(
         topBar = {
@@ -61,13 +62,28 @@ fun PrintListScreen(navController: NavController, openDrawer: () -> Unit) {
         }
     ) { paddingValues ->
         ScreenContainer(modifier = Modifier.padding(paddingValues), scrollable = false) {
-            if (routes.isEmpty()) {
+            if (routeEntries.isEmpty()) {
                 Text(text = stringResource(R.string.no_passenger_routes))
             } else {
                 LazyColumn {
-                    items(routes) { route ->
-                        Text(route.name)
-                        val passengers = passengerNames[route.id].orEmpty()
+                    items(routeEntries, key = { it.key }) { entry ->
+                        val routeMovings = entry.value
+                        val firstMoving = routeMovings.firstOrNull()
+                        val routeLabel = firstMoving?.routeName.takeIf { it.isNotBlank() }
+                            ?: entry.key.ifBlank { stringResource(R.string.route) }
+                        Text(routeLabel)
+                        val passengers = routeMovings.map { moving ->
+                            val passengerId = moving.userId
+                            when {
+                                passengerId.isNotBlank() -> {
+                                    passengerNames[passengerId]?.takeIf { it.isNotBlank() }
+                                        ?: moving.createdByName.takeIf { it.isNotBlank() }
+                                        ?: passengerId
+                                }
+                                moving.createdByName.isNotBlank() -> moving.createdByName
+                                else -> stringResource(R.string.passenger)
+                            }
+                        }.distinct()
                         if (passengers.isEmpty()) {
                             Text(text = stringResource(R.string.no_reservations))
                         } else {


### PR DESCRIPTION
## Summary
- stop filtering passenger search results by moving status so all records from MOVINGS are considered
- rebuild the passenger list printout to source routes and passenger names from MOVINGS with cached lookups

## Testing
- ./gradlew --console=plain :app:compileDebugKotlin *(fails: Android SDK not available in container)*

------
https://chatgpt.com/codex/tasks/task_e_68cc35f50ab08328a56101871b6f7730