### PR TITLE
Handle notification permission before showing welcome alert

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -7,6 +7,7 @@
     <uses-permission android:name="android.permission.ACCESS_COARSE_LOCATION" />
     <uses-permission android:name="android.permission.ACCESS_FINE_LOCATION" />
     <uses-permission android:name="android.permission.CAMERA" />
+    <uses-permission android:name="android.permission.POST_NOTIFICATIONS" />
 
     <application
         android:name=".MySmartRouteApplication"

--- a/app/src/main/java/com/ioannapergamali/mysmartroute/utils/NotificationUtils.kt
+++ b/app/src/main/java/com/ioannapergamali/mysmartroute/utils/NotificationUtils.kt
@@ -1,13 +1,16 @@
 package com.ioannapergamali.mysmartroute.utils
 
+import android.Manifest
 import android.app.NotificationChannel
 import android.app.NotificationManager
 import android.app.PendingIntent
 import android.content.Context
+import android.content.pm.PackageManager
 import android.os.Build
 import android.util.Log
 import androidx.core.app.NotificationCompat
 import androidx.core.app.NotificationManagerCompat
+import androidx.core.content.ContextCompat
 import com.ioannapergamali.mysmartroute.R
 import com.ioannapergamali.mysmartroute.data.local.MySmartRouteDatabase
 import com.ioannapergamali.mysmartroute.data.local.NotificationEntity
@@ -38,32 +41,43 @@ object NotificationUtils {
         senderId: String = SessionManager.currentUserId().orEmpty(),
         roomNotificationId: String? = null
     ) {
-        // Δημιουργία καναλιού ειδοποίησης για Android 8+
-        // Create notification channel for Android 8+
-        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
-            val channel = NotificationChannel(
-                CHANNEL_ID,
-                context.getString(R.string.notifications),
-                NotificationManager.IMPORTANCE_DEFAULT
-            )
-            context.getSystemService(NotificationManager::class.java)
-                .createNotificationChannel(channel)
+        val canPostNotifications =
+            Build.VERSION.SDK_INT < Build.VERSION_CODES.TIRAMISU ||
+                ContextCompat.checkSelfPermission(
+                    context,
+                    Manifest.permission.POST_NOTIFICATIONS
+                ) == PackageManager.PERMISSION_GRANTED
+
+        if (canPostNotifications) {
+            // Δημιουργία καναλιού ειδοποίησης για Android 8+
+            // Create notification channel for Android 8+
+            if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
+                val channel = NotificationChannel(
+                    CHANNEL_ID,
+                    context.getString(R.string.notifications),
+                    NotificationManager.IMPORTANCE_DEFAULT
+                )
+                context.getSystemService(NotificationManager::class.java)
+                    .createNotificationChannel(channel)
+            }
+
+            val builder = NotificationCompat.Builder(context, CHANNEL_ID)
+                .setSmallIcon(R.drawable.ic_notification)
+                .setContentTitle(title)
+                .setContentText(text)
+                .setPriority(NotificationCompat.PRIORITY_DEFAULT)
+
+            pendingIntent?.let {
+                builder.setContentIntent(it)
+                    .setAutoCancel(true)
+            }
+
+            val notification = builder.build()
+
+            NotificationManagerCompat.from(context).notify(id, notification)
+        } else {
+            Log.w(TAG, "Skipping system notification because POST_NOTIFICATIONS is not granted")
         }
-
-        val builder = NotificationCompat.Builder(context, CHANNEL_ID)
-            .setSmallIcon(R.drawable.ic_notification)
-            .setContentTitle(title)
-            .setContentText(text)
-            .setPriority(NotificationCompat.PRIORITY_DEFAULT)
-
-        pendingIntent?.let {
-            builder.setContentIntent(it)
-                .setAutoCancel(true)
-        }
-
-        val notification = builder.build()
-
-        NotificationManagerCompat.from(context).notify(id, notification)
 
         if (storeInRoom) {
             val targetReceiver = receiverId ?: SessionManager.currentUserId()

--- a/app/src/main/java/com/ioannapergamali/mysmartroute/viewmodel/MainActivity.kt
+++ b/app/src/main/java/com/ioannapergamali/mysmartroute/viewmodel/MainActivity.kt
@@ -1,5 +1,6 @@
 package com.ioannapergamali.mysmartroute.viewmodel
 
+import android.os.Build
 import android.os.Bundle
 import android.util.Log
 import android.Manifest
@@ -51,6 +52,11 @@ import com.ioannapergamali.mysmartroute.data.local.MySmartRouteDatabase
  */
 @AndroidEntryPoint
 class MainActivity : ComponentActivity() {
+    private companion object {
+        private const val LOCATION_PERMISSION_REQUEST_CODE = 0
+        private const val NOTIFICATION_PERMISSION_REQUEST_CODE = 1
+    }
+
     private val settingsViewModel: SettingsViewModel by viewModels()
     private val requestViewModel: VehicleRequestViewModel by viewModels()
     private val vehicleRepository by lazy {
@@ -74,8 +80,13 @@ class MainActivity : ComponentActivity() {
                 Manifest.permission.ACCESS_FINE_LOCATION
             ) != PackageManager.PERMISSION_GRANTED
         ) {
-            ActivityCompat.requestPermissions(this, locationPermissions, 0)
+            ActivityCompat.requestPermissions(
+                this,
+                locationPermissions,
+                LOCATION_PERMISSION_REQUEST_CODE
+            )
         }
+        requestNotificationPermissionIfNeeded()
         // Προαιρετικός έλεγχος ύπαρξης του MIUI Service Delivery provider
         // Optional check for MIUI Service Delivery provider
         MiuiUtils.callServiceDelivery(this, "ping")
@@ -164,5 +175,21 @@ class MainActivity : ComponentActivity() {
     override fun onDestroy() {
         SoundManager.release()
         super.onDestroy()
+    }
+
+    private fun requestNotificationPermissionIfNeeded() {
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU) {
+            val hasPermission = ContextCompat.checkSelfPermission(
+                this,
+                Manifest.permission.POST_NOTIFICATIONS
+            ) == PackageManager.PERMISSION_GRANTED
+            if (!hasPermission) {
+                ActivityCompat.requestPermissions(
+                    this,
+                    arrayOf(Manifest.permission.POST_NOTIFICATIONS),
+                    NOTIFICATION_PERMISSION_REQUEST_CODE
+                )
+            }
+        }
     }
 }


### PR DESCRIPTION
## Summary
- add the Android 13+ POST_NOTIFICATIONS permission to the manifest
- guard NotificationUtils.showNotification behind a runtime permission check
- request the notification runtime permission when MainActivity is created

## Testing
- ./gradlew test *(fails: SDK location not found in CI environment)*

------
https://chatgpt.com/codex/tasks/task_e_68d1f61cd1648328a71a93b6fd0d3186