### PR TITLE
Αντικατάσταση wisdom_item με vector πόρο

### DIFF
--- a/app/src/main/res/drawable/wisdom_item.xml
+++ b/app/src/main/res/drawable/wisdom_item.xml
@@ -1,0 +1,13 @@
+<?xml version="1.0" encoding="utf-8"?>
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="24dp"
+    android:height="24dp"
+    android:viewportWidth="24"
+    android:viewportHeight="24">
+    <path
+        android:fillColor="#FFE082"
+        android:pathData="M12,2L14.472,8.027 21,9 16.5,13.5 17.708,20 12,16.8 6.292,20 7.5,13.5 3,9 9.528,8.027z" />
+    <path
+        android:fillColor="#F9A825"
+        android:pathData="M12,4.8L13.63,8.83 17.94,9.44 14.7,12.66 15.51,16.94 12,14.85 8.49,16.94 9.3,12.66 6.06,9.44 10.37,8.83z" />
+</vector>


### PR DESCRIPTION
## Summary
- Αντικαταστάθηκε το wisdom_item.gif με διανυσματικό πόρο wisdom_item.xml ώστε να διατεθεί ο ελλείπων drawable χωρίς χρήση δυαδικού αρχείου

## Testing
- ./gradlew test --console=plain --no-daemon *(αποτυχία: δεν υπάρχει εγκατεστημένο Android SDK στο περιβάλλον CI)*

------
https://chatgpt.com/codex/tasks/task_e_68d1e75767f08328885060136c55e983