### PR TITLE
Add modern HUD progress bar for GameFragment

### DIFF
--- a/app/src/main/java/ioannapergamali/savejoannepink/view/GameFragment.kt
+++ b/app/src/main/java/ioannapergamali/savejoannepink/view/GameFragment.kt
@@ -1,33 +1,88 @@
 package ioannapergamali.savejoannepink.view
 
+import android.content.Context
 import android.os.Bundle
 import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
 import android.widget.LinearLayout
 import android.widget.TextView
+import androidx.core.content.ContextCompat
 import androidx.fragment.app.Fragment
+import com.google.android.material.progressindicator.LinearProgressIndicator
+import com.ioannapergamali.mysmartroute.R
+import kotlin.math.roundToInt
 
 class GameFragment : Fragment() {
+
+    private lateinit var scoreIndicator: LinearProgressIndicator
+    private lateinit var scoreTextView: TextView
+    private var score = STARTING_SCORE
 
     override fun onCreateView(
         inflater: LayoutInflater,
         container: ViewGroup?,
-        savedInstanceState: Bundle?
+        savedInstanceState: Bundle?,
     ): View {
         val context = requireContext()
+
         val rootLayout = LinearLayout(context).apply {
             orientation = LinearLayout.VERTICAL
-            setPadding(32, 32, 32, 32)
+            setPadding(
+                24.dp(context),
+                24.dp(context),
+                24.dp(context),
+                24.dp(context),
+            )
         }
+
+        val progressTitleView = TextView(context).apply {
+            text = getString(R.string.game_progress_title)
+            textSize = 18f
+            layoutParams = LinearLayout.LayoutParams(
+                LinearLayout.LayoutParams.MATCH_PARENT,
+                LinearLayout.LayoutParams.WRAP_CONTENT,
+            ).apply {
+                bottomMargin = 8.dp(context)
+            }
+        }
+
+        scoreIndicator = LinearProgressIndicator(context).apply {
+            layoutParams = LinearLayout.LayoutParams(
+                LinearLayout.LayoutParams.MATCH_PARENT,
+                LinearLayout.LayoutParams.WRAP_CONTENT,
+            ).apply {
+                bottomMargin = 12.dp(context)
+            }
+            min = MIN_SCORE
+            max = MAX_SCORE
+            isIndeterminate = false
+            trackThickness = 12.dp(context)
+            trackCornerRadius = 6.dp(context)
+            setTrackColor(ContextCompat.getColor(context, R.color.progress_track))
+        }
+
+        scoreTextView = TextView(context).apply {
+            textSize = 20f
+            layoutParams = LinearLayout.LayoutParams(
+                LinearLayout.LayoutParams.MATCH_PARENT,
+                LinearLayout.LayoutParams.WRAP_CONTENT,
+            ).apply {
+                bottomMargin = 24.dp(context)
+            }
+        }
+
+        rootLayout.addView(progressTitleView)
+        rootLayout.addView(scoreIndicator)
+        rootLayout.addView(scoreTextView)
 
         val questionTextView = TextView(context).apply {
             textSize = 20f
             layoutParams = LinearLayout.LayoutParams(
                 LinearLayout.LayoutParams.MATCH_PARENT,
-                LinearLayout.LayoutParams.WRAP_CONTENT
+                LinearLayout.LayoutParams.WRAP_CONTENT,
             ).apply {
-                bottomMargin = 24
+                bottomMargin = 24.dp(context)
             }
         }
 
@@ -36,10 +91,17 @@ class GameFragment : Fragment() {
                 textSize = 18f
                 layoutParams = LinearLayout.LayoutParams(
                     LinearLayout.LayoutParams.MATCH_PARENT,
-                    LinearLayout.LayoutParams.WRAP_CONTENT
+                    LinearLayout.LayoutParams.WRAP_CONTENT,
                 ).apply {
-                    topMargin = 16
+                    topMargin = 16.dp(context)
                 }
+                setPadding(
+                    16.dp(context),
+                    12.dp(context),
+                    16.dp(context),
+                    12.dp(context),
+                )
+                isClickable = true
             }
         }
 
@@ -50,18 +112,35 @@ class GameFragment : Fragment() {
             text = "Ποιο είναι το αποτέλεσμα του 2 + 2;",
             correctAnswer = "4",
             wrongAnswer1 = "3",
-            wrongAnswer2 = "5"
+            wrongAnswer2 = "5",
         )
 
         bindQuestion(question, questionTextView, optionViews)
 
+        updateScore(score, animate = false)
+
         return rootLayout
+    }
+
+    fun onWisdomItemTouched() {
+        adjustScoreBy(SCORE_STEP)
+    }
+
+    fun onDamageItemTouched() {
+        adjustScoreBy(-SCORE_STEP)
+    }
+
+    fun registerItemCollision(item: GameItem) {
+        when (item) {
+            GameItem.WISDOM -> onWisdomItemTouched()
+            GameItem.DAMAGE -> onDamageItemTouched()
+        }
     }
 
     private fun bindQuestion(
         question: Question,
         questionView: TextView,
-        optionViews: List<TextView>
+        optionViews: List<TextView>,
     ) {
         val (text, correctAnswer, wrongAnswer1, wrongAnswer2) = question
 
@@ -70,7 +149,48 @@ class GameFragment : Fragment() {
 
         optionViews.zip(shuffledOptions).forEach { (view, option) ->
             view.text = option
+            view.setOnClickListener {
+                if (option == correctAnswer) {
+                    onWisdomItemTouched()
+                } else {
+                    onDamageItemTouched()
+                }
+            }
         }
+    }
+
+    private fun adjustScoreBy(delta: Int, animate: Boolean = true) {
+        updateScore(score + delta, animate)
+    }
+
+    private fun updateScore(newScore: Int, animate: Boolean) {
+        score = newScore.coerceIn(MIN_SCORE, MAX_SCORE)
+        scoreTextView.text = getString(R.string.game_score_format, score)
+        scoreIndicator.setProgressCompat(score, animate)
+        updateIndicatorColor()
+    }
+
+    private fun updateIndicatorColor() {
+        val colorRes = when {
+            score >= HIGH_SCORE_THRESHOLD -> R.color.progress_high
+            score >= MEDIUM_SCORE_THRESHOLD -> R.color.progress_medium
+            else -> R.color.progress_low
+        }
+
+        val context = scoreIndicator.context
+        scoreIndicator.setIndicatorColor(ContextCompat.getColor(context, colorRes))
+    }
+
+    private fun Int.dp(context: Context): Int =
+        (this * context.resources.displayMetrics.density).roundToInt()
+
+    private companion object {
+        const val STARTING_SCORE = 100
+        const val SCORE_STEP = 10
+        const val MIN_SCORE = 0
+        const val MAX_SCORE = 200
+        const val MEDIUM_SCORE_THRESHOLD = 90
+        const val HIGH_SCORE_THRESHOLD = 140
     }
 }
 
