### PR TITLE
Προσθήκη κινούμενου φόντου binary στην αρχική οθόνη

### DIFF
--- a/app/src/main/java/com/ioannapergamali/mysmartroute/view/ui/animation/FallingBinaryBackground.kt
+++ b/app/src/main/java/com/ioannapergamali/mysmartroute/view/ui/animation/FallingBinaryBackground.kt
@@ -1,0 +1,142 @@
+package com.ioannapergamali.mysmartroute.view.ui.animation
+
+import androidx.compose.animation.core.withFrameNanos
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.BoxWithConstraints
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.offset
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateListOf
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clipToBounds
+import androidx.compose.ui.graphics.Color
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Text
+import androidx.compose.ui.platform.LocalDensity
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.unit.IntOffset
+import androidx.compose.ui.unit.sp
+import kotlin.math.roundToInt
+import kotlin.random.Random
+import kotlinx.coroutines.isActive
+
+/**
+ * Απλή σύνθεση που σχεδιάζει «ψηφία» τα οποία πέφτουν συνεχώς στην οθόνη
+ * χωρίς να εξαφανίζονται πριν φτάσουν στο κάτω άκρο.
+ */
+@Composable
+fun FallingBinaryBackground(
+    modifier: Modifier = Modifier,
+    objectCount: Int = 28,
+    speedRange: ClosedFloatingPointRange<Float> = 70f..150f,
+    sizeRange: ClosedFloatingPointRange<Float> = 14f..24f,
+    color: Color = MaterialTheme.colorScheme.primary.copy(alpha = 0.25f)
+) {
+    BoxWithConstraints(modifier = modifier.clipToBounds()) {
+        val density = LocalDensity.current
+        val widthPx = with(density) { maxWidth.toPx() }
+        val heightPx = with(density) { maxHeight.toPx() }
+
+        if (!widthPx.isFinite() || !heightPx.isFinite() || widthPx <= 0f || heightPx <= 0f || objectCount <= 0) {
+            return@BoxWithConstraints
+        }
+
+        val items = remember { mutableStateListOf<FallingBinaryItem>() }
+
+        LaunchedEffect(
+            objectCount,
+            widthPx,
+            heightPx,
+            speedRange.start,
+            speedRange.endInclusive,
+            sizeRange.start,
+            sizeRange.endInclusive
+        ) {
+            if (!widthPx.isFinite() || !heightPx.isFinite() || widthPx <= 0f || heightPx <= 0f || objectCount <= 0) {
+                return@LaunchedEffect
+            }
+
+            items.clear()
+            repeat(objectCount) {
+                items += createItem(widthPx, heightPx, speedRange, sizeRange)
+            }
+
+            var lastFrame = withFrameNanos { it }
+            while (isActive) {
+                val frameTime = withFrameNanos { it }
+                val deltaSeconds = (frameTime - lastFrame) / 1_000_000_000f
+                lastFrame = frameTime
+
+                items.forEach { item ->
+                    item.y += item.speed * deltaSeconds
+                    if (item.y - item.fontSizePx > heightPx) {
+                        item.y = -item.fontSizePx
+                        item.x = Random.nextFloat() * widthPx
+                        item.speed = speedRange.randomValue()
+                        item.fontSizePx = sizeRange.randomValue()
+                        item.char = randomBinaryChar()
+                    }
+                }
+            }
+        }
+
+        Box(modifier = Modifier.fillMaxSize()) {
+            items.forEach { item ->
+                val fontSize = with(density) { item.fontSizePx.toSp() }
+                Text(
+                    text = item.char.toString(),
+                    color = color,
+                    fontWeight = FontWeight.Bold,
+                    fontSize = fontSize,
+                    modifier = Modifier.offset {
+                        IntOffset(item.x.roundToInt(), item.y.roundToInt())
+                    }
+                )
+            }
+        }
+    }
+}
+
+private class FallingBinaryItem(
+    x: Float,
+    y: Float,
+    speed: Float,
+    fontSizePx: Float,
+    char: Char
+) {
+    var x by mutableStateOf(x)
+    var y by mutableStateOf(y)
+    var speed by mutableStateOf(speed)
+    var fontSizePx by mutableStateOf(fontSizePx)
+    var char by mutableStateOf(char)
+}
+
+private fun createItem(
+    width: Float,
+    height: Float,
+    speedRange: ClosedFloatingPointRange<Float>,
+    sizeRange: ClosedFloatingPointRange<Float>
+): FallingBinaryItem {
+    val x = Random.nextFloat() * width
+    val y = Random.nextFloat() * height
+    val speed = speedRange.randomValue()
+    val size = sizeRange.randomValue()
+    return FallingBinaryItem(x, y, speed, size, randomBinaryChar())
+}
+
+private fun ClosedFloatingPointRange<Float>.randomValue(): Float {
+    val lower = start
+    val upper = endInclusive
+    return if (upper <= lower) {
+        lower
+    } else {
+        lower + Random.nextFloat() * (upper - lower)
+    }
+}
+
+private fun randomBinaryChar(): Char = if (Random.nextBoolean()) '0' else '1'

