### PR TITLE
Διόρθωση imports στο MovingStatusTest

### DIFF
--- a/app/src/test/java/com/ioannapergamali/mysmartroute/data/local/MovingStatusTest.kt
+++ b/app/src/test/java/com/ioannapergamali/mysmartroute/data/local/MovingStatusTest.kt
@@ -1,7 +1,7 @@
 package com.ioannapergamali.mysmartroute.data.local
 
-import kotlin.test.Test
-import kotlin.test.assertEquals
+import org.junit.Assert.assertEquals
+import org.junit.Test
 
 class MovingStatusTest {
     private val now = 1_000_000L


### PR DESCRIPTION
## Σύνοψη
- Αντικατέστησα τα imports του `MovingStatusTest` ώστε να χρησιμοποιεί τις κλάσεις του JUnit που είναι ήδη διαθέσιμες στο project.

## Έλεγχοι
- ⚠️ `./gradlew test --console=plain --no-build-cache --rerun-tasks` *(αποτυχία επειδή το περιβάλλον δεν διαθέτει ρυθμισμένο Android SDK)*

------
https://chatgpt.com/codex/tasks/task_e_68cc59fbe0b8832897901cdf8a466229