### PR TITLE
Αποφυγή δεσμευμένων ονομάτων σε αποσυσκευές ζευγών

### DIFF
--- a/app/src/main/java/com/ioannapergamali/mysmartroute/repository/AdminRouteRepository.kt
+++ b/app/src/main/java/com/ioannapergamali/mysmartroute/repository/AdminRouteRepository.kt
@@ -34,8 +34,8 @@ class AdminRouteRepository(private val db: MySmartRouteDatabase) {
                 .groupBy { it.value }
                 .values
                 .map { group ->
-                    group.mapNotNull { (routeId, _) ->
-                        routes.find { it.id == routeId }
+                    group.mapNotNull { entry ->
+                        routes.find { it.id == entry.key }
                     }
                 }
                 .filter { it.size > 1 }

--- a/app/src/main/java/com/ioannapergamali/mysmartroute/view/ui/screens/AvailableTransportsScreen.kt
+++ b/app/src/main/java/com/ioannapergamali/mysmartroute/view/ui/screens/AvailableTransportsScreen.kt
@@ -306,7 +306,8 @@ fun AvailableTransportsScreen(
                                     Button(
                                         onClick = {
                                             scope.launch {
-                                                val segments = selectedForDecl.map { (_, detail) ->
+                                                val segments = selectedForDecl.map { selection ->
+                                                    val detail = selection.second
                                                     ReservationSegment(
                                                         detail.startPoiId,
                                                         detail.endPoiId,
@@ -327,7 +328,8 @@ fun AvailableTransportsScreen(
                                                 )
                                                 result.onSuccess {
                                                     val map = detailReservationCounts.getOrPut(decl.id) { mutableMapOf() }
-                                                    selectedForDecl.forEach { (_, detail) ->
+                                                    selectedForDecl.forEach { selection ->
+                                                        val detail = selection.second
                                                         val reservedSeg = map[detail.id] ?: 0
                                                         map[detail.id] = reservedSeg + 1
                                                         selectedDetails.remove(detail.id)

--- a/app/src/main/java/com/ioannapergamali/mysmartroute/view/ui/screens/BookSeatScreen.kt
+++ b/app/src/main/java/com/ioannapergamali/mysmartroute/view/ui/screens/BookSeatScreen.kt
@@ -249,11 +249,12 @@ fun BookSeatScreen(
                     viewModel.refreshRoutes()
                     routeViewModel.loadRoutes(context, includeAll = true)
                     scope.launch {
-                        val (_, path) = routeViewModel.getRouteDirections(
+                        val directions = routeViewModel.getRouteDirections(
                             context,
                             newRoute,
                             VehicleType.CAR
                         )
+                        val path = directions.second
                         pathPoints = path
                         poiIds.clear()
                         userPoiIds.clear()
@@ -382,11 +383,12 @@ fun BookSeatScreen(
                                 routeMenuExpanded = false
                                 editedRouteName = ""
                                 scope.launch {
-                                    val (_, path) = routeViewModel.getRouteDirections(
+                                    val directions = routeViewModel.getRouteDirections(
                                         context,
                                         route.id,
                                         VehicleType.CAR
                                     )
+                                    val path = directions.second
                                     pathPoints = path
                                     poiIds.clear()
                                     userPoiIds.clear()
@@ -629,7 +631,8 @@ fun BookSeatScreen(
                             val endId = endIndex?.let { pois[it].id } ?: return@launch
                             val timeMillis = selectedTimeMillis ?: return@launch
 
-                            val (resolvedRouteId, _) = resolveRouteForRequest()
+                            val resolvedRouteInfo = resolveRouteForRequest()
+                            val resolvedRouteId = resolvedRouteInfo.first
                             if (resolvedRouteId.isBlank()) {
                                 message = context.getString(R.string.request_unsuccessful)
                                 return@launch

--- a/app/src/main/java/com/ioannapergamali/mysmartroute/view/ui/screens/DefinePoiScreen.kt
+++ b/app/src/main/java/com/ioannapergamali/mysmartroute/view/ui/screens/DefinePoiScreen.kt
@@ -106,11 +106,12 @@ fun DefinePoiScreen(
             routeViewModel.loadRoutes(context, includeAll = true)
             val pois = routeViewModel.getRoutePois(context, routeId)
             routePois = pois
-            val (_, points) = routeViewModel.getRouteDirections(
+            val directions = routeViewModel.getRouteDirections(
                 context,
                 routeId,
                 VehicleType.CAR
             )
+            val points = directions.second
             pathPoints = points
             points.firstOrNull()?.let {
                 cameraPositionState.move(CameraUpdateFactory.newLatLngZoom(it, 13f))

--- a/app/src/main/java/com/ioannapergamali/mysmartroute/view/ui/screens/FindVehicleScreen.kt
+++ b/app/src/main/java/com/ioannapergamali/mysmartroute/view/ui/screens/FindVehicleScreen.kt
@@ -474,7 +474,8 @@ fun FindVehicleScreen(navController: NavController, openDrawer: () -> Unit) {
                             val toId = routePois.getOrNull(toIdx)?.id ?: return@launch
                             val cost = maxCostText.toDoubleOrNull()
 
-                            val (routeId, _) = resolveRouteForVehicleSearch()
+                            val routeInfo = resolveRouteForVehicleSearch()
+                            val routeId = routeInfo.first
                             if (routeId.isBlank()) {
                                 if (message.isBlank()) {
                                     message = context.getString(R.string.request_unsuccessful)

--- a/app/src/main/java/com/ioannapergamali/mysmartroute/view/ui/screens/PrepareCompleteRouteScreen.kt
+++ b/app/src/main/java/com/ioannapergamali/mysmartroute/view/ui/screens/PrepareCompleteRouteScreen.kt
@@ -124,7 +124,8 @@ fun PrepareCompleteRouteScreen(navController: NavController, openDrawer: () -> U
 
     LaunchedEffect(selectedRoute, selectedDate, declarations, selectedDriverId) {
         selectedRoute?.let { route ->
-            val (_, path) = routeViewModel.getRouteDirections(context, route.id, VehicleType.CAR)
+            val directions = routeViewModel.getRouteDirections(context, route.id, VehicleType.CAR)
+            val path = directions.second
             pathPoints = path
             pois = routeViewModel.getRoutePois(context, route.id)
 

--- a/app/src/main/java/com/ioannapergamali/mysmartroute/view/ui/screens/RouteModeScreen.kt
+++ b/app/src/main/java/com/ioannapergamali/mysmartroute/view/ui/screens/RouteModeScreen.kt
@@ -518,7 +518,8 @@ fun RouteModeScreen(
                             val date = datePickerState.selectedDateMillis ?: 0L
                             val time = selectedTimeMillis
 
-                            val (resolvedRouteId, _) = resolveRouteForRequest()
+                            val resolvedRouteInfo = resolveRouteForRequest()
+                            val resolvedRouteId = resolvedRouteInfo.first
                             if (resolvedRouteId.isBlank()) {
                                 if (message.isBlank()) {
                                     message = context.getString(R.string.request_unsuccessful)

--- a/app/src/main/java/com/ioannapergamali/mysmartroute/view/ui/screens/SelectRoutePoisScreen.kt
+++ b/app/src/main/java/com/ioannapergamali/mysmartroute/view/ui/screens/SelectRoutePoisScreen.kt
@@ -80,11 +80,12 @@ fun SelectRoutePoisScreen(navController: NavController, openDrawer: () -> Unit) 
                                 selectedRoute = route
                                 expanded = false
                                 scope.launch {
-                                    val (_, path) = routeViewModel.getRouteDirections(
+                                    val directions = routeViewModel.getRouteDirections(
                                         context,
                                         route.id,
                                         VehicleType.CAR
                                     )
+                                    val path = directions.second
                                     pathPoints = path
                                     pois = routeViewModel.getRoutePois(context, route.id)
                                     selectedPoiIds.clear()


### PR DESCRIPTION
## Summary
- Αποθήκευσα ρητά το αποτέλεσμα του `getRouteDirections` και χρησιμοποίησα το `second` στις οθόνες κράτησης/δημιουργίας διαδρομών ώστε να μην χρειάζονται placeholders `_`.
- Χειρίστηκα την τιμή `Pair.first` από τα `resolveRouteForRequest`/`resolveRouteForVehicleSearch` πριν από τους ελέγχους και την πλοήγηση.
- Έκανα τον υπολογισμό διπλών διαδρομών να βασίζεται σε accessors αντί για αποσυσκευή με `_` στο `AdminRouteRepository`.

## Testing
- `./gradlew test` *(αποτυχία: λείπει Android SDK στο περιβάλλον δοκιμών)*

------
https://chatgpt.com/codex/tasks/task_e_68d21897b75c8328a6a278f95b783df5