### PR TITLE
Αποφυγή επικάλυψης των falling objects

### DIFF
--- a/app/src/main/java/com/ioannapergamali/mysmartroute/view/ui/components/FallingObjectsBackground.kt
+++ b/app/src/main/java/com/ioannapergamali/mysmartroute/view/ui/components/FallingObjectsBackground.kt
@@ -47,7 +47,8 @@ fun FallingObjectsBackground(
     maxSpeed: Dp = 84.dp,
     minSize: TextUnit = 16.sp,
     maxSize: TextUnit = 28.sp,
-    baseAlpha: Float = 0.35f
+    baseAlpha: Float = 0.35f,
+    minObjectSpacing: Dp = 8.dp
 ) {
     val density = LocalDensity.current
     val random = remember { Random(System.currentTimeMillis()) }
@@ -62,6 +63,7 @@ fun FallingObjectsBackground(
     val maxSizePx = with(density) { maxSize.toPx() }
     val minSizeSp = minSize.value
     val maxSizeSp = maxSize.value
+    val minSpacingPx = with(density) { minObjectSpacing.toPx() }
 
     val actualMinSpeed = min(minSpeedPx, maxSpeedPx)
     val actualMaxSpeed = max(minSpeedPx, maxSpeedPx)
@@ -88,7 +90,8 @@ fun FallingObjectsBackground(
             actualMinSizePx,
             actualMaxSizePx,
             actualMinSizeSp,
-            actualMaxSizeSp
+            actualMaxSizeSp,
+            minSpacingPx
         ) {
             if (widthPx <= 0f || heightPx <= 0f) {
                 objects.clear()
@@ -96,7 +99,7 @@ fun FallingObjectsBackground(
             }
             objects.clear()
             repeat(objectCount) {
-                objects += createFallingObject(
+                val newObject = createFallingObject(
                     random = random,
                     widthPx = widthPx,
                     heightPx = heightPx,
@@ -107,8 +110,11 @@ fun FallingObjectsBackground(
                     maxSizeSp = actualMaxSizeSp,
                     minSpeedPx = actualMinSpeed,
                     maxSpeedPx = actualMaxSpeed,
+                    minSpacingPx = minSpacingPx,
+                    existingObjects = objects,
                     startAbove = false
                 )
+                objects += newObject
             }
         }
 
@@ -122,7 +128,8 @@ fun FallingObjectsBackground(
             actualMinSizePx,
             actualMaxSizePx,
             actualMinSizeSp,
-            actualMaxSizeSp
+            actualMaxSizeSp,
+            minSpacingPx
         ) {
             if (widthPx <= 0f || heightPx <= 0f) return@LaunchedEffect
             var lastFrameTime = withFrameNanos { it }
@@ -134,6 +141,7 @@ fun FallingObjectsBackground(
                     val obj = objects[index]
                     val newY = obj.y + obj.speedPxPerSec * deltaSec
                     val updated = if (newY - obj.sizePx > heightPx) {
+                        val others = objects.filterIndexed { i, _ -> i != index }
                         createFallingObject(
                             random = random,
                             widthPx = widthPx,
@@ -145,6 +153,8 @@ fun FallingObjectsBackground(
                             maxSizeSp = actualMaxSizeSp,
                             minSpeedPx = actualMinSpeed,
                             maxSpeedPx = actualMaxSpeed,
+                            minSpacingPx = minSpacingPx,
+                            existingObjects = others,
                             startAbove = true
                         )
                     } else {
@@ -181,17 +191,26 @@ private fun createFallingObject(
     maxSizeSp: Float,
     minSpeedPx: Float,
     maxSpeedPx: Float,
+    minSpacingPx: Float,
+    existingObjects: List<FallingObject> = emptyList(),
     startAbove: Boolean
 ): FallingObject {
     val sizePx = random.between(minSizePx, maxSizePx)
     val sizeSp = random.between(minSizeSp, maxSizeSp)
-    val availableWidth = (widthPx - sizePx).coerceAtLeast(0f)
-    val x = if (availableWidth == 0f) 0f else random.between(0f, availableWidth)
     val y = if (startAbove) {
         -sizePx - random.between(0f, heightPx * 0.25f)
     } else {
         random.between(0f, heightPx)
     }
+    val availableWidth = (widthPx - sizePx).coerceAtLeast(0f)
+    val x = if (availableWidth == 0f) 0f else findNonOverlappingX(
+        random = random,
+        availableWidth = availableWidth,
+        sizePx = sizePx,
+        y = y,
+        existingObjects = existingObjects,
+        minSpacingPx = minSpacingPx
+    )
     val speed = random.between(minSpeedPx, maxSpeedPx)
     val alpha = random.between(0.45f, 0.95f)
     val symbol = symbols[random.nextInt(symbols.size)]
@@ -209,4 +228,55 @@ private fun createFallingObject(
 private fun Random.between(minValue: Float, maxValue: Float): Float {
     if (maxValue <= minValue) return minValue
     return minValue + nextFloat() * (maxValue - minValue)
+}
+
+private fun findNonOverlappingX(
+    random: Random,
+    availableWidth: Float,
+    sizePx: Float,
+    y: Float,
+    existingObjects: List<FallingObject>,
+    minSpacingPx: Float,
+    maxAttempts: Int = 12
+): Float {
+    if (existingObjects.isEmpty()) {
+        return random.between(0f, availableWidth)
+    }
+    repeat(maxAttempts) {
+        val candidate = random.between(0f, availableWidth)
+        val overlaps = existingObjects.any { other ->
+            isOverlapping(
+                candidateX = candidate,
+                candidateY = y,
+                candidateSize = sizePx,
+                other = other,
+                spacing = minSpacingPx
+            )
+        }
+        if (!overlaps) {
+            return candidate
+        }
+    }
+    return random.between(0f, availableWidth)
+}
+
+private fun isOverlapping(
+    candidateX: Float,
+    candidateY: Float,
+    candidateSize: Float,
+    other: FallingObject,
+    spacing: Float
+): Boolean {
+    val candidateStartX = candidateX - spacing
+    val candidateEndX = candidateX + candidateSize + spacing
+    val otherStartX = other.x - spacing
+    val otherEndX = other.x + other.sizePx + spacing
+    val horizontalOverlap = candidateStartX < otherEndX && otherStartX < candidateEndX
+    if (!horizontalOverlap) return false
+
+    val candidateStartY = candidateY - spacing
+    val candidateEndY = candidateY + candidateSize + spacing
+    val otherStartY = other.y - spacing
+    val otherEndY = other.y + other.sizePx + spacing
+    return candidateStartY < otherEndY && otherStartY < candidateEndY
 }


### PR DESCRIPTION
## Summary
- προστέθηκε ελάχιστη απόσταση μεταξύ των falling objects ώστε να μην εμφανίζονται το ένα πάνω στο άλλο
- εφαρμόστηκε αναζήτηση νέας θέσης τόσο στην αρχικοποίηση όσο και στην επαναδημιουργία των αντικειμένων

## Testing
- ./gradlew :app:lintDebug --console=plain --no-daemon *(αποτυχία: λείπει Android SDK στο περιβάλλον)*

------
https://chatgpt.com/codex/tasks/task_e_68d400a35be48328ab1c57f70328a0bf