### PR TITLE
Fix falling binary animation

### DIFF
--- a/app/src/main/java/ioannapergamali/savejoannepink/view/FallingBinaryView.kt
+++ b/app/src/main/java/ioannapergamali/savejoannepink/view/FallingBinaryView.kt
@@ -1,0 +1,139 @@
+package ioannapergamali.savejoannepink.view
+
+import android.content.Context
+import android.graphics.Canvas
+import android.graphics.Color
+import android.graphics.Paint
+import android.util.AttributeSet
+import android.view.View
+import android.graphics.Typeface
+import kotlin.math.max
+import kotlin.random.Random
+
+private data class FallingBinaryItem(
+    var x: Float,
+    var y: Float,
+    var speed: Float,
+    var text: String,
+    var width: Float
+)
+
+/**
+ * Απλό custom View που ζωγραφίζει τυχαία "δυαδικά" αντικείμενα
+ * τα οποία πέφτουν από την κορυφή της οθόνης μέχρι το τέλος της.
+ */
+class FallingBinaryView @JvmOverloads constructor(
+    context: Context,
+    attrs: AttributeSet? = null,
+    defStyleAttr: Int = 0
+) : View(context, attrs, defStyleAttr) {
+
+    private val paint = Paint(Paint.ANTI_ALIAS_FLAG).apply {
+        color = Color.parseColor("#8033FF33")
+        textSize = 18f * resources.displayMetrics.scaledDensity
+        typeface = Typeface.MONOSPACE
+    }
+    private val fontMetrics = Paint.FontMetrics()
+    private val random = Random(System.currentTimeMillis())
+    private val items = mutableListOf<FallingBinaryItem>()
+    private var lastFrameNanos = 0L
+
+    init {
+        paint.getFontMetrics(fontMetrics)
+    }
+
+    override fun onAttachedToWindow() {
+        super.onAttachedToWindow()
+        postInvalidateOnAnimation()
+    }
+
+    override fun onDetachedFromWindow() {
+        super.onDetachedFromWindow()
+        lastFrameNanos = 0L
+    }
+
+    override fun onSizeChanged(w: Int, h: Int, oldw: Int, oldh: Int) {
+        super.onSizeChanged(w, h, oldw, oldh)
+        if (w <= 0 || h <= 0) {
+            items.clear()
+            return
+        }
+
+        paint.getFontMetrics(fontMetrics)
+        val area = w * h
+        val density = resources.displayMetrics.density
+        val baseCount = max(12, (area / (120f * density * density)).toInt())
+
+        items.clear()
+        repeat(baseCount) {
+            val text = nextBinaryText()
+            val textWidth = paint.measureText(text)
+            val startY = random.nextFloat() * h
+            items += FallingBinaryItem(
+                x = randomX(textWidth, w.toFloat()),
+                y = startY,
+                speed = randomSpeed(h.toFloat()),
+                text = text,
+                width = textWidth
+            )
+        }
+        lastFrameNanos = 0L
+    }
+
+    override fun onDraw(canvas: Canvas) {
+        super.onDraw(canvas)
+        if (width == 0 || height == 0 || items.isEmpty()) {
+            return
+        }
+
+        val now = System.nanoTime()
+        if (lastFrameNanos == 0L) {
+            lastFrameNanos = now
+        }
+        val deltaSeconds = (now - lastFrameNanos) / 1_000_000_000f
+        lastFrameNanos = now
+
+        val viewHeight = height.toFloat()
+        val viewWidth = width.toFloat()
+
+        for (item in items) {
+            item.y += item.speed * deltaSeconds
+            if (item.y + fontMetrics.top > viewHeight) {
+                resetItem(item, viewWidth)
+            }
+            canvas.drawText(item.text, item.x, item.y, paint)
+        }
+
+        postInvalidateOnAnimation()
+    }
+
+    private fun resetItem(item: FallingBinaryItem, viewWidth: Float) {
+        item.text = nextBinaryText()
+        item.width = paint.measureText(item.text)
+        paint.getFontMetrics(fontMetrics)
+        item.x = randomX(item.width, viewWidth)
+        item.y = -fontMetrics.bottom
+        item.speed = randomSpeed(height.toFloat())
+    }
+
+    private fun randomX(textWidth: Float, viewWidth: Float): Float {
+        val maxX = viewWidth - textWidth
+        return if (maxX <= 0f) 0f else random.nextFloat() * maxX
+    }
+
+    private fun randomSpeed(viewHeight: Float): Float {
+        if (viewHeight <= 0f) return 100f
+        val min = viewHeight / 8f
+        val maxSpeed = viewHeight / 3f
+        return min + random.nextFloat() * (maxSpeed - min)
+    }
+
+    private fun nextBinaryText(): String {
+        val length = random.nextInt(4, 9)
+        return buildString(length) {
+            repeat(length) {
+                append(if (random.nextBoolean()) '1' else '0')
+            }
+        }
+    }
+}

--- a/app/src/main/java/ioannapergamali/savejoannepink/view/GameFragment.kt
+++ b/app/src/main/java/ioannapergamali/savejoannepink/view/GameFragment.kt
@@ -4,6 +4,8 @@ import android.os.Bundle
 import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
+import android.view.Gravity
+import android.widget.FrameLayout
 import android.widget.LinearLayout
 import android.widget.TextView
 import androidx.fragment.app.Fragment
@@ -16,10 +18,26 @@ class GameFragment : Fragment() {
         savedInstanceState: Bundle?
     ): View {
         val context = requireContext()
-        val rootLayout = LinearLayout(context).apply {
+        val rootLayout = FrameLayout(context)
+
+        val fallingView = FallingBinaryView(context).apply {
+            layoutParams = FrameLayout.LayoutParams(
+                FrameLayout.LayoutParams.MATCH_PARENT,
+                FrameLayout.LayoutParams.MATCH_PARENT
+            )
+        }
+        rootLayout.addView(fallingView)
+
+        val contentLayout = LinearLayout(context).apply {
             orientation = LinearLayout.VERTICAL
             setPadding(32, 32, 32, 32)
         }
+        val contentParams = FrameLayout.LayoutParams(
+            FrameLayout.LayoutParams.MATCH_PARENT,
+            FrameLayout.LayoutParams.WRAP_CONTENT,
+            Gravity.TOP
+        )
+        rootLayout.addView(contentLayout, contentParams)
 
         val questionTextView = TextView(context).apply {
             textSize = 20f
@@ -43,8 +61,8 @@ class GameFragment : Fragment() {
             }
         }
 
-        rootLayout.addView(questionTextView)
-        optionViews.forEach(rootLayout::addView)
+        contentLayout.addView(questionTextView)
+        optionViews.forEach(contentLayout::addView)
 
         val question = Question(
             text = "Ποιο είναι το αποτέλεσμα του 2 + 2;",


### PR DESCRIPTION
## Summary
- add a `FallingBinaryView` custom view that keeps binary strings visible until they leave the screen before respawning
- host the animation behind the existing quiz layout in `GameFragment`

## Testing
- `./gradlew test --console=plain --no-daemon` *(fails: Android SDK not present in container)*

------
https://chatgpt.com/codex/tasks/task_e_68d2301f60b083289350570fd854edca