@@ -78,5 +198,10 @@ data class Question(
     val text: String,
     val correctAnswer: String,
     val wrongAnswer1: String,
-    val wrongAnswer2: String
+    val wrongAnswer2: String,
 )
+
+enum class GameItem {
+    WISDOM,
+    DAMAGE,
+}

--- a/app/src/main/res/values/colors.xml
+++ b/app/src/main/res/values/colors.xml
@@ -2,4 +2,8 @@
 <resources>
     <color name="black">#FF000000</color>
     <color name="white">#FFFFFFFF</color>
+    <color name="progress_high">#FF26A69A</color>
+    <color name="progress_medium">#FFFFC107</color>
+    <color name="progress_low">#FFF44336</color>
+    <color name="progress_track">#1F000000</color>
 </resources>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -1,5 +1,7 @@
 <resources>
     <string name="app_name">mysmartroute</string>
+    <string name="game_progress_title">Πρόοδος χαρακτήρα</string>
+    <string name="game_score_format">Σκορ: %1$d</string>
     <string name="invalid_coordinates">Invalid coordinates</string>
     <string name="no_internet">No internet connection</string>
     <string name="directions">Get Directions</string>


### PR DESCRIPTION
## Summary
- create a material-based score HUD in `GameFragment` with a LinearProgressIndicator that starts from 100 points and reacts to wisdom/damage item touches
- expose helper methods for updating the score and hook option taps into the collision handling logic
- add dedicated colors and strings for the new progress indicator styling

## Testing
- `./gradlew :app:compileDebugKotlin --console=plain --no-daemon` *(fails: Android SDK location not found in CI environment)*

------
https://chatgpt.com/codex/tasks/task_e_68d22fd01f8083288ee4178de8c913f7