--- a/app/src/main/java/com/ioannapergamali/mysmartroute/view/ui/screens/HomeScreen.kt
+++ b/app/src/main/java/com/ioannapergamali/mysmartroute/view/ui/screens/HomeScreen.kt
@@ -18,6 +18,7 @@ import com.ioannapergamali.mysmartroute.view.ui.components.LogoImage
 import com.ioannapergamali.mysmartroute.view.ui.components.LogoAssets
 import com.ioannapergamali.mysmartroute.R
 import androidx.compose.ui.res.stringResource
+import com.ioannapergamali.mysmartroute.view.ui.animation.FallingBinaryBackground
 import com.ioannapergamali.mysmartroute.view.ui.animation.rememberBreathingAnimation
 import com.ioannapergamali.mysmartroute.view.ui.animation.rememberSlideFadeInAnimation
 import androidx.compose.ui.platform.LocalContext
@@ -152,101 +153,105 @@ private fun HomeContent(
     modifier: Modifier = Modifier
 ) {
     val bubbleState = LocalKeyboardBubbleState.current!!
-    Column(
-        modifier = modifier,
-        horizontalAlignment = Alignment.CenterHorizontally
-    ) {
-        Text(
-            text = stringResource(R.string.welcome),
-            style = MaterialTheme.typography.headlineLarge,
-            modifier = Modifier
-                .offset(y = textOffset)
-                .graphicsLayer { this.alpha = textAlpha }
-        )
+    Box(modifier = modifier, contentAlignment = Alignment.TopCenter) {
+        FallingBinaryBackground(modifier = Modifier.fillMaxSize())
 
-        Spacer(modifier = Modifier.height(12.dp))
-
-        LogoImage(
-            drawableRes = LogoAssets.LOGO,
-            contentDescription = "Animated Logo",
-            modifier = Modifier.graphicsLayer {
-                scaleX = logoScale
-                scaleY = logoScale
-                this.alpha = logoAlpha
-            }
-        )
-
-        Spacer(modifier = Modifier.height(16.dp))
-
-        if (FirebaseAuth.getInstance().currentUser == null) {
-            OutlinedTextField(
-                value = email,
-                onValueChange = onEmailChange,
-                label = { Text(stringResource(R.string.email)) },
-                modifier = Modifier
-                    .fillMaxWidth()
-                    .observeBubble(bubbleState, 0) { email },
-                shape = MaterialTheme.shapes.small,
-                colors = OutlinedTextFieldDefaults.colors(
-                    focusedBorderColor = MaterialTheme.colorScheme.primary,
-                    unfocusedBorderColor = MaterialTheme.colorScheme.primary
-                )
-            )
-
-            Spacer(Modifier.height(8.dp))
-
-            OutlinedTextField(
-                value = password,
-                onValueChange = onPasswordChange,
-                label = { Text(stringResource(R.string.password)) },
-                visualTransformation = PasswordVisualTransformation(),
-                modifier = Modifier
-                    .fillMaxWidth()
-                    .observeBubble(bubbleState, 1) { password },
-                shape = MaterialTheme.shapes.small,
-                colors = OutlinedTextFieldDefaults.colors(
-                    focusedBorderColor = MaterialTheme.colorScheme.primary,
-                    unfocusedBorderColor = MaterialTheme.colorScheme.primary
-                )
-            )
-
-            if (uiState is AuthenticationViewModel.LoginState.Error) {
-                Spacer(modifier = Modifier.height(8.dp))
-                Text(
-                    text = uiState.message,
-                    color = MaterialTheme.colorScheme.error
-                )
-            }
-
-            Spacer(Modifier.height(16.dp))
-
-            Button(onClick = onLogin) {
-                Text(stringResource(R.string.login))
-            }
-
-            Spacer(modifier = Modifier.height(8.dp))
-
+        Column(
+            modifier = Modifier.fillMaxWidth(),
+            horizontalAlignment = Alignment.CenterHorizontally
+        ) {
             Text(
-                text = stringResource(R.string.forgot_password),
-                color = MaterialTheme.colorScheme.primary,
-                modifier = Modifier.clickable { onForgotPassword() }
+                text = stringResource(R.string.welcome),
+                style = MaterialTheme.typography.headlineLarge,
+                modifier = Modifier
+                    .offset(y = textOffset)
+                    .graphicsLayer { this.alpha = textAlpha }
             )
 
-            Spacer(modifier = Modifier.height(8.dp))
+            Spacer(modifier = Modifier.height(12.dp))
 
-            Row {
-                Text(stringResource(R.string.no_account))
-                Text(
-                    text = stringResource(R.string.sign_up),
-                    color = MaterialTheme.colorScheme.primary,
-                    modifier = Modifier.clickable { onNavigateToSignUp() }
+            LogoImage(
+                drawableRes = LogoAssets.LOGO,
+                contentDescription = "Animated Logo",
+                modifier = Modifier.graphicsLayer {
+                    scaleX = logoScale
+                    scaleY = logoScale
+                    this.alpha = logoAlpha
+                }
+            )
+
+            Spacer(modifier = Modifier.height(16.dp))
+
+            if (FirebaseAuth.getInstance().currentUser == null) {
+                OutlinedTextField(
+                    value = email,
+                    onValueChange = onEmailChange,
+                    label = { Text(stringResource(R.string.email)) },
+                    modifier = Modifier
+                        .fillMaxWidth()
+                        .observeBubble(bubbleState, 0) { email },
+                    shape = MaterialTheme.shapes.small,
+                    colors = OutlinedTextFieldDefaults.colors(
+                        focusedBorderColor = MaterialTheme.colorScheme.primary,
+                        unfocusedBorderColor = MaterialTheme.colorScheme.primary
+                    )
                 )
-            }
-        } else {
-            Spacer(Modifier.height(16.dp))
 
-            Button(onClick = onLogout) {
-                Text(stringResource(R.string.logout))
+                Spacer(Modifier.height(8.dp))
+
+                OutlinedTextField(
+                    value = password,
+                    onValueChange = onPasswordChange,
+                    label = { Text(stringResource(R.string.password)) },
+                    visualTransformation = PasswordVisualTransformation(),
+                    modifier = Modifier
+                        .fillMaxWidth()
+                        .observeBubble(bubbleState, 1) { password },
+                    shape = MaterialTheme.shapes.small,
+                    colors = OutlinedTextFieldDefaults.colors(
+                        focusedBorderColor = MaterialTheme.colorScheme.primary,
+                        unfocusedBorderColor = MaterialTheme.colorScheme.primary
+                    )
+                )
+
+                if (uiState is AuthenticationViewModel.LoginState.Error) {
+                    Spacer(modifier = Modifier.height(8.dp))
+                    Text(
+                        text = uiState.message,
+                        color = MaterialTheme.colorScheme.error
+                    )
+                }
+
+                Spacer(Modifier.height(16.dp))
+
+                Button(onClick = onLogin) {
+                    Text(stringResource(R.string.login))
+                }
+
+                Spacer(modifier = Modifier.height(8.dp))
+
+                Text(
+                    text = stringResource(R.string.forgot_password),
+                    color = MaterialTheme.colorScheme.primary,
+                    modifier = Modifier.clickable { onForgotPassword() }
+                )
+
+                Spacer(modifier = Modifier.height(8.dp))
+
+                Row {
+                    Text(stringResource(R.string.no_account))
+                    Text(
+                        text = stringResource(R.string.sign_up),
+                        color = MaterialTheme.colorScheme.primary,
+                        modifier = Modifier.clickable { onNavigateToSignUp() }
+                    )
+                }
+            } else {
+                Spacer(Modifier.height(16.dp))
+
+                Button(onClick = onLogout) {
+                    Text(stringResource(R.string.logout))
+                }
             }
         }
     }


### PR DESCRIPTION
## Summary
- Προστέθηκε το `FallingBinaryBackground` που υπολογίζει συνεχώς τις θέσεις των binary ψηφίων έως ότου εξέλθουν από το κάτω άκρο της οθόνης πριν επανεμφανιστούν
- Ενσωματώθηκε το νέο κινούμενο φόντο στην `HomeContent` ώστε τα falling objects να μην εξαφανίζονται στη μέση της οθόνης

## Testing
- ./gradlew test --console=plain *(αποτυγχάνει: λείπει η ρύθμιση SDK - απαιτείται valid sdk.dir ή ANDROID_HOME με Build Tools 35.0.0)*

------
https://chatgpt.com/codex/tasks/task_e_68d1f8d2fd688328a846bfd660bebe4e