### PR TITLE
Fix nullable route name handling in PrintListScreen

### DIFF
--- a/app/src/main/java/com/ioannapergamali/mysmartroute/view/ui/screens/PrintListScreen.kt
+++ b/app/src/main/java/com/ioannapergamali/mysmartroute/view/ui/screens/PrintListScreen.kt
@@ -69,7 +69,7 @@ fun PrintListScreen(navController: NavController, openDrawer: () -> Unit) {
                     items(routeEntries, key = { it.key }) { entry ->
                         val routeMovings = entry.value
                         val firstMoving = routeMovings.firstOrNull()
-                        val routeLabel = firstMoving?.routeName.takeIf { it.isNotBlank() }
+                        val routeLabel = firstMoving?.routeName?.takeIf { it.isNotBlank() }
                             ?: entry.key.ifBlank { stringResource(R.string.route) }
                         Text(routeLabel)
                         val passengers = routeMovings.map { moving ->


### PR DESCRIPTION
## Summary
- ensure the route name lookup in PrintListScreen uses a safe call before invoking takeIf
- keep a fallback label when the stored route name is blank

## Testing
- ./gradlew :app:assembleDebug --console=plain > gradle.log && tail -n 20 gradle.log *(fails: missing Android SDK)*

------
https://chatgpt.com/codex/tasks/task_e_68cc391970cc832889cb34abd82f78